### PR TITLE
docs: strengthen README positioning and enrich skill content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ worktrees/
 # Agent work artifacts
 docs/breadcrumbs.md
 docs/choices.md
+
+# Local notes
+docs/internal/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 </p>
 
 <p align="center">
-  <b>Talk to your smart home. In plain language. From your terminal.</b>
+  <b>Talk to your smart home. In plain language. From your terminal.</b><br>
+  <sub>Not an MCP server. Not a chatbot. Skills that teach your AI how Home Assistant works.</sub>
 </p>
 
 ---
@@ -63,9 +64,13 @@ HA NOVA has two parts:
 
 That's it. The intelligence comes from your AI — the skills just give it the playbook.
 
-> **Why not just connect the AI directly to Home Assistant?**
+> **Why not put all the logic into a server?**
 >
-> Two reasons: **security** and **speed**. The relay keeps your HA access token safely on the HA host (never on your machine). And it maintains a permanent connection so every request is fast — no reconnecting each time.
+> Because then every new feature means more server code, more bugs, more deployments. With skills, adding a new capability is just editing a text file. Your AI already understands Home Assistant — skills just teach it the specifics of *your* setup. No tool definitions, no schema updates, no release cycle.
+
+> **Why a relay at all?**
+>
+> Two reasons: **security** and **speed**. The relay keeps your HA access token safely on the HA host (never on your machine). Auth tokens on your side are encrypted in macOS Keychain — never in config files, URLs, or logs. And the relay maintains a permanent connection so every request is fast — no reconnecting each time.
 
 ## 🚀 Quick Start
 
@@ -107,18 +112,23 @@ Each skill teaches your AI a different aspect of Home Assistant:
 | **guide** | Discover HA features you might not know about |
 | **onboarding** | Setup diagnostics and troubleshooting |
 
+Skills are just Markdown files. Want to teach your AI something new? [Write your own](CONTRIBUTING.md) — no code required.
+
 ## 🛡️ Safety First
 
 Your AI never makes changes without asking. Every write follows three steps:
 
 1. **Look** — Finds the right entities and checks the current config
 2. **Show** — Previews exactly what will change and asks for your OK
-3. **Do** — Applies the change, then reads it back to make sure it worked
+3. **Do** — Applies the change, reads it back to verify it actually worked, then checks the result against best practices
+
+No silent failures — if something didn't stick, you'll know. And after every write, your AI automatically reviews the result: are triggers reliable? Could something conflict with an existing automation?
 
 On top of that:
-- Deleting anything requires a special confirmation code
+- Deleting anything requires a special confirmation code — not just "yes", an actual code
 - Your HA access token never leaves your HA host
-- Auth tokens are stored in macOS Keychain — never visible in prompts or logs
+- Auth tokens are encrypted in macOS Keychain — never in config files, URLs, or logs
+- Skills guide your AI to fetch only what it needs — no flooding the conversation with thousands of entities
 - Everything runs locally — no cloud, no tracking
 
 ## 🔧 Troubleshooting

--- a/skills/ha-nova/best-practices.md
+++ b/skills/ha-nova/best-practices.md
@@ -31,6 +31,21 @@ Refresh step checks:
 - automation services + tracing guidance
 - release notes affecting automation semantics
 
+## Automation Mode Selection
+
+Pick the right `mode` based on the automation's behavior:
+
+| Mode | When to use | Example |
+|------|-------------|---------|
+| `single` | Only one instance should ever run. Re-trigger while active is ignored. | Garage door open/close sequence |
+| `restart` | Re-trigger should cancel the current run and start fresh. Best for motion lights with timeout. | Motion → light on → wait 2 min → light off. New motion restarts the timer. |
+| `queued` | Each trigger should run in order, one after another. Use `max` to cap queue depth. | Sequential lock/unlock commands |
+| `parallel` | All triggers run independently at the same time. Use `max` to cap concurrency. | Per-room climate adjustment via a single automation |
+
+**Default is `single`** — always set mode explicitly so intent is clear.
+
+**Common mistake:** Using `single` for motion lights. The light turns on, but re-triggering during the wait period is ignored — the light turns off too early. Use `restart` instead.
+
 ## Enforcement Checklist
 
 1. `mode` is explicit.

--- a/skills/ha-nova/helper-schemas.md
+++ b/skills/ha-nova/helper-schemas.md
@@ -3,6 +3,24 @@
 Reference for AI agents constructing helper payloads via WebSocket CRUD commands.
 These are JSON payloads for `{type}/create` and `{type}/update` via the `/ws` relay endpoint.
 
+## When to Use Which Helper
+
+Pick the right helper type for the job:
+
+| Need | Use | Not |
+|------|-----|-----|
+| On/off flag (sleep mode, guest mode, vacation) | `input_boolean` | Template sensor |
+| Numeric value with range (target temp, brightness threshold) | `input_number` | Template sensor with `set_value` service |
+| User-selectable option (house mode: home/away/sleep) | `input_select` | Multiple `input_boolean` toggles |
+| Free-form text (welcome message, last visitor name) | `input_text` | — |
+| Specific time (wake-up time, quiet hours start) | `input_datetime` | `input_text` with manual parsing |
+| Manual trigger (doorbell test, run cleanup) | `input_button` | `input_boolean` toggled on then immediately off |
+| Counting occurrences (failed login attempts, door opens today) | `counter` | `input_number` with increment automation |
+| Countdown / delayed action (laundry reminder, motion light timeout) | `timer` | `delay` in automation (blocks the run) |
+| Recurring weekly schedule (heating, irrigation) | `schedule` | Multiple time-based automations |
+
+**Rule of thumb:** If HA has a built-in helper for it, use the helper. Only resort to template sensors when you need derived/calculated values that no helper can store.
+
 ## Common Rules
 
 - **Create:** `name` is always required. Type-specific fields vary.


### PR DESCRIPTION
## Summary
- Add sub-tagline differentiating from MCP servers
- Add "Why not put all logic into a server?" callout in How It Works
- Strengthen safety section: verified reads, no silent failures, confirmation codes, context efficiency, Keychain encryption
- Add "write your own skill" hint after skills table
- Add automation mode selection guide to `best-practices.md` (restart vs queued vs parallel)
- Add helper type decision matrix to `helper-schemas.md` (when to use which helper)
- Gitignore `docs/internal/` for local-only notes

## Test plan
- [x] `bash scripts/check-docs.sh` passes (11/11)
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)