### PR TITLE
fix: use PNG banner for Android compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/banner.svg" alt="HA NOVA — Talk to your smart home with AI" width="700">
+  <img src="assets/social-preview.png" alt="HA NOVA — Talk to your smart home with AI" width="700">
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Switch README banner from SVG to PNG (social-preview.png)
- GitHub's mobile app and Android browsers have known SVG rendering issues causing "Error loading page"
- Reported by Reddit user during launch post on r/homeassistant

## Test plan
- [ ] Verify README renders correctly on desktop
- [ ] Verify README renders correctly on Android mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)