### PR TITLE
fix(ci): guard dependabot prepare context

### DIFF
--- a/.github/workflows/dependabot-safe-lane-prepare.yml
+++ b/.github/workflows/dependabot-safe-lane-prepare.yml
@@ -20,25 +20,51 @@ env:
 
 jobs:
   approve-safe-dev-deps:
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Capture PR context
+        id: pr
+        env:
+          EVENT_PATH: ${{ github.event_path }}
+        run: |
+          set -euo pipefail
+
+          pr_number="$(jq -r '.pull_request.number // ""' "${EVENT_PATH}")"
+          pr_author="$(jq -r '.pull_request.user.login // ""' "${EVENT_PATH}")"
+          pr_draft="$(jq -r '.pull_request.draft // false' "${EVENT_PATH}")"
+          pr_base_sha="$(jq -r '.pull_request.base.sha // ""' "${EVENT_PATH}")"
+          pr_url="$(jq -r '.pull_request.html_url // ""' "${EVENT_PATH}")"
+
+          echo "pr-number=${pr_number}" >> "${GITHUB_OUTPUT}"
+          echo "pr-author=${pr_author}" >> "${GITHUB_OUTPUT}"
+          echo "pr-draft=${pr_draft}" >> "${GITHUB_OUTPUT}"
+          echo "pr-base-sha=${pr_base_sha}" >> "${GITHUB_OUTPUT}"
+          echo "pr-url=${pr_url}" >> "${GITHUB_OUTPUT}"
+          if [[ "${pr_author}" == "dependabot[bot]" && "${pr_draft}" != "true" ]]; then
+            echo "should-process=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "should-process=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Fetch Dependabot metadata
         id: metadata
+        if: ${{ steps.pr.outputs.should-process == 'true' }}
         uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a
         with:
           github-token: ${{ github.token }}
 
       - name: Evaluate safe auto-merge lane
         id: guard
+        if: ${{ steps.pr.outputs.should-process == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr-number }}
           DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
           PACKAGE_ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
           DEPENDENCY_GROUP: ${{ steps.metadata.outputs.dependency-group }}
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
-          POLICY_REF: ${{ github.event.pull_request.base.sha }}
+          POLICY_REF: ${{ steps.pr.outputs.pr-base-sha }}
         run: |
           set -euo pipefail
 
@@ -141,7 +167,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_URL: ${{ steps.pr.outputs.pr-url }}
         run: |
           set -euo pipefail
           review_decision="$(gh pr view "${PR_URL}" --json reviewDecision --jq '.reviewDecision')"
@@ -154,7 +180,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr-number }}
           SAFE_LABEL: ${{ steps.guard.outputs.safe-label }}
         run: |
           set -euo pipefail
@@ -165,7 +191,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr-number }}
           SAFE_LABEL: ${{ steps.guard.outputs.safe-label }}
           POLICY_SHA: ${{ steps.guard.outputs.policy-sha }}
         run: |
@@ -197,11 +223,11 @@ EOF
           fi
 
       - name: Remove safe auto-merge marker when lane becomes ineligible
-        if: ${{ steps.guard.outputs.eligible != 'true' }}
+        if: ${{ steps.pr.outputs.should-process == 'true' && steps.guard.outputs.eligible != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr-number }}
           SAFE_LABEL: ${{ steps.guard.outputs.safe-label }}
         run: |
           set -euo pipefail

--- a/.github/workflows/dependabot-safe-lane-prepare.yml
+++ b/.github/workflows/dependabot-safe-lane-prepare.yml
@@ -197,13 +197,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          comment_body="$(
-            cat <<EOF
-${SAFE_POLICY_MARKER}
-safe_label=${SAFE_LABEL}
-policy_sha=${POLICY_SHA}
-EOF
-          )"
+          comment_body="$(printf '%s\n%s\n%s\n' \
+            "${SAFE_POLICY_MARKER}" \
+            "safe_label=${SAFE_LABEL}" \
+            "policy_sha=${POLICY_SHA}")"
           comments_json="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate --slurp)"
           comment_id="$(
             printf '%s' "${comments_json}" | jq -r --arg marker "${SAFE_POLICY_MARKER}" '

--- a/tests/onboarding/dependabot-automation-contract.test.ts
+++ b/tests/onboarding/dependabot-automation-contract.test.ts
@@ -92,7 +92,15 @@ describe("dependabot automation contract", () => {
   it("only auto-approves and auto-merges the safe Dependabot manifest lane without checking out PR code", () => {
     expect(prepareWorkflow).toContain("pull_request_target:");
     expect(prepareWorkflow).not.toContain("workflow_run:");
-    expect(prepareWorkflow).toContain('POLICY_REF: ${{ github.event.pull_request.base.sha }}');
+    expect(prepareWorkflow).toContain("Capture PR context");
+    expect(prepareWorkflow).toContain("github.event_path");
+    expect(prepareWorkflow).toContain("pull_request.number //");
+    expect(prepareWorkflow).toContain("pull_request.user.login //");
+    expect(prepareWorkflow).toContain("pull_request.draft // false");
+    expect(prepareWorkflow).toContain('if: ${{ github.event_name == \'pull_request_target\' }}');
+    expect(prepareWorkflow).toContain('if: ${{ steps.pr.outputs.should-process == \'true\' }}');
+    expect(prepareWorkflow).toContain('PR_NUMBER: ${{ steps.pr.outputs.pr-number }}');
+    expect(prepareWorkflow).toContain('POLICY_REF: ${{ steps.pr.outputs.pr-base-sha }}');
     expect(prepareWorkflow).toContain("dependabot[bot]");
     expect(prepareWorkflow).toContain("dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a");
     expect(prepareWorkflow).toContain('DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}');
@@ -114,6 +122,9 @@ describe("dependabot automation contract", () => {
     expect(prepareWorkflow).toContain('gh pr edit "${PR_NUMBER}" --remove-label "${SAFE_LABEL}"');
     expect(prepareWorkflow).not.toContain("actions/checkout");
     expect(prepareWorkflow).not.toContain("workflow_run");
+    expect(prepareWorkflow).not.toContain("github.event.pull_request.number");
+    expect(prepareWorkflow).not.toContain("github.event.pull_request.base.sha");
+    expect(prepareWorkflow).not.toContain("github.event.pull_request.html_url");
 
     expect(mergeWorkflow).toContain("workflow_run:");
     expect(mergeWorkflow).not.toContain("pull_request_target:");


### PR DESCRIPTION
## Summary
- remove direct pull_request context expressions from the Dependabot prepare workflow
- capture PR metadata from the event payload and gate processing through explicit step outputs
- extend the Dependabot workflow contract so push-time validation cannot regress

## Testing
- npx vitest run tests/onboarding/dependabot-automation-contract.test.ts
- npm run test:safe
