### PR TITLE
feat: unified self-update mechanism (0.1.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
         "source": "url",
         "url": "https://github.com/markusleben/ha-nova.git"
       },
-      "version": "0.1.7",
+      "version": "0.1.8",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -45,6 +45,6 @@ Relay is rebuilt via Docker on the HA host — no npm publish. Users update by p
 ## Post-Release
 
 - `git tag -l 'v*'` — verify tag exists
-- Claude Code marketplace picks up new version automatically via git
-- Codex/OpenCode users: `git pull` in their clone
-- Gemini users: `git pull && npm run install:gemini-skill`
+- All clients: users run `~/.config/ha-nova/update` (auto-detects installed clients)
+- Claude Code marketplace also picks up new version automatically via git
+- SessionStart hook will show `UPDATE AVAILABLE` to users still on the old version

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -96,7 +96,11 @@ if [[ -f "$version_file" ]]; then
     cached_json=$(cat "$update_cache_file" 2>/dev/null || true)
     latest_skill_version=$(extract_json_string "skill_version" "$cached_json")
     if [[ -n "$latest_skill_version" && "$latest_skill_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ && -n "$SKILL_VERSION" ]] && semver_lt "$SKILL_VERSION" "$latest_skill_version"; then
-      update_notice="[ha-nova] UPDATE AVAILABLE: v${SKILL_VERSION} -> v${latest_skill_version}. See: https://github.com/markusleben/ha-nova/blob/main/skills/ha-nova/update-guide.md\\n"
+      if [[ -x "${HOME}/.config/ha-nova/update" ]]; then
+        update_notice="[ha-nova] UPDATE AVAILABLE: v${SKILL_VERSION} -> v${latest_skill_version}. Run: ~/.config/ha-nova/update\\n"
+      else
+        update_notice="[ha-nova] UPDATE AVAILABLE: v${SKILL_VERSION} -> v${latest_skill_version}. Run: git pull in your ha-nova repo, then re-run setup.\\n"
+      fi
     fi
 
     # Check if cache is still fresh

--- a/install.sh
+++ b/install.sh
@@ -149,6 +149,13 @@ handle_existing_install() {
       git -C "$INSTALL_DIR" pull --ff-only
       (cd "$INSTALL_DIR" && npm install --no-audit --no-fund)
       link_cli
+      # Deploy shared tools to ~/.config/ha-nova/
+      local config_dir="${HOME}/.config/ha-nova"
+      mkdir -p "$config_dir"
+      [[ -f "${INSTALL_DIR}/scripts/relay.sh" ]]        && cp "${INSTALL_DIR}/scripts/relay.sh" "${config_dir}/relay" && chmod 755 "${config_dir}/relay"
+      [[ -f "${INSTALL_DIR}/scripts/update.sh" ]]       && cp "${INSTALL_DIR}/scripts/update.sh" "${config_dir}/update" && chmod 755 "${config_dir}/update"
+      [[ -f "${INSTALL_DIR}/scripts/version-check.sh" ]] && cp "${INSTALL_DIR}/scripts/version-check.sh" "${config_dir}/version-check" && chmod 755 "${config_dir}/version-check"
+      [[ -f "${INSTALL_DIR}/version.json" ]]            && cp "${INSTALL_DIR}/version.json" "${config_dir}/version.json"
       echo ""
       info "Updated. Run 'ha-nova doctor' to verify."
       exit 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -40,6 +40,51 @@ jq --arg v "$NEW_VERSION" '.version = $v' "$REPO_ROOT/.claude-plugin/plugin.json
 tmp=$(mktemp)
 jq --arg v "$NEW_VERSION" '.plugins[0].version = $v' "$REPO_ROOT/.claude-plugin/marketplace.json" > "$tmp" && mv "$tmp" "$REPO_ROOT/.claude-plugin/marketplace.json"
 
+# 5. Migrate Claude Code plugin cache (if installed)
+plugins_json="${HOME}/.claude/plugins/installed_plugins.json"
+if [[ -f "$plugins_json" ]]; then
+  old_path=$(
+    sed -n '/"ha-nova@ha-nova"/,/installPath/s/.*"installPath"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+      "$plugins_json" | head -1
+  )
+  old_path="${old_path/#\~/$HOME}"
+
+  if [[ -n "$old_path" ]]; then
+    cache_parent="$(dirname "$old_path")"  # e.g. ~/.claude/plugins/cache/ha-nova/ha-nova
+    new_path="${cache_parent}/${NEW_VERSION}"
+
+    if [[ -d "$old_path" && "$old_path" != "$new_path" ]]; then
+      mv "$old_path" "$new_path" || { echo "  Warning: could not rename plugin cache dir"; }
+      echo "  Plugin cache: renamed $(basename "$old_path") → ${NEW_VERSION}"
+    elif [[ ! -d "$old_path" && -d "$cache_parent" ]]; then
+      # Old dir already gone (Claude Code cleaned up) — find latest and rename
+      actual=$(ls -1d "${cache_parent}"/[0-9]* 2>/dev/null | sort -V | tail -1)
+      if [[ -n "$actual" && "$actual" != "$new_path" ]]; then
+        mv "$actual" "$new_path" || { echo "  Warning: could not rename plugin cache dir"; }
+        echo "  Plugin cache: renamed $(basename "$actual") → ${NEW_VERSION}"
+      fi
+    fi
+
+    # Update installed_plugins.json — keep absolute paths (Claude Code native format)
+    if [[ -d "$new_path" ]]; then
+      old_stored=$(
+        sed -n '/"ha-nova@ha-nova"/,/installPath/s/.*"installPath"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+          "$plugins_json" | head -1
+      )
+      if [[ -n "$old_stored" && "$old_stored" != "$new_path" ]]; then
+        # Scope replacement to ha-nova block only
+        sed -i '' "/"ha-nova@ha-nova"/,/installPath/{s|\"installPath\": \"${old_stored}\"|\"installPath\": \"${new_path}\"|;}" "$plugins_json"
+      fi
+      old_ver=$(sed -n '/"ha-nova@ha-nova"/,/\"version\"/s/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$plugins_json" | head -1)
+      if [[ -n "$old_ver" && "$old_ver" != "$NEW_VERSION" ]]; then
+        sed -i '' "/"ha-nova@ha-nova"/,/\"version\"/{s/\"version\": \"${old_ver}\"/\"version\": \"${NEW_VERSION}\"/;}" "$plugins_json"
+      fi
+      echo "  installed_plugins.json: updated to v${NEW_VERSION}"
+    fi
+  fi
+fi
+
+echo ""
 echo "Bumped skill version to $NEW_VERSION in:"
 echo "  version.json"
 echo "  package.json"

--- a/scripts/dev-sync.sh
+++ b/scripts/dev-sync.sh
@@ -32,9 +32,37 @@ sync_claude() {
   # Expand ~ if present
   install_path="${install_path/#\~/$HOME}"
 
+  # ── Version-resilient cache discovery ──────────────────────────────
+  # Claude Code stores plugins at cache/{registry}/{name}/{version}/.
+  # After a version bump the old path may be gone while a new one exists.
+  # Strategy: try exact path first → fallback to latest versioned dir →
+  # if nothing exists, create the correct dir for the current repo version.
   if [[ ! -d "$install_path" ]]; then
-    echo "[dev:sync] Claude Code: cache dir missing ($install_path) — skipped"
-    return
+    local cache_parent
+    cache_parent="$(dirname "$install_path")"   # e.g. cache/ha-nova/ha-nova
+
+    local actual_dir=""
+    if [[ -d "$cache_parent" ]]; then
+      # Find the latest (or only) versioned subdir
+      actual_dir=$(ls -1d "${cache_parent}"/[0-9]* 2>/dev/null | sort -V | tail -1)
+    fi
+
+    if [[ -z "$actual_dir" ]]; then
+      # No versioned dir at all — create one for the repo version
+      local repo_version
+      repo_version=$(sed -n 's/.*"skill_version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${REPO_ROOT}/version.json")
+      if [[ -z "$repo_version" ]]; then
+        echo "[dev:sync] Claude Code: could not read version from version.json — skipped"
+        return
+      fi
+      actual_dir="${cache_parent}/${repo_version}"
+      mkdir -p "$actual_dir"
+      echo "[dev:sync] Claude Code: created cache dir ${actual_dir}"
+    else
+      echo "[dev:sync] Claude Code: installPath stale ($install_path), found ${actual_dir}"
+    fi
+
+    install_path="$actual_dir"
   fi
 
   # Sync skills, hooks, plugin manifest, and version
@@ -43,9 +71,30 @@ sync_claude() {
   rsync -a --delete "${REPO_ROOT}/.claude-plugin/" "${install_path}/.claude-plugin/"
   cp "${REPO_ROOT}/version.json" "${install_path}/version.json"
 
-  local version
-  version=$(sed -n 's/.*"skill_version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${REPO_ROOT}/version.json")
-  echo "[dev:sync] Claude Code plugin cache synced (v${version}) → ${install_path}"
+  # ── Keep installed_plugins.json in sync ────────────────────────────
+  # Update installPath and version so Claude Code finds the plugin.
+  local repo_version
+  repo_version=$(sed -n 's/.*"skill_version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${REPO_ROOT}/version.json")
+  # Keep absolute paths — Claude Code uses absolute, not ~-prefixed
+  local abs_path="$install_path"
+
+  # Update installPath
+  local old_path_pattern
+  old_path_pattern=$(sed -n '/"ha-nova@ha-nova"/,/installPath/s/.*"installPath"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$plugins_json" | head -1)
+  if [[ -n "$old_path_pattern" && "$old_path_pattern" != "$abs_path" ]]; then
+    # Scope replacement to ha-nova block only
+    sed -i '' "/"ha-nova@ha-nova"/,/installPath/{s|\"installPath\": \"${old_path_pattern}\"|\"installPath\": \"${abs_path}\"|;}" "$plugins_json"
+  fi
+
+  # Update version
+  local old_version
+  old_version=$(sed -n '/"ha-nova@ha-nova"/,/\"version\"/s/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$plugins_json" | head -1)
+  if [[ -n "$old_version" && "$old_version" != "$repo_version" ]]; then
+    # Scope the replacement to the ha-nova block: replace first occurrence of old version after ha-nova@ha-nova
+    sed -i '' "/"ha-nova@ha-nova"/,/\"version\"/{s/\"version\": \"${old_version}\"/\"version\": \"${repo_version}\"/;}" "$plugins_json"
+  fi
+
+  echo "[dev:sync] Claude Code plugin cache synced (v${repo_version}) → ${install_path}"
   synced+=("Claude Code")
 }
 
@@ -80,12 +129,18 @@ sync_relay() {
   cp "$relay_src" "$relay_dst"
   chmod 755 "$relay_dst"
 
-  # Sync version-check script + version.json
+  # Sync version-check, update script + version.json
   local vc_src="${REPO_ROOT}/scripts/version-check.sh"
   if [[ -f "$vc_src" ]]; then
     cp "$vc_src" "${HOME}/.config/ha-nova/version-check"
     chmod 755 "${HOME}/.config/ha-nova/version-check"
     cp "${REPO_ROOT}/version.json" "${HOME}/.config/ha-nova/version.json"
+  fi
+
+  local update_src="${REPO_ROOT}/scripts/update.sh"
+  if [[ -f "$update_src" ]]; then
+    cp "$update_src" "${HOME}/.config/ha-nova/update"
+    chmod 755 "${HOME}/.config/ha-nova/update"
   fi
 
   echo "[dev:sync] Relay CLI updated"

--- a/scripts/onboarding/install-local-skills.sh
+++ b/scripts/onboarding/install-local-skills.sh
@@ -191,6 +191,13 @@ install_target() {
     cp "${REPO_ROOT}/version.json" "${HOME}/.config/ha-nova/version.json"
     log "[${target}] Installed version-check + version.json"
   fi
+
+  # Self-update script (allows agent-driven updates without repo checkout)
+  if [[ -f "${REPO_ROOT}/scripts/update.sh" ]]; then
+    cp "${REPO_ROOT}/scripts/update.sh" "${HOME}/.config/ha-nova/update"
+    chmod 755 "${HOME}/.config/ha-nova/update"
+    log "[${target}] Installed self-update script"
+  fi
 }
 
 main() {

--- a/scripts/onboarding/macos-lib.sh
+++ b/scripts/onboarding/macos-lib.sh
@@ -159,7 +159,11 @@ run_doctor_checks() {
       local latest_skill_version
       latest_skill_version=$(echo "$remote_json" | grep -o '"skill_version"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/')
       if [[ -n "$latest_skill_version" && "$latest_skill_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ && -n "$local_skill_version" ]] && semver_lt "$local_skill_version" "$latest_skill_version"; then
-        echo "  [warn] Skills update available: v${local_skill_version} -> v${latest_skill_version}. See: https://github.com/markusleben/ha-nova/blob/main/skills/ha-nova/update-guide.md"
+        if [[ -x "${HOME}/.config/ha-nova/update" ]]; then
+          echo "  [warn] Skills update available: v${local_skill_version} -> v${latest_skill_version}. Run: ~/.config/ha-nova/update"
+        else
+          echo "  [warn] Skills update available: v${local_skill_version} -> v${latest_skill_version}. Run: git pull in your ha-nova repo, then re-run setup."
+        fi
       else
         echo "  [ok] Skills version: ${local_skill_version:-unknown} (up to date)"
       fi
@@ -193,6 +197,7 @@ HA_NOVA_SUB_SKILLS=(
   "onboarding"
   "service-call"
   "review"
+  "guide"
 )
 
 detect_setup_state() {

--- a/scripts/onboarding/uninstall.sh
+++ b/scripts/onboarding/uninstall.sh
@@ -16,6 +16,7 @@ FLAT_SKILLS=(
   "ha-nova-entity-discovery"
   "ha-nova-onboarding"
   "ha-nova-service-call"
+  "ha-nova-guide"
 )
 
 log() { echo "[ha-nova] $*"; }
@@ -39,6 +40,9 @@ remove_known_config() {
   local config_dir="${HOME}/.config/ha-nova"
   [[ -d "$config_dir" ]] || return 0
   remove_path "${config_dir}/relay"
+  remove_path "${config_dir}/update"
+  remove_path "${config_dir}/version-check"
+  remove_path "${config_dir}/version.json"
   remove_path "${config_dir}/onboarding.env"
   remove_path "${config_dir}/doctor-cache.env"
   # Remove dir only if empty (preserves user's custom files)

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Self-update for HA NOVA skills — all supported clients.
+# Installed to ~/.config/ha-nova/update during onboarding.
+# Runnable from any directory.
+#
+# Client archetypes:
+#   native    — client has own plugin system (delegate update)
+#   symlink   — git pull in source clone (symlink auto-resolves)
+#   flat-copy — git pull + re-copy files
+set -euo pipefail
+
+# ─── Helpers ──────────────────────────────────────────────────────────
+
+log()  { echo "[ha-nova:update] $*"; }
+warn() { echo "[ha-nova:update] WARNING: $*" >&2; }
+die()  { echo "[ha-nova:update] ERROR: $*" >&2; exit 1; }
+
+extract_json_string() {
+  local key="$1" json="$2"
+  echo "$json" | grep -o "\"${key}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" 2>/dev/null | head -1 \
+    | sed 's/.*"\([^"]*\)"$/\1/'
+}
+
+# Portable readlink -f (stock macOS lacks it)
+resolve_link() {
+  local path="$1"
+  while [[ -L "$path" ]]; do
+    local dir; dir="$(cd -P "$(dirname "$path")" && pwd)"
+    path="$(readlink "$path")"
+    [[ "$path" != /* ]] && path="${dir}/${path}"
+  done
+  cd -P "$(dirname "$path")" && echo "$(pwd)/$(basename "$path")"
+}
+
+CONFIG_DIR="${HOME}/.config/ha-nova"
+DETECTED_CLIENTS=()
+UPDATED_CLIENTS=()
+CLONE_ROOT=""
+NEW_VERSION=""
+CURRENT_VERSION=""
+
+# ─── Phase 1: Detect installed clients ────────────────────────────────
+
+detect_clients() {
+  # Claude Code — native plugin system
+  local pj="${HOME}/.claude/plugins/installed_plugins.json"
+  if [[ -f "$pj" ]] && grep -q '"ha-nova@ha-nova"' "$pj" 2>/dev/null; then
+    DETECTED_CLIENTS+=("claude")
+  fi
+
+  # Codex — symlink
+  if [[ -L "${HOME}/.agents/skills/ha-nova" ]]; then
+    DETECTED_CLIENTS+=("codex")
+  fi
+
+  # OpenCode — symlink
+  if [[ -L "${HOME}/.config/opencode/skills/ha-nova" ]]; then
+    DETECTED_CLIENTS+=("opencode")
+  fi
+
+  # Gemini — flat copies (marker: read sub-skill exists)
+  if [[ -f "${HOME}/.agents/skills/ha-nova-read/SKILL.md" ]]; then
+    DETECTED_CLIENTS+=("gemini")
+  fi
+
+  if [[ ${#DETECTED_CLIENTS[@]} -eq 0 ]]; then
+    die "No HA NOVA client installations detected. Run setup first."
+  fi
+
+  log "Detected clients: ${DETECTED_CLIENTS[*]}"
+}
+
+# ─── Phase 2: Find source git clone ──────────────────────────────────
+# Priority: symlink targets first (user's actual checkout),
+# then Claude Code plugin cache as last resort.
+
+find_source_clone() {
+  # 1. Codex symlink → parent of skills dir
+  local link="${HOME}/.agents/skills/ha-nova"
+  if [[ -L "$link" ]]; then
+    local target; target=$(resolve_link "$link" 2>/dev/null || true)
+    local repo; repo="$(dirname "$target")"
+    if [[ -d "${repo}/.git" ]]; then
+      echo "$repo"; return 0
+    fi
+  fi
+
+  # 2. OpenCode symlink → parent of skills dir
+  link="${HOME}/.config/opencode/skills/ha-nova"
+  if [[ -L "$link" ]]; then
+    local target; target=$(resolve_link "$link" 2>/dev/null || true)
+    local repo; repo="$(dirname "$target")"
+    if [[ -d "${repo}/.git" ]]; then
+      echo "$repo"; return 0
+    fi
+  fi
+
+  # 3. Claude Code plugin cache (git clone root)
+  local pj="${HOME}/.claude/plugins/installed_plugins.json"
+  if [[ -f "$pj" ]]; then
+    local install_path
+    install_path=$(
+      sed -n '/"ha-nova@ha-nova"/,/installPath/s/.*"installPath"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+        "$pj" | head -1
+    )
+    install_path="${install_path/#\~/$HOME}"
+    if [[ -n "$install_path" ]]; then
+      # installPath = cache/ha-nova/ha-nova/{version}/ → clone root = 2 levels up
+      local clone; clone="$(dirname "$(dirname "$install_path")")"
+      if [[ -d "${clone}/.git" ]]; then
+        echo "$clone"; return 0
+      fi
+    fi
+  fi
+
+  return 1
+}
+
+# ─── Phase 3: Update source (git pull) ───────────────────────────────
+
+update_source() {
+  CLONE_ROOT="$1"
+
+  CURRENT_VERSION="unknown"
+  if [[ -f "${CLONE_ROOT}/version.json" ]]; then
+    CURRENT_VERSION=$(extract_json_string "skill_version" "$(cat "${CLONE_ROOT}/version.json")")
+  fi
+
+  echo "Checking for updates..."
+  echo "Current version: v${CURRENT_VERSION}"
+
+  git -C "$CLONE_ROOT" fetch origin main --quiet 2>/dev/null || \
+    die "Could not reach GitHub. Check your internet connection."
+
+  local local_sha remote_sha
+  local_sha=$(git -C "$CLONE_ROOT" rev-parse HEAD 2>/dev/null)
+  remote_sha=$(git -C "$CLONE_ROOT" rev-parse origin/main 2>/dev/null)
+
+  if [[ "$local_sha" == "$remote_sha" ]]; then
+    echo "Already up to date (v${CURRENT_VERSION})."
+    return 1  # signal: no changes pulled
+  fi
+
+  git -C "$CLONE_ROOT" pull --ff-only origin main --quiet 2>/dev/null || \
+    die "git pull failed (local changes or diverged branch). Try: cd ${CLONE_ROOT} && git status"
+
+  NEW_VERSION="unknown"
+  if [[ -f "${CLONE_ROOT}/version.json" ]]; then
+    NEW_VERSION=$(extract_json_string "skill_version" "$(cat "${CLONE_ROOT}/version.json")")
+  fi
+
+  echo "New version: v${NEW_VERSION}"
+}
+
+# ─── Phase 4: Per-client update functions ─────────────────────────────
+
+# Archetype: native — delegate to client's own plugin manager
+update_claude() {
+  if command -v claude &>/dev/null; then
+    log "Updating Claude Code plugin..."
+    if claude plugin update ha-nova@ha-nova 2>/dev/null; then
+      UPDATED_CLIENTS+=("Claude Code")
+    else
+      warn "claude plugin update failed — try: claude plugin install ha-nova@ha-nova"
+    fi
+  else
+    warn "claude CLI not available — Claude Code plugin will update on next 'claude plugin update'"
+  fi
+}
+
+# Archetype: symlink — git pull already updated the target, just verify
+update_symlink_client() {
+  local name="$1" link_path="$2"
+  local target; target=$(resolve_link "$link_path" 2>/dev/null || true)
+  if [[ -d "$target" ]]; then
+    UPDATED_CLIENTS+=("$name")
+  else
+    warn "$name symlink broken: $link_path → $target"
+  fi
+}
+
+# Archetype: flat-copy — re-copy from updated source
+update_gemini() {
+  local source_skills="${CLONE_ROOT}/skills"
+  local skills_dir="${HOME}/.agents/skills"
+
+  # Context skill (skip if Codex symlink provides it)
+  local context_dir="${skills_dir}/ha-nova"
+  if [[ -d "$context_dir" && ! -L "$context_dir" ]]; then
+    cp "${source_skills}/ha-nova/SKILL.md" "${context_dir}/SKILL.md"
+  fi
+
+  # Sub-skills
+  for skill_md in "${source_skills}"/*/SKILL.md; do
+    local skill_name; skill_name=$(basename "$(dirname "$skill_md")")
+    [[ "$skill_name" == "ha-nova" ]] && continue
+
+    local dest_dir="${skills_dir}/ha-nova-${skill_name}"
+    mkdir -p "$dest_dir"
+    sed "s|docs/reference/|${CLONE_ROOT}/docs/reference/|g" "$skill_md" > "${dest_dir}/SKILL.md"
+  done
+
+  UPDATED_CLIENTS+=("Gemini")
+}
+
+# ─── Phase 5: Update shared tools ────────────────────────────────────
+
+update_shared_tools() {
+  local src="$1"
+  mkdir -p "$CONFIG_DIR"
+
+  [[ -f "${src}/scripts/relay.sh" ]]        && cp "${src}/scripts/relay.sh" "${CONFIG_DIR}/relay" && chmod 755 "${CONFIG_DIR}/relay"
+  # Atomic self-update: copy to temp then move (script may be running from CONFIG_DIR/update)
+  if [[ -f "${src}/scripts/update.sh" ]]; then
+    local tmp; tmp=$(mktemp "${CONFIG_DIR}/update.XXXXXX")
+    cp "${src}/scripts/update.sh" "$tmp"
+    chmod 755 "$tmp"
+    mv -f "$tmp" "${CONFIG_DIR}/update"
+  fi
+  [[ -f "${src}/scripts/version-check.sh" ]] && cp "${src}/scripts/version-check.sh" "${CONFIG_DIR}/version-check" && chmod 755 "${CONFIG_DIR}/version-check"
+  [[ -f "${src}/version.json" ]]            && cp "${src}/version.json" "${CONFIG_DIR}/version.json"
+
+  # Clear update cache so next session shows fresh state
+  rm -f "${HOME}/.cache/ha-nova/latest-version.json"
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────
+
+main() {
+  detect_clients
+
+  # Determine if we need a git pull (anything besides native-only Claude)
+  local needs_pull=false
+  for client in "${DETECTED_CLIENTS[@]}"; do
+    [[ "$client" != "claude" ]] && needs_pull=true
+  done
+  # Claude without CLI also needs pull (fallback path)
+  if [[ " ${DETECTED_CLIENTS[*]} " == *" claude "* ]] && ! command -v claude &>/dev/null; then
+    needs_pull=true
+  fi
+
+  local clone_root=""
+  local source_updated=false
+  if $needs_pull; then
+    clone_root=$(find_source_clone) || die "No HA NOVA git clone found. Re-install with the setup script."
+    if update_source "$clone_root"; then
+      source_updated=true
+    fi
+  fi
+
+  # Per-client updates
+  for client in "${DETECTED_CLIENTS[@]}"; do
+    case "$client" in
+      claude)   update_claude ;;
+      codex)    update_symlink_client "Codex" "${HOME}/.agents/skills/ha-nova" ;;
+      opencode) update_symlink_client "OpenCode" "${HOME}/.config/opencode/skills/ha-nova" ;;
+      gemini)   update_gemini ;;
+    esac
+  done
+
+  # Shared tools (need a source — either from pull or Claude plugin cache)
+  if [[ -z "$clone_root" ]]; then
+    clone_root=$(find_source_clone) || true
+  fi
+  if [[ -n "$clone_root" ]]; then
+    update_shared_tools "$clone_root"
+  fi
+
+  # Report
+  echo ""
+  if ! $source_updated && [[ ${#UPDATED_CLIENTS[@]} -eq 0 ]]; then
+    echo "Everything is up to date."
+  else
+    if [[ -n "$NEW_VERSION" && "$NEW_VERSION" != "unknown" ]]; then
+      echo "Updated: v${CURRENT_VERSION} → v${NEW_VERSION}"
+    fi
+    if [[ ${#UPDATED_CLIENTS[@]} -gt 0 ]]; then
+      echo "Clients updated: ${UPDATED_CLIENTS[*]}"
+    fi
+    echo "Please start a new session to use the updated skills."
+  fi
+}
+
+main "$@"

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -68,6 +68,10 @@ remote_v=$(extract_version "$CACHE")
 [[ -z "$remote_v" ]] && exit 0
 
 if semver_lt "$local_v" "$remote_v"; then
-  echo "⚠️ SKILL UPDATE: v${local_v} → v${remote_v} | Command: ha-nova update | URL: https://github.com/markusleben/ha-nova/blob/main/skills/ha-nova/update-guide.md"
-  echo "AGENT: Include version, command AND URL above in your response to the user."
+  if [[ -x "${HOME}/.config/ha-nova/update" ]]; then
+    echo "⚠️ UPDATE AVAILABLE: v${local_v} → v${remote_v} | Run: ~/.config/ha-nova/update"
+  else
+    echo "⚠️ UPDATE AVAILABLE: v${local_v} → v${remote_v} | Run: git pull in your ha-nova repo, then re-run setup."
+  fi
+  echo "AGENT: Include version info and update command above in your response to the user."
 fi

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -27,6 +27,13 @@ Before HA operations in this session:
 
 Do not ask user to paste tokens in chat.
 
+## Self-Update
+
+If the SessionStart context includes `UPDATE AVAILABLE`, inform the user and offer to update:
+1. Run: `~/.config/ha-nova/update`
+2. If the script doesn't exist (older install): run `bash scripts/update.sh` from the repo root, or tell the user to re-run `ha-nova setup`.
+3. After success: tell the user to **start a new session** for the updated skills to take effect.
+
 ## Quoting Reliability (Critical)
 
 Quoting is shell-dependent (bash/zsh vs PowerShell), not primarily OS-dependent.

--- a/skills/ha-nova/update-guide.md
+++ b/skills/ha-nova/update-guide.md
@@ -1,5 +1,19 @@
 # HA NOVA Update Guide
 
+## Quick Update
+
+All clients (Claude Code, Codex, OpenCode, Gemini) — one command:
+
+```bash
+~/.config/ha-nova/update
+```
+
+The script auto-detects which clients are installed and updates each using the appropriate method. No arguments needed.
+
+**Older installations** (before v0.1.7) may not have this script yet. In that case:
+1. `cd <ha-nova-repo> && git pull` to get the latest code
+2. Re-run `ha-nova setup` (or `bash scripts/onboarding/install-local-skills.sh <client>`) to deploy the update script
+
 ## Two Independent Version Lines
 
 | Track | File | Scope | Bumped when |
@@ -15,17 +29,22 @@
 
 HA Settings > Apps > NOVA Relay > Update (or reinstall from App Store).
 
-## Skills (per client)
+## How the Update Script Works
 
-| Client | Command |
-|--------|---------|
-| Claude Code | `claude plugin update ha-nova` |
-| Codex / OpenCode | `cd <ha-nova-repo> && git pull` |
-| Gemini CLI | `cd <ha-nova-repo> && git pull && npm run install:gemini-skill` |
+The script uses three update archetypes depending on the client:
+
+| Client | Archetype | What happens |
+|--------|-----------|--------------|
+| Claude Code | Native | `claude plugin update ha-nova@ha-nova` |
+| Codex | Symlink | `git pull --ff-only` in source clone (symlink auto-resolves) |
+| OpenCode | Symlink | `git pull --ff-only` in source clone (symlink auto-resolves) |
+| Gemini | Flat-copy | `git pull --ff-only` + re-copy skill files |
+
+After client updates, shared tools (relay CLI, version-check, update script itself) are refreshed from the latest source.
 
 ## Check Versions
 
-- **Skills:** `cat version.json` → `skill_version` field
+- **Skills:** `cat ~/.config/ha-nova/version.json` → `skill_version` field
 - **Relay:** `~/.config/ha-nova/relay health` → `"version"` field (matches `config.yaml`)
 - **Compatibility:** `version.json:min_relay_version` must be <= running Relay version
 
@@ -36,4 +55,14 @@ Two checks run automatically:
 1. **Skill update check** — All clients: context skill runs `~/.config/ha-nova/version-check` (cached 24h). Claude Code also checks via SessionStart hook. Shows: `UPDATE AVAILABLE: v0.1.2 -> v0.2.0`
 2. **Relay compat check** — SessionStart hook (Claude Code only) compares Relay version against `min_relay_version`. Shows: `WARNING: Relay version X is below minimum Y`
 
-The `doctor` command (`npm run onboarding:macos:doctor` from the repo) runs both checks synchronously and also refreshes the update cache.
+The `doctor` command (`npx ha-nova doctor` from the repo) runs both checks synchronously and also refreshes the update cache.
+
+## Agent-Driven Updates
+
+When the agent detects `UPDATE AVAILABLE` in its session context, it can run the update script directly:
+
+```bash
+~/.config/ha-nova/update
+```
+
+After a successful update, the user must start a new session for the updated skills to take effect.

--- a/tests/hooks/session-start.test.ts
+++ b/tests/hooks/session-start.test.ts
@@ -74,7 +74,7 @@ describe("S-6: session-start hook", () => {
 
     expect(hookContent).toContain("latest-version.json");
     expect(hookContent).toContain("UPDATE AVAILABLE");
-    expect(hookContent).toContain("update-guide.md");
+    expect(hookContent).toContain("ha-nova/update");
   });
 
   it("does not leak secrets in JSON output", () => {

--- a/tests/onboarding/install-skills-per-client.test.ts
+++ b/tests/onboarding/install-skills-per-client.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from "vitest";
 
 import { REPO_ROOT } from "./_helpers.js";
 
-const SUB_SKILLS = ["write", "read", "entity-discovery", "onboarding", "service-call", "review"];
+const SUB_SKILLS = ["write", "read", "helper", "entity-discovery", "onboarding", "service-call", "review", "guide"];
 
 function installSkills(client: string): { home: string; result: ReturnType<typeof spawnSync> } {
   const home = mkdtempSync(join(tmpdir(), `ha-nova-skill-${client}-`));

--- a/tests/onboarding/self-update-contract.test.ts
+++ b/tests/onboarding/self-update-contract.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Contract tests for scripts/update.sh — the self-update script.
+ * Verifies client detection, modular architecture, and safety properties.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { REPO_ROOT } from "./_helpers.js";
+
+const updateScript = readFileSync(
+  resolve(REPO_ROOT, "scripts/update.sh"),
+  "utf8",
+);
+
+describe("self-update script contract", () => {
+  it("script exists and is executable", () => {
+    const path = resolve(REPO_ROOT, "scripts/update.sh");
+    expect(existsSync(path)).toBe(true);
+  });
+
+  describe("client detection", () => {
+    it("detects all 4 supported clients", () => {
+      // Each client has a distinct filesystem marker
+      expect(updateScript).toContain("ha-nova@ha-nova");        // Claude Code
+      expect(updateScript).toContain(".agents/skills/ha-nova");  // Codex
+      expect(updateScript).toContain("opencode/skills/ha-nova"); // OpenCode
+      expect(updateScript).toContain("ha-nova-read/SKILL.md");   // Gemini
+    });
+
+    it("populates DETECTED_CLIENTS array", () => {
+      expect(updateScript).toContain("DETECTED_CLIENTS+=(");
+      expect(updateScript).toMatch(/DETECTED_CLIENTS\+=\("claude"\)/);
+      expect(updateScript).toMatch(/DETECTED_CLIENTS\+=\("codex"\)/);
+      expect(updateScript).toMatch(/DETECTED_CLIENTS\+=\("opencode"\)/);
+      expect(updateScript).toMatch(/DETECTED_CLIENTS\+=\("gemini"\)/);
+    });
+  });
+
+  describe("three update archetypes", () => {
+    it("uses native claude plugin update for Claude Code", () => {
+      expect(updateScript).toContain("claude plugin update ha-nova@ha-nova");
+    });
+
+    it("uses symlink verification for Codex and OpenCode", () => {
+      expect(updateScript).toContain("update_symlink_client");
+      expect(updateScript).toMatch(/update_symlink_client.*Codex/);
+      expect(updateScript).toMatch(/update_symlink_client.*OpenCode/);
+    });
+
+    it("uses flat-copy re-creation for Gemini", () => {
+      expect(updateScript).toContain("update_gemini");
+      // Gemini needs path resolution for docs/reference/
+      expect(updateScript).toContain("docs/reference/");
+    });
+  });
+
+  describe("safety", () => {
+    it("uses git pull --ff-only, not reset --hard", () => {
+      expect(updateScript).toContain("pull --ff-only");
+      expect(updateScript).not.toContain("reset --hard");
+    });
+
+    it("skips git pull when only Claude Code is installed", () => {
+      // Logic: needs_pull stays false if all clients are "claude"
+      expect(updateScript).toContain('!= "claude"');
+      expect(updateScript).toContain("needs_pull");
+    });
+
+    it("clears update cache after update", () => {
+      expect(updateScript).toContain("latest-version.json");
+    });
+  });
+
+  describe("shared tools", () => {
+    it("updates relay CLI, update script, and version-check", () => {
+      expect(updateScript).toContain("relay.sh");
+      expect(updateScript).toContain("update.sh");
+      expect(updateScript).toContain("version-check.sh");
+      expect(updateScript).toContain("version.json");
+    });
+  });
+
+  describe("extensibility", () => {
+    it("has per-client case statement for easy addition", () => {
+      // main() dispatches via case statement — new client = new case branch
+      expect(updateScript).toMatch(/case.*\$client.*in/);
+      expect(updateScript).toContain("claude)");
+      expect(updateScript).toContain("codex)");
+      expect(updateScript).toContain("opencode)");
+      expect(updateScript).toContain("gemini)");
+    });
+  });
+
+  describe("install script deploys update", () => {
+    it("install-local-skills.sh copies update.sh to config dir", () => {
+      const installScript = readFileSync(
+        resolve(REPO_ROOT, "scripts/onboarding/install-local-skills.sh"),
+        "utf8",
+      );
+      expect(installScript).toContain("update.sh");
+      expect(installScript).toContain("ha-nova/update");
+    });
+
+    it("uninstall.sh cleans up update script", () => {
+      const uninstallScript = readFileSync(
+        resolve(REPO_ROOT, "scripts/onboarding/uninstall.sh"),
+        "utf8",
+      );
+      expect(uninstallScript).toContain("update");
+    });
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.1.7",
+  "skill_version": "0.1.8",
   "min_relay_version": "0.1.0"
 }


### PR DESCRIPTION
## Summary

- **New**: `scripts/update.sh` — unified self-update for all 4 clients (Claude Code, Codex, OpenCode, Gemini), deployed to `~/.config/ha-nova/update` during onboarding
- **Backward compat**: Graceful fallbacks when update script doesn't exist (older installs get "git pull + re-run setup" guidance)
- **Bug fixes**: Portable `readlink -f` replacement for stock macOS, absolute paths in `installed_plugins.json`, scoped sed replacements, `guide` skill in uninstall/setup arrays
- **Docs**: Rewritten `update-guide.md`, consistent update messages across all entry points
- **Tests**: 13 new contract tests for the update script, `helper`/`guide` added to skill install test

## Test plan

- [ ] `npx vitest run` — 222 tests pass
- [ ] `bash scripts/dev-sync.sh` — deploys new scripts to `~/.config/ha-nova/`
- [ ] `~/.config/ha-nova/update` — runs without error, detects installed clients
- [ ] Delete `~/.config/ha-nova/update`, start new Claude session → fallback message shown
- [ ] Codex: verify symlink still resolves after git pull
- [ ] `claude plugin update ha-nova@ha-nova` — picks up 0.1.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)