### PR TITLE
docs(agents): track codex review summary comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,10 +56,16 @@ Work style: Be radically precise. No fluff. Pure information only (drop grammar;
 - If user types a command (“pull and push”), that’s consent for that command.
 - Big review: `git --no-pager diff --color=never`.
 - **PR Merge — MANDATORY CHECKLIST (do NOT skip any step):**
-  The `codex-review-gate` workflow waits ~9 min for the Codex review bot. Bot signals: 👍 reaction = no findings, review comments = findings.
+  The `codex-review-gate` workflow waits ~9 min for the Codex review bot. Bot signals span three channels:
+  - reactions on the PR issue (`👍` = clean)
+  - inline PR review comments (`pulls/<nr>/comments` = findings)
+  - PR discussion comments / review summaries (`issues/<nr>/comments` or `gh pr view --comments`), including clean summaries like `Codex Review: Didn't find any major issues.`
   - [ ] 1. `gh pr create ...`
   - [ ] 2. `gh pr checks <nr> --watch` — wait for ALL checks including `codex-review-gate`
-  - [ ] 3. Check bot signal: `gh api repos/<o>/<r>/issues/<nr>/reactions` (👍 = clean) AND `gh api repos/<o>/<r>/pulls/<nr>/comments` (findings)
+  - [ ] 3. Check bot signals:
+         `gh api repos/<o>/<r>/issues/<nr>/reactions`
+         `gh api repos/<o>/<r>/pulls/<nr>/comments`
+         `gh api repos/<o>/<r>/issues/<nr>/comments` or `gh pr view <nr> --comments`
   - [ ] 4. If findings → fix, push, then **trigger re-review**: `gh pr comment <nr> --body "@codex review"` — this is the ONLY reliable way to get the bot to review fix commits (pushes alone do NOT trigger re-review). Then go back to step 2.
   - [ ] 5. If 👍 or timeout (no findings) → resolve ALL review threads (branch protection blocks unresolved):
          `gh api graphql -f query='{ repository(owner:"<o>",name:"<r>") { pullRequest(number:<nr>) { reviewThreads(first:20) { nodes { id isResolved } } } } }'`

--- a/docs/superpowers/specs/2026-03-12-codex-review-signal-flow-design.md
+++ b/docs/superpowers/specs/2026-03-12-codex-review-signal-flow-design.md
@@ -1,0 +1,26 @@
+# Spec: Codex Review Signal Flow
+
+Date: 2026-03-12
+
+## Problem
+
+The PR merge flow already checks GitHub checks, bot reactions, and inline PR review comments, but Codex can also report a clean result through PR discussion comments like `Codex Review: Didn't find any major issues.` If that channel is ignored, a human can miss the final clean signal or misread a pending gate as unresolved review work.
+
+## Decision
+
+Treat Codex review as a multi-signal check:
+
+- workflow status via `gh pr checks`
+- bot reactions via `issues/<nr>/reactions`
+- inline findings via `pulls/<nr>/comments`
+- summary / clean comments via `issues/<nr>/comments` or `gh pr view --comments`
+
+## Scope
+
+- `AGENTS.md`
+- local project notes (`docs/choices.md`, `docs/breadcrumbs.md`)
+
+## Non-Goals
+
+- no automation script yet
+- no change to branch protection itself


### PR DESCRIPTION
## Summary
- document the Codex review summary-comment channel in the mandatory PR merge checklist
- clarify that clean bot signals can come from reactions, inline comments, or PR discussion comments
- add a minimal spec note for the expanded review-signal flow

## Testing
- pre-push full suite: 44 files, 240 tests
