### PR TITLE
chore: prepare package.json for npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,33 @@
+# Internal development files
+docs/
+tests/
+.github/
+.env*
+tsconfig.json
+vitest.config.*
+.codex/
+.claude/
+.agents/
+AGENTS.md
+CLAUDE.md
+PROJECT.md
+CONTRIBUTING.md
+SECURITY.md
+SUPPORT.md
+CODE_OF_CONDUCT.md
+
+# Dev scripts
+scripts/dev/
+scripts/deploy/
+scripts/smoke/
+scripts/e2e/
+scripts/dev-seed-ha-llat.mjs
+
+# Source (dist/ has compiled output)
+src/
+
+# HA Add-on Docker files (built separately)
+Dockerfile
+config.yaml
+repository.yaml
+run

--- a/package.json
+++ b/package.json
@@ -1,8 +1,21 @@
 {
   "name": "ha-nova",
   "version": "0.1.0",
-  "private": true,
+  "description": "AI-powered Home Assistant management through Claude Code, Codex, and OpenCode",
+  "private": false,
   "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/markusleben/ha-nova.git"
+  },
+  "keywords": [
+    "home-assistant",
+    "ai",
+    "claude",
+    "automation",
+    "smart-home"
+  ],
   "bin": {
     "ha-nova": "scripts/onboarding/bin/ha-nova"
   },


### PR DESCRIPTION
## Summary

- Set `private: false` in package.json
- Add description, repository URL, keywords, license field
- Create `.npmignore` to exclude internal files
- Final package: 22 files, 18.6 kB

## Test plan

- [x] 136/136 tests pass
- [x] `npm pack --dry-run` shows clean package (no tests, docs, src, Docker files)
- [x] Package name `ha-nova` available on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)