### PR TITLE
fix: tighten automation refresh routing for KISS

### DIFF
--- a/.agents/skills/ha-nova/SKILL.md
+++ b/.agents/skills/ha-nova/SKILL.md
@@ -82,7 +82,8 @@ Output rule for this shortcut:
 - Device control:
   - use `"$NOVA_REPO_ROOT/skills/ha-control.md"`
 - Automation CRUD:
-  - for `create`/`update`/`delete` use `"$NOVA_REPO_ROOT/skills/ha-automation-best-practices.md"` + `"$NOVA_REPO_ROOT/skills/ha-automation-crud.md"` + `"$NOVA_REPO_ROOT/skills/ha-safety.md"`
+  - for `create`/`update` use `"$NOVA_REPO_ROOT/skills/ha-automation-best-practices.md"` + `"$NOVA_REPO_ROOT/skills/ha-automation-crud.md"` + `"$NOVA_REPO_ROOT/skills/ha-safety.md"`
+  - for `delete` use `"$NOVA_REPO_ROOT/skills/ha-automation-crud.md"` + `"$NOVA_REPO_ROOT/skills/ha-safety.md"`
   - for `read`/`list` use `"$NOVA_REPO_ROOT/skills/ha-automation-crud.md"`
 - Automation enable/disable/toggle:
   - use `"$NOVA_REPO_ROOT/skills/ha-automation-control.md"` + `"$NOVA_REPO_ROOT/skills/ha-safety.md"`

--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -276,6 +276,10 @@
   - `docs/plans/2026-03-01-automation-bp-refresh-session-gate-design.md`
 - Added skill contract checks:
   - `tests/skills/ha-nova-skill-contract.test.ts` now asserts routing through best-practice skill and refresh-gate language in automation CRUD.
+- KISS follow-up after subreview findings:
+  - narrowed routing so `delete` does not load `ha-automation-best-practices` (only `create`/`update` do).
+  - aligned installed skill routing in `.agents/skills/ha-nova/SKILL.md`.
+  - expanded skill contract tests to assert delete exemption and installed-skill routing invariants.
   - `docs/plans/2026-02-26-llat-mandatory-policy-design.md`
 - Enforced mandatory LLAT in runtime and App start path:
   - removed upstream fallback to `SUPERVISOR_TOKEN` in token resolver/runtime bootstrap.

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -143,3 +143,4 @@
 - Source-authority policy for automation refresh: use only official Home Assistant docs/integration docs/release notes as authoritative references.
 - Write gate policy refinement: if best-practice refresh fails, block automation `create`/`update` and return explicit remediation steps.
 - Routing policy refinement: automation write intents must load `ha-automation-best-practices` together with `ha-automation-crud` and `ha-safety`.
+- KISS refinement: route automation `delete` directly to `ha-automation-crud` + `ha-safety`; keep best-practice refresh skill only on `create`/`update`.

--- a/skills/ha-nova.md
+++ b/skills/ha-nova.md
@@ -53,9 +53,10 @@ Primary model:
 1. Setup, auth, connectivity, onboarding failures -> `ha-onboarding`
 2. Read/search/list entities -> `ha-entities`
 3. Device control (service calls) -> `ha-control` + `ha-safety` for writes
-4. Automation create/update/delete -> `ha-automation-best-practices` + `ha-automation-crud` + `ha-safety`
-5. Automation read/list -> `ha-automation-crud`
-6. Automation enable/disable/toggle -> `ha-automation-control` + `ha-safety`
+4. Automation create/update -> `ha-automation-best-practices` + `ha-automation-crud` + `ha-safety`
+5. Automation delete -> `ha-automation-crud` + `ha-safety`
+6. Automation read/list -> `ha-automation-crud`
+7. Automation enable/disable/toggle -> `ha-automation-control` + `ha-safety`
 
 ## Best-Practice Freshness Policy
 

--- a/tests/skills/ha-nova-skill-contract.test.ts
+++ b/tests/skills/ha-nova-skill-contract.test.ts
@@ -24,14 +24,25 @@ describe("ha-nova skill contract", () => {
     const content = readFileSync("skills/ha-nova.md", "utf8");
 
     expect(content).toContain("ha-automation-best-practices");
-    expect(content).toContain("Automation create/update/delete");
+    expect(content).toContain("Automation create/update");
+    expect(content).toContain("Automation delete -> `ha-automation-crud` + `ha-safety`");
   });
 
   it("enforces best-practice refresh gate before automation create/update writes", () => {
     const content = readFileSync("skills/ha-automation-crud.md", "utf8");
+    const bestPractices = readFileSync("skills/ha-automation-best-practices.md", "utf8");
 
     expect(content).toContain("Required Companion Skill for Writes");
     expect(content).toContain("Enforce best-practice session refresh gate");
     expect(content).toContain("no best-practice session refresh -> no write");
+    expect(bestPractices).toContain("`delete` operations are exempt from the refresh gate");
+  });
+
+  it("keeps installed codex skill routing aligned with delete exemption", () => {
+    const installedSkill = readFileSync(".agents/skills/ha-nova/SKILL.md", "utf8");
+
+    expect(installedSkill).toContain("for `create`/`update` use");
+    expect(installedSkill).toContain("for `delete` use");
+    expect(installedSkill).not.toContain("for `create`/`update`/`delete` use");
   });
 });


### PR DESCRIPTION
## Summary
- narrow automation routing so `delete` does not load best-practice refresh skill
- keep refresh gate scope strictly on automation `create`/`update`
- align installed codex skill routing with the same rule
- add contract assertions for installed skill routing + delete exemption semantics

## Why
Subreview found a scope mismatch that could cause unnecessary refresh checks on delete paths. This keeps behavior minimal and deterministic.

## Validation
- `npm run typecheck`
- `npm test`
- `npm test -- tests/skills/ha-nova-skill-contract.test.ts`
