### PR TITLE
chore: disable automatic release-please runs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,7 @@
 name: Release Please
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -446,3 +446,8 @@
 - Verification after removal:
   - `npm run typecheck` (pass)
   - `npm test` (pass, 20 files / 68 tests)
+
+## 2026-03-01
+- Disabled noisy release workflow trigger until release phase:
+  - `.github/workflows/release-please.yml` now uses `workflow_dispatch` only (no `push` on `main`).
+- Rationale: keep CI signal clean during MVP iteration and avoid repeated non-actionable release-automation failure emails.

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -144,3 +144,4 @@
 - Write gate policy refinement: if best-practice refresh fails, block automation `create`/`update` and return explicit remediation steps.
 - Routing policy refinement: automation write intents must load `ha-automation-best-practices` together with `ha-automation-crud` and `ha-safety`.
 - KISS refinement: route automation `delete` directly to `ha-automation-crud` + `ha-safety`; keep best-practice refresh skill only on `create`/`update`.
+- Release automation timing policy (user intent): keep `release-please` manual-only (`workflow_dispatch`) until release phase starts; avoid per-merge failure noise on `main`.


### PR DESCRIPTION
## Summary
- switch `Release Please` workflow trigger from `push` on `main` to manual `workflow_dispatch`
- keep release automation available, but only when intentionally started
- document policy decision in `docs/choices.md` and `docs/breadcrumbs.md`

## Why
During MVP iteration, automatic release automation creates noisy failure emails and low-signal red checks before release phase.
