### PR TITLE
docs: fix stale claims across project documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,12 +39,12 @@ Every PR should explain:
 - **Risk** — what could break
 - **Verification** — how to confirm it works
 
-## 🤖 Codex PR Automation
+### What happens after you open a PR
 
-- Automatic Codex review comments are disabled to reduce noise.
-- Optional auto-fix requests are failure-driven and label-gated via `.github/workflows/pr-review-watchdog.yml`.
-- Manual Codex review: comment `@codex review` on the PR.
-- Enable auto-fix: add label `autofix:enabled`. Remove to disable.
+1. **CI runs automatically** — typecheck, tests, build, docs fact-check, CodeQL analysis.
+2. **Codex review bot** may post inline code review comments (optional, non-blocking).
+3. **Maintainer review** — all PRs require an approving review before merge.
+4. **Squash merge** — PRs are squash-merged to keep the history clean.
 
 ## 🧠 Architecture Philosophy
 
@@ -74,10 +74,9 @@ Before adding code to the relay, run these four questions:
 | Domain knowledge (*"lights have brightness"*) | 📝 **Skill** | LLMs know this. The skill reinforces HA-specific details. |
 | Detect conflicting triggers | 📝 **Skill** | Requires reasoning about trigger semantics — pure intelligence. |
 | Suggest energy-saving automations | 📝 **Skill** | Pure reasoning over existing config data. |
-| Backup before config write | 🔧 **Relay** | Needs filesystem access on the HA host. |
-| YAML file access | 🔧 **Relay** | Needs filesystem access. |
-| Entity pre-filtering by domain | 🔧 **Relay** | Proxies HA's own API filter — passes data through, doesn't interpret it. |
-| Real-time state streaming | 🔧 **Relay** | Needs persistent WebSocket subscription on the host. |
+| WebSocket message forwarding | 🔧 **Relay** | Needs persistent WebSocket connection on the host. |
+| REST request forwarding | 🔧 **Relay** | Needs network access to the HA API on the host. |
+| Token storage on HA host | 🔧 **Relay** | Needs filesystem access — keeps secrets off the client. |
 
 ### 📐 What "Infrastructure" Means
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -40,10 +40,10 @@ Use a client-specific entrypoint instead of manual environment editing.
 **Phase 1: Infrastructure + skill-system consolidation**
 
 Current deliverables:
-1. Relay MVP: `POST /ws` + `GET /health`
+1. Relay MVP: `GET /health`, `POST /ws`, `POST /core`
 2. Context skill: `ha-nova` (auto-loaded via SessionStart hook; sub-skills discovered independently)
-3. Sub-skills (flat under `skills/`): write, read, helper, entity-discovery, service-call, review, onboarding
-4. Shared references under `skills/ha-nova/` (`relay-api.md`, `best-practices.md`, `agents/*`)
+3. Sub-skills (flat under `skills/`): write, read, helper, entity-discovery, service-call, review, guide, onboarding
+4. Shared references under `skills/ha-nova/` (`relay-api.md`, `best-practices.md`, `payload-schemas.md`, `helper-schemas.md`, `template-guidelines.md`, `safe-refactoring.md`, `update-guide.md`, `agents/*`)
 
 ## Tech Stack
 

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-HA NOVA uses a flat skill layout with one context skill and 7 independent sub-skills under `skills/`.
+HA NOVA uses a flat skill layout with one context skill and 8 independent sub-skills under `skills/`.
 
 Claude Code discovers all skills via `skills/{name}/SKILL.md` (1 level deep). The context skill is auto-loaded via a SessionStart hook.
 
@@ -14,6 +14,9 @@ skills/
   ha-nova/best-practices.md     (reference doc)
   ha-nova/payload-schemas.md    (reference doc)
   ha-nova/helper-schemas.md     (reference doc — helper type payloads)
+  ha-nova/template-guidelines.md (reference doc — when to use templates vs native primitives)
+  ha-nova/safe-refactoring.md   (reference doc — rename, delete, orphan cleanup workflows)
+  ha-nova/update-guide.md       (reference doc — version checks and update flows)
   ha-nova/agents/               (agent templates: resolve, apply, review)
   read/SKILL.md                 (ha-nova:read — automation/script list/get/trace)
   write/SKILL.md                (ha-nova:write — automation/script create/update/delete)
@@ -21,6 +24,7 @@ skills/
   review/SKILL.md               (ha-nova:review — config quality review + collision scan)
   entity-discovery/SKILL.md     (ha-nova:entity-discovery — entity lookup)
   service-call/SKILL.md         (ha-nova:service-call — service calls + runtime control)
+  guide/SKILL.md                (ha-nova:guide — discover HA features and capabilities)
   onboarding/SKILL.md           (ha-nova:onboarding — onboarding + diagnostics)
 ```
 

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -63,14 +63,14 @@ else
   fail "Found ${DOMAIN_HITS} domain-logic patterns in src/ — README claims zero business logic."
 fi
 
-# ── 5. Planned features not yet shipped ──
-# README marks auto-backup, filesystem access, state streaming as "(planned)"
-echo "[5] Planned features still unimplemented"
+# ── 5. No unplanned feature creep ──
+# Relay must stay minimal — no backup, filesystem, or streaming endpoints
+echo "[5] No backup/filesystem/streaming endpoints"
 PLANNED_HITS=$(count_matches "backup\|/backup\|/files\|filesystem\|/stream\|EventSource\|SSE" "$REPO_ROOT/nova/src/http/handlers/")
 if (( PLANNED_HITS == 0 )); then
-  pass "No backup/filesystem/streaming endpoints found — correctly marked as (planned)"
+  pass "No backup/filesystem/streaming endpoints found"
 else
-  fail "Found ${PLANNED_HITS} hits for planned features in handlers/ — remove '(planned)' from README if shipped."
+  fail "Found ${PLANNED_HITS} hits for backup/filesystem/streaming in handlers/ — relay should stay minimal."
 fi
 
 # ── 6. Internal links ──


### PR DESCRIPTION
## Summary
- **CONTRIBUTING.md**: Remove internal Codex automation section (not relevant for contributors), fix concrete examples table (3 unimplemented features → actual relay functions), add "What happens after you open a PR" section
- **PROJECT.md**: Add missing `/core` endpoint, `guide` skill, and 5 shared reference files
- **skill-architecture.md**: Update sub-skill count 7→8, add guide skill and new reference docs to skill tree
- **check-docs.sh**: Update stale "(planned)" comments

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `bash scripts/check-docs.sh` — all 11 checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)