### PR TITLE
fix(onboarding): avoid false green setup on ws failures

### DIFF
--- a/docs/superpowers/plans/2026-03-12-setup-ws-degraded-flow.md
+++ b/docs/superpowers/plans/2026-03-12-setup-ws-degraded-flow.md
@@ -1,0 +1,63 @@
+# Setup WS-Degraded Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ha-nova setup` handle degraded relay-to-HA WebSocket connectivity inside setup and avoid false `Setup complete!` banners.
+
+**Architecture:** Keep the existing onboarding structure. Tighten the verify phase so relay health plus upstream WS state produce an explicit setup result (`complete` vs `incomplete`) and reuse existing retry UX patterns instead of inventing a new flow.
+
+**Tech Stack:** Bash onboarding scripts, Vitest onboarding integration tests
+
+---
+
+## Chunk 1: Red Tests
+
+### Task 1: Add degraded-setup expectations
+
+**Files:**
+- Modify: `tests/onboarding/setup-fresh-install.test.ts`
+- Modify: `tests/onboarding/setup-relay-failures.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 2: Run focused Vitest commands and confirm current behavior is wrong**
+
+### Task 2: Add softer doctor expectation
+
+**Files:**
+- Modify: `tests/onboarding/doctor-checks.test.ts`
+
+- [ ] **Step 1: Write the failing test/assertions**
+- [ ] **Step 2: Run the focused doctor test and confirm failure**
+
+## Chunk 2: Green Implementation
+
+### Task 3: Tighten setup verify flow
+
+**Files:**
+- Modify: `scripts/onboarding/macos-lib.sh`
+
+- [ ] **Step 1: Add a tracked setup result for degraded WS verification**
+- [ ] **Step 2: Reuse retry-style prompts for WS degraded verification**
+- [ ] **Step 3: Change the final banner to `Setup incomplete` when needed**
+
+### Task 4: Soften degraded WS diagnosis
+
+**Files:**
+- Modify: `scripts/onboarding/macos-lib.sh`
+- Modify: `scripts/onboarding/lib/relay.sh`
+
+- [ ] **Step 1: Remove unconditional `ha_llat is required` copy**
+- [ ] **Step 2: Keep specific LLAT wording only when the `/ws` body proves it**
+
+## Chunk 3: Verification
+
+### Task 5: Focused verification
+
+**Files:**
+- Test: `tests/onboarding/setup-fresh-install.test.ts`
+- Test: `tests/onboarding/setup-relay-failures.test.ts`
+- Test: `tests/onboarding/doctor-checks.test.ts`
+
+- [ ] **Step 1: Run focused tests**
+- [ ] **Step 2: Fix any regressions**
+- [ ] **Step 3: Run broader `tests/onboarding` verification**

--- a/docs/superpowers/specs/2026-03-12-setup-ws-degraded-flow-design.md
+++ b/docs/superpowers/specs/2026-03-12-setup-ws-degraded-flow-design.md
@@ -1,0 +1,38 @@
+# Setup WS-Degraded Flow Design
+
+## Problem
+
+`ha-nova setup` can currently end with `Setup complete!` even when the relay is reachable but upstream Home Assistant WebSocket connectivity is still degraded (`ha_ws_connected=false` and `/ws` probe fails).
+
+This creates two UX problems:
+
+- the final success banner overstates the real system state
+- setup pushes the user to `ha-nova doctor` too early instead of helping inside setup
+
+## Decision
+
+- Keep setup permissive enough to save config and installed skills.
+- Do not show `Setup complete!` when the relay-to-HA WS path is still degraded.
+- Reuse the existing retry style from the relay reachability path:
+  - `[Enter] retry`
+  - bounded retries
+  - save config if the user still exits
+- End in `Setup incomplete` when relay health is reachable but HA WS is not healthy after retries.
+- `ha-nova doctor` remains a later re-check command, not the primary setup recovery path.
+
+## Messaging Rules
+
+- Only claim a concrete `ha_llat` problem when the `/ws` probe response explicitly proves it.
+- Otherwise describe the state generically:
+  - relay reachable
+  - Home Assistant WebSocket not connected yet
+- Final incomplete banner must still tell the user what to do next and mention `ha-nova doctor` as a later follow-up command.
+
+## Implementation Scope
+
+- Update doctor degraded messaging to remove the unconditional `ha_llat is required` statement.
+- Update setup verification flow to retry degraded WS connectivity before finishing.
+- Track final setup state so the banner can show `Setup complete!` vs `Setup incomplete`.
+- Add regression coverage for:
+  - degraded WS during setup
+  - doctor messaging for generic degraded WS

--- a/scripts/onboarding/lib/relay.sh
+++ b/scripts/onboarding/lib/relay.sh
@@ -358,6 +358,10 @@ probe_relay_ws_ping() {
   return 1
 }
 
+relay_ws_issue_is_llat() {
+  [[ "${LAST_RELAY_WS_STATUS_CODE:-}" == "502" && "${LAST_RELAY_WS_BODY:-}" == *"LLAT is required"* ]]
+}
+
 # ---------------------------------------------------------------------------
 # Relay diagnostics
 # ---------------------------------------------------------------------------
@@ -369,7 +373,7 @@ explain_relay_ws_degraded() {
       echo "         Action: verify the exact value in the \"Relay Auth Token\" field (\"relay_auth_token\") in App options." >&2
       ;;
     "502")
-      if [[ "${LAST_RELAY_WS_BODY:-}" == *"LLAT is required"* ]]; then
+      if relay_ws_issue_is_llat; then
         echo "         Cause: Relay is reachable, but HA WS authentication failed because the Home Assistant Access Token is missing or mismatched." >&2
         echo "         Action: set the \"Home Assistant Access Token\" field (\"ha_llat\") in App options to a valid Long-Lived Access Token and restart the App." >&2
       else

--- a/scripts/onboarding/macos-lib.sh
+++ b/scripts/onboarding/macos-lib.sh
@@ -136,7 +136,11 @@ run_doctor_checks() {
         echo "  [ok] Relay /ws ping succeeded (upstream WS operational)."
       else
         echo "  [fail] Relay reports degraded upstream WS capability (ha_ws_connected=false)."
-        echo "         Action: the \"Home Assistant Access Token\" field (\"ha_llat\") is required in App options. Verify it and restart the App."
+        if relay_ws_issue_is_llat; then
+          echo "         Action: verify the \"Home Assistant Access Token\" field (\"ha_llat\") in App options, then restart the App."
+        else
+          echo "         Action: Home Assistant WebSocket is not connected yet. Check NOVA Relay app settings and restart the App."
+        fi
         explain_relay_ws_degraded
         overall_ok="0"
       fi
@@ -428,6 +432,8 @@ run_setup() {
   local skip_llat="0"
   local skip_verify="0"
   local skip_skills="0"
+  local setup_status="complete"
+  local setup_issue=""
 
   if [[ "$SETUP_HAS_CONFIG" == "1" ]]; then
     skip_app_install="1"
@@ -630,16 +636,57 @@ run_setup() {
     # Quick WS re-check if relay was already OK (no full verify needed)
     if [[ "$skip_verify" == "1" ]]; then
       echo ""
-      if with_spinner "Checking connection..." probe_relay_health "$RELAY_BASE_URL" "$relay_auth_token"; then
+      print_info "Checking connection..."
+      if probe_relay_health "$RELAY_BASE_URL" "$relay_auth_token"; then
         if [[ "$LAST_RELAY_HA_WS_CONNECTED" == "true" ]]; then
           print_success "Connected to Home Assistant"
         elif probe_relay_ws_ping "$RELAY_BASE_URL" "$relay_auth_token"; then
           print_success "Connected to Home Assistant"
         else
-          print_fail "Relay is running but can't reach Home Assistant. Run: ha-nova doctor"
+          local ws_attempt=0
+          while true; do
+            ws_attempt=$((ws_attempt + 1))
+            print_fail "Home Assistant WebSocket is not connected yet."
+            if relay_ws_issue_is_llat; then
+              print_info "The Home Assistant Access Token in NOVA Relay still needs to be checked."
+            else
+              print_info "NOVA Relay is running, but it still can't finish the Home Assistant connection."
+            fi
+            explain_relay_ws_degraded
+            echo ""
+            print_info "Quick checklist — please verify:"
+            print_info "  1. Is the \"Home Assistant Access Token\" field (\"ha_llat\") saved in the app settings?"
+            print_info "  2. Did you click Save in the app settings?"
+            print_info "  3. Did you click Start or Restart for the NOVA Relay app?"
+            print_info "  4. Is Home Assistant fully up and reachable in the browser?"
+            echo ""
+            if (( ws_attempt >= 3 )); then
+              print_info "Saving your settings now. Setup will finish as incomplete."
+              setup_status="incomplete"
+              setup_issue="ws_degraded"
+              break
+            fi
+
+            local ws_retry_input=""
+            if ! read -r -p "  [Enter] retry · [q] finish setup as incomplete: " ws_retry_input; then
+              die "Interactive input required. Re-run in a terminal."
+            fi
+            if [[ "$ws_retry_input" =~ ^[Qq]$ ]]; then
+              print_info "Saving your settings now. Setup will finish as incomplete."
+              setup_status="incomplete"
+              setup_issue="ws_degraded"
+              break
+            fi
+            if probe_relay_ws_ping "$RELAY_BASE_URL" "$relay_auth_token"; then
+              print_success "Connected to Home Assistant"
+              break
+            fi
+          done
         fi
       else
-        print_fail "Can't reach the relay. Run: ha-nova doctor"
+        print_fail "Can't reach the relay."
+        setup_status="incomplete"
+        setup_issue="relay_unreachable"
       fi
     fi
   fi
@@ -666,24 +713,55 @@ run_setup() {
 
     local attempt=0
     while true; do
-      if with_spinner "Connecting to NOVA Relay..." probe_relay_health "$RELAY_BASE_URL" "$relay_auth_token"; then
+      print_info "Connecting to NOVA Relay..."
+      if probe_relay_health "$RELAY_BASE_URL" "$relay_auth_token"; then
         print_success "NOVA Relay is running at ${RELAY_BASE_URL}"
         if [[ "$LAST_RELAY_HA_WS_CONNECTED" == "true" ]]; then
           print_success "Connected to Home Assistant"
         elif [[ "$LAST_RELAY_HA_WS_CONNECTED" == "false" ]]; then
-          if probe_relay_ws_ping "$RELAY_BASE_URL" "$relay_auth_token"; then
-            print_success "Connected to Home Assistant"
-          else
-            echo ""
-            print_fail "The relay is running but can't reach Home Assistant."
-            print_info "This usually means the \"Home Assistant Access Token\" field (\"ha_llat\") is missing or incorrect."
-            explain_relay_ws_degraded
-            if [[ "$non_interactive_verify" == "1" ]]; then
-              print_info "Continuing — you can fix this later with: ha-nova doctor"
-            elif ! prompt_yes_no "Continue anyway? (you can fix this later)" "Y"; then
-              die "Setup aborted."
+          local ws_ok="0"
+          local ws_attempt=0
+          while true; do
+            if probe_relay_ws_ping "$RELAY_BASE_URL" "$relay_auth_token"; then
+              print_success "Connected to Home Assistant"
+              ws_ok="1"
+              break
             fi
-          fi
+
+            ws_attempt=$((ws_attempt + 1))
+            echo ""
+            print_fail "Home Assistant WebSocket is not connected yet."
+            if relay_ws_issue_is_llat; then
+              print_info "The Home Assistant Access Token in NOVA Relay still needs to be checked."
+            else
+              print_info "NOVA Relay is running, but it still can't finish the Home Assistant connection."
+            fi
+            explain_relay_ws_degraded
+            echo ""
+            print_info "Quick checklist — please verify:"
+            print_info "  1. Is the \"Home Assistant Access Token\" field (\"ha_llat\") saved in the app settings?"
+            print_info "  2. Did you click Save in the app settings?"
+            print_info "  3. Did you click Start or Restart for the NOVA Relay app?"
+            print_info "  4. Is Home Assistant fully up and reachable in the browser?"
+            echo ""
+            if (( ws_attempt >= max_retries )) || [[ "$non_interactive_verify" == "1" ]]; then
+              print_info "Saving your settings now. Setup will finish as incomplete."
+              setup_status="incomplete"
+              setup_issue="ws_degraded"
+              break
+            fi
+
+            local ws_retry_input=""
+            if ! read -r -p "  [Enter] retry · [q] finish setup as incomplete: " ws_retry_input; then
+              die "Interactive input required. Re-run in a terminal."
+            fi
+            if [[ "$ws_retry_input" =~ ^[Qq]$ ]]; then
+              print_info "Saving your settings now. Setup will finish as incomplete."
+              setup_status="incomplete"
+              setup_issue="ws_degraded"
+              break
+            fi
+          done
         fi
         break
       else
@@ -702,6 +780,8 @@ run_setup() {
         echo ""
         if (( attempt >= max_retries )) || [[ "$non_interactive_verify" == "1" ]]; then
           print_info "Saving your settings anyway. You can troubleshoot later with: ha-nova doctor"
+          setup_status="incomplete"
+          setup_issue="relay_unreachable"
           break
         fi
         if [[ "$non_interactive_verify" == "0" ]]; then
@@ -745,6 +825,10 @@ run_setup() {
       print_success "HA NOVA skills installed for ${client}"
     else
       print_fail "Skill installation had issues. You can retry with: npm run install:${client}-skill"
+      setup_status="incomplete"
+      if [[ -z "$setup_issue" ]]; then
+        setup_issue="skills_install"
+      fi
     fi
   fi
 
@@ -763,16 +847,20 @@ run_setup() {
     *)        client_label="your AI assistant" ;;
   esac
 
-  echo ""
-  print_success "Setup complete!"
-  echo ""
-  print_info "Open ${client_label} and try asking:"
-  echo ""
-  echo "    \"Turn off the living room light\""
-  echo "    \"List my automations\""
-  echo ""
-  print_info "Need help? Run: ha-nova doctor"
-  echo ""
+  if [[ "$setup_status" == "complete" ]]; then
+    echo ""
+    print_success "Setup complete!"
+    echo ""
+    print_info "Open ${client_label} and try asking:"
+    echo ""
+    echo "    \"Turn off the living room light\""
+    echo "    \"List my automations\""
+    echo ""
+    print_info "Need help? Run: ha-nova doctor"
+    echo ""
+  else
+    print_setup_incomplete_banner "${setup_issue:-generic}"
+  fi
 }
 
 run_doctor() {
@@ -783,6 +871,36 @@ run_doctor() {
     invalidate_doctor_cache
     return 1
   fi
+}
+
+print_setup_incomplete_banner() {
+  local issue="${1:-generic}"
+
+  echo ""
+  print_fail "Setup incomplete"
+  echo ""
+
+  case "$issue" in
+    ws_degraded)
+      print_info "NOVA Relay is reachable, but Home Assistant WebSocket is not connected yet."
+      print_info "Open Home Assistant > Settings > Apps > NOVA Relay, verify the app settings, and restart the App."
+      ;;
+    relay_unreachable)
+      print_info "HA NOVA saved your local setup, but the relay could not be verified yet."
+      print_info "Open Home Assistant > Settings > Apps > NOVA Relay, start the app, then try again."
+      ;;
+    skills_install)
+      print_info "The Home Assistant connection is configured, but local skill installation still needs another run."
+      print_info "Re-run setup or install the HA NOVA skills again for your client."
+      ;;
+    *)
+      print_info "HA NOVA saved your local setup, but the system is not fully ready yet."
+      ;;
+  esac
+
+  echo ""
+  print_info "Need to re-check later? Run: ha-nova doctor"
+  echo ""
 }
 
 run_env() {

--- a/tests/fixtures/relay-ws-upstream-error.json
+++ b/tests/fixtures/relay-ws-upstream-error.json
@@ -1,0 +1,1 @@
+{"ok":false,"error":{"code":"UPSTREAM_WS_CONNECT_ERROR","message":"Failed to connect to Home Assistant WebSocket"}}

--- a/tests/onboarding/_helpers.ts
+++ b/tests/onboarding/_helpers.ts
@@ -56,6 +56,8 @@ export interface MockBinaryOpts {
   healthFixture?: string;
   /** Fixture file to serve for /ws requests (default: relay-ws-pong.json) */
   wsFixture?: string;
+  /** HTTP status code to serve for /ws requests (default: 200) */
+  wsStatusCode?: number;
   /** Fixture file to serve for /api/discovery_info (default: ha-discovery-info.json) */
   discoveryFixture?: string;
   /** Make curl fail (simulates unreachable relay) */
@@ -93,6 +95,7 @@ exit 0
   // --- curl mock (fixture router) ---
   const healthFixture = join(FIXTURES_DIR, opts.healthFixture ?? "relay-health-ok.json");
   const wsFixture = join(FIXTURES_DIR, opts.wsFixture ?? "relay-ws-pong.json");
+  const wsStatusCode = String(opts.wsStatusCode ?? 200);
   const discoveryFixture = join(FIXTURES_DIR, opts.discoveryFixture ?? "ha-discovery-info.json");
 
   const curlScript = opts.curlFails
@@ -136,7 +139,20 @@ serve_fixture() {
 
 case "$url" in
   */health) serve_fixture "${healthFixture}" ;;
-  */ws) serve_fixture "${wsFixture}" ;;
+  */ws)
+    if [[ -n "$outfile" ]]; then
+      cat "${wsFixture}" > "$outfile"
+    else
+      cat "${wsFixture}"
+    fi
+    if [[ -n "$headers_file" ]]; then
+      printf 'content-type: application/json\\n' > "$headers_file"
+    fi
+    if [[ -n "$write_code" ]]; then
+      printf '${wsStatusCode}'
+    fi
+    exit 0
+    ;;
   */api/discovery_info) serve_fixture "${discoveryFixture}" ;;
   */manifest.json)
     # Not found — let HA probing continue

--- a/tests/onboarding/doctor-checks.test.ts
+++ b/tests/onboarding/doctor-checks.test.ts
@@ -14,6 +14,7 @@ function runDoctor(
   opts: {
     healthFixture?: string;
     wsFixture?: string;
+    wsStatusCode?: number;
     curlFails?: boolean;
     keychainToken?: string;
     config?: { HA_HOST: string; HA_URL: string; RELAY_BASE_URL: string };
@@ -31,6 +32,7 @@ function runDoctor(
   const binDir = createMockBinaries({
     ...(opts.healthFixture != null && { healthFixture: opts.healthFixture }),
     ...(opts.wsFixture != null && { wsFixture: opts.wsFixture }),
+    ...(opts.wsStatusCode != null && { wsStatusCode: opts.wsStatusCode }),
     ...(opts.curlFails != null && { curlFails: opts.curlFails }),
   });
 
@@ -107,6 +109,19 @@ describe.skipIf(!isMac)("S-10: doctor variants", () => {
     expect(r.output).toContain("[ok] Relay health reachable");
     // WS ping succeeds so it should show ok
     expect(r.output).toContain("Relay /ws ping succeeded");
+  });
+
+  it("uses generic degraded wording when WS fails without LLAT proof", () => {
+    const r = runDoctor({
+      healthFixture: "relay-health-ws-down.json",
+      wsFixture: "relay-ws-upstream-error.json",
+      wsStatusCode: 502,
+    });
+
+    expect(r.output).toContain("Relay reports degraded upstream WS capability");
+    expect(r.output).toContain("Home Assistant WebSocket is not connected yet");
+    expect(r.output).not.toContain('the "Home Assistant Access Token" field ("ha_llat") is required');
+    expect(r.status).not.toBe(0);
   });
 
   it("shows version when relay reports version", () => {

--- a/tests/onboarding/macos-onboarding-script-contract.test.ts
+++ b/tests/onboarding/macos-onboarding-script-contract.test.ts
@@ -131,7 +131,8 @@ describe("macOS onboarding script contract", () => {
     expect(content).toContain("leave empty to keep existing or auto-generate");
     expect(content).toContain("Using existing relay auth token from Keychain");
     expect(content).toContain("ha_ws_connected=false");
-    expect(content).toContain('the \\"Home Assistant Access Token\\" field (\\"ha_llat\\") is required in App options');
+    expect(content).toContain("Home Assistant WebSocket is not connected yet");
+    expect(content).toContain("Setup incomplete");
     expect(content).toContain('Home Assistant Access Token field ("ha_llat") lives in App options');
     expect(content).not.toContain("unset HA_LLAT");
   });

--- a/tests/onboarding/self-update-contract.test.ts
+++ b/tests/onboarding/self-update-contract.test.ts
@@ -116,7 +116,7 @@ describe("self-update script contract", () => {
     });
   });
 
-  it("refreshes Gemini flat copies and companion markdown from the source clone", () => {
+  it("refreshes Gemini flat copies and companion markdown from the source clone", { timeout: 45000 }, () => {
     const sandbox = mkdtempSync(join(tmpdir(), "ha-nova-update-"));
     const repoCopy = join(sandbox, "repo");
     const originBare = join(sandbox, "origin.git");

--- a/tests/onboarding/setup-relay-failures.test.ts
+++ b/tests/onboarding/setup-relay-failures.test.ts
@@ -94,4 +94,49 @@ describe.skipIf(!isMac)("S-7: relay unreachable during setup", () => {
     expect(output).toContain("NOVA Relay app started");
     expect(output).toContain('Is the "Relay Auth Token" field ("relay_auth_token") saved');
   });
+
+  it("ends as setup incomplete when relay is up but HA WS stays degraded", { timeout: 30000 }, () => {
+    const home = createMockHome();
+    const binDir = createMockBinaries({
+      healthFixture: "relay-health-ws-down.json",
+      wsFixture: "relay-ws-upstream-error.json",
+      wsStatusCode: 502,
+    });
+
+    const input = [
+      "192.168.1.5",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+    ].join("\n");
+
+    const result = spawnSync(
+      "bash",
+      ["scripts/onboarding/macos-onboarding.sh", "setup", "claude"],
+      {
+        cwd: REPO_ROOT,
+        input,
+        encoding: "utf8",
+        timeout: 30000,
+        env: mockEnv(home, binDir),
+      },
+    );
+
+    const output = (result.stdout ?? "") + (result.stderr ?? "");
+
+    expect(result.status).toBe(0);
+    expect(output).toContain("Home Assistant WebSocket is not connected yet");
+    expect(output).toContain("Setup incomplete");
+    expect(output).not.toContain("Setup complete!");
+    expect(output).toContain("ha-nova doctor");
+    expect(readFileSync(join(home, ".config/ha-nova/onboarding.env"), "utf8")).toContain("HA_HOST=192.168.1.5");
+  });
 });

--- a/tests/onboarding/setup-resume.test.ts
+++ b/tests/onboarding/setup-resume.test.ts
@@ -372,4 +372,51 @@ describe.skipIf(!isMac)("S-3: resume after partial abort", () => {
     // Should save config despite failures
     expect(output).toContain("Saving your settings anyway");
   });
+
+  it("retries degraded WS inside resume flow before finishing incomplete", { timeout: 30000 }, () => {
+    const home = createMockHome({
+      config: {
+        HA_HOST: "192.168.1.5",
+        HA_URL: "http://192.168.1.5:8123",
+        RELAY_BASE_URL: "http://192.168.1.5:8791",
+      },
+      keychainToken: "existing-token-xyz",
+    });
+    const binDir = createMockBinaries({
+      healthFixture: "relay-health-ws-down.json",
+      wsFixture: "relay-ws-upstream-error.json",
+      wsStatusCode: 502,
+    });
+
+    const input = [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+    ].join("\n");
+
+    const result = spawnSync(
+      "bash",
+      ["scripts/onboarding/macos-onboarding.sh", "setup", "claude"],
+      {
+        cwd: REPO_ROOT,
+        input,
+        encoding: "utf8",
+        timeout: 30000,
+        env: mockEnv(home, binDir),
+      },
+    );
+
+    expect(result.status).toBe(0);
+
+    const output = (result.stdout ?? "") + (result.stderr ?? "");
+    expect(output).toContain("Already done:");
+    expect(output).toContain("connection check");
+    expect(output).toContain("Home Assistant WebSocket is not connected yet");
+    expect(output).toContain("Quick checklist");
+    expect(output).toContain("Setup incomplete");
+    expect(output).not.toContain("Setup complete!");
+  });
 });


### PR DESCRIPTION
## Summary
- make setup end as incomplete instead of green when relay WS stays degraded
- keep WS/token diagnostics honest and only blame ha_llat when the probe proves it
- add regression coverage for full setup, resume flow, and doctor messaging

## Verification
- npm test -- --run tests/onboarding