### PR TITLE
docs: add phase 1b REST skills and acceptance matrix

### DIFF
--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -1,0 +1,26 @@
+# Breadcrumbs
+
+## 2026-02-25
+- Vollständige Bestandsaufnahme der vorhandenen Doku in `ha-nova` abgeschlossen.
+- Zielbild bestätigt: Thin Bridge (dumm) + Skills (schlau), kein Business-Logic-Drift in Server.
+- Brainstorming-Session mit 10 Klärungsfragen abgeschlossen.
+- Umsetzungsplan für Phase 1a erstellt:
+  - `docs/plans/2026-02-25-phase-1a-foundation-design.md`
+- Plan nachgeschärft: LLT (`HA_TOKEN`) im Onboarding als Pflichtentscheidung verankert.
+- Ausführung gestartet auf Branch `feat/phase-1a-foundation` (Worktree wegen fehlendem Initial-Commit nicht möglich).
+- Remote-Setup abgeschlossen: `origin` -> `https://github.com/markusleben/ha-nova.git`, Branch `feat/phase-1a-foundation` gepusht.
+- Batch 2 (Tasks 4-6) umgesetzt: WS-Client, Health-Handler, WS-Allowlist inkl. Tests und Verifikation.
+- Batch 3 (Tasks 7-9) umgesetzt: `/ws`-Handler, Phase-1a-Skills, Acceptance-Matrix mit Curl-Smoke-Evidenz.
+- PR #1 (`feat/phase-1a-foundation` -> `main`) erstellt und direkt gemerged.
+- Post-Merge-Codex-Review ausgeführt; Wiring-Lücke für `/health` + `/ws` identifiziert und in `main` gefixt.
+- Follow-up Review auf Fix-Commit ohne Findings; verbleibendes Risiko nur für unbekannte alte `createApp()`-Callsites ohne Optionen.
+- Striktes Code-Review für `2e6d924..f640807`: keine kritischen Bugs, aber Health/WS-Handler noch nicht im Router registriert, daher Integrationstoff fehlt.
+- Phase 1b gestartet auf Branch `feat/phase-1b-rest-skills`.
+- Phase-1b-Design und Deliverables erstellt:
+  - `docs/plans/2026-02-25-phase-1b-rest-skills-design.md`
+  - `skills/ha-entities.md`
+  - `skills/ha-control.md`
+  - `skills/ha-automation-crud.md`
+  - `skills/ha-automation-control.md`
+  - `docs/phase-1b-acceptance.md`
+- Konsistenzcheck (`ha-nova` Routing vs Skill-Dateien) und Vollverifikation (`test`, `typecheck`, `build`) erfolgreich.

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -1,0 +1,25 @@
+# Choices
+
+## 2026-02-25
+
+### User Decisions (Brainstorm Q1-Q10)
+- Priorität: Balance (`Demo + API + Skill`).
+- DoD: Kombi-DoD mit reduziertem Scope.
+- Ziel-Client: client-agnostisch.
+- Security-Härte in 1a: dev-first.
+- Runtime-Qualität: funktional + sichere Fehler.
+- `ha-onboarding.md`: ultra-lean.
+- Onboarding auth: user-generated LLT mandatory (`HA_TOKEN`), supervisor token not onboarding credential.
+- `ha-safety.md`: core-only.
+- `ha-nova.md`: nur aktive 1a/1b Skills.
+- Teststrategie: leicht automatisiert (Vitest).
+- Ergebnisformat: eine Plan-Datei.
+
+### Planning Defaults (Agent)
+- Planstruktur: Vertical-Slice-Ansatz (empfohlen gegenüber infra-first/skill-first).
+- Fehlervertrag: einheitlicher JSON-Error-Envelope über alle Endpoints.
+- Execution workspace: Worktree-Skill fallback genutzt (Repo ohne Commit/HEAD), daher Feature-Branch `feat/phase-1a-foundation` im aktuellen Workspace.
+- GitHub owner for remote operations: canonical API login `markusleben` used (rename from `w0nk1`).
+- Branch strategy after repo bootstrap: set `main` as default branch, merge PR #1 into `main`, then apply post-merge wiring fix directly on `main`.
+- Phase 1b execution mode: skill-first (REST workflow skills + acceptance doc), no new bridge endpoints in this step.
+- Branch for 1b: `feat/phase-1b-rest-skills` from `main`.

--- a/docs/phase-1b-acceptance.md
+++ b/docs/phase-1b-acceptance.md
@@ -1,0 +1,34 @@
+# Phase 1b Acceptance Matrix
+
+Date: 2026-02-25  
+Branch: `feat/phase-1b-rest-skills`
+
+## Skill Deliverables
+
+| Check | Evidence | Status |
+|---|---|---|
+| `ha-entities` exists | `skills/ha-entities.md` | PASS |
+| `ha-control` exists | `skills/ha-control.md` | PASS |
+| `ha-automation-crud` exists | `skills/ha-automation-crud.md` | PASS |
+| `ha-automation-control` exists | `skills/ha-automation-control.md` | PASS |
+
+## Bootstrap Consistency
+
+| Check | Evidence | Status |
+|---|---|---|
+| Bootstrap catalog references Phase 1b skills | `skills/ha-nova.md` active skill catalog | PASS |
+| Routing rules include 1b automation flows | `skills/ha-nova.md` routing rules 4-5 | PASS |
+| LLT remains mandatory | `skills/ha-nova.md` required inputs include `HA_TOKEN` as LLT | PASS |
+
+## Safety and Flow Quality
+
+| Check | Evidence | Status |
+|---|---|---|
+| Entity resolution before writes | `ha-control`, `ha-automation-control`, `ha-automation-crud` | PASS |
+| Preview + confirmation before writes | all write-oriented skills | PASS |
+| Verify-after-execute guidance | control and automation skill flows | PASS |
+
+## Notes
+
+- Phase 1b intentionally adds no Bridge endpoints.
+- Trace/diagnostics remain Phase 1c+ scope.

--- a/docs/plans/2026-02-25-phase-1b-rest-skills-design.md
+++ b/docs/plans/2026-02-25-phase-1b-rest-skills-design.md
@@ -1,0 +1,43 @@
+# Phase 1b REST Skills Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Deliver the Phase 1b skill layer for direct REST-based entity discovery, device control, and automation lifecycle/control flows.
+
+**Architecture:** Keep Bridge unchanged for Phase 1b. Add domain skills that route operations directly to Home Assistant REST API with LLT auth. Enforce core safety pattern (resolve -> preview -> confirm -> execute -> verify) for all writes.
+
+**Tech Stack:** Markdown skills, Home Assistant REST API, existing `ha-nova` bootstrap routing.
+
+---
+
+## Scope
+
+- Create `skills/ha-entities.md`
+- Create `skills/ha-control.md`
+- Create `skills/ha-automation-crud.md`
+- Create `skills/ha-automation-control.md`
+- Update `skills/ha-nova.md` only if routing/table gaps exist
+- Create acceptance checklist `docs/phase-1b-acceptance.md`
+
+## Out of Scope
+
+- New Bridge endpoints
+- Trace/diagnostics features (Phase 1c+)
+- Full best-practice catalog integration (Phase 2)
+
+## Acceptance Criteria
+
+1. Four Phase 1b skill files exist and define concrete REST call flows.
+2. Bootstrap routing references only existing skill files for Phase 1a/1b.
+3. All write flows document preview + confirmation + verification.
+4. LLT (`HA_TOKEN`) remains mandatory across workflow docs.
+5. `docs/phase-1b-acceptance.md` records verification evidence.
+
+## Execution Steps
+
+1. Author `ha-entities` with discovery/search/get/service-list flows.
+2. Author `ha-control` with service-call and post-call verification flow.
+3. Author `ha-automation-crud` with list/get/create/update/delete/reload sequence.
+4. Author `ha-automation-control` with enable/disable/toggle/trigger flow.
+5. Run consistency checks between `ha-nova` catalog and actual files.
+6. Record results in `docs/phase-1b-acceptance.md`.

--- a/skills/ha-automation-control.md
+++ b/skills/ha-automation-control.md
@@ -1,0 +1,50 @@
+---
+name: ha-automation-control
+description: Control existing automations via automation service calls.
+---
+
+# HA Automation Control
+
+## Purpose
+
+Enable, disable, toggle, or trigger existing automations through REST service calls.
+
+## Required Inputs
+
+- `HA_URL`
+- `HA_TOKEN` (Long-Lived Token)
+
+## Primary Endpoint
+
+- `POST {HA_URL}/api/services/automation/{service}`
+
+Common services:
+- `turn_on`
+- `turn_off`
+- `toggle`
+- `trigger`
+
+## Control Flow
+
+1. Resolve exact automation entity IDs (use `ha-entities`).
+2. Preview service name + target payload.
+3. Ask explicit confirmation.
+4. Execute service call.
+5. Verify post-state when relevant:
+   - `turn_on` expected state `on`
+   - `turn_off` expected state `off`
+
+## Payload Patterns
+
+- Single target:
+  - `{"entity_id":"automation.my_rule"}`
+- Batch target:
+  - `{"entity_id":["automation.a","automation.b"]}`
+- Trigger with skipped conditions when intentionally requested:
+  - `{"entity_id":"automation.my_rule","skip_condition":true}`
+
+## Safety Rules
+
+- Do not trigger unknown automations.
+- For batch operations, execute sequentially and report per-item result.
+- Stop batch on hard errors unless user explicitly asks to continue-on-error.

--- a/skills/ha-automation-crud.md
+++ b/skills/ha-automation-crud.md
@@ -1,0 +1,59 @@
+---
+name: ha-automation-crud
+description: Manage automation configs via Home Assistant REST automation config endpoints.
+---
+
+# HA Automation CRUD
+
+## Purpose
+
+Create, read, update, and delete automations through REST config endpoints, then reload and verify.
+
+## Required Inputs
+
+- `HA_URL`
+- `HA_TOKEN` (Long-Lived Token)
+
+## Primary Endpoints
+
+- List runtime automations:
+  - `GET {HA_URL}/api/states` (filter `automation.*`)
+- Read config:
+  - `GET {HA_URL}/api/config/automation/config/{id}`
+- Create/Update config:
+  - `POST {HA_URL}/api/config/automation/config/{id}`
+- Delete config:
+  - `DELETE {HA_URL}/api/config/automation/config/{id}`
+- Reload:
+  - `POST {HA_URL}/api/services/automation/reload`
+
+## CRUD Flow
+
+### List
+1. Call `GET /api/states`.
+2. Filter to `entity_id` starting with `automation.`.
+
+### Get
+1. Resolve config id (not full entity id).
+2. Call `GET /api/config/automation/config/{id}`.
+
+### Create / Update
+1. Build full automation config (`alias`, `triggers`, `conditions`, `actions`, `mode`).
+2. Preview full config JSON/YAML-equivalent to user.
+3. Ask explicit confirmation.
+4. `POST /api/config/automation/config/{id}`.
+5. `POST /api/services/automation/reload`.
+6. Verify with `GET /api/states/automation.{id}` where naming matches slug.
+
+### Delete
+1. Preview target automation id.
+2. Ask explicit confirmation.
+3. `DELETE /api/config/automation/config/{id}`.
+4. `POST /api/services/automation/reload`.
+5. Verify target is absent or unavailable in states list.
+
+## Safety Rules
+
+- Never overwrite unknown IDs.
+- Never execute create/update/delete without preview + confirmation.
+- On ambiguity in ID mapping (`id` vs `entity_id`), resolve explicitly before write.

--- a/skills/ha-control.md
+++ b/skills/ha-control.md
@@ -1,0 +1,45 @@
+---
+name: ha-control
+description: Control Home Assistant entities through REST service calls with verification.
+---
+
+# HA Control
+
+## Purpose
+
+Execute device control actions (lights, switches, climate, covers, media, fans, locks) via REST service calls.
+
+## Required Inputs
+
+- `HA_URL`
+- `HA_TOKEN` (Long-Lived Token)
+
+## Primary Endpoint
+
+- `POST {HA_URL}/api/services/{domain}/{service}`
+
+## Control Flow
+
+1. Resolve entity IDs first (use `ha-entities`).
+2. Build service payload:
+   - required target (`entity_id` list or single)
+   - optional `data` fields (for example `brightness_pct`, `temperature`)
+3. Preview exact service call payload.
+4. Ask explicit confirmation for write action.
+5. Execute service call.
+6. Verify resulting state via `GET /api/states/{entity_id}` when practical.
+
+## Common Patterns
+
+- Light on:
+  - `POST /api/services/light/turn_on` with `{"entity_id":"light.x","brightness_pct":50}`
+- Switch off:
+  - `POST /api/services/switch/turn_off` with `{"entity_id":"switch.x"}`
+- Climate set temperature:
+  - `POST /api/services/climate/set_temperature` with `{"entity_id":"climate.x","temperature":21}`
+
+## Error Handling
+
+- 401: token invalid/expired -> request new LLT.
+- 400: invalid payload/service params -> show offending field.
+- 404: bad route/domain/service -> re-check service list (`GET /api/services`).

--- a/skills/ha-entities.md
+++ b/skills/ha-entities.md
@@ -1,0 +1,45 @@
+---
+name: ha-entities
+description: Discover, list, and filter Home Assistant entities via REST states and service metadata.
+---
+
+# HA Entities
+
+## Purpose
+
+Resolve exact entity IDs and service capabilities before control or write operations.
+
+## Required Inputs
+
+- `HA_URL`
+- `HA_TOKEN` (Long-Lived Token)
+
+## Primary Endpoints
+
+- `GET {HA_URL}/api/states`
+- `GET {HA_URL}/api/states/{entity_id}`
+- `GET {HA_URL}/api/services`
+
+## Workflow
+
+1. For broad discovery, call `GET /api/states` once.
+2. Filter client-side by:
+   - domain (`light.`, `switch.`, `sensor.`, `automation.`)
+   - `friendly_name`
+   - area/device hints embedded in `entity_id` or attributes
+3. For exact detail, call `GET /api/states/{entity_id}`.
+4. For available actions, call `GET /api/services`.
+
+## Output Format
+
+For each returned entity provide:
+- `entity_id`
+- `state`
+- `friendly_name` (if available)
+- key attributes relevant to user intent
+
+## Safety Rules
+
+- Never guess entity IDs.
+- If multiple candidates match, return shortlist and ask user to pick.
+- Prefer exact `entity_id` confirmation before downstream writes.


### PR DESCRIPTION
## Summary
- add Phase 1b REST domain skills for entity discovery, control, automation CRUD, and automation control
- add Phase 1b design and acceptance docs
- update project choices and breadcrumbs for branch strategy and execution defaults

## Verification
- [x] npm test
- [x] npm run typecheck
- [x] npm run build