### PR TITLE
fix(onboarding): resolve symlinks in bin/ha-nova for npx compatibility

### DIFF
--- a/scripts/onboarding/bin/ha-nova
+++ b/scripts/onboarding/bin/ha-nova
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Resolve symlinks — npx creates symlinks in node_modules/.bin.
+# macOS lacks readlink -f, so follow the chain manually.
+REAL_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$REAL_PATH" ]]; do
+  LINK_DIR="$(cd -P "$(dirname "$REAL_PATH")" && pwd)"
+  REAL_PATH="$(readlink "$REAL_PATH")"
+  [[ "$REAL_PATH" != /* ]] && REAL_PATH="${LINK_DIR}/${REAL_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$REAL_PATH")/.." && pwd)"
 
 case "${1:-help}" in
   setup)


### PR DESCRIPTION
## Summary

- Fix symlink resolution in `bin/ha-nova` so `npx ha-nova setup` works when npm creates a symlink in `node_modules/.bin`
- Follow the symlink chain manually (portable across macOS and Linux)
- Addresses PR #19 review comment from codex-connector

## Test plan

- [x] Direct execution: `bash scripts/onboarding/bin/ha-nova --help`
- [x] Symlink execution: create symlink, execute via symlink, verify correct SCRIPT_DIR resolution
- [x] All 124 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)