### PR TITLE
chore: release 0.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.3.1"
+    "version": "0.3.2"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/docs/work/2026-04-03-release-0.3.2-notes.md
+++ b/docs/work/2026-04-03-release-0.3.2-notes.md
@@ -1,0 +1,11 @@
+## New Features
+
+- Windows now has one clear install path: `install.ps1`. The old WinGet path has been removed.
+- Claude installs now match the HA NOVA version you installed more reliably.
+- HA NOVA now catches more automation issues when creating or editing automations.
+- Review and write feedback is now easier to understand, with clearer warnings and practical suggestions instead of internal rule codes.
+- Setup guidance for Claude, Codex, Gemini, and OpenCode is now simpler and easier to follow.
+
+## Bug Fixes
+
+- Leftover files from older Windows installs are cleaned up more reliably so they do not interfere with new installs.

--- a/docs/work/2026-04-03-release-0.3.2-spec.md
+++ b/docs/work/2026-04-03-release-0.3.2-spec.md
@@ -1,0 +1,27 @@
+# Release 0.3.2 Spec
+
+Date: 2026-04-03
+
+## Goal
+
+Ship `v0.3.2` as the next stable release after `v0.3.1`.
+
+## Scope
+
+- Bump all synced release-version files from `0.3.1` to `0.3.2`.
+- Keep the release user-facing and short.
+- Publish stable release notes with the agreed user-facing bullets.
+
+## Release Notes
+
+### New Features
+
+- Windows now has one clear install path: `install.ps1`. The old WinGet path has been removed.
+- Claude installs now match the HA NOVA version you installed more reliably.
+- HA NOVA now catches more automation issues when creating or editing automations.
+- Review and write feedback is now easier to understand, with clearer warnings and practical suggestions instead of internal rule codes.
+- Setup guidance for Claude, Codex, Gemini, and OpenCode is now simpler and easier to follow.
+
+### Bug Fixes
+
+- Leftover files from older Windows installs are cleaned up more reliably so they do not interfere with new installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.3.1",
+  "skill_version": "0.3.2",
   "min_relay_version": "0.1.0"
 }


### PR DESCRIPTION
## Summary
- bump the synced HA NOVA release metadata from 0.3.1 to 0.3.2
- record the agreed short user-facing 0.3.2 release notes in repo work docs
- prepare the next stable tag/release from the current reviewed main delta

## Release Notes Draft
### New Features
- Windows now has one clear install path: `install.ps1`. The old WinGet path has been removed.
- Claude installs now match the HA NOVA version you installed more reliably.
- HA NOVA now catches more automation issues when creating or editing automations.
- Review and write feedback is now easier to understand, with clearer warnings and practical suggestions instead of internal rule codes.
- Setup guidance for Claude, Codex, Gemini, and OpenCode is now simpler and easier to follow.

### Bug Fixes
- Leftover files from older Windows installs are cleaned up more reliably so they do not interfere with new installs.

## Verification
- `npm run verify:next-release-version -- v0.3.2`
- `bash scripts/release/verify-release-metadata.sh v0.3.2`
- `npm run verify`
- pre-push gate: typecheck, `npm test`, build, docs fact-check
