### PR TITLE
fix: correct Claude Code plugin install docs and optimize read skill

### DIFF
--- a/.claude/INSTALL.md
+++ b/.claude/INSTALL.md
@@ -1,6 +1,6 @@
 # Installing HA NOVA for Claude Code
 
-## Quick Start (Plugin)
+## Quick Start
 
 ```bash
 git clone https://github.com/markusleben/ha-nova.git ~/ha-nova
@@ -8,8 +8,32 @@ cd ~/ha-nova && npm install
 npx ha-nova setup
 ```
 
-Claude Code automatically discovers skills via the plugin system (`.claude-plugin/plugin.json`).
-No manual skill installation needed.
+## Activating Skills
+
+Claude Code requires explicit plugin registration. Choose one:
+
+**Option A — Per-session (development):**
+```bash
+claude --plugin-dir ~/ha-nova
+```
+
+**Option B — Persistent (recommended):**
+
+Add to `~/.claude/settings.json`:
+```json
+{
+  "extraKnownMarketplaces": {
+    "ha-nova-local": {
+      "source": { "source": "directory", "path": "/absolute/path/to/ha-nova" }
+    }
+  },
+  "enabledPlugins": {
+    "ha-nova@ha-nova-local": true
+  }
+}
+```
+
+Skills are then available as `/ha-nova:read`, `/ha-nova:write`, etc.
 
 ## Already Set Up?
 

--- a/scripts/onboarding/install-local-skills.sh
+++ b/scripts/onboarding/install-local-skills.sh
@@ -142,7 +142,8 @@ install_target() {
       install_symlink "codex" "${HOME}/.agents/skills"
       ;;
     claude)
-      log "[claude] Skipped — use Claude Code plugin system: claude plugin add ${REPO_ROOT}"
+      log "[claude] Skipped — use: claude --plugin-dir ${REPO_ROOT}"
+      log "[claude] For persistent setup see: .claude/INSTALL.md"
       ;;
     opencode)
       install_symlink "opencode" "${HOME}/.config/opencode/skills"


### PR DESCRIPTION
## Summary

- Claude Code requires explicit `--plugin-dir` or marketplace registration — `.claude-plugin/plugin.json` is NOT auto-discovered
- Updated `.claude/INSTALL.md` with per-session (`--plugin-dir`) and persistent (`extraKnownMarketplaces`) install options
- Fixed install script hint for Claude target
- Optimized read skill: always resolve config key via entity registry (consistent 2 calls) instead of slug-first-then-404-fallback (1–3 calls)

## Test plan

- [x] `npm test` — 139/139 passing
- [x] Verified Gemini CLI live test with new registry-first lookup
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)