### PR TITLE
feat: runtime LLAT bootstrap with persistent app option flow

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,0 +1,24 @@
+name: HA Nova Bridge
+version: "0.1.0"
+slug: ha_nova_bridge
+description: Thin Home Assistant bridge for WS proxy and skill workflows
+url: https://github.com/markusleben/ha-nova
+arch:
+  - amd64
+  - aarch64
+startup: services
+boot: auto
+init: false
+ingress: true
+ingress_port: 8791
+homeassistant_api: true
+hassio_api: true
+panel_icon: mdi:bridge
+
+options:
+  ha_llat: null
+  ws_allowlist_append: ""
+
+schema:
+  ha_llat: "password?"
+  ws_allowlist_append: "str?"

--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -24,3 +24,33 @@
   - `skills/ha-automation-control.md`
   - `docs/phase-1b-acceptance.md`
 - Konsistenzcheck (`ha-nova` Routing vs Skill-Dateien) und Vollverifikation (`test`, `typecheck`, `build`) erfolgreich.
+
+## 2026-02-26
+- Mini-Spec für LLAT-Handling + Dev-Seeding erstellt:
+  - `docs/plans/2026-02-26-token-resolution-dev-seed-design.md`
+- Token-Resolver ergänzt:
+  - `src/security/token-resolver.ts`
+  - `tests/security/token-resolver.test.ts`
+- Env-Parsing erweitert für optionale Tokenquellen (`HA_LLAT`, `SUPERVISOR_TOKEN`):
+  - `src/config/env.ts`
+  - `tests/security/auth.test.ts`
+- Idempotentes Dev-Seed-Skript ergänzt (Supervisor validate+write, dry-run support):
+  - `scripts/dev-seed-ha-llat.mjs`
+  - `package.json` script `seed:llat`
+  - `docs/llat-dev-testing.md`
+- Neuer verbindlicher Doku-Gate für zukünftige Planung ergänzt:
+  - `docs/reference/ha-doc-gate-2026-02-26.md`
+- Runtime-Integration für LLAT/Supervisor-Fallback umgesetzt:
+  - `src/runtime/start.ts`
+  - `src/runtime/main.ts`
+  - `src/config/addon-options.ts`
+  - `tests/bootstrap/runtime-start.test.ts`
+  - `tests/config/addon-options.test.ts`
+- Add-on/App-Options-Schema für persistentes `ha_llat` ergänzt:
+  - `addon/config.yaml`
+- Env-Modell erweitert:
+  - neue Felder `HA_URL`, `BRIDGE_VERSION`, `ADDON_OPTIONS_PATH`
+  - auth split mit `BRIDGE_AUTH_TOKEN` + optionalem Legacy-`HA_TOKEN`-Fallback
+- Dev-Startpfad auf Runtime-Entrypoint umgestellt:
+  - `package.json` (`dev` -> `src/runtime/main.ts`)
+- Vollverifikation nach Runtime-Integration erfolgreich (`test`, `typecheck`, `build`).

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -23,3 +23,14 @@
 - Branch strategy after repo bootstrap: set `main` as default branch, merge PR #1 into `main`, then apply post-merge wiring fix directly on `main`.
 - Phase 1b execution mode: skill-first (REST workflow skills + acceptance doc), no new bridge endpoints in this step.
 - Branch for 1b: `feat/phase-1b-rest-skills` from `main`.
+
+## 2026-02-26
+
+### Planning Defaults (Agent)
+- Upstream token policy: dual auth with deterministic fallback (`HA_LLAT` > addon option `ha_llat` > legacy `HA_TOKEN` > `SUPERVISOR_TOKEN`).
+- Compatibility policy: keep `HA_TOKEN` required for existing bridge auth behavior, mark `HA_TOKEN` as deprecated only for upstream LLAT resolution.
+- Dev ergonomics policy: provide idempotent LLAT seed command (`npm run seed:llat`) that validates options before write.
+- Supervisor API write policy: merge existing addon options before posting update to avoid unintended option loss.
+- Planning gate policy: no new plan without prior review of current official HA docs (developer + apps/add-ons + user docs).
+- Runtime auth split policy: bridge endpoint auth token and upstream token selection are separated (`BRIDGE_AUTH_TOKEN` preferred for bridge auth; upstream fallback uses `HA_TOKEN` only when bridge auth is explicitly separated).
+- Runtime capability policy: if upstream auth is limited/none, bridge stays up and returns explicit WS error instead of crashing startup.

--- a/docs/llat-dev-testing.md
+++ b/docs/llat-dev-testing.md
@@ -1,0 +1,67 @@
+# LLAT Dev/Test Workflow
+
+Date: 2026-02-26
+
+## Objective
+
+Avoid manual LLAT re-entry after each dev deployment while keeping full-scope API/WS test coverage.
+
+## Token Resolution Order
+
+1. `HA_LLAT` (local env; preferred for local dev and CI)
+2. app option `ha_llat` (persistent in `/data/options.json`)
+3. legacy `HA_TOKEN` (fallback only when `BRIDGE_AUTH_TOKEN` is set separately)
+4. `SUPERVISOR_TOKEN` (limited mode)
+
+## Bridge Auth vs Upstream Auth
+
+- Bridge endpoint auth:
+  - `BRIDGE_AUTH_TOKEN` preferred
+  - fallback: `HA_TOKEN`
+- Upstream legacy LLAT fallback:
+  - only active when `BRIDGE_AUTH_TOKEN` is set and `HA_TOKEN` is also set
+  - this avoids accidental coupling where one token silently drives both concerns
+
+## Seed LLAT Once Into App Options
+
+Prerequisites:
+- `SUPERVISOR_TOKEN` available in runtime
+- LLAT string available from user profile in Home Assistant
+
+Command:
+
+```bash
+npm run seed:llat -- '<YOUR_LLAT>'
+```
+
+Optional:
+
+```bash
+ADDON_SLUG=self SUPERVISOR_URL=http://supervisor npm run seed:llat -- '<YOUR_LLAT>' --dry-run
+```
+
+Behavior:
+- Reads current options
+- Merges `ha_llat`
+- Validates merged options via Supervisor API
+- Writes only when value changed
+
+## Runtime Start
+
+```bash
+npm run dev
+```
+
+Runtime bootstrap flow:
+1. load env
+2. read `/data/options.json` (or `ADDON_OPTIONS_PATH`)
+3. resolve upstream token source
+4. create app with allowlist and auth
+5. start HTTP server
+
+## Test Matrix
+
+1. Unit tests (`resolveUpstreamToken`): source precedence, warnings, empty input handling
+2. Unit tests (`loadEnv`): optional `HA_LLAT` and `SUPERVISOR_TOKEN`
+3. Integration tests (`/ws`, `/health`): unchanged behavior
+4. Optional live smoke test: set LLAT once with seed script, then deploy/restart and verify token remains active

--- a/docs/plans/2026-02-26-token-resolution-dev-seed-design.md
+++ b/docs/plans/2026-02-26-token-resolution-dev-seed-design.md
@@ -1,0 +1,49 @@
+# Token Resolution + Dev Seeding (Phase 1a.1)
+
+Date: 2026-02-26  
+Status: approved-for-implementation
+
+## Goal
+
+Enable full-scope Home Assistant access with LLAT while keeping dev/test ergonomics high.
+
+## Scope
+
+1. Add a deterministic upstream token resolver with explicit priority.
+2. Extend environment parsing for LLAT/supervisor token inputs.
+3. Add an idempotent helper script that persists LLAT in app options through Supervisor API.
+4. Add tests for resolver behavior and env parsing.
+
+## Non-Goals
+
+- No new runtime endpoint.
+- No bridge transport refactor.
+- No secrets manager integration.
+
+## Token Priority
+
+1. `HA_LLAT` (local env; best for dev and CI).
+2. App option `ha_llat` (persistent across restarts/updates in `/data/options.json`).
+3. Legacy fallback `HA_TOKEN` (compat only; deprecation warning).
+4. `SUPERVISOR_TOKEN` fallback (limited capability mode).
+5. No token -> restricted mode with explicit warning.
+
+## Expected Behavior
+
+- Resolver returns: selected token, source, capability (`full | limited | none`), warnings.
+- Empty/whitespace values are ignored.
+- Env parser keeps existing required `HA_TOKEN` behavior for bridge auth compatibility.
+
+## Testing
+
+- Unit tests for every priority branch and warning branch.
+- Unit tests for env parser reading optional `HA_LLAT` and `SUPERVISOR_TOKEN`.
+- Full suite verification: `npm test && npm run typecheck && npm run build`.
+
+## Dev Seeding Strategy
+
+- Script validates input and `SUPERVISOR_TOKEN` presence.
+- Script validates options via `/addons/<slug>/options/validate` before write.
+- Script applies options via `/addons/<slug>/options`.
+- Script defaults to `self` slug; override via `ADDON_SLUG`.
+- Idempotent intent: repeated run writes same value safely.

--- a/docs/reference/ha-doc-gate-2026-02-26.md
+++ b/docs/reference/ha-doc-gate-2026-02-26.md
@@ -1,0 +1,53 @@
+# Home Assistant Doc Gate (Mandatory Before Planning)
+
+Date: 2026-02-26
+
+## Rule
+
+Before any new implementation plan, review current official Home Assistant docs in three buckets:
+
+1. Developer APIs (REST, WS, Auth, Supervisor)
+2. Apps (formerly add-ons): configuration, communication, testing, security
+3. User docs: automations/scripts/dashboard/common tasks
+
+No plan starts before this gate is checked.
+
+## Reviewed Sources (Official)
+
+### 1) Developer + API
+- https://developers.home-assistant.io/docs/api/rest/
+- https://developers.home-assistant.io/docs/api/websocket/
+- https://developers.home-assistant.io/docs/auth_api/
+- https://developers.home-assistant.io/docs/api/supervisor/endpoints/
+
+### 2) Apps / Add-ons
+- https://developers.home-assistant.io/docs/apps/configuration/
+- https://developers.home-assistant.io/docs/apps/communication/
+- https://developers.home-assistant.io/docs/apps/testing/
+- https://developers.home-assistant.io/docs/apps/security/
+- https://developers.home-assistant.io/docs/apps/tutorial/
+
+### 3) User Docs
+- https://www.home-assistant.io/docs/
+- https://www.home-assistant.io/common-tasks/general/
+- https://www.home-assistant.io/docs/automation/editor/
+- https://www.home-assistant.io/docs/automation/modes/
+- https://www.home-assistant.io/docs/tools/dev-tools/
+- https://www.home-assistant.io/docs/configuration/secrets/
+
+## Hard Findings For ha-nova
+
+1. App options persist in `/data/options.json`; this is the right place for persistent LLAT storage in app config.
+2. Supervisor proxy supports `http://supervisor/core/api` and `ws://supervisor/core/websocket` via `SUPERVISOR_TOKEN`.
+3. Supervisor endpoint supports `/addons/<addon>/options` and `/addons/<addon>/options/validate`; `self` slug is supported for app-scoped calls.
+4. LLAT remains valid for long-lived integration scenarios and is created in user profile.
+5. Official local app testing baseline is devcontainer-based with Supervisor + Home Assistant.
+6. Security guidance favors least-privilege roles, no host-network unless required, and ingress/auth best practices.
+
+## Planning Checklist (Must Pass)
+
+- [ ] API transport choice mapped (REST vs WS vs Supervisor)
+- [ ] Auth model mapped (`SUPERVISOR_TOKEN` vs LLAT) with fallback behavior
+- [ ] App option schema impact checked (`config.yaml` options/schema)
+- [ ] Local test path defined (unit + integration + local app testing)
+- [ ] User-facing impact checked against user docs workflow

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "node --enable-source-maps --watch src/index.ts",
+    "dev": "node --enable-source-maps --watch src/runtime/main.ts",
+    "seed:llat": "node scripts/dev-seed-ha-llat.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/scripts/dev-seed-ha-llat.mjs
+++ b/scripts/dev-seed-ha-llat.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+const HELP = `Usage:
+  node scripts/dev-seed-ha-llat.mjs <LLAT> [--dry-run]
+
+Environment:
+  SUPERVISOR_TOKEN  Required. Token used for Supervisor API calls.
+  SUPERVISOR_URL    Optional. Default: http://supervisor
+  ADDON_SLUG        Optional. Default: self
+
+Behavior:
+  - Reads current addon options.
+  - Merges and validates ha_llat.
+  - Writes options only when value changed.
+`;
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const positional = args.filter((value) => !value.startsWith("--"));
+
+if (args.includes("-h") || args.includes("--help")) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+const seedToken = normalize(positional[0] ?? process.env.HA_LLAT);
+if (!seedToken) {
+  fail("Missing LLAT. Pass it as first argument or set HA_LLAT.");
+}
+
+const supervisorToken = normalize(process.env.SUPERVISOR_TOKEN);
+if (!supervisorToken) {
+  fail("SUPERVISOR_TOKEN is required.");
+}
+
+const supervisorUrl = normalize(process.env.SUPERVISOR_URL) ?? "http://supervisor";
+const addonSlug = normalize(process.env.ADDON_SLUG) ?? "self";
+
+const headers = {
+  authorization: `Bearer ${supervisorToken}`,
+  "content-type": "application/json"
+};
+
+const info = await requestJson(`/addons/${addonSlug}/info`, { method: "GET", headers });
+const currentOptions = toOptionsObject(info.data?.options);
+
+if (currentOptions.ha_llat === seedToken) {
+  console.log(`No changes needed. ha_llat already set for '${addonSlug}'.`);
+  process.exit(0);
+}
+
+const nextOptions = {
+  ...currentOptions,
+  ha_llat: seedToken
+};
+
+const validation = await requestJson(`/addons/${addonSlug}/options/validate`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify(nextOptions)
+});
+
+const valid = validation.data?.valid;
+if (valid !== true) {
+  const message = typeof validation.data?.message === "string"
+    ? validation.data.message
+    : "Options validation failed";
+  fail(message);
+}
+
+if (dryRun) {
+  console.log(`Dry run only. Would update ha_llat for '${addonSlug}'.`);
+  process.exit(0);
+}
+
+await requestJson(`/addons/${addonSlug}/options`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({ options: nextOptions })
+});
+
+console.log(`Updated ha_llat in options for '${addonSlug}'.`);
+
+function normalize(value) {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function toOptionsObject(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value;
+  }
+  return {};
+}
+
+async function requestJson(path, init) {
+  const response = await fetch(`${supervisorUrl}${path}`, init);
+  const text = await response.text();
+  const payload = text.length > 0 ? safeJsonParse(text) : null;
+
+  if (!response.ok) {
+    const details = payload && typeof payload === "object" ? JSON.stringify(payload) : text;
+    fail(`Supervisor API call failed (${response.status}) on ${path}: ${details}`);
+  }
+
+  if (payload && typeof payload === "object") {
+    return payload;
+  }
+
+  return { result: "ok", data: null };
+}
+
+function safeJsonParse(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function fail(message) {
+  console.error(`[dev-seed-ha-llat] ${message}`);
+  process.exit(1);
+}

--- a/src/config/addon-options.ts
+++ b/src/config/addon-options.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+
+export interface AddonOptions {
+  ha_llat?: string;
+  [key: string]: unknown;
+}
+
+export function readAddonOptions(path: string): AddonOptions {
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+
+    return parsed as AddonOptions;
+  } catch (error) {
+    if (isMissingFile(error)) {
+      return {};
+    }
+
+    const message = error instanceof Error ? error.message : "Unknown error";
+    throw new Error(`Failed to read addon options from '${path}': ${message}`);
+  }
+}
+
+function isMissingFile(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ENOENT";
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -2,6 +2,12 @@ export type LogLevel = "trace" | "debug" | "info" | "warn" | "error";
 
 export interface EnvConfig {
   haToken: string;
+  legacyHaToken?: string;
+  haLlat?: string;
+  supervisorToken?: string;
+  haUrl: string;
+  bridgeVersion: string;
+  addonOptionsPath: string;
   bridgePort: number;
   logLevel: LogLevel;
   wsAllowlistExtra: string[];
@@ -9,6 +15,9 @@ export interface EnvConfig {
 
 const DEFAULT_BRIDGE_PORT = 8791;
 const DEFAULT_LOG_LEVEL: LogLevel = "info";
+const DEFAULT_HA_URL = "http://supervisor/core";
+const DEFAULT_BRIDGE_VERSION = "dev";
+const DEFAULT_ADDON_OPTIONS_PATH = "/data/options.json";
 const ALLOWED_LOG_LEVELS = new Set<LogLevel>([
   "trace",
   "debug",
@@ -18,10 +27,21 @@ const ALLOWED_LOG_LEVELS = new Set<LogLevel>([
 ]);
 
 export function loadEnv(source: NodeJS.ProcessEnv = process.env): EnvConfig {
-  const haToken = source.HA_TOKEN?.trim();
-  if (!haToken) {
-    throw new Error("HA_TOKEN is required");
+  const bridgeAuthToken = parseOptionalToken(source.BRIDGE_AUTH_TOKEN) ?? parseOptionalToken(source.HA_TOKEN);
+  if (!bridgeAuthToken) {
+    throw new Error("BRIDGE_AUTH_TOKEN or HA_TOKEN is required");
   }
+  const legacyHaToken = parseOptionalToken(source.BRIDGE_AUTH_TOKEN)
+    ? parseOptionalToken(source.HA_TOKEN)
+    : undefined;
+  const haLlat = parseOptionalToken(source.HA_LLAT);
+  const supervisorToken = parseOptionalToken(source.SUPERVISOR_TOKEN);
+  const haUrl = parseRequiredLike(source.HA_URL, DEFAULT_HA_URL);
+  const bridgeVersion = parseRequiredLike(source.BRIDGE_VERSION, DEFAULT_BRIDGE_VERSION);
+  const addonOptionsPath = parseRequiredLike(
+    source.ADDON_OPTIONS_PATH,
+    DEFAULT_ADDON_OPTIONS_PATH
+  );
 
   const portRaw = source.BRIDGE_PORT?.trim();
   const bridgePort = portRaw ? Number.parseInt(portRaw, 10) : DEFAULT_BRIDGE_PORT;
@@ -36,12 +56,29 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): EnvConfig {
 
   const wsAllowlistExtra = parseCsvList(source.WS_ALLOWLIST_APPEND);
 
-  return {
-    haToken,
+  const config: EnvConfig = {
+    haToken: bridgeAuthToken,
+    haUrl,
+    bridgeVersion,
+    addonOptionsPath,
     bridgePort,
     logLevel: logRaw as LogLevel,
     wsAllowlistExtra
   };
+
+  if (legacyHaToken) {
+    config.legacyHaToken = legacyHaToken;
+  }
+
+  if (haLlat) {
+    config.haLlat = haLlat;
+  }
+
+  if (supervisorToken) {
+    config.supervisorToken = supervisorToken;
+  }
+
+  return config;
 }
 
 function parseCsvList(input: string | undefined): string[] {
@@ -53,4 +90,22 @@ function parseCsvList(input: string | undefined): string[] {
     .split(",")
     .map((value) => value.trim())
     .filter((value) => value.length > 0);
+}
+
+function parseOptionalToken(input: string | undefined): string | undefined {
+  const value = input?.trim();
+  if (!value) {
+    return undefined;
+  }
+
+  return value;
+}
+
+function parseRequiredLike(input: string | undefined, fallback: string): string {
+  const value = input?.trim();
+  if (!value) {
+    return fallback;
+  }
+
+  return value;
 }

--- a/src/runtime/main.ts
+++ b/src/runtime/main.ts
@@ -1,0 +1,7 @@
+import { startBridge } from "./start.js";
+
+startBridge().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : "Unknown startup error";
+  console.error(JSON.stringify({ level: "error", message: "Bridge failed to start", context: { error: message } }));
+  process.exit(1);
+});

--- a/src/runtime/start.ts
+++ b/src/runtime/start.ts
@@ -1,0 +1,223 @@
+import { type Server } from "node:http";
+
+import { createConnection, createLongLivedTokenAuth } from "home-assistant-js-websocket";
+
+import { createApp, type App } from "../index.js";
+import { readAddonOptions, type AddonOptions } from "../config/addon-options.js";
+import { loadEnv, type EnvConfig, type LogLevel } from "../config/env.js";
+import { createHaWsClient, type HaWsClient, type HaWsConnection, type HaWsRequest } from "../ha/ws-client.js";
+import {
+  resolveUpstreamToken,
+  type ResolveUpstreamTokenInput,
+  type UpstreamCapability,
+  type UpstreamTokenResolution
+} from "../security/token-resolver.js";
+import { createWsAllowlist } from "../security/ws-allowlist.js";
+
+export interface RuntimeBootstrapResult {
+  app: App;
+  env: EnvConfig;
+  addonOptions: AddonOptions;
+  upstreamAuth: UpstreamTokenResolution;
+}
+
+interface Logger {
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+export interface RuntimeDependencies {
+  loadEnv?: () => EnvConfig;
+  readAddonOptions?: (path: string) => AddonOptions;
+  createWsClient?: (input: RuntimeWsClientInput) => HaWsClient;
+  logger?: Logger;
+  listen?: (server: Server, port: number) => Promise<void>;
+}
+
+export interface RuntimeWsClientInput {
+  env: EnvConfig;
+  addonOptions: AddonOptions;
+  upstreamAuth: UpstreamTokenResolution;
+}
+
+export interface StartBridgeResult extends RuntimeBootstrapResult {
+  port: number;
+}
+
+export function bootstrapRuntime(dependencies: RuntimeDependencies = {}): RuntimeBootstrapResult {
+  const env = (dependencies.loadEnv ?? loadEnv)();
+  const addonOptions = (dependencies.readAddonOptions ?? readAddonOptions)(env.addonOptionsPath);
+
+  const upstreamAuth = resolveUpstreamToken(
+    buildTokenResolutionInput(env, normalizeAddonOptionToken(addonOptions.ha_llat))
+  );
+
+  const wsClient = (dependencies.createWsClient ?? createDefaultWsClient)({
+    env,
+    addonOptions,
+    upstreamAuth
+  });
+
+  const app = createApp({
+    authToken: env.haToken,
+    version: env.bridgeVersion,
+    wsClient,
+    allowlist: createWsAllowlist({
+      extraPatterns: env.wsAllowlistExtra
+    })
+  });
+
+  return {
+    app,
+    env,
+    addonOptions,
+    upstreamAuth
+  };
+}
+
+export async function startBridge(dependencies: RuntimeDependencies = {}): Promise<StartBridgeResult> {
+  const logger = dependencies.logger ?? createConsoleLogger();
+  const runtime = bootstrapRuntime(dependencies);
+
+  logStartup(logger, runtime);
+
+  const listen = dependencies.listen ?? listenServer;
+  await listen(runtime.app.server, runtime.env.bridgePort);
+
+  logger.info("Bridge listening", {
+    port: runtime.env.bridgePort
+  });
+
+  return {
+    ...runtime,
+    port: runtime.env.bridgePort
+  };
+}
+
+export function createDefaultWsClient(input: RuntimeWsClientInput): HaWsClient {
+  const token = input.upstreamAuth.token;
+  if (!token || input.upstreamAuth.capability !== "full") {
+    const reason = capabilityToMessage(input.upstreamAuth.capability);
+    return createUnavailableWsClient(reason);
+  }
+
+  return createHaWsClient({
+    createConnection: async () => {
+      if (typeof WebSocket === "undefined") {
+        throw new Error(
+          "Global WebSocket is unavailable in this Node runtime. Use Node runtime with WebSocket support."
+        );
+      }
+
+      const auth = createLongLivedTokenAuth(input.env.haUrl, token);
+      const connection = await createConnection({ auth });
+
+      const wrapped: HaWsConnection = {
+        sendMessagePromise: (message: HaWsRequest) => connection.sendMessagePromise(message)
+      };
+
+      return wrapped;
+    }
+  });
+}
+
+function buildTokenResolutionInput(
+  env: EnvConfig,
+  addonOptionHaLlat: string | undefined
+): ResolveUpstreamTokenInput {
+  const input: ResolveUpstreamTokenInput = {};
+
+  if (env.haLlat) {
+    input.envHaLlat = env.haLlat;
+  }
+
+  if (addonOptionHaLlat) {
+    input.addonOptionHaLlat = addonOptionHaLlat;
+  }
+
+  if (env.legacyHaToken) {
+    input.legacyHaToken = env.legacyHaToken;
+  }
+
+  if (env.supervisorToken) {
+    input.supervisorToken = env.supervisorToken;
+  }
+
+  return input;
+}
+
+function createUnavailableWsClient(message: string): HaWsClient {
+  return {
+    isConnected(): boolean {
+      return false;
+    },
+    async sendMessage(): Promise<never> {
+      throw new Error(message);
+    }
+  };
+}
+
+function capabilityToMessage(capability: UpstreamCapability): string {
+  if (capability === "limited") {
+    return "LLAT is required for full WebSocket scope. Configure HA_LLAT or addon option 'ha_llat'.";
+  }
+
+  return "No upstream token available. Configure HA_LLAT or addon option 'ha_llat'.";
+}
+
+function normalizeAddonOptionToken(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return trimmed;
+}
+
+function createConsoleLogger(): Logger {
+  return {
+    info(message, context) {
+      logLine("info", message, context);
+    },
+    warn(message, context) {
+      logLine("warn", message, context);
+    },
+    error(message, context) {
+      logLine("error", message, context);
+    }
+  };
+}
+
+function logStartup(logger: Logger, runtime: RuntimeBootstrapResult): void {
+  logger.info("Bridge bootstrap", {
+    ha_url: runtime.env.haUrl,
+    auth_source: runtime.upstreamAuth.source,
+    auth_capability: runtime.upstreamAuth.capability
+  });
+
+  for (const warning of runtime.upstreamAuth.warnings) {
+    logger.warn(warning);
+  }
+}
+
+function logLine(level: LogLevel | "error", message: string, context?: Record<string, unknown>): void {
+  const payload = {
+    level,
+    message,
+    ...(context ? { context } : {})
+  };
+
+  console.log(JSON.stringify(payload));
+}
+
+async function listenServer(server: Server, port: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.listen(port, "0.0.0.0", () => resolve());
+    server.on("error", reject);
+  });
+}

--- a/src/security/token-resolver.ts
+++ b/src/security/token-resolver.ts
@@ -1,0 +1,82 @@
+export type UpstreamTokenSource =
+  | "env_ha_llat"
+  | "addon_option_ha_llat"
+  | "legacy_ha_token"
+  | "supervisor_token"
+  | "none";
+
+export type UpstreamCapability = "full" | "limited" | "none";
+
+export interface UpstreamTokenResolution {
+  token: string | null;
+  source: UpstreamTokenSource;
+  capability: UpstreamCapability;
+  warnings: string[];
+}
+
+export interface ResolveUpstreamTokenInput {
+  envHaLlat?: string;
+  addonOptionHaLlat?: string;
+  legacyHaToken?: string;
+  supervisorToken?: string;
+}
+
+const LEGACY_WARNING = "HA_TOKEN is a legacy LLAT fallback. Prefer HA_LLAT or addon option 'ha_llat'.";
+const SUPERVISOR_WARNING =
+  "LLAT missing. Falling back to SUPERVISOR_TOKEN with limited API scope.";
+const MISSING_TOKEN_WARNING =
+  "No upstream token available. Configure HA_LLAT or addon option 'ha_llat'.";
+
+export function resolveUpstreamToken(
+  input: ResolveUpstreamTokenInput
+): UpstreamTokenResolution {
+  const envHaLlat = normalizeToken(input.envHaLlat);
+  if (envHaLlat) {
+    return success(envHaLlat, "env_ha_llat", "full");
+  }
+
+  const addonOptionHaLlat = normalizeToken(input.addonOptionHaLlat);
+  if (addonOptionHaLlat) {
+    return success(addonOptionHaLlat, "addon_option_ha_llat", "full");
+  }
+
+  const legacyHaToken = normalizeToken(input.legacyHaToken);
+  if (legacyHaToken) {
+    return success(legacyHaToken, "legacy_ha_token", "full", [LEGACY_WARNING]);
+  }
+
+  const supervisorToken = normalizeToken(input.supervisorToken);
+  if (supervisorToken) {
+    return success(supervisorToken, "supervisor_token", "limited", [SUPERVISOR_WARNING]);
+  }
+
+  return {
+    token: null,
+    source: "none",
+    capability: "none",
+    warnings: [MISSING_TOKEN_WARNING]
+  };
+}
+
+function success(
+  token: string,
+  source: UpstreamTokenSource,
+  capability: UpstreamCapability,
+  warnings: string[] = []
+): UpstreamTokenResolution {
+  return {
+    token,
+    source,
+    capability,
+    warnings
+  };
+}
+
+function normalizeToken(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return trimmed;
+}

--- a/tests/bootstrap/runtime-start.test.ts
+++ b/tests/bootstrap/runtime-start.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { bootstrapRuntime } from "../../src/runtime/start.js";
+
+describe("runtime bootstrap", () => {
+  const servers: Array<ReturnType<typeof bootstrapRuntime>["app"]["server"]> = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.map(
+        (server) =>
+          new Promise<void>((resolve, reject) => {
+            server.close((error) => {
+              if (error) {
+                reject(error);
+                return;
+              }
+              resolve();
+            });
+          })
+      )
+    );
+    servers.length = 0;
+  });
+
+  it("uses addon option LLAT when env LLAT is missing", () => {
+    let seenSource: string | null = null;
+
+    const runtime = bootstrapRuntime({
+      loadEnv: () => ({
+        haToken: "bridge-token",
+        haUrl: "http://supervisor/core",
+        bridgeVersion: "1.2.3",
+        addonOptionsPath: "/data/options.json",
+        bridgePort: 8791,
+        logLevel: "info",
+        wsAllowlistExtra: []
+      }),
+      readAddonOptions: () => ({
+        ha_llat: "addon-llat"
+      }),
+      createWsClient: (input) => {
+        seenSource = input.upstreamAuth.source;
+        return {
+          isConnected: () => true,
+          sendMessage: async <T>() => ({ ok: true } as T)
+        };
+      }
+    });
+
+    expect(runtime.upstreamAuth.source).toBe("addon_option_ha_llat");
+    expect(seenSource).toBe("addon_option_ha_llat");
+    expect(runtime.app.version).toBe("1.2.3");
+  });
+
+  it("starts in limited mode when only supervisor token is available", async () => {
+    const runtime = bootstrapRuntime({
+      loadEnv: () => ({
+        haToken: "bridge-token",
+        supervisorToken: "supervisor-token",
+        haUrl: "http://supervisor/core",
+        bridgeVersion: "1.2.3",
+        addonOptionsPath: "/data/options.json",
+        bridgePort: 8791,
+        logLevel: "info",
+        wsAllowlistExtra: []
+      }),
+      readAddonOptions: () => ({})
+    });
+
+    servers.push(runtime.app.server);
+    const baseUrl = await startServer(runtime.app.server);
+
+    const health = await fetch(`${baseUrl}/health`, {
+      headers: { authorization: "Bearer bridge-token" }
+    });
+
+    expect(health.status).toBe(200);
+    await expect(health.json()).resolves.toEqual({
+      ok: true,
+      data: {
+        status: "ok",
+        ha_ws_connected: false,
+        version: "1.2.3",
+        uptime_s: expect.any(Number)
+      }
+    });
+
+    const ws = await fetch(`${baseUrl}/ws`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer bridge-token",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ type: "ping" })
+    });
+
+    expect(runtime.upstreamAuth.source).toBe("supervisor_token");
+    expect(runtime.upstreamAuth.capability).toBe("limited");
+    expect(ws.status).toBe(502);
+    await expect(ws.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "UPSTREAM_WS_ERROR",
+        message: "LLAT is required for full WebSocket scope. Configure HA_LLAT or addon option 'ha_llat'."
+      }
+    });
+  });
+});
+
+async function startServer(
+  server: ReturnType<typeof bootstrapRuntime>["app"]["server"]
+): Promise<string> {
+  const address = await new Promise<{ port: number }>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const serverAddress = server.address();
+      if (!serverAddress || typeof serverAddress === "string") {
+        reject(new Error("Server did not return a TCP address"));
+        return;
+      }
+      resolve(serverAddress);
+    });
+    server.on("error", reject);
+  });
+
+  return `http://127.0.0.1:${address.port}`;
+}

--- a/tests/config/addon-options.test.ts
+++ b/tests/config/addon-options.test.ts
@@ -1,0 +1,38 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { readAddonOptions } from "../../src/config/addon-options.js";
+
+describe("readAddonOptions", () => {
+  it("returns parsed options when file exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ha-nova-options-"));
+    const file = join(dir, "options.json");
+    writeFileSync(file, JSON.stringify({ ha_llat: "token", feature_flag: true }), "utf8");
+
+    const result = readAddonOptions(file);
+
+    expect(result).toEqual({
+      ha_llat: "token",
+      feature_flag: true
+    });
+  });
+
+  it("returns empty object when file does not exist", () => {
+    const result = readAddonOptions("/tmp/ha-nova-non-existent-options.json");
+
+    expect(result).toEqual({});
+  });
+
+  it("throws on invalid json", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ha-nova-options-"));
+    const file = join(dir, "options.json");
+    writeFileSync(file, "{ broken-json", "utf8");
+
+    expect(() => readAddonOptions(file)).toThrowError(
+      `Failed to read addon options from '${file}':`
+    );
+  });
+});

--- a/tests/security/auth.test.ts
+++ b/tests/security/auth.test.ts
@@ -45,8 +45,49 @@ describe("loadEnv", () => {
 
     expect(env).toEqual({
       haToken: "llt-token",
+      haUrl: "http://supervisor/core",
+      bridgeVersion: "dev",
+      addonOptionsPath: "/data/options.json",
       bridgePort: 9000,
       logLevel: "debug",
+      wsAllowlistExtra: []
+    });
+  });
+
+  it("reads optional HA_LLAT and SUPERVISOR_TOKEN values", () => {
+    const env = loadEnv({
+      HA_TOKEN: "bridge-token",
+      HA_LLAT: "  user-llat  ",
+      SUPERVISOR_TOKEN: "  supervisor-token  "
+    });
+
+    expect(env).toEqual({
+      haToken: "bridge-token",
+      haLlat: "user-llat",
+      supervisorToken: "supervisor-token",
+      haUrl: "http://supervisor/core",
+      bridgeVersion: "dev",
+      addonOptionsPath: "/data/options.json",
+      bridgePort: 8791,
+      logLevel: "info",
+      wsAllowlistExtra: []
+    });
+  });
+
+  it("maps BRIDGE_AUTH_TOKEN to bridge auth and HA_TOKEN to legacy upstream token", () => {
+    const env = loadEnv({
+      BRIDGE_AUTH_TOKEN: "bridge-auth",
+      HA_TOKEN: "legacy-upstream-token"
+    });
+
+    expect(env).toEqual({
+      haToken: "bridge-auth",
+      legacyHaToken: "legacy-upstream-token",
+      haUrl: "http://supervisor/core",
+      bridgeVersion: "dev",
+      addonOptionsPath: "/data/options.json",
+      bridgePort: 8791,
+      logLevel: "info",
       wsAllowlistExtra: []
     });
   });

--- a/tests/security/token-resolver.test.ts
+++ b/tests/security/token-resolver.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveUpstreamToken } from "../../src/security/token-resolver.js";
+
+describe("resolveUpstreamToken", () => {
+  it("prefers HA_LLAT env over all other sources", () => {
+    const result = resolveUpstreamToken({
+      envHaLlat: "env-token",
+      addonOptionHaLlat: "addon-token",
+      legacyHaToken: "legacy-token",
+      supervisorToken: "supervisor-token"
+    });
+
+    expect(result).toEqual({
+      token: "env-token",
+      source: "env_ha_llat",
+      capability: "full",
+      warnings: []
+    });
+  });
+
+  it("uses app option LLAT when env LLAT is missing", () => {
+    const result = resolveUpstreamToken({
+      addonOptionHaLlat: "addon-token",
+      legacyHaToken: "legacy-token",
+      supervisorToken: "supervisor-token"
+    });
+
+    expect(result).toEqual({
+      token: "addon-token",
+      source: "addon_option_ha_llat",
+      capability: "full",
+      warnings: []
+    });
+  });
+
+  it("falls back to legacy HA_TOKEN with deprecation warning", () => {
+    const result = resolveUpstreamToken({
+      legacyHaToken: "legacy-token",
+      supervisorToken: "supervisor-token"
+    });
+
+    expect(result).toEqual({
+      token: "legacy-token",
+      source: "legacy_ha_token",
+      capability: "full",
+      warnings: ["HA_TOKEN is a legacy LLAT fallback. Prefer HA_LLAT or addon option 'ha_llat'."]
+    });
+  });
+
+  it("falls back to supervisor token in limited mode", () => {
+    const result = resolveUpstreamToken({
+      supervisorToken: "supervisor-token"
+    });
+
+    expect(result).toEqual({
+      token: "supervisor-token",
+      source: "supervisor_token",
+      capability: "limited",
+      warnings: ["LLAT missing. Falling back to SUPERVISOR_TOKEN with limited API scope."]
+    });
+  });
+
+  it("returns none mode when no token source is available", () => {
+    const result = resolveUpstreamToken({});
+
+    expect(result).toEqual({
+      token: null,
+      source: "none",
+      capability: "none",
+      warnings: ["No upstream token available. Configure HA_LLAT or addon option 'ha_llat'."]
+    });
+  });
+
+  it("trims values and ignores empty token strings", () => {
+    const result = resolveUpstreamToken({
+      envHaLlat: "   ",
+      addonOptionHaLlat: "  addon-token  ",
+      legacyHaToken: "\t",
+      supervisorToken: " supervisor-token "
+    });
+
+    expect(result).toEqual({
+      token: "addon-token",
+      source: "addon_option_ha_llat",
+      capability: "full",
+      warnings: []
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add runtime bootstrap/start entrypoint with deterministic upstream token resolution
- add addon options reader and addon config schema for persistent `ha_llat`
- add idempotent LLAT seeding script via Supervisor API (`options/validate` + `options`)
- split bridge auth token vs legacy upstream token fallback behavior
- add bootstrap/runtime/config tests and update env/auth tests

## Verification
- npm test
- npm run typecheck
- npm run build
