### PR TITLE
docs: refresh README copy, remove banner image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 <p align="center">
-  <img src="assets/social-preview.png" alt="HA NOVA">
-</p>
-
-<p align="center">
   <a href="https://github.com/markusleben/ha-nova/actions/workflows/ci.yml"><img src="https://github.com/markusleben/ha-nova/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/markusleben/ha-nova/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/node-%3E%3D20-brightgreen" alt="Node >= 20">
@@ -11,23 +7,19 @@
 
 ## What is HA NOVA?
 
-HA NOVA gives AI a clear and safe way to work with Home Assistant.
+HA NOVA gives your AI a way to actually work with Home Assistant AND without randomly breaking things.
 
-Instead of letting an agent randomly create, change, or delete things, HA NOVA pushes it through the right path for the task. Risky changes should be researched first, then previewed, then checked after they are applied.
+Here's the problem: let an AI agent loose on your smart home and it'll happily create, change, or delete stuff without thinking twice. HA NOVA stops that. Every risky change goes through a clear path: research first, preview what's about to happen, apply it, then check if it actually worked.
 
-A big part of that logic lives in plain markdown files called *skills*. They teach the AI how to work with Home Assistant.
+The brain of the whole thing? Plain markdown files called *skills*. They tell the AI how Home Assistant works, what to watch out for, and how to do things properly. No code. Just text files.
 
-And in the background there is a small app on your HA server called the *relay*. It is kind of the little secret weapon of the whole setup :)
+Then there's the *relay* — a small app running directly on your Home Assistant server. Think of it as the quiet helper in the background. It keeps your token safe on the server (never on your machine), handles WebSocket stuff, and does the things that only work when you're actually on the HA host. It stays small on purpose. The intelligence lives in the skills, not in the relay.
 
-The relay is not an MCP server — it is just a small helper on the Home Assistant server, while the real logic and workflows live in the skills.
-
-It does not replace the normal Home Assistant API. The special thing is that it runs directly on the Home Assistant server. That means it can help with things where being close to Home Assistant really matters.
-
-A setup wizard installs the relay on your HA server and configures your AI client, so you do not need to understand the internals to get started.
+A setup wizard handles the installation. Pick your AI client, follow the prompts, done.
 
 Works with **Claude Desktop, Claude Code, Codex CLI, OpenCode, and Gemini CLI**.
 
-> **Early Access:** The core works well, but you might hit rough edges. macOS only for now (Linux/Windows coming). Back up your configs before letting AI make changes. Found a problem? [Open an issue](https://github.com/markusleben/ha-nova/issues).
+> **Early Access:** The core works well, but expect some rough edges. macOS only for now (Linux/Windows coming). Back up your configs before letting AI touch anything. Hit a problem? [Open an issue](https://github.com/markusleben/ha-nova/issues).
 
 ### See it in action
 
@@ -43,29 +35,29 @@ Works with **Claude Desktop, Claude Code, Codex CLI, OpenCode, and Gemini CLI**.
 curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/main/install.sh | bash
 ```
 
-The wizard handles everything: relay, tokens, skills. Just pick your AI client. Once done, open your AI client and try: *"Show me all my automations."*
+The wizard handles relay, tokens, skills — everything. Just pick your AI client. Once it's done, open your client and try: *"Show me all my automations."*
 
-**Cloned the repo manually?** `./scripts/onboarding/bin/ha-nova setup` | **Installed already and something broken?** `ha-nova doctor`
+**Cloned the repo manually?** `./scripts/onboarding/bin/ha-nova setup` | **Something broken?** `ha-nova doctor`
 
 ## 💬 What Can You Do?
 
-Automation and script changes follow a careful path:
+Automation and script changes follow a four-step safety flow:
 
-1. **Research:** Looks up your devices, checks existing configs, resolves the right entities
-2. **Preview:** Shows you the exact config that will be written. Nothing happens until you say OK.
-3. **Apply & Verify:** Writes it, reads it back to make sure it actually stuck
+1. **Research:** Finds your devices, checks existing configs, resolves the right entity IDs
+2. **Preview:** Shows you exactly what will be written. Nothing happens until you say OK.
+3. **Apply & Verify:** Writes it, reads it back, makes sure it actually stuck
 4. **Review:** Checks the result against 40+ rules for common mistakes, conflicts, and reliability issues
 
-Reads and simple control tasks can stay lighter. But the main goal is always the same: no random actions, no guessed IDs, and no risky writes without a clear check first.
+Simple stuff like turning on a light? That stays lightweight. But anything that touches your config goes through the full flow. No guessed entity IDs, no random writes, no surprises.
 
-Deleting anything requires a confirmation code, not just "yes".
+Deleting anything requires a confirmation code. Not just "yes" — an actual code. Because "yes" is too easy to say.
 
 | You say | What happens |
 |---------|-------------|
-| *"Turn on the porch light at sunset and off at 11 PM"* | Creates a fully reviewed automation using the safety flow above |
-| *"Why didn't my motion automation trigger last night?"* | Analyzes the actual trace logs, explains what went wrong |
-| *"Check my automations for problems"* | Runs a thorough config audit across your setup |
-| *"Turn off the living room lights"* | Controls it, confirms the new state |
+| *"Turn on the porch light at sunset and off at 11 PM"* | Creates a fully reviewed automation through the safety flow |
+| *"Why didn't my motion automation trigger last night?"* | Digs into the actual trace logs and explains what went wrong |
+| *"Check my automations for problems"* | Runs a full config audit across your setup |
+| *"Turn off the living room lights"* | Turns it off, confirms the new state |
 | *"Show me all sensors in the bedroom"* | Finds entities by room, area, or name |
 | *"Create a counter helper for my coffee intake"* | Creates the helper, shows the result |
 
@@ -75,14 +67,9 @@ Deleting anything requires a confirmation code, not just "yes".
   <img src="assets/how-it-works.png" alt="How HA NOVA works: Your AI Client talks to the NOVA Relay on your HA server, which connects to Home Assistant. Skills teach the AI what to do.">
 </p>
 
-**The Skills** are plain text files on your machine. They hold the rules, the logic, and the flow the AI should follow. Each skill is self-contained — your AI loads only the one it needs for the current task. Want to teach your AI something new about Home Assistant? Write a markdown file. No code, no compilation, no deployment.
+**The Skills** are plain text files on your machine. Rules, logic, workflows — all in markdown. Your AI loads only the skill it needs for the current task. Want to teach it something new? Write a markdown file. No code, no compilation, no deployment. That's it.
 
-**The Relay** runs directly on your Home Assistant server. It keeps your access token on the server — never on your machine — and quietly helps with the things the AI cannot or should not do directly. For example: WebSocket features today, and later maybe things like safe backup or restore flows on the Home Assistant side. It stays small on purpose and does not try to become the intelligence layer.
-
-### 🗺️ What's coming
-
-- **Automation versioning:** automatic backup before every change, stored locally on the HA host
-- **Linux & Windows support**
+**The Relay** runs on your Home Assistant server. It keeps your access token where it belongs — on the server, not on your laptop — and handles the things that only work with direct host access. WebSocket features today, maybe safe backup flows later. It stays small on purpose. The relay is the hands. The skills are the brain.
 
 ### 📊 How does this compare to MCP servers?
 
@@ -95,15 +82,15 @@ Deleting anything requires a confirmation code, not just "yes".
 | 🛡️ **Safety** | Per-tool (annotations, confirm flags) | 4-phase: research → preview → apply → review |
 | 🖥️ **Clients** | Any MCP-compatible client | 5 tested clients |
 
-Both approaches work. MCP servers have broader client support out of the box. We chose skills because adding a new capability means editing a text file instead of writing code — different trade-off, not a better/worse one.
+Both approaches work. MCP servers have broader client support out of the box. HA NOVA trades that for simplicity — adding a new capability means editing a text file instead of writing and deploying code. Different trade-off, not better or worse.
 
-**Can't I just call the HA API directly?** You can! But HA NOVA adds a safer and more guided way to solve Home Assistant tasks, plus a small relay on the Home Assistant side for things where host-side access really helps.
+**Can't I just call the HA API directly?** Sure. But HA NOVA adds a guided safety layer on top, plus a relay on the HA side for things where host access actually matters.
 
 ## 🧩 Skills
 
 | Skill ID | What it does |
 |-------|-------------|
-| ✏️ **ha-nova-write** | Create, update, delete automations and scripts with the 4-phase safety flow |
+| ✏️ **ha-nova-write** | Create, update, delete automations and scripts through the 4-phase safety flow |
 | 📖 **ha-nova-read** | Browse configs, inspect automations, debug with trace analysis |
 | 🔍 **ha-nova-review** | Audit for 40+ common mistakes, conflicts, and best-practice violations |
 | 🎛️ **ha-nova-service-call** | Control devices: lights, climate, covers, switches, media players |
@@ -117,11 +104,11 @@ Want to add a new capability? → [CONTRIBUTING.md](CONTRIBUTING.md)
 ## 🛡️ Safety
 
 - **Preview first:** every change is shown before it happens
-- **Confirmation codes:** deletes require a specific code, not just "yes"
+- **Confirmation codes:** deletes need a specific code, not just "yes"
 - **Post-write review:** after every change, the AI checks for mistakes and conflicts
-- **Token isolation:** your HA token stays on the HA server, never on your machine
+- **Token isolation:** your HA token stays on the server, never on your machine
 - **Encrypted auth:** client-side credentials in macOS Keychain, not in config files
-- **Runs on your network:** no cloud dependency, no tracking (your AI client's own cloud usage is separate)
+- **Your network, your data:** no cloud dependency, no tracking (your AI client's own cloud usage is separate)
 
 ## 🖥️ Supported AI Clients
 
@@ -133,14 +120,14 @@ Want to add a new capability? → [CONTRIBUTING.md](CONTRIBUTING.md)
 | [OpenCode](https://github.com/nicepkg/OpenCode) | Terminal |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Terminal |
 
-> **Don't like terminals?** Claude Desktop gives you the same capabilities in a graphical chat interface:
+> **Not a terminal person?** Claude Desktop gives you the same capabilities in a graphical chat interface:
 > 1. Run the install command and select "Claude Code" (they share the same config)
 > 2. Open Claude Desktop and switch to the **Code** tab
 > 3. Pick any folder on your Mac as workspace and start talking
 
 ## 🤝 Contributing
 
-HA NOVA is early — a good time to help shape it.
+HA NOVA is early. Good time to help shape it.
 
 - **Write a skill:** just a markdown file, no code needed
 - **Test on your setup:** find what works, report what doesn't
@@ -150,11 +137,13 @@ HA NOVA is early — a good time to help shape it.
 
 ## 📖 The Story Behind It
 
-I spent over a year building an MCP server for Home Assistant. Hundreds of tool definitions, thousands of lines of code. I kept polishing, never releasing. By the time I looked up, others had shipped theirs while mine was still on my machine.
+I spent over a year building an MCP server for Home Assistant. Hundreds of tool definitions, thousands of lines of code. I kept polishing, kept adding features, never releasing. By the time I looked up, others had shipped theirs while mine was still sitting on my machine.
 
 **[Here's an early demo](https://youtu.be/ylak867RkzM)** from that time.
 
-Then I realized the approach was wrong. Instead of encoding domain knowledge into a server, I could write it as plain text that the AI reads directly. I scrapped everything and started fresh. HA NOVA is the result.
+Then it hit me! The whole approach was wrong. Instead of encoding everything into a server, I could just... write it down. Plain text that the AI reads directly. I scrapped everything and started fresh.
+
+HA NOVA is what came out of that.
 
 ## 📁 Project Structure
 


### PR DESCRIPTION
## Summary
- Remove social-preview banner from README top (kept in repo for GitHub social preview)
- Rewrite intro, feature, and safety sections with more direct, conversational tone
- Tighten Quick Start, MCP comparison, and story sections

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `how-it-works.png` and `demo.webp` still display
- [ ] Docs fact-check passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)