### PR TITLE
fix: split relay and skill version lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/) and [Semantic Versioning](https://semver.org/).
 
+## [Relay 0.2.0] - 2026-03-07
+
+### Changed
+- **Independent version lines** — Relay (`config.yaml`) and Skills (`version.json`) are now versioned separately; skill-only updates no longer trigger unnecessary HA App rebuilds
+- **Bump script** — No longer touches `config.yaml`; only bumps skill version files
+
 ## [0.1.4] - 2026-03-07
 
 ### Added

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: NOVA Relay
-version: "0.1.4"
+version: "0.2.0"
 slug: ha_nova_relay
 description: Thin Home Assistant relay for WS proxy and skill workflows
 url: https://github.com/markusleben/ha-nova

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Bump skill_version across all version-bearing files.
+# Bump skill_version across all skill version-bearing files.
+# Does NOT touch config.yaml (Relay version) — managed independently.
 # Usage: bash scripts/bump-version.sh 0.2.0
 set -euo pipefail
 
@@ -39,16 +40,11 @@ jq --arg v "$NEW_VERSION" '.version = $v' "$REPO_ROOT/.claude-plugin/plugin.json
 tmp=$(mktemp)
 jq --arg v "$NEW_VERSION" '.plugins[0].version = $v' "$REPO_ROOT/.claude-plugin/marketplace.json" > "$tmp" && mv "$tmp" "$REPO_ROOT/.claude-plugin/marketplace.json"
 
-# 5. config.yaml (HA App version — Supervisor uses this for update detection)
-# Use temp file instead of sed -i (BSD vs GNU portability)
-tmp=$(mktemp)
-sed "s/^version: \".*\"/version: \"$NEW_VERSION\"/" "$REPO_ROOT/config.yaml" > "$tmp" && mv "$tmp" "$REPO_ROOT/config.yaml"
-
-echo "Bumped to $NEW_VERSION in:"
+echo "Bumped skill version to $NEW_VERSION in:"
 echo "  version.json"
 echo "  package.json"
 echo "  .claude-plugin/plugin.json"
 echo "  .claude-plugin/marketplace.json"
-echo "  config.yaml"
 echo ""
-echo "Next: npm test && git add version.json package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json config.yaml && git commit -m 'chore: bump version to $NEW_VERSION'"
+echo "Note: config.yaml (Relay version) is managed independently."
+echo "Next: npm test && git add version.json package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json && git commit -m 'chore: bump skill version to $NEW_VERSION'"

--- a/skills/ha-nova/update-guide.md
+++ b/skills/ha-nova/update-guide.md
@@ -1,5 +1,16 @@
 # HA NOVA Update Guide
 
+## Two Independent Version Lines
+
+| Track | File | Scope | Bumped when |
+|-------|------|-------|-------------|
+| **Skill** | `version.json:skill_version` | Skills, plugin, package | Skill logic changes |
+| **Relay** | `config.yaml:version` | HA App (Supervisor) | Relay runtime changes |
+
+`version.json:min_relay_version` bridges the two: skills declare the minimum Relay version they need. The SessionStart hook warns if the running Relay is too old.
+
+**Why separate?** Skill-only improvements (new checks, better prompts) should not force a Relay reinstall/rebuild on the user's HA instance.
+
 ## Relay (Home Assistant App)
 
 HA Settings > Apps > NOVA Relay > Update (or reinstall from App Store).
@@ -14,9 +25,9 @@ HA Settings > Apps > NOVA Relay > Update (or reinstall from App Store).
 
 ## Check Versions
 
-- **Skills:** `cat version.json` (in repo root)
-- **Relay:** `~/.config/ha-nova/relay health` (look for `"version"`)
-- **Compatibility:** `version.json:min_relay_version` must be <= Relay version
+- **Skills:** `cat version.json` → `skill_version` field
+- **Relay:** `~/.config/ha-nova/relay health` → `"version"` field (matches `config.yaml`)
+- **Compatibility:** `version.json:min_relay_version` must be <= running Relay version
 
 ## Automatic Checks
 

--- a/tests/app/config-contract.test.ts
+++ b/tests/app/config-contract.test.ts
@@ -35,4 +35,26 @@ describe("app config contract", () => {
       ha_llat: "password?"
     });
   });
+
+  it("has relay version >= min_relay_version from version.json", () => {
+    const raw = readFileSync("config.yaml", "utf8");
+    const parsed = YAML.parse(raw) as Record<string, unknown>;
+    const relayVersion = parsed.version as string;
+
+    const versionJson = JSON.parse(readFileSync("version.json", "utf8"));
+    const minRelay = versionJson.min_relay_version as string;
+
+    const semverRe = /^\d+\.\d+\.\d+$/;
+    expect(relayVersion).toMatch(semverRe);
+    expect(minRelay).toMatch(semverRe);
+
+    const toNum = (v: string): [number, number, number] => {
+      const parts = v.split(".").map(Number);
+      return [parts[0]!, parts[1]!, parts[2]!];
+    };
+    const [rMaj, rMin, rPat] = toNum(relayVersion);
+    const [mMaj, mMin, mPat] = toNum(minRelay);
+    const gte = rMaj > mMaj || (rMaj === mMaj && (rMin > mMin || (rMin === mMin && rPat >= mPat)));
+    expect(gte, `config.yaml ${relayVersion} must be >= min_relay_version ${minRelay}`).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- **Independent versioning**: Relay (`config.yaml:0.2.0`) and skills (`version.json:0.1.4`) now have separate version lines
- **Bump script decoupled**: `bump-version.sh` no longer touches `config.yaml` — relay version changes are manual
- **Safety-net test**: New contract test ensures `config.yaml:version >= version.json:min_relay_version`
- **Update guide**: Documents the two-track versioning model

## Why
Skill-only improvements (new checks, better prompts) should not force a Relay reinstall/rebuild on the user's HA instance.

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npx vitest run tests/app/config-contract.test.ts` — both tests green (incl. new safety-net)
- [ ] `npx vitest run tests/skills/ha-nova-contract.test.ts` — version sync test still passes
- [ ] `npx vitest run tests/onboarding/bump-version.test.ts` — bump script tests pass
- [ ] Verify `config.yaml` shows `0.2.0`, `version.json` shows `0.1.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)