### PR TITLE
feat: add Claude Code marketplace for global skill discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "name": "ha-nova",
+  "owner": { "name": "Markus Leben" },
+  "plugins": [
+    {
+      "name": "ha-nova",
+      "source": ".",
+      "description": "AI-powered Home Assistant control through LLM skills and a local relay"
+    }
+  ]
+}

--- a/.claude/INSTALL.md
+++ b/.claude/INSTALL.md
@@ -10,30 +10,19 @@ npx ha-nova setup
 
 ## Activating Skills
 
-Claude Code requires explicit plugin registration. Choose one:
+Install the plugin via marketplace (works globally in any directory):
 
-**Option A — Per-session (development):**
-```bash
-claude --plugin-dir ~/ha-nova
 ```
-
-**Option B — Persistent (recommended):**
-
-Add to `~/.claude/settings.json`:
-```json
-{
-  "extraKnownMarketplaces": {
-    "ha-nova-local": {
-      "source": { "source": "directory", "path": "/absolute/path/to/ha-nova" }
-    }
-  },
-  "enabledPlugins": {
-    "ha-nova@ha-nova-local": true
-  }
-}
+/plugin marketplace add markusleben/ha-nova
+/plugin install ha-nova@markusleben/ha-nova
 ```
 
 Skills are then available as `/ha-nova:read`, `/ha-nova:write`, etc.
+
+**Alternative — per-session (development):**
+```bash
+claude --plugin-dir ~/ha-nova
+```
 
 ## Already Set Up?
 


### PR DESCRIPTION
## Summary

- Add `.claude-plugin/marketplace.json` so ha-nova can be installed as a persistent Claude Code plugin
- Users install with two commands — skills then work in any directory:
  ```
  /plugin marketplace add markusleben/ha-nova
  /plugin install ha-nova@markusleben/ha-nova
  ```
- Update INSTALL.md with marketplace as primary install method

## Test plan

- [x] `npm test` — 139/139 passing
- [ ] CI checks
- [ ] Manual test: marketplace add + plugin install in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)