### PR TITLE
fix(onboarding): address post-merge codex findings

### DIFF
--- a/docs/superpowers/specs/2026-03-12-post-merge-codex-findings-design.md
+++ b/docs/superpowers/specs/2026-03-12-post-merge-codex-findings-design.md
@@ -1,0 +1,30 @@
+# Spec: Post-Merge Codex Findings Cleanup
+
+Date: 2026-03-12
+
+## Problem
+
+PR #75 left two Codex findings functionally unaddressed in the shipped code:
+
+1. Gemini readiness checks can treat a flat-copy install as complete even if required companion markdown files are missing.
+2. Local sync behavior around Gemini roots is inconsistent with the current install layout and legacy migration path.
+
+## Decision
+
+Ship a small follow-up fix:
+
+- make Gemini setup readiness validate required companion markdown files per sub-skill
+- make `dev-sync` refresh file-based clients via the local installer again, with:
+  - Codex/OpenCode guarded by symlink markers
+  - Gemini detected via current `~/.gemini/skills/...` and legacy `~/.agents/skills/...`
+
+## Scope
+
+- `scripts/onboarding/macos-lib.sh`
+- `scripts/dev-sync.sh`
+- focused onboarding regression tests
+
+## Non-Goals
+
+- no new installer UX work
+- no broader refactor of onboarding state handling

--- a/scripts/dev-sync.sh
+++ b/scripts/dev-sync.sh
@@ -11,27 +11,39 @@ REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 synced=()
 file_clients_synced=0
 
-sync_file_client() {
+refresh_file_client() {
   local name="$1"
   local target="$2"
-  shift 2
-  local markers=("$@")
-  local marker
 
-  for marker in "${markers[@]}"; do
-    if [[ -e "$marker" || -L "$marker" ]]; then
-      bash "${REPO_ROOT}/scripts/onboarding/install-local-skills.sh" "$target"
-      echo "[dev:sync] ${name}: refreshed via install-local-skills.sh ${target}"
-      synced+=("${name}")
-      file_clients_synced=1
-      return
-    fi
-  done
+  bash "${REPO_ROOT}/scripts/onboarding/install-local-skills.sh" "$target"
+  echo "[dev:sync] ${name}: refreshed via install-local-skills.sh ${target}"
+  synced+=("${name}")
+  file_clients_synced=1
+}
 
-  if [[ ${#markers[@]} -eq 0 ]]; then
-    echo "[dev:sync] ${name}: not installed — skipped"
+sync_symlink_client() {
+  local name="$1"
+  local link_path="$2"
+  local target="$3"
+
+  if [[ -L "$link_path" && -e "$link_path" ]]; then
+    refresh_file_client "$name" "$target"
+    return
   fi
+
   echo "[dev:sync] ${name}: not installed — skipped"
+}
+
+sync_gemini() {
+  local current_marker="${HOME}/.gemini/skills/ha-nova-read/SKILL.md"
+  local legacy_marker="${HOME}/.agents/skills/ha-nova-read/SKILL.md"
+
+  if [[ -f "$current_marker" || -f "$legacy_marker" ]]; then
+    refresh_file_client "Gemini" "gemini"
+    return
+  fi
+
+  echo "[dev:sync] Gemini: not installed — skipped"
 }
 
 # ─── Claude Code plugin cache ────────────────────────────────────────
@@ -224,9 +236,9 @@ verify_plugin_integrity() {
 }
 
 # ─── Run ──────────────────────────────────────────────────────────────
-sync_file_client "Codex" "codex" "${HOME}/.agents/skills/ha-nova"
-sync_file_client "OpenCode" "opencode" "${HOME}/.config/opencode/skills/ha-nova"
-sync_file_client "Gemini" "gemini" "${HOME}/.gemini/skills/ha-nova-read/SKILL.md" "${HOME}/.agents/skills/ha-nova-read/SKILL.md"
+sync_symlink_client "Codex" "${HOME}/.agents/skills/ha-nova" "codex"
+sync_symlink_client "OpenCode" "${HOME}/.config/opencode/skills/ha-nova" "opencode"
+sync_gemini
 sync_claude
 if [[ "$file_clients_synced" -eq 0 ]]; then
   sync_shared_tools

--- a/scripts/onboarding/macos-lib.sh
+++ b/scripts/onboarding/macos-lib.sh
@@ -200,6 +200,21 @@ HA_NOVA_SUB_SKILLS=(
   "ha-nova-guide"
 )
 
+flat_skill_has_required_markdown() {
+  local install_dir="$1"
+  local source_dir="$2"
+  local source_file required_name
+
+  for source_file in "${source_dir}"/*.md; do
+    required_name="$(basename "${source_file}")"
+    if [[ ! -f "${install_dir}/${required_name}" ]]; then
+      return 1
+    fi
+  done
+
+  return 0
+}
+
 detect_setup_state() {
   local client="$1"
   local relay_auth_token
@@ -253,11 +268,11 @@ detect_setup_state() {
       ;;
     gemini)
       # Flat copy check: ha-nova/SKILL.md + namespaced sub-skill dirs
-      if [[ ! -f "${HOME}/.gemini/skills/ha-nova/SKILL.md" ]]; then
+      if ! flat_skill_has_required_markdown "${HOME}/.gemini/skills/ha-nova" "${REPO_ROOT}/skills/ha-nova"; then
         SETUP_SKILLS_OK="0"
       else
         for sub_skill in "${HA_NOVA_SUB_SKILLS[@]}"; do
-          if [[ ! -f "${HOME}/.gemini/skills/${sub_skill}/SKILL.md" ]]; then
+          if ! flat_skill_has_required_markdown "${HOME}/.gemini/skills/${sub_skill}" "${REPO_ROOT}/skills/${sub_skill}"; then
             SETUP_SKILLS_OK="0"
             break
           fi
@@ -287,14 +302,23 @@ detect_setup_state() {
     all)
       # Check each client's skills without recursive detect_setup_state
       # (which would overwrite SETUP_HAS_CONFIG/TOKEN/RELAY_OK/WS_OK)
+      if [[ ! -L "${HOME}/.agents/skills/ha-nova" ]] || [[ ! -f "${HOME}/.agents/skills/ha-nova/ha-nova/SKILL.md" ]]; then
+        SETUP_SKILLS_OK="0"
+      fi
+      if [[ "$SETUP_SKILLS_OK" == "1" ]] && ! flat_skill_has_required_markdown "${HOME}/.gemini/skills/ha-nova" "${REPO_ROOT}/skills/ha-nova"; then
+        SETUP_SKILLS_OK="0"
+      fi
       for sub_skill in "${HA_NOVA_SUB_SKILLS[@]}"; do
+        if [[ "$SETUP_SKILLS_OK" != "1" ]]; then
+          break
+        fi
         # Codex symlink (flat layout: skills/{sub}/SKILL.md through symlink)
-        if [[ ! -L "${HOME}/.agents/skills/ha-nova" ]] || [[ ! -f "${HOME}/.agents/skills/ha-nova/${sub_skill}/SKILL.md" ]]; then
+        if [[ ! -f "${HOME}/.agents/skills/ha-nova/${sub_skill}/SKILL.md" ]]; then
           SETUP_SKILLS_OK="0"
           break
         fi
         # Gemini flat
-        if [[ ! -f "${HOME}/.gemini/skills/${sub_skill}/SKILL.md" ]]; then
+        if ! flat_skill_has_required_markdown "${HOME}/.gemini/skills/${sub_skill}" "${REPO_ROOT}/skills/${sub_skill}"; then
           SETUP_SKILLS_OK="0"
           break
         fi

--- a/tests/onboarding/dev-sync-contract.test.ts
+++ b/tests/onboarding/dev-sync-contract.test.ts
@@ -7,13 +7,18 @@ describe("dev-sync contract", () => {
 
   it("delegates file clients back to install-local-skills.sh", () => {
     expect(content).toContain('bash "${REPO_ROOT}/scripts/onboarding/install-local-skills.sh" "$target"');
-    expect(content).toContain('sync_file_client "Codex" "codex"');
-    expect(content).toContain('sync_file_client "OpenCode" "opencode"');
-    expect(content).toContain('sync_file_client "Gemini" "gemini"');
+    expect(content).toContain('refresh_file_client "$name" "$target"');
+    expect(content).toContain('refresh_file_client "Gemini" "gemini"');
   });
 
   it("keeps legacy Gemini marker support during migration", () => {
     expect(content).toContain('.gemini/skills/ha-nova-read/SKILL.md');
     expect(content).toContain('.agents/skills/ha-nova-read/SKILL.md');
+  });
+
+  it("requires symlink markers for Codex and OpenCode", () => {
+    expect(content).toContain('[[ -L "$link_path" && -e "$link_path" ]]');
+    expect(content).toContain('sync_symlink_client "Codex"');
+    expect(content).toContain('sync_symlink_client "OpenCode"');
   });
 });

--- a/tests/onboarding/setup-resume.test.ts
+++ b/tests/onboarding/setup-resume.test.ts
@@ -2,7 +2,7 @@
  * S-2: Upgrade (everything present) — "Already set up"
  * S-3: Resume after partial abort
  */
-import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -10,6 +10,41 @@ import { describe, expect, it } from "vitest";
 import { createMockBinaries, createMockHome, mockEnv, REPO_ROOT } from "./_helpers.js";
 
 const isMac = process.platform === "darwin";
+const GEMINI_SUB_SKILLS = [
+  "ha-nova-write",
+  "ha-nova-read",
+  "ha-nova-helper",
+  "ha-nova-entity-discovery",
+  "ha-nova-onboarding",
+  "ha-nova-service-call",
+  "ha-nova-review",
+  "ha-nova-guide",
+];
+
+function seedGeminiSkills(home: string, options: { includeReviewChecks?: boolean } = {}) {
+  const geminiSkillsDir = join(home, ".gemini/skills");
+
+  const copyRepoMarkdown = (skillName: string) => {
+    const repoSkillDir = join(REPO_ROOT, "skills", skillName);
+    const destDir = join(geminiSkillsDir, skillName);
+    mkdirSync(destDir, { recursive: true });
+
+    for (const file of readdirSync(repoSkillDir)) {
+      if (!file.endsWith(".md")) {
+        continue;
+      }
+      if (!(options.includeReviewChecks ?? true) && skillName === "ha-nova-review" && file === "checks.md") {
+        continue;
+      }
+      writeFileSync(join(destDir, file), readFileSync(join(repoSkillDir, file), "utf8"), "utf8");
+    }
+  };
+
+  copyRepoMarkdown("ha-nova");
+  for (const sub of GEMINI_SUB_SKILLS) {
+    copyRepoMarkdown(sub);
+  }
+}
 
 describe.skipIf(!isMac)("S-2: smart resume — already set up", () => {
   it("exits early when relay + WS + skills all OK", () => {
@@ -97,23 +132,7 @@ describe.skipIf(!isMac)("S-2: smart resume — already set up", () => {
     });
     const binDir = createMockBinaries();
 
-    const geminiSkillsDir = join(home, ".gemini/skills");
-    mkdirSync(join(geminiSkillsDir, "ha-nova"), { recursive: true });
-    writeFileSync(join(geminiSkillsDir, "ha-nova", "SKILL.md"), "# skill", "utf8");
-    for (const sub of [
-      "ha-nova-write",
-      "ha-nova-read",
-      "ha-nova-helper",
-      "ha-nova-entity-discovery",
-      "ha-nova-onboarding",
-      "ha-nova-service-call",
-      "ha-nova-review",
-      "ha-nova-guide",
-    ]) {
-      mkdirSync(join(geminiSkillsDir, sub), { recursive: true });
-      writeFileSync(join(geminiSkillsDir, sub, "SKILL.md"), "# skill", "utf8");
-    }
-    writeFileSync(join(geminiSkillsDir, "ha-nova-review", "checks.md"), "# checks", "utf8");
+    seedGeminiSkills(home);
 
     const result = spawnSync(
       "bash",
@@ -134,6 +153,39 @@ describe.skipIf(!isMac)("S-2: smart resume — already set up", () => {
     expect(output).toContain("Skills installed");
   });
 
+  it("does not treat Gemini as fully installed when review companions are missing", () => {
+    const home = createMockHome({
+      config: {
+        HA_HOST: "192.168.1.5",
+        HA_URL: "http://192.168.1.5:8123",
+        RELAY_BASE_URL: "http://192.168.1.5:8791",
+      },
+      keychainToken: "test-relay-token-abc123",
+    });
+    const binDir = createMockBinaries();
+
+    seedGeminiSkills(home, { includeReviewChecks: false });
+
+    const result = spawnSync(
+      "bash",
+      ["scripts/onboarding/macos-onboarding.sh", "setup", "gemini"],
+      {
+        cwd: REPO_ROOT,
+        input: "",
+        encoding: "utf8",
+        timeout: 15000,
+        env: mockEnv(home, binDir),
+      },
+    );
+
+    expect(result.status).toBe(0);
+
+    const output = (result.stdout ?? "") + (result.stderr ?? "");
+    expect(output).not.toContain("Everything is already set up!");
+    expect(output).toContain("Installing HA NOVA skills");
+    expect(output).toContain("Skills not installed");
+  });
+
   it("treats setup all with namespaced skills as fully installed", () => {
     const home = createMockHome({
       config: {
@@ -148,23 +200,7 @@ describe.skipIf(!isMac)("S-2: smart resume — already set up", () => {
     mkdirSync(join(home, ".agents/skills"), { recursive: true });
     symlinkSync(join(REPO_ROOT, "skills"), join(home, ".agents/skills/ha-nova"));
 
-    const geminiSkillsDir = join(home, ".gemini/skills");
-    mkdirSync(join(geminiSkillsDir, "ha-nova"), { recursive: true });
-    writeFileSync(join(geminiSkillsDir, "ha-nova", "SKILL.md"), "# skill", "utf8");
-    for (const sub of [
-      "ha-nova-write",
-      "ha-nova-read",
-      "ha-nova-helper",
-      "ha-nova-entity-discovery",
-      "ha-nova-onboarding",
-      "ha-nova-service-call",
-      "ha-nova-review",
-      "ha-nova-guide",
-    ]) {
-      mkdirSync(join(geminiSkillsDir, sub), { recursive: true });
-      writeFileSync(join(geminiSkillsDir, sub, "SKILL.md"), "# skill", "utf8");
-    }
-    writeFileSync(join(geminiSkillsDir, "ha-nova-review", "checks.md"), "# checks", "utf8");
+    seedGeminiSkills(home);
 
     mkdirSync(join(home, ".config/opencode/skills"), { recursive: true });
     symlinkSync(join(REPO_ROOT, "skills"), join(home, ".config/opencode/skills/ha-nova"));
@@ -186,6 +222,43 @@ describe.skipIf(!isMac)("S-2: smart resume — already set up", () => {
     const output = (result.stdout ?? "") + (result.stderr ?? "");
     expect(output).toContain("Everything is already set up!");
     expect(output).toContain("Skills installed");
+  });
+
+  it("does not treat setup all as complete when Gemini companions are missing", () => {
+    const home = createMockHome({
+      config: {
+        HA_HOST: "192.168.1.5",
+        HA_URL: "http://192.168.1.5:8123",
+        RELAY_BASE_URL: "http://192.168.1.5:8791",
+      },
+      keychainToken: "test-relay-token-abc123",
+    });
+    const binDir = createMockBinaries();
+
+    mkdirSync(join(home, ".agents/skills"), { recursive: true });
+    symlinkSync(join(REPO_ROOT, "skills"), join(home, ".agents/skills/ha-nova"));
+    seedGeminiSkills(home, { includeReviewChecks: false });
+    mkdirSync(join(home, ".config/opencode/skills"), { recursive: true });
+    symlinkSync(join(REPO_ROOT, "skills"), join(home, ".config/opencode/skills/ha-nova"));
+
+    const result = spawnSync(
+      "bash",
+      ["scripts/onboarding/macos-onboarding.sh", "setup", "all"],
+      {
+        cwd: REPO_ROOT,
+        input: "",
+        encoding: "utf8",
+        timeout: 15000,
+        env: mockEnv(home, binDir),
+      },
+    );
+
+    expect(result.status).toBe(0);
+
+    const output = (result.stdout ?? "") + (result.stderr ?? "");
+    expect(output).not.toContain("Everything is already set up!");
+    expect(output).toContain("Installing HA NOVA skills");
+    expect(output).toContain("Skills not installed");
   });
 });
 


### PR DESCRIPTION
## Summary
- require live symlink markers before Codex/OpenCode dev-sync runs
- treat Gemini flat installs as incomplete when companion markdown files are missing
- add focused regression coverage for both Codex review findings

## Testing
- npm test -- --run tests/onboarding
- pre-push full suite: 44 files, 239 tests
