### PR TITLE
ci: add codex-review-gate workflow

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -1,0 +1,58 @@
+name: Codex Review Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: codex-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  codex-review-gate:
+    name: codex-review-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for Codex review bot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "⏳ Waiting for chatgpt-codex-connector[bot] to post review..."
+          echo "Initial wait: 3 minutes"
+          sleep 180
+
+          for attempt in 1 2 3; do
+            echo "Poll attempt ${attempt}/3..."
+
+            # Check inline review comments (paginate merges all pages, then jq counts)
+            INLINE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --paginate \
+              2>/dev/null | jq '[.[].user.login // empty] | map(select(. == "chatgpt-codex-connector[bot]")) | length' \
+              || echo "0")
+
+            # Check PR-level reviews
+            REVIEWS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate \
+              2>/dev/null | jq '[.[].user.login // empty] | map(select(. == "chatgpt-codex-connector[bot]")) | length' \
+              || echo "0")
+
+            TOTAL=$(( INLINE + REVIEWS ))
+
+            if [ "$TOTAL" -gt 0 ]; then
+              echo "✅ Codex review bot posted ${TOTAL} review(s). Gate passed."
+              exit 0
+            fi
+
+            if [ "$attempt" -lt 3 ]; then
+              echo "Bot not found yet. Waiting 60s..."
+              sleep 60
+            fi
+          done
+
+          echo "⚠️ Codex review bot did not post after ~6 minutes."
+          echo "Proceeding — bot may have skipped this PR."
+          exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,19 +55,12 @@ Work style: Be radically precise. No fluff. Pure information only (drop grammar;
 - Avoid manual `git stash`; if Git auto-stashes during pull/rebase, that’s fine (hint, not hard guardrail).
 - If user types a command (“pull and push”), that’s consent for that command.
 - Big review: `git --no-pager diff --color=never`.
-- **PR Merge — MANDATORY WAIT (non-negotiable):**
-  Do NOT use auto-merge. Do NOT merge immediately after CI passes.
-  The review bot (`chatgpt-codex-connector[bot]`) needs ~3-5 min AFTER CI to post findings.
-  An empty comments response does NOT mean "no findings" — it means "bot not done yet".
+- **PR Merge:** Do NOT use auto-merge. The `codex-review-gate` workflow blocks merge for ~6 min while waiting for the Codex review bot. ALWAYS follow this workflow:
   1. `gh pr create ...` — create the PR.
-  2. Wait for CI checks to pass (`gh pr checks <nr> --watch`).
-  3. **Sleep 3 minutes** (`sleep 180`) — this is mandatory, not optional.
-  4. Poll for bot comments — repeat up to 3 times with 60s gaps:
-     `gh api repos/<owner>/<repo>/pulls/<nr>/comments --jq '.[].user.login'`
-     - If `chatgpt-codex-connector[bot]` appears → bot is done, read findings.
-     - If empty after 3 polls (total ~6 min wait) → bot likely skipped, safe to proceed.
-  5. If findings: fix, push, wait for CI + bot again.
-  6. Only then: `gh pr merge --squash --delete-branch`.
+  2. Wait for ALL checks to pass (`gh pr checks <nr> --watch`), including `codex-review-gate`.
+  3. Check for bot review comments: `gh api repos/<owner>/<repo>/pulls/<nr>/comments`.
+  4. Resolve any findings (fix or acknowledge).
+  5. Then merge: `gh pr merge --squash --delete-branch`.
 
 ## Error Handling
 - Expected issues: explicit result types (not throw/try/catch).


### PR DESCRIPTION
## Summary

- Adds `codex-review-gate` workflow that polls for `chatgpt-codex-connector[bot]` reviews before passing
- While running (~6 min), the status check is pending → merge is blocked
- Simplifies AGENTS.md PR merge instructions (no more manual sleep/poll)

## How it works

1. PR opened/pushed → workflow starts
2. Sleeps 3 minutes (initial bot latency)
3. Polls 3× at 60s intervals for bot reviews (inline + PR-level)
4. If bot found → pass immediately
5. If not found after ~6 min → pass anyway (bot may have skipped)

## Risk

- Low — workflow always exits 0, never blocks permanently
- If bot is down/uninstalled, PRs still merge after ~6 min delay

## Verification

- [x] YAML validates
- [x] Pagination handled correctly (pipe to `jq`, not `--jq` with `--paginate`)
- [x] `set -eo pipefail` safe (`|| echo "0"` catches failures)
- [ ] Live test: this PR itself runs the gate workflow

## Next step (manual)

Add `codex-review-gate` as required status check in branch protection settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)