### PR TITLE
chore: bump skill version to 0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.3.2"
+    "version": "0.4.0"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.3.2",
+  "skill_version": "0.4.0",
   "min_relay_version": "0.1.0"
 }


### PR DESCRIPTION
## Summary
- bump release metadata from 0.3.2 to 0.4.0
- keep package.json, package-lock.json, version.json, and Claude plugin metadata in sync
- prepare the next stable release on top of origin/main at 1132ce7

## Verification
- npm run verify:next-release-version -- v0.4.0
- npm run verify:release-metadata
- npm run verify:release-contracts
- npx vitest run tests/onboarding/bump-version.test.ts tests/onboarding/release-contract.test.ts
- pre-push hook: typecheck, full vitest, build, docs fact-check
