### PR TITLE
feat: auto-install Claude Code plugin via CLI during onboarding

### DIFF
--- a/scripts/onboarding/install-local-skills.sh
+++ b/scripts/onboarding/install-local-skills.sh
@@ -132,6 +132,28 @@ install_gemini_flat() {
   done
 }
 
+install_claude_plugin() {
+  if ! command -v claude &>/dev/null; then
+    log "[claude] Skipped — claude CLI not found"
+    return 0
+  fi
+
+  # Add marketplace (idempotent — overwrites if already present)
+  if claude plugin marketplace add "${REPO_ROOT}" 2>/dev/null; then
+    log "[claude] Marketplace registered: ${REPO_ROOT}"
+  else
+    log "[claude] Warning: could not register marketplace"
+    return 0
+  fi
+
+  # Install plugin
+  if claude plugin install ha-nova@ha-nova 2>/dev/null; then
+    log "[claude] Plugin installed: ha-nova@ha-nova"
+  else
+    log "[claude] Warning: could not install plugin (may already be installed)"
+  fi
+}
+
 install_target() {
   local target="$1"
   local relay_cli_source="${REPO_ROOT}/scripts/relay.sh"
@@ -142,8 +164,7 @@ install_target() {
       install_symlink "codex" "${HOME}/.agents/skills"
       ;;
     claude)
-      log "[claude] Skipped — use: claude --plugin-dir ${REPO_ROOT}"
-      log "[claude] For persistent setup see: .claude/INSTALL.md"
+      install_claude_plugin
       ;;
     opencode)
       install_symlink "opencode" "${HOME}/.config/opencode/skills"

--- a/scripts/onboarding/macos-lib.sh
+++ b/scripts/onboarding/macos-lib.sh
@@ -208,8 +208,12 @@ detect_setup_state() {
       fi
       ;;
     claude)
-      # Plugin system — check plugin.json exists in repo
-      if [[ ! -f "${REPO_ROOT}/.claude-plugin/plugin.json" ]]; then
+      # Check plugin is installed via claude CLI
+      if command -v claude &>/dev/null; then
+        if ! claude plugin list 2>/dev/null | grep -q "ha-nova"; then
+          SETUP_SKILLS_OK="0"
+        fi
+      elif [[ ! -f "${REPO_ROOT}/.claude-plugin/plugin.json" ]]; then
         SETUP_SKILLS_OK="0"
       fi
       ;;

--- a/tests/onboarding/macos-onboarding-script-contract.test.ts
+++ b/tests/onboarding/macos-onboarding-script-contract.test.ts
@@ -237,7 +237,7 @@ exit 1
     expect(config).toContain("HA_URL=http://192.168.1.5:18123");
   });
 
-  it("installs skills: codex/opencode as symlinks, gemini as flat copies, claude skipped", () => {
+  it("installs skills: codex/opencode as symlinks, gemini as flat copies, claude via plugin CLI", () => {
     const workDir = mkdtempSync(join(tmpdir(), "ha-nova-skill-install-"));
     const repoRoot = process.cwd();
 
@@ -283,7 +283,8 @@ exit 1
       expect(content).toContain(`name: ${sub}`);
     }
 
-    // Claude: skipped (plugin system) — no ~/.claude/skills/ha-nova
+    // Claude: uses plugin CLI (skipped in test env since `claude` not available)
+    // No file-based skill install — plugin registration is handled by `claude` CLI
     expect(() => statSync(join(workDir, ".claude/skills/ha-nova"))).toThrow();
   });
 


### PR DESCRIPTION
## Summary

- Installer now runs `claude plugin marketplace add` + `claude plugin install` automatically
- Gracefully skips if `claude` CLI is not available (e.g. test env, non-Claude users)
- `detect_setup_state` checks `claude plugin list` for installed ha-nova plugin
- Test updated to reflect new Claude install behavior

## Install flow (after this PR)

```bash
npx ha-nova setup        # runs onboarding wizard
# → automatically registers marketplace + installs plugin
# → skills available globally as /ha-nova:read, /ha-nova:write, etc.
```

## Test plan

- [x] `npm test` — 139/139 passing
- [ ] CI checks
- [ ] Manual test: run install script with Claude CLI available

🤖 Generated with [Claude Code](https://claude.com/claude-code)