### PR TITLE
docs: relay-only automation CRUD fast-path + perf plan

### DIFF
--- a/docs/plans/2026-03-01-relay-only-automation-crud-fastpath-design.md
+++ b/docs/plans/2026-03-01-relay-only-automation-crud-fastpath-design.md
@@ -37,6 +37,27 @@ Minimal validation (only what is necessary):
 - `path` must be a relative HA API path starting with `/api/`.
 - reject absolute URLs and path traversal patterns.
 
+Transport allowlist (v1, method+path tuples):
+- `GET /api/config/automation/config/{id}`
+- `POST /api/config/automation/config/{id}`
+- `DELETE /api/config/automation/config/{id}`
+- `GET /api/states`
+- `GET /api/states/automation.{id}`
+- `POST /api/services/automation/reload` (optional recovery only)
+
+If tuple is not allowlisted:
+- `403 CORE_PATH_NOT_ALLOWED`
+
+Path normalization (before allowlist match):
+1. Parse as relative URL path.
+2. Decode once.
+3. Reject path if it contains:
+   - `..`
+   - backslashes (`\`)
+   - encoded slash variants (`%2f`, `%5c`)
+   - control chars / non-printable bytes
+4. Reject overlong path (`>2048` chars).
+
 Forwarding behavior:
 - Upstream target: `${HA_URL}${path}`.
 - Auth header injected by Relay: `Authorization: Bearer <LLAT from App option ha_llat>`.
@@ -79,8 +100,12 @@ Nominal path: **1 write call + 1 confirmation**
 ## Reload Policy (Performance-first)
 
 - Do not auto-call `automation.reload` after each CRUD write by default.
-- If explicit user request or stale-state symptom appears, perform one targeted reload call:
-  - `POST /core` -> `POST /api/services/automation/reload`
+- After any write (`create/update/delete`), mark session `automation_state_dirty=true`.
+- If next intent is `list` via state endpoint (`/api/states`):
+  - run exactly one recovery reload first:
+    - `POST /core` -> `POST /api/services/automation/reload`
+  - clear `automation_state_dirty`.
+- `get` by config id does not require reload.
 
 ## Error Policy
 
@@ -90,20 +115,20 @@ Nominal path: **1 write call + 1 confirmation**
 
 ## Implementation Files
 
-Runtime:
+Phase 1 (minimal transport delivery):
 - `src/index.ts` (register `/core`)
 - `src/runtime/start.ts` (wire REST client dependency)
 - `src/ha/rest-client.ts` (new, thin upstream caller with keep-alive)
 - `src/http/handlers/core-proxy.ts` (new, validate + forward)
 - `src/types/api.ts` (request/response types)
 
-Tests:
+Phase 1 tests:
 - `tests/http/core-proxy.test.ts` (new)
 - `tests/bootstrap/app-wiring.test.ts`
 - `tests/bootstrap/runtime-start.test.ts`
 - `tests/http/error-envelope.test.ts`
 
-Skills/contracts:
+Phase 2 (skill routing update):
 - `skills/ha-nova.md`
 - `.agents/skills/ha-nova/SKILL.md`
 - `skills/ha-automation-crud.md`

--- a/docs/plans/2026-03-01-relay-only-automation-crud-performance-verification-design.md
+++ b/docs/plans/2026-03-01-relay-only-automation-crud-performance-verification-design.md
@@ -7,19 +7,18 @@ Status: Proposed
 
 Define a low-noise, low-runtime verification strategy for the new relay-only automation CRUD path:
 - fast CI-safe performance gate
-- optional live performance check
-- deterministic contract coverage for perf outputs
+- deterministic output contract
 
 ## Scope
 
 In scope:
 - relay request path used by automation CRUD through `POST /core`.
-- latency SLOs for CI and live checks.
+- latency SLOs for CI checks.
 - script/test layout and CI wiring with minimal overhead.
 
 Out of scope:
+- live benchmark mode in this first delivery (follow-up phase).
 - load/stress testing at production concurrency.
-- new runtime transport features.
 - replacing current functional smoke/e2e checks.
 
 ## Constraints
@@ -30,115 +29,77 @@ Out of scope:
 
 ## Strategy
 
-Use a 2-tier model:
-
-1. CI-safe micro-benchmark (blocking)
+Use one blocking CI-safe benchmark in v1:
 - deterministic local mode, no external HA dependency.
-- validates latency budget + zero-error contract.
+- runs real relay `/core` path and real `rest-client` against a local fake HA HTTP server (loopback).
+- validates zero-error + sequence-latency budget.
 - runtime target: <= 15s total.
 
-2. Live benchmark (non-blocking by default)
-- real Relay + HA path for reality check.
-- used in contributor loop/nightly/manual.
-- produces artifact + summary; fail only when explicitly requested.
+## Proposed SLOs (CI v1)
 
-## Proposed SLOs
+Blocking gates:
+1. `error_rate = 0%` (hard fail)
+2. sequence `p95 <= 650ms` for:
+   - `create -> get -> update -> get -> delete -> get(404)`
+3. `relay_calls_per_write == 1` in nominal write path (hard fail)
 
-### CI-safe micro-benchmark SLOs (blocking)
+Sampling/stability defaults:
+- `warmup = 5`
+- `samples = 30`
+- `max` is report-only (not a blocker) to reduce flakiness on shared runners.
 
-Test mode: local relay instance + deterministic mocked upstream REST client.
+## Contract Tests (minimal v1)
 
-- `error_rate` = `0%` (hard fail).
-- Per operation (`create/get/update/delete`):
-  - `p50 <= 20ms`
-  - `p95 <= 60ms`
-  - `max <= 120ms`
-- Full CRUD sequence (`create -> get -> update -> get -> delete -> get(404)`):
-  - `p95 <= 320ms`
-
-Why these numbers:
-- wide enough for GitHub-runner variance.
-- strict enough to catch accidental slow paths (sync blocking, extra round-trips, serialization regressions).
-
-### Live benchmark SLOs (optional, report-first)
-
-Test mode: real Relay endpoint + real HA backend.
-
-- `error_rate` = `0%` expected (warn on first failure, hard fail only with `--assert`).
-- Per operation:
-  - `p95 <= 700ms` (`create/get/update/delete`)
-- Full CRUD sequence:
-  - `p95 <= 4500ms`
-
-These are operational SLO targets (environment-dependent), not default PR blockers.
-
-## Contract Tests (fast, deterministic)
-
-Add perf-contract tests only; keep benchmark heavy work out of `npm test`.
-
-1. `tests/perf/relay-crud-perf-script-contract.test.ts`
-- script exists and is executable.
-- supports `--mode ci|live`, `--assert`, `--json-out`.
-- prints stable machine line: `PERF_CRUD_RESULT ...`.
-
-2. `tests/perf/relay-crud-perf-thresholds-contract.test.ts`
-- threshold config schema is valid.
-- required operations exist.
-- `p50 <= p95 <= max` invariant holds for each operation.
-
-3. `tests/perf/relay-crud-perf-output-contract.test.ts`
-- JSON output includes:
-  - metadata (`mode`, `timestamp`, `sample_size`, `warmup`)
-  - per-op stats (`count`, `p50`, `p95`, `max`, `errors`)
-  - sequence stats + pass/fail decisions
+One fast contract test only:
+- `tests/perf/relay-crud-perf-script-contract.test.ts`
+  - script exists/executable
+  - supports `--mode ci`, `--assert`, `--json-out`
+  - emits one machine line: `PERF_CRUD_RESULT ...`
+  - JSON output includes required metadata and pass/fail fields
 
 ## Benchmark Script Approach
 
 Add one script:
 - `scripts/perf/relay-automation-crud-bench.mjs`
 
-Modes:
-
-1. `--mode ci`
-- starts local relay server with injected deterministic REST client stub.
-- runs warmup + bounded samples (default `warmup=3`, `samples=12`).
-- computes percentiles in-process.
-- enforces CI thresholds when `--assert` is set.
-
-2. `--mode live`
-- requires `RELAY_BASE_URL`, `RELAY_AUTH_TOKEN`, `MVP_AUTOMATION_ID` (or generated id).
-- executes same CRUD sequence against real system through `POST /core`.
-- report-only by default; optional `--assert` for strict runs.
+Mode:
+- `--mode ci`
+  - starts local relay server
+  - starts local fake HA HTTP server (loopback)
+  - routes `/core` through real relay transport + real rest client
+  - runs warmup + samples (`warmup=5`, `samples=30`)
+  - computes percentiles in-process (monotonic clock)
+  - enforces CI thresholds with `--assert`
 
 Output:
 - console summary (single-line contract + table-like lines).
 - JSON artifact (default: `artifacts/perf/relay-crud-bench.json`).
+- include auth-source metadata:
+  - `client_has_ha_llat` (must be `false` in benchmark environment)
+  - `upstream_auth_source` (must be `relay_runtime`)
 
 ## Minimal CI Integration
 
 `package.json` scripts (proposal):
 - `perf:crud:ci`: `node scripts/perf/relay-automation-crud-bench.mjs --mode ci --assert`
-- `perf:crud:live`: `node scripts/perf/relay-automation-crud-bench.mjs --mode live`
 
 CI workflow:
 - add one step after `npm test`:
   - `npm run perf:crud:ci`
 - expected added CI time: ~10-15s.
-
-Live checks:
-- manual contributor loop and/or scheduled workflow.
-- non-blocking by default to avoid noisy failures from environment drift.
+- run this step only on relay/skills/perf path changes (or nightly fallback) to keep PR latency low.
+- optional retry-once before final fail to reduce shared-runner flakiness.
 
 ## Rollout Plan
 
 1. Implement relay MITM endpoint (`POST /core`) first.
-2. Add script + threshold config + perf contract tests.
-3. Add `perf:crud:ci` step to CI.
-4. Document live usage in contributor guide.
-5. After 1-2 weeks of data, tighten or relax SLOs once based on observed variance.
+2. Add CI benchmark script + minimal contract test.
+3. Add `perf:crud:ci` step to CI (path-scoped trigger).
+4. Tune thresholds after 1-2 weeks of data.
+5. Add live benchmark mode as explicit follow-up.
 
 ## Definition of Done
 
 - CI has deterministic perf gate for relay-only CRUD path.
-- Perf contracts protect script/output/threshold schema from drift.
-- Contributors can run optional live benchmark without changing CI stability.
+- Gate measures real relay `/core` path, not stub-bypassed internals.
+- Auth model proof is present (`client_has_ha_llat=false`, `upstream_auth_source=relay_runtime`).


### PR DESCRIPTION
## Summary
- add implementation plan for relay-only automation CRUD fast path (no client HA_LLAT)
- add performance verification plan with CI-safe micro-benchmark + optional live benchmark
- keep scope KISS and low-overhead for MVP velocity

## Notes
- Planning-only PR (no runtime/skill code changes yet)
- plan content is based on parallel subagent recommendations focused on low latency and minimal blast radius
