### PR TITLE
fix(onboarding): use repo-based add-on slug for end-user deep-links

### DIFF
--- a/scripts/onboarding/macos-lib.sh
+++ b/scripts/onboarding/macos-lib.sh
@@ -197,13 +197,7 @@ run_setup() {
   if [[ "$relay_auth_token" != "${existing_relay_auth_token:-}" ]]; then
     echo ""
     wait_for_enter "Press [Enter] to open the add-on config... "
-    # Try direct link if we know the HA URL
-    load_config
-    if [[ -n "${HA_URL:-}" ]]; then
-      open_browser "${HA_URL}/hassio/addon/local_ha_nova_relay/config"
-    else
-      open_browser "https://my.home-assistant.io/redirect/supervisor_addon/?addon=local_ha_nova_relay"
-    fi
+    open_browser "https://my.home-assistant.io/redirect/supervisor_addon/?addon=2368fcfa_ha_nova_relay"
     echo ""
     wait_for_enter "Press [Enter] when you've saved the relay token... "
   fi


### PR DESCRIPTION
## Summary

- Replace `local_ha_nova_relay` slug with `2368fcfa_ha_nova_relay` in wizard deep-links
- Use `my.home-assistant.io` redirect exclusively (no direct HA URLs)
- `local_` slug only exists for SSH-deployed dev installs, end users get `2368fcfa_` prefix

## Test plan

- [x] All 124 tests pass
- [ ] Wizard deep-link opens correct add-on config page for repo-installed add-on

🤖 Generated with [Claude Code](https://claude.com/claude-code)