### PR TITLE
feat: add husky pre-push hook for local CI checks

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,18 @@
+#!/bin/sh
+echo "[pre-push] Running local checks before push..."
+echo ""
+
+echo "[1/4] Typecheck..."
+npm run typecheck || { echo "[pre-push] FAILED: typecheck"; exit 1; }
+
+echo "[2/4] Tests..."
+npm test || { echo "[pre-push] FAILED: tests"; exit 1; }
+
+echo "[3/4] Build..."
+npm run build || { echo "[pre-push] FAILED: build"; exit 1; }
+
+echo "[4/4] Docs fact-check..."
+bash scripts/check-docs.sh || { echo "[pre-push] FAILED: docs fact-check"; exit 1; }
+
+echo ""
+echo "[pre-push] All 4 checks passed."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,25 @@
 {
   "name": "ha-nova",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.1.0",
+      "version": "0.1.4",
+      "license": "MIT",
       "dependencies": {
         "axios": "^1.13.5",
         "home-assistant-js-websocket": "^9.6.0",
         "ws": "^8.19.0",
         "yaml": "^2.8.2"
       },
+      "bin": {
+        "ha-nova": "scripts/onboarding/bin/ha-nova"
+      },
       "devDependencies": {
         "@types/node": "^25.3.0",
+        "husky": "^9.1.7",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       },
@@ -1344,6 +1349,22 @@
       "resolved": "https://registry.npmjs.org/home-assistant-js-websocket/-/home-assistant-js-websocket-9.6.0.tgz",
       "integrity": "sha512-TK8HWW6UjCsUdjIBQRB2sBbEya0VniOBFqFjgqSznJiB7YriNgN8jghyThxOkgxwrnt2eN6oWoZMCTSp1o7H+w==",
       "license": "Apache-2.0"
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "update:ha-reference": "node scripts/update-ha-template-reference.mjs"
+    "update:ha-reference": "node scripts/update-ha-template-reference.mjs",
+    "prepare": "husky"
   },
   "dependencies": {
     "axios": "^1.13.5",
@@ -69,6 +70,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.3.0",
+    "husky": "^9.1.7",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   }


### PR DESCRIPTION
## Summary

- Adds [Husky](https://typicode.github.io/husky/) pre-push hook that runs all 4 CI-replicable checks locally before push
- Catches common failures in ~12s instead of waiting 3-6 min for remote CI round-trip

## What runs locally

| Step | Command | Duration |
|------|---------|----------|
| 1/4 | `npm run typecheck` | ~3s |
| 2/4 | `npm test` | ~5s |
| 3/4 | `npm run build` | ~3s |
| 4/4 | `bash scripts/check-docs.sh` | <1s |

## What stays CI-only

- CodeQL security scanning
- Dependency review
- Codex bot code review
- Gitleaks secret scanning

## No redundancy

Local hook and CI call the **same scripts** — one source of truth. CI remains the authoritative merge gate; local hook is early warning.

## Test plan

- [x] Hook runs all 4 checks and blocks push on failure
- [x] Verified locally: typecheck, test, build, check-docs all pass
- [x] Push succeeded with hook active
- [ ] Fresh clone: `npm install` auto-installs hooks via `prepare` script

🤖 Generated with [Claude Code](https://claude.com/claude-code)