### PR TITLE
fix: add repository.yaml for HA add-on repository discovery

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: HA NOVA
+url: https://github.com/markusleben/ha-nova
+maintainer: Markus Leben (@markusleben)


### PR DESCRIPTION
## Summary

- Add `repository.yaml` at repo root so HA Supervisor recognizes this as a valid add-on repository
- Without this file, adding `https://github.com/markusleben/ha-nova` as custom repository fails with "not a valid add-on repository"
- The existing `app/config.yaml` is already in the correct location for add-on discovery

## Test plan

- [x] `repository.yaml` contains required `name` field
- [ ] Add repo URL in HA → Settings → Add-ons → Repositories → succeeds
- [ ] "NOVA Relay" appears in Add-on Store

🤖 Generated with [Claude Code](https://claude.com/claude-code)