### PR TITLE
fix: redirect stdin from /dev/tty in curl-piped install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -212,7 +212,9 @@ main() {
   echo ""
 
   # Hand off to the setup wizard
-  exec "${BIN_LINK}" setup
+  # Redirect stdin from /dev/tty so interactive input works even when
+  # the script is piped from curl (curl occupies stdin with the script).
+  exec "${BIN_LINK}" setup < /dev/tty
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Fix interactive setup wizard failing with `[ha-nova] Interactive input required` when installed via `curl ... | bash`
- Root cause: `curl` occupies stdin with the script content, so the setup wizard can't read user input
- Fix: redirect stdin from `/dev/tty` before `exec` to the wizard

## Test plan

- [ ] `curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/fix/install-stdin-tty/install.sh | bash` — wizard should prompt for client selection
- [ ] Direct `ha-nova setup` still works (stdin is already the terminal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)