### PR TITLE
fix: address open Codex review findings before release

### DIFF
--- a/.agents/skills/ha-nova-entity-discovery/SKILL.md
+++ b/.agents/skills/ha-nova-entity-discovery/SKILL.md
@@ -55,7 +55,8 @@ If no match:
 For area-based targeting (e.g., "all lights in the bedroom"):
 - `~/.config/ha-nova/relay ws -d '{"type":"config/area_registry/list"}'`
 - `~/.config/ha-nova/relay ws -d '{"type":"config/device_registry/list"}'`
-- Match area name to area_id, then filter entities by area.
+- `~/.config/ha-nova/relay ws -d '{"type":"config/entity_registry/list"}'`
+- Match area name to area_id, then filter entities by area_id from entity registry entries.
 
 ## Guardrails
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,13 +14,6 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Dependency Review
-        continue-on-error: true
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
-
-      - name: Note unsupported setup
-        if: ${{ failure() }}
-        run: |
-          echo "Dependency review is unsupported in current repo security settings."
-          echo "Enable dependency graph + GitHub Advanced Security to enforce this gate strictly."

--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@ tsconfig.json
 vitest.config.*
 .codex/
 .claude/
-.agents/
 AGENTS.md
 CLAUDE.md
 PROJECT.md

--- a/skills/ha-nova/agents/resolve-agent.md
+++ b/skills/ha-nova/agents/resolve-agent.md
@@ -90,7 +90,7 @@ Return exactly these sections:
 - compact JSON or `null`
 
 `BP_STATUS:`
-- `status: fresh|stale|missing|invalid`
+- `status: fresh|stale|missing|invalid|n/a`
 - `age_days: <number|unknown>`
 - `source_count: <number|0>`
 

--- a/tests/skills/service-call-contract.test.ts
+++ b/tests/skills/service-call-contract.test.ts
@@ -1,78 +1,55 @@
 // tests/skills/service-call-contract.test.ts
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const relayApi = readFileSync(
+  resolve(__dirname, "../../skills/ha-nova/relay-api.md"),
+  "utf-8",
+);
+const skillDoc = readFileSync(
+  resolve(__dirname, "../../.agents/skills/ha-nova-service-call/SKILL.md"),
+  "utf-8",
+);
 
 describe("service call contract", () => {
-  describe("service call request shape via /core", () => {
-    it("calls a service with entity target", () => {
-      const request = {
-        method: "POST" as const,
-        path: "/api/services/light/turn_on",
-        body: {
-          entity_id: "light.living_room",
-        },
-      };
-      expect(request.method).toBe("POST");
-      expect(request.path).toMatch(/^\/api\/services\/\w+\/\w+$/);
-      expect(request.body.entity_id).toBe("light.living_room");
+  describe("relay-api.md documents service call paths", () => {
+    it("documents POST /api/services/{domain}/{service}", () => {
+      expect(relayApi).toContain("/api/services/light/turn_on");
     });
 
-    it("supports service data fields", () => {
-      const request = {
-        method: "POST" as const,
-        path: "/api/services/light/turn_on",
-        body: {
-          entity_id: "light.kitchen",
-          brightness: 128,
-          color_temp: 350,
-        },
-      };
-      expect(request.body).toHaveProperty("brightness");
-      expect(request.body).toHaveProperty("color_temp");
+    it("documents GET /api/services for listing", () => {
+      expect(relayApi).toContain('"method":"GET","path":"/api/services"');
     });
 
-    it("supports multiple entity targets", () => {
-      const request = {
-        method: "POST" as const,
-        path: "/api/services/light/turn_off",
-        body: {
-          entity_id: ["light.living_room", "light.kitchen"],
-        },
-      };
-      expect(Array.isArray(request.body.entity_id)).toBe(true);
+    it("documents return_response query parameter", () => {
+      expect(relayApi).toContain("return_response");
     });
 
-    it("supports area_id target", () => {
-      const request = {
-        method: "POST" as const,
-        path: "/api/services/light/turn_on",
-        body: {
-          area_id: "living_room",
-        },
-      };
-      expect(request.body).toHaveProperty("area_id");
-    });
-
-    it("supports return_response query parameter", () => {
-      const request = {
-        method: "POST" as const,
-        path: "/api/services/weather/get_forecasts?return_response",
-        body: {
-          entity_id: "weather.home",
-          type: "daily",
-        },
-      };
-      expect(request.path).toContain("return_response");
+    it("documents supported target fields", () => {
+      expect(relayApi).toContain("entity_id");
+      expect(relayApi).toContain("area_id");
+      expect(relayApi).toContain("device_id");
     });
   });
 
-  describe("service list request shape via /core", () => {
-    it("lists all available services", () => {
-      const request = {
-        method: "GET" as const,
-        path: "/api/services",
-      };
-      expect(request.method).toBe("GET");
-      expect(request.path).toBe("/api/services");
+  describe("service-call skill matches relay-api contract", () => {
+    it("skill references /api/services path pattern", () => {
+      expect(skillDoc).toContain("/api/services/{domain}/{service}");
+    });
+
+    it("skill references /api/states for verification", () => {
+      expect(skillDoc).toContain("/api/states/{entity_id}");
+    });
+
+    it("skill declares entity_id, area_id, device_id targeting", () => {
+      expect(skillDoc).toContain("entity_id");
+      expect(skillDoc).toContain("area_id");
+      expect(skillDoc).toContain("device_id");
+    });
+
+    it("skill uses /core endpoint for execution", () => {
+      expect(skillDoc).toMatch(/relay.*core/);
     });
   });
 });

--- a/tests/skills/trace-contract.test.ts
+++ b/tests/skills/trace-contract.test.ts
@@ -1,56 +1,49 @@
+// tests/skills/trace-contract.test.ts
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const relayApi = readFileSync(
+  resolve(__dirname, "../../skills/ha-nova/relay-api.md"),
+  "utf-8",
+);
+const readSkill = readFileSync(
+  resolve(__dirname, "../../.agents/skills/ha-nova-read/SKILL.md"),
+  "utf-8",
+);
 
 describe("trace contract", () => {
-  describe("trace/list request shape", () => {
-    it("requires domain field", () => {
-      const request = { type: "trace/list", domain: "automation" };
-      expect(request.type).toBe("trace/list");
-      expect(request.domain).toBe("automation");
+  describe("relay-api.md documents trace WS types", () => {
+    it("documents trace/list with domain and item_id", () => {
+      expect(relayApi).toContain('"type":"trace/list"');
+      expect(relayApi).toContain('"domain":"automation"');
+      expect(relayApi).toContain('"item_id"');
     });
 
-    it("accepts optional item_id for filtering", () => {
-      const request = {
-        type: "trace/list",
-        domain: "automation",
-        item_id: "motion_kitchen",
-      };
-      expect(request.item_id).toBe("motion_kitchen");
+    it("documents trace/get with domain, item_id, and run_id", () => {
+      expect(relayApi).toContain('"type":"trace/get"');
+      expect(relayApi).toContain('"run_id"');
     });
 
-    it("supports script domain", () => {
-      const request = { type: "trace/list", domain: "script" };
-      expect(request.domain).toBe("script");
+    it("documents trace response structure", () => {
+      expect(relayApi).toContain("trace.trigger");
+      expect(relayApi).toContain("trace.condition");
+      expect(relayApi).toContain("trace.action");
     });
   });
 
-  describe("trace/get request shape", () => {
-    it("requires domain, item_id, and run_id", () => {
-      const request = {
-        type: "trace/get",
-        domain: "automation",
-        item_id: "motion_kitchen",
-        run_id: "abc123",
-      };
-      expect(request.type).toBe("trace/get");
-      expect(request.domain).toBe("automation");
-      expect(request.item_id).toBe("motion_kitchen");
-      expect(request.run_id).toBe("abc123");
+  describe("ha-nova-read skill references trace types", () => {
+    it("skill documents trace/list usage", () => {
+      expect(readSkill).toContain("trace/list");
     });
-  });
 
-  describe("trace relay path", () => {
-    it("trace types go through /ws endpoint (same as get_states)", () => {
-      const traceList = { type: "trace/list", domain: "automation" };
-      const traceGet = {
-        type: "trace/get",
-        domain: "automation",
-        item_id: "x",
-        run_id: "y",
-      };
-      expect(typeof traceList.type).toBe("string");
-      expect(traceList.type.length).toBeGreaterThan(0);
-      expect(typeof traceGet.type).toBe("string");
-      expect(traceGet.type.length).toBeGreaterThan(0);
+    it("skill documents trace/get usage", () => {
+      expect(readSkill).toContain("trace/get");
+    });
+
+    it("skill supports both automation and script traces", () => {
+      expect(readSkill).toMatch(/automation.*trace|trace.*automation/i);
+      expect(readSkill).toMatch(/script.*trace|trace.*script/i);
     });
   });
 });


### PR DESCRIPTION
## Summary
- **P1**: Include `.agents/` in npm package — was excluded by `.npmignore`, which broke `npx ha-nova setup` (no skill files in published tarball)
- **P2**: Add `n/a` to BP_STATUS format spec for script flows (resolve-agent.md)
- **P2**: Add `entity_registry/list` to entity discovery skill for proper area filtering
- **P2**: Rewrite contract tests to validate against actual skill/relay-api docs instead of self-referential inline literals
- **P2**: Remove `continue-on-error: true` from dependency-review workflow so the security gate actually blocks

## Test plan
- [x] 139 tests passing (3 new assertions from improved contract tests)
- [x] `npm pack --dry-run` confirms `.agents/skills/*/SKILL.md` included (29 files, 24 kB)
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)