### PR TITLE
fix: check-docs grep fallback + PR merge wait policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,19 @@ Work style: Be radically precise. No fluff. Pure information only (drop grammar;
 - Avoid manual `git stash`; if Git auto-stashes during pull/rebase, that’s fine (hint, not hard guardrail).
 - If user types a command (“pull and push”), that’s consent for that command.
 - Big review: `git --no-pager diff --color=never`.
-- **PR Merge:** Do NOT use auto-merge. The Codex review bot needs ~3-5 min to post findings after CI passes. ALWAYS follow this Workflow:
+- **PR Merge — MANDATORY WAIT (non-negotiable):**
+  Do NOT use auto-merge. Do NOT merge immediately after CI passes.
+  The review bot (`chatgpt-codex-connector[bot]`) needs ~3-5 min AFTER CI to post findings.
+  An empty comments response does NOT mean "no findings" — it means "bot not done yet".
   1. `gh pr create ...` — create the PR.
-  2. Wait for CI checks to pass.
-  3. Check for bot review comments: `gh api repos/<owner>/<repo>/pulls/<nr>/comments`.
-  4. Resolve any findings (fix or acknowledge).
-  5. Then merge: `gh pr merge --squash --delete-branch`.
+  2. Wait for CI checks to pass (`gh pr checks <nr> --watch`).
+  3. **Sleep 3 minutes** (`sleep 180`) — this is mandatory, not optional.
+  4. Poll for bot comments — repeat up to 3 times with 60s gaps:
+     `gh api repos/<owner>/<repo>/pulls/<nr>/comments --jq '.[].user.login'`
+     - If `chatgpt-codex-connector[bot]` appears → bot is done, read findings.
+     - If empty after 3 polls (total ~6 min wait) → bot likely skipped, safe to proceed.
+  5. If findings: fix, push, wait for CI + bot again.
+  6. Only then: `gh pr merge --squash --delete-branch`.
 
 ## Error Handling
 - Expected issues: explicit result types (not throw/try/catch).

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -94,7 +94,7 @@ fi
 # ── 8. Supported clients match install scripts ──
 echo "[8] Supported AI clients have install scripts"
 for client in claude codex opencode gemini; do
-  SCRIPT_EXISTS=$(grep -c "install.*${client}" "$REPO_ROOT/package.json" 2>/dev/null || echo 0)
+  SCRIPT_EXISTS=$(grep -c "install.*${client}" "$REPO_ROOT/package.json" 2>/dev/null || true)
   if (( SCRIPT_EXISTS > 0 )); then
     pass "Install script for ${client} found"
   else
@@ -104,7 +104,7 @@ done
 
 # ── 9. Route count — verify relay stays minimal ──
 echo "[9] Relay route count"
-ROUTE_COUNT=$(grep -c "router.register" "$REPO_ROOT/src/index.ts" 2>/dev/null || echo 0)
+ROUTE_COUNT=$(grep -c "router.register" "$REPO_ROOT/src/index.ts" 2>/dev/null || true)
 if (( ROUTE_COUNT <= 5 )); then
   pass "Relay has ${ROUTE_COUNT} routes (≤5 — still minimal)"
 else


### PR DESCRIPTION
## Summary

- **Fix review finding from #44**: `grep -c ... || echo 0` produces `"0\n0"` when grep finds zero matches (exit code 1 triggers fallback, appending a second "0"). Changed to `|| true` — `grep -c` already outputs "0", the fallback only needs to suppress the exit code.
- **AGENTS.md**: Rewrote PR Merge section with mandatory `sleep 180` + 3-poll pattern to prevent merging before the review bot (`chatgpt-codex-connector[bot]`) has posted its findings.

## Test plan

- [x] `bash scripts/check-docs.sh` — all 11 checks pass
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` passes
- [ ] CI passes on PR
- [ ] Wait for review bot before merge (testing the new policy right now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)