### PR TITLE
fix: entity area-device fallback + stop auto-merge

### DIFF
--- a/.agents/skills/ha-nova-entity-discovery/SKILL.md
+++ b/.agents/skills/ha-nova-entity-discovery/SKILL.md
@@ -56,7 +56,9 @@ For area-based targeting (e.g., "all lights in the bedroom"):
 - `~/.config/ha-nova/relay ws -d '{"type":"config/area_registry/list"}'`
 - `~/.config/ha-nova/relay ws -d '{"type":"config/device_registry/list"}'`
 - `~/.config/ha-nova/relay ws -d '{"type":"config/entity_registry/list"}'`
-- Match area name to area_id, then filter entities by area_id from entity registry entries.
+- Match area name to area_id, then filter entities:
+  1. Direct match: entity registry entry has `area_id` matching target area.
+  2. Device fallback: if entity `area_id` is null, look up its `device_id` in device registry — if that device's `area_id` matches, include the entity.
 
 ## Guardrails
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,12 @@ Work style: Be radically precise. No fluff. Pure information only (drop grammar;
 - Avoid manual `git stash`; if Git auto-stashes during pull/rebase, that’s fine (hint, not hard guardrail).
 - If user types a command (“pull and push”), that’s consent for that command.
 - Big review: `git --no-pager diff --color=never`.
-- **PR Merge:** Use auto-merge after creating PRs: `gh pr create ... && gh pr merge --auto --squash --delete-branch`. GitHub merges automatically when CI passes. No polling needed.
+- **PR Merge:** Do NOT use auto-merge. The Codex review bot needs ~3 min to post findings after CI passes. Workflow:
+  1. `gh pr create ...` — create the PR.
+  2. Wait for CI checks to pass.
+  3. Check for bot review comments: `gh api repos/<owner>/<repo>/pulls/<nr>/comments`.
+  4. Resolve any findings (fix or acknowledge).
+  5. Then merge: `gh pr merge --squash --delete-branch`.
 
 ## Error Handling
 - Expected issues: explicit result types (not throw/try/catch).


### PR DESCRIPTION
## Summary
- **Entity discovery**: Add device→area fallback for area-based filtering. Many HA entities have `area_id: null` but inherit their area from their parent device — the discovery skill now checks both paths.
- **AGENTS.md**: Replace `gh pr merge --auto` with manual merge-after-bot-review workflow. Auto-merge races the Codex review bot (~3 min delay), causing findings to arrive after the PR is already merged.

Addresses: PR #32 Codex finding (P2 - device-area fallback)

## Test plan
- [x] 139 tests passing
- [x] Entity discovery skill now documents both direct and device-inherited area matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)