### PR TITLE
fix: tighten Claude attachment verification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,16 @@ Emergency cleanup if a local desktop-validation helper was interrupted:
 pkill -f 'npm run dev:validation:harness|start-local-validation-harness\.sh|http\.server 8917|vitest|mock-ha-relay\.py|ha-nova setup' || true
 ```
 
+## Project Structure
+
+```
+cli/         Local command-line app (setup, doctor, update, uninstall, relay)
+nova/        Relay app (runs on your HA server)
+skills/      AI skills (markdown files)
+scripts/     Setup, deploy, diagnostics
+tests/       Test suite
+```
+
 ## Security
 
 Do not open public issues for vulnerabilities. Follow `SECURITY.md`.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -21,7 +21,7 @@ Active doc ownership lives in `docs/reference/documentation-governance.md`.
 Deliverables:
 1. Relay MVP: `GET /health`, `POST /ws`, `POST /core`
 2. Context skill: `ha-nova` (auto-loaded via SessionStart hook; sub-skills discovered independently)
-3. Sub-skills (flat under `skills/`): write, read, helper, entity-discovery, service-call, review, fallback, onboarding
+3. Sub-skills (flat under `skills/`): write, read, review, dashboard, organize, history, helper, entity-discovery, service-call, fallback, onboarding
 4. Shared references under `skills/ha-nova/` (`relay-api.md`, `best-practices.md`, `payload-schemas.md`, `helper-schemas.md`, `template-guidelines.md`, `safe-refactoring.md`, `automation-patterns.md`, `update-guide.md`, `agents.md`)
 
 ## Tech Stack

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 > *"When I get home, set my main lights to a warm welcome scene"* — one sentence in, a fully reviewed automation out, including suggestions you might not have thought of.
 
 <p align="center">
-  <b><a href="#-what-you-can-do">What it does</a></b> · <b><a href="#%EF%B8%8F-safe-by-design">Is it safe?</a></b> · <b><a href="#-get-started">Get started</a></b> · <b><a href="#%EF%B8%8F-how-it-works">How it works</a></b>
+  <b><a href="#-what-you-can-do">What it does</a></b> · <b><a href="#%EF%B8%8F-safe-by-design">Is it safe?</a></b> · <b><a href="#-get-started">Get started</a></b> · <b><a href="#-how-it-works">How it works</a></b>
 </p>
 
 > **Early access.** The core works, and this is a good time to help shape the product. Back up your configs before letting AI touch anything. Hit a problem? [Open an issue](https://github.com/markusleben/ha-nova/issues).
@@ -137,7 +137,7 @@ Once it finishes, try: *"Show me all my automations."*
 
 When HA NOVA gets a new workflow, that's a text file update on your machine. The Relay doesn't change. No rebuild, no restart, no risk to a running system.
 
-And because the Relay sits right next to Home Assistant, it can do things a remote client can't. Coming soon: automatic backups of every automation change — a safety net Home Assistant doesn't offer natively.
+And because the Relay sits right next to Home Assistant, it can do things a remote client can't. Coming soon: per-change automation snapshots — so you can always roll back, something Home Assistant doesn't do out of the box.
 
 ---
 
@@ -183,7 +183,7 @@ Want to add a new capability? → [CONTRIBUTING.md](CONTRIBUTING.md)
 | [Claude Code](https://github.com/anthropics/claude-code) | Terminal |
 | [Claude Desktop](https://claude.com/download) (Code tab) | Desktop app |
 | [Codex CLI](https://github.com/openai/codex) | Terminal |
-| [OpenCode](https://github.com/nicepkg/OpenCode) | Terminal |
+| [OpenCode](https://github.com/opencode-ai/opencode) | Terminal |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Terminal |
 
 ---

--- a/cli/client_claude.go
+++ b/cli/client_claude.go
@@ -66,7 +66,10 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 			if strings.Contains(strings.ToLower(text), "not found") || strings.Contains(strings.ToLower(text), "not installed") {
 				installCmd := exec.Command("claude", "plugin", "install", "ha-nova@ha-nova")
 				if installOutput, installErr := installCmd.CombinedOutput(); installErr == nil {
-					return verifyClaudePluginInstalled(paths.Home)
+					if err := verifyClaudePluginAttachment(paths.Home, marketplaceRoot); err != nil {
+						return restoreMarketplace(err)
+					}
+					return nil
 				} else {
 					return fmt.Errorf("claude plugin command failed: %s (%s)", strings.Join(installCmd.Args[1:], " "), strings.TrimSpace(string(installOutput)))
 				}
@@ -74,7 +77,7 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 		}
 		return fmt.Errorf("claude plugin command failed: %s (%s)", strings.Join(refreshArgs, " "), strings.TrimSpace(string(output)))
 	}
-	if err := verifyClaudePluginInstalled(paths.Home); err != nil {
+	if err := verifyClaudePluginAttachment(paths.Home, marketplaceRoot); err != nil {
 		return restoreMarketplace(err)
 	}
 	if localMode {
@@ -85,7 +88,10 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 	return nil
 }
 
-func verifyClaudePluginInstalled(home string) error {
+func verifyClaudePluginAttachment(home, desiredMarketplaceSource string) error {
+	if err := verifyClaudeMarketplaceRegistration(home, desiredMarketplaceSource); err != nil {
+		return err
+	}
 	if !claudePluginInstalled(home) {
 		return fmt.Errorf("Claude plugin ha-nova@ha-nova not found after sync")
 	}
@@ -122,15 +128,8 @@ func claudePluginInstalled(home string) bool {
 	if strings.TrimSpace(home) == "" {
 		return false
 	}
-	data, err := os.ReadFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))
-	if err != nil {
-		return false
-	}
-	var raw map[string]any
-	if err := unmarshalClaudeJSON(data, &raw); err == nil {
-		return claudeInstalledPluginsContain(raw["plugins"])
-	}
-	return strings.Contains(string(data), "ha-nova@ha-nova")
+	_, installed, known := readClaudePluginState(home)
+	return known && installed
 }
 
 func removeClaudeMarketplace(home string, report *uninstallReport) error {
@@ -293,11 +292,56 @@ func claudePluginInstallValuePresent(value any) bool {
 	case map[string]any:
 		installPath, _ := typed["installPath"].(string)
 		if strings.TrimSpace(installPath) == "" {
-			return true
+			return false
 		}
 		return fileExists(installPath)
 	default:
 		return true
+	}
+}
+
+func readClaudePluginState(home string) (recordPresent bool, installed bool, known bool) {
+	if strings.TrimSpace(home) == "" {
+		return false, false, true
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))
+	if err != nil {
+		if isNotExist(err) {
+			return false, false, true
+		}
+		return false, false, false
+	}
+
+	var raw map[string]any
+	if err := unmarshalClaudeJSON(data, &raw); err == nil {
+		recordPresent = claudeInstalledPluginRecordPresent(raw["plugins"])
+		installed = claudeInstalledPluginsContain(raw["plugins"])
+		return recordPresent, installed, true
+	}
+	return false, false, false
+}
+
+func claudeInstalledPluginRecordPresent(value any) bool {
+	switch typed := value.(type) {
+	case []any:
+		for _, entry := range typed {
+			if claudeInstalledPluginRecordPresent(entry) {
+				return true
+			}
+		}
+		return false
+	case map[string]any:
+		if pluginValue, ok := typed["ha-nova@ha-nova"]; ok {
+			return claudeInstalledPluginRecordPresent(pluginValue)
+		}
+		for _, key := range []string{"name", "id", "plugin"} {
+			if name, ok := typed[key].(string); ok && name == "ha-nova@ha-nova" {
+				return true
+			}
+		}
+		return false
+	default:
+		return claudePluginRecordMatches(value)
 	}
 }
 

--- a/cli/clients_test.go
+++ b/cli/clients_test.go
@@ -202,6 +202,28 @@ func TestInstallClaudePluginUpdatesExistingPlugin(t *testing.T) {
 	}
 }
 
+func TestInstallClaudePluginFailsWhenMarketplaceDisappearsAfterInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_TEST_CLAUDE_DROP_MARKETPLACE_ON_INSTALL", "1")
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	logPath := filepath.Join(home, "claude.log")
+	t.Setenv("PATH", installClaudeMock(t, home, logPath)+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	sourceRoot := paths.InstallRoot
+	writeClaudeMarketplaceFixture(t, sourceRoot)
+
+	err = installClaudePlugin(paths, sourceRoot)
+	if err == nil || !strings.Contains(err.Error(), "Claude marketplace ha-nova not found after sync") {
+		t.Fatalf("expected marketplace verification failure, got %v", err)
+	}
+}
+
 func TestInstallClaudePluginLocalModeReinstallsAndClearsCache(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -426,6 +448,42 @@ func TestInstallClaudePluginFallsBackToInstallWhenUpdateStateIsStale(t *testing.
 	}
 	if !strings.Contains(log, "plugin install ha-nova@ha-nova") {
 		t.Fatalf("expected fresh install for local marketplace sync, got:\n%s", log)
+	}
+}
+
+func TestInstallClaudePluginFallbackInstallRestoresStateWhenMarketplaceDisappears(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "plugins"), 0o755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	writeInstalledClaudePluginFixture(t, home)
+
+	logPath := filepath.Join(home, "claude.log")
+	t.Setenv("HA_NOVA_TEST_CLAUDE_UPDATE_STALE", "1")
+	t.Setenv("HA_NOVA_TEST_CLAUDE_DROP_MARKETPLACE_ON_INSTALL", "1")
+	t.Setenv("PATH", installClaudeMock(t, home, logPath)+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	sourceRoot := paths.InstallRoot
+	writeClaudeMarketplaceFixture(t, sourceRoot)
+
+	err = installClaudePlugin(paths, sourceRoot)
+	if err == nil || !strings.Contains(err.Error(), "Claude marketplace ha-nova not found after sync") {
+		t.Fatalf("expected fallback install verification failure, got %v", err)
+	}
+
+	source, hasSource, readErr := readClaudeMarketplaceSource(home)
+	if readErr != nil {
+		t.Fatalf("readClaudeMarketplaceSource() error: %v", readErr)
+	}
+	if hasSource {
+		t.Fatalf("expected rollback to restore pre-install empty marketplace state, got %+v", source)
 	}
 }
 
@@ -692,6 +750,9 @@ JSON
       exit 1
     fi
     write_installed
+    if [[ "${HA_NOVA_TEST_CLAUDE_DROP_MARKETPLACE_ON_INSTALL:-0}" == "1" ]]; then
+      rm -f "${known_file}"
+    fi
     ;;
  "plugin update ha-nova@ha-nova")
     if [[ "${HA_NOVA_TEST_CLAUDE_UPDATE_STALE:-0}" == "1" ]]; then

--- a/cli/setup_state_test.go
+++ b/cli/setup_state_test.go
@@ -205,3 +205,67 @@ func TestClientAppearsInstalledForClaudeIgnoresBrokenInstallPathRecord(t *testin
 		t.Fatal("expected broken Claude installPath record to count as not installed")
 	}
 }
+
+func TestClientAppearsInstalledForClaudeIgnoresBlankInstallPathRecord(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "plugins"), 0o755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"), []byte(`{
+  "plugins": {
+    "ha-nova@ha-nova": [
+      {
+        "installPath": ""
+      }
+    ]
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write installed_plugins.json: %v", err)
+	}
+
+	entry, ok, err := findRegistryClient(paths, "claude")
+	if err != nil {
+		t.Fatalf("findRegistryClient() error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected claude registry entry")
+	}
+	if evaluateClientStatus(paths, installState{}, entry).Ready {
+		t.Fatal("expected blank Claude installPath record to count as not installed")
+	}
+}
+
+func TestClientAppearsInstalledForClaudeIgnoresUnparseableRegistry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "plugins"), 0o755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"), []byte(`{"plugins":{"ha-nova@ha-nova":`), 0o644); err != nil {
+		t.Fatalf("write installed_plugins.json: %v", err)
+	}
+
+	entry, ok, err := findRegistryClient(paths, "claude")
+	if err != nil {
+		t.Fatalf("findRegistryClient() error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected claude registry entry")
+	}
+	if evaluateClientStatus(paths, installState{}, entry).Ready {
+		t.Fatal("expected unparseable Claude registry to count as not installed")
+	}
+}

--- a/docs/work/2026-04-10-readme-rewrite-plan.md
+++ b/docs/work/2026-04-10-readme-rewrite-plan.md
@@ -1,3 +1,69 @@
+# README Rewrite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite README.md from a technical document into a compelling, Apple-like product page that converts visitors into users.
+
+**Architecture:** Single-file rewrite of `README.md` plus moving "Project Structure" into `CONTRIBUTING.md`. No code changes, no new files beyond these two edits.
+
+**Tech Stack:** Markdown, GitHub-flavored Markdown (HTML center tags, details/summary, blockquotes, tables)
+
+**Spec:** `docs/work/2026-04-10-readme-rewrite-spec.md`
+
+---
+
+### Task 1: Add Project Structure to CONTRIBUTING.md
+
+**Files:**
+- Modify: `CONTRIBUTING.md` (add section before "Security" at bottom)
+
+- [ ] **Step 1: Add Project Structure section to CONTRIBUTING.md**
+
+Insert this section before the existing `## Security` section (line 125) in `CONTRIBUTING.md`:
+
+```markdown
+## Project Structure
+
+```
+cli/         Local command-line app (setup, doctor, update, uninstall, relay)
+nova/        Relay app (runs on your HA server)
+skills/      AI skills (markdown files)
+scripts/     Setup, deploy, diagnostics
+tests/       Test suite
+```
+```
+
+- [ ] **Step 2: Verify CONTRIBUTING.md renders correctly**
+
+Run: `head -5 CONTRIBUTING.md && echo "..." && tail -15 CONTRIBUTING.md`
+Expected: Project Structure section visible near the bottom, followed by Security.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs: move project structure from README to CONTRIBUTING
+
+Part of README rewrite — project structure is contributor info,
+not user-facing product info.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Write the new README.md
+
+**Files:**
+- Modify: `README.md` (full rewrite)
+
+**Reference:** Read the spec at `docs/work/2026-04-10-readme-rewrite-spec.md` for design decisions and rationale.
+
+- [ ] **Step 1: Write the complete new README.md**
+
+Replace the entire contents of `README.md` with the following:
+
+```markdown
 <p align="center">
   <a href="https://github.com/markusleben/ha-nova/actions/workflows/ci.yml"><img src="https://github.com/markusleben/ha-nova/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/markusleben/ha-nova/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
@@ -7,7 +73,7 @@
 <h2 align="center">AI that checks its work before touching your Home Assistant</h2>
 
 <p align="center">
-  Preview changes before they're written. Catch mistakes automatically.<br>
+  Preview every change. Catch mistakes automatically.<br>
   Your token never leaves the server.
 </p>
 
@@ -44,7 +110,7 @@ Say what you want. HA NOVA figures out the rest.
 | *"Turn off the upstairs lights"* | Turns them off, confirms the new state |
 | *"Show me all temperature sensors"* | Finds entities by name, room, area, or label |
 
-> Automations and scripts get the full workflow today: preview, review, and a 40+ rule audit. Helpers, dashboards, and device control get preview-and-verify — deeper audits are rolling out with every release.
+> Automations and scripts get the full treatment today: preview, review, and a 40+ rule audit. Helpers, dashboards, and device control get preview-and-verify — deeper audits are rolling out with every release.
 
 ---
 
@@ -90,12 +156,7 @@ Once it finishes, try: *"Show me all my automations."*
 
 **Linux** — same installer, passes automated checks. Real-machine testing is ongoing.
 
-**Windows** — ships x64 builds (ARM64 works via x64 emulation).
-- Claude Code is the most tested client on Windows today
-- Gemini CLI has basic validation
-- Codex and OpenCode are still early
-- Native prerequisites: Claude Code needs Git for Windows / Git Bash; Gemini CLI needs Node.js
-- See [.claude/INSTALL.md](.claude/INSTALL.md) and [.gemini/INSTALL.md](.gemini/INSTALL.md)
+**Windows** — ships x64 builds (ARM64 works via x64 emulation). Claude Code is the most tested client on Windows today; Gemini CLI has basic validation; Codex and OpenCode are still early. Native client prerequisites apply: Claude Code needs Git for Windows / Git Bash, Gemini CLI needs Node.js. See [.claude/INSTALL.md](.claude/INSTALL.md) and [.gemini/INSTALL.md](.gemini/INSTALL.md).
 
 > Do not download the `ha-nova-installer-bundle-*.tar.gz` / `.zip` assets manually. Those archives are used by the installer behind the scenes. Always use the one-liner or `ha-nova update`.
 
@@ -135,9 +196,9 @@ Once it finishes, try: *"Show me all my automations."*
 
 **The Relay** lives on your Home Assistant server. It's the only part that talks to Home Assistant directly, and it keeps your access token there — never on your laptop, never in a prompt.
 
-When HA NOVA gets a new workflow, that's a text file update on your machine. The Relay doesn't change. No rebuild, no restart, no risk to a running system.
+When HA NOVA learns a new workflow, that's a text file update on your machine. The Relay doesn't change. No rebuild, no restart, no risk to a running system.
 
-And because the Relay sits right next to Home Assistant, it can do things a remote client can't. Coming soon: automatic backups of every automation change — a safety net Home Assistant doesn't offer natively.
+And because the Relay sits right next to Home Assistant, it can do things a remote client can't — like automatic backups of every automation change before it happens. That's coming soon: a safety net Home Assistant doesn't offer natively.
 
 ---
 
@@ -190,7 +251,7 @@ Want to add a new capability? → [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## 🤝 Contributing
 
-This is the best time to get involved.
+HA NOVA is early. This is the best time to help shape it.
 
 - **Write a skill** — add a new workflow in markdown, no server code needed
 - **Test on your setup** — edge cases from real installs make everything better
@@ -218,3 +279,123 @@ HA NOVA is what came out of that. **[Here's an early demo](https://youtu.be/ylak
 ## 🙏 Acknowledgments
 
 Safety-rule ideas inspired by [HALMark](https://github.com/nathan-curtis/HALMark) by Nathan Curtis. Automation patterns, helper guidance, and device-control patterns adapted from [homeassistant-ai/skills](https://github.com/homeassistant-ai/skills) by Sergey Kadentsev ([@sergeykad](https://github.com/sergeykad)) and Julien Lapointe ([@julienld](https://github.com/julienld)).
+```
+
+- [ ] **Step 2: Verify line count is within target**
+
+Run: `wc -l README.md`
+Expected: 140–170 lines (down from 229).
+
+- [ ] **Step 3: Verify all internal links resolve**
+
+Run: `for f in CONTRIBUTING.md LICENSE .claude/INSTALL.md .gemini/INSTALL.md; do test -f "$f" && echo "OK: $f" || echo "MISSING: $f"; done`
+Expected: All OK.
+
+- [ ] **Step 4: Verify asset files exist**
+
+Run: `ls -la assets/demo.webp assets/how-it-works.png`
+Expected: Both files exist.
+
+---
+
+### Task 3: Run CI verification
+
+**Files:** None (read-only verification)
+
+- [ ] **Step 1: Run docs verification**
+
+Run: `npm run verify:docs`
+Expected: All documentation claims verified. Key checks:
+- Skill directory count = 12 (we list 11 in table, ha-nova context skill is the 12th dir)
+- No MCP patterns in src/
+- No domain-handler patterns in src/
+- No telemetry patterns in src/
+- Internal links (CONTRIBUTING.md, LICENSE) resolve
+- install.sh exists
+- Supported client install scripts exist
+
+- [ ] **Step 2: If verify:docs fails, review the failure**
+
+The check-docs.sh script validates README claims against the codebase. If any check fails:
+- Check [1] (LOC): We no longer mention LOC — check still validates the range 1000–2000. Should pass.
+- Check [2] (Skill count): Expects 12 directories. We have 12. Should pass.
+- Check [6] (Internal links): We link CONTRIBUTING.md and LICENSE. Both exist. Should pass.
+
+If a check fails unexpectedly, read the error and fix the README claim, not the check script.
+
+- [ ] **Step 3: Verify GitHub anchor links**
+
+The navigation line uses anchor links. Verify they match the actual section headings:
+- `#-what-you-can-do` → `## 💬 What You Can Do`
+- `#️-safe-by-design` → `## 🛡️ Safe by Design`
+- `#-get-started` → `## 🚀 Get Started`
+- `#️-how-it-works` → `## ⚙️ How It Works`
+
+GitHub generates anchors by lowercasing, replacing spaces with hyphens, and stripping most special characters. Emoji handling varies. Test by pushing and checking the rendered page, or use the URL-encoded anchors in the hero section.
+
+---
+
+### Task 4: Commit the README
+
+**Files:**
+- Modified: `README.md`
+
+- [ ] **Step 1: Review the diff**
+
+Run: `git diff README.md | head -200`
+Expected: Full rewrite — old sections removed, new sections in place. Verify:
+- No "What is HA NOVA?" section
+- No "Why People Use It" section
+- No "Why Not Just Use a Generic MCP Server" section
+- No "Why The Relay + Skills Split Matters" section
+- No "Project Structure" section
+- No Node.js badge
+- New sections present: "Safe by Design", "What's Next", navigation line
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: rewrite README as product page with Apple-like flow
+
+Restructure from technical documentation to conversion-focused
+product page. Safety before install, capabilities table first,
+architecture brief, roadmap for early adopters.
+
+Key changes:
+- New tagline: 'AI that checks its work before touching your HA'
+- Safety section moved before Quick Start
+- MCP comparison removed (own strengths, not competitor comparison)
+- Platform notes collapsed into <details>
+- 3 new skills (dashboard, organize, history) in capability table
+- What's Next roadmap section with backup feature teaser
+- Project Structure moved to CONTRIBUTING.md
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Final visual verification
+
+**Files:** None (review only)
+
+- [ ] **Step 1: Check rendered README on GitHub**
+
+After push (if requested), verify on GitHub:
+1. Demo GIF loads and plays
+2. Architecture diagram loads
+3. Navigation anchor links work (click each one)
+4. `<details>` sections expand/collapse correctly
+5. Tables render with correct alignment
+6. Emoji headings display properly
+7. Blockquotes render as callout boxes
+8. Horizontal rules create visual separation
+9. All external links work (client repos, YouTube, release page)
+
+- [ ] **Step 2: Mobile check**
+
+GitHub README on mobile is narrower. Verify:
+1. Tables don't overflow horizontally
+2. Demo GIF is visible (not clipped)
+3. Navigation line wraps gracefully

--- a/docs/work/2026-04-10-readme-rewrite-spec.md
+++ b/docs/work/2026-04-10-readme-rewrite-spec.md
@@ -1,0 +1,340 @@
+# README Rewrite Spec
+
+**Date:** 2026-04-10
+**Goal:** Rewrite README.md to be more marketing-oriented, Apple-like, visually appealing, and honest about the project's current state — while making the Relay+Skills architecture advantage tangible for non-technical Home Assistant users.
+
+## Context
+
+The current README (~230 lines) is technically accurate but reads like documentation, not a product page. At 2 GitHub stars, the README is the primary conversion tool. Every line must earn its place.
+
+### Research Performed
+
+- 8 specialized agents analyzed: marketing psychology, conversion copywriting, UX writing, competitor positioning, README best practices, skill capabilities, unreleased features, undocumented features
+- Key competitor: ha-mcp (2,177 stars) — has adopted skills concept, but requires token on client side
+- Community sentiment: token security is fear #1, HA community rewards authenticity and punishes marketing-speak
+
+### Key Insights
+
+1. **Token isolation** is the #1 differentiator — no other project keeps the token on the HA server
+2. **40+ quality checks** only apply to automations/scripts today — be honest about this
+3. **3 new skills** (dashboard, organize, history) are on main but unreleased
+4. **Several features** exist but aren't in the README (auto-discovery, self-update with rollback, doctor diagnostics)
+5. **"Early" is a feature** — frame it as an opportunity, not an apology
+
+## Design Decisions
+
+### Approach: "Honest Builder"
+
+Authentic, vision-forward, no corporate tone. The README sells AND shows the vision. Early adopters should feel they're at the start of something bigger.
+
+### No MCP Comparison
+
+At 2 stars vs 2,177, a comparison table would advertise the competitor. Instead, differentiate through own strengths (token isolation, safety flow, text-file updates). No mention of MCP in the README.
+
+### Safety Before Installation
+
+Mental flow: "What can it do?" → "Is it safe?" → "How do I get it?" — Safety section moves before Quick Start.
+
+### Honest About Scope
+
+The full 4-step safety flow (Research → Preview → Apply → Review with 40+ checks) currently covers automations and scripts. Helpers, dashboards, and device control get preview-and-verify. This is stated clearly, framed as "expanding with every release."
+
+### Apple-Like Visual Style
+
+- Short sentences, breathing room, visual hierarchy
+- Horizontal rules between major sections
+- Emoji headings (one per section, consistent)
+- Tables over prose wherever possible
+- `<details>` for platform notes and CLI commands
+- Navigation line under the hero for quick jumps
+- Blockquotes for pull-quotes and important callouts
+
+## Section Specification
+
+### 1. Hero
+
+**Badges:** CI, License, Platform (drop Node badge — false prerequisite impression)
+
+**Tagline (h2, centered):**
+```
+AI that checks its work before touching your Home Assistant
+```
+
+**Sub-tagline (centered):**
+```
+Preview every change. Catch mistakes automatically.
+Your token never leaves the server.
+```
+
+**Client line (centered, bold names):**
+```
+Works with Claude Code · Claude Desktop · Codex CLI · OpenCode · Gemini CLI
+```
+
+Rationale: At 2 stars, the client line in the hero borrows credibility from 5 recognized AI platforms. This stays.
+
+**Demo GIF:** `assets/demo.webp` with existing caption. No heading before it (saves 2 lines of vertical space).
+
+**Navigation line (centered, after demo):**
+```
+What it does · Safe by design · Get started · How it works
+```
+Linked to section anchors for quick jumps.
+
+**Early access note:** Moves BELOW the demo GIF. Show value first, then set expectations.
+
+### 2. What You Can Do
+
+**Heading:** `## 💬 What You Can Do`
+
+**Intro (1 sentence):**
+```
+Say what you want. HA NOVA figures out the rest.
+```
+
+**Table (8 rows, differentiators first):**
+
+| You say | What happens |
+|---------|-------------|
+| "Check my automations for problems" | Audits against 40+ rules — catches conflicts, dead triggers, and mistakes you'd never spot manually |
+| "Why didn't my motion light trigger last night?" | Replays the actual trace and tells you exactly where it failed and why |
+| "Turn on the porch light at sunset and off at 11 PM" | Builds, previews, and reviews the automation before it touches your config |
+| "What happened to my living room temperature overnight?" | Pulls history and summarizes the timeline in plain language |
+| "Add a weather card to my main dashboard" | Reads the dashboard, shows the change, writes only after you confirm |
+| "Move all kitchen devices to the Kitchen area" | Reassigns entities and devices — shows what will change first |
+| "Turn off the upstairs lights" | Turns them off, confirms the new state |
+| "Show me all temperature sensors" | Finds entities by name, room, area, or label |
+
+Row order rationale: Review/debug first (unique differentiators), create/manage middle (breadth), quick control last.
+
+**Honesty blockquote (below table):**
+```
+> Automations and scripts get the full treatment today: preview, review,
+> and a 40+ rule audit. Helpers, dashboards, and device control get
+> preview-and-verify — deeper audits are rolling out with every release.
+```
+
+### 3. Safe by Design
+
+**Heading:** `## 🛡️ Safe by Design`
+
+**Emotional hook (1 line):**
+```
+We built this because we didn't trust AI with our own config either.
+```
+
+**Scenario walkthrough (numbered, bold leads):**
+
+1. **Researches first.** Finds your devices, checks your setup, resolves entity names. No guessing.
+2. **Shows you the change.** Full diff, before anything is written.
+3. **You approve it.** Deletes require a specific confirmation code — not just "yes."
+4. **Writes and verifies.** Reads the config back to confirm the change stuck.
+5. **Audits itself.** Checks for mistakes, conflicts, and reliability issues.
+
+**Ground rules (emoji bullets):**
+
+- 🔒 Your HA token stays on your server. The AI never sees it.
+- 🔑 Credentials live in your OS keychain, not config files.
+- 📖 Every rule the AI follows is a markdown file you can read.
+- 🏠 Nothing leaves your network. No cloud relay, no telemetry.
+
+### 4. Get Started
+
+**Heading:** `## 🚀 Get Started`
+
+**Intro:**
+```
+One installer. One wizard. Done.
+It even finds your Home Assistant automatically.
+```
+
+**Prerequisite:** Home Assistant OS or Supervised (blockquote).
+
+**3 steps:**
+1. Open the latest release (linked)
+2. Copy the one-liner for your OS
+3. Run it — the wizard discovers your HA, sets up the connection, and configures your AI client
+
+**First command suggestion:**
+```
+Once it finishes, try: "Show me all my automations."
+```
+
+**Collapsed sections:**
+
+`<details>` **Platform notes:**
+- macOS: fully tested on real hardware
+- Linux: same installer, passes automated checks, real-machine testing ongoing
+- Windows: x64 builds (ARM64 via x64 emulation), Claude most tested, Gemini basic validation, Codex/OpenCode early
+- Windows prereqs: Claude needs Git for Windows / Git Bash, Gemini needs Node.js
+- Link to .claude/INSTALL.md and .gemini/INSTALL.md
+- "Do not download tar.gz manually" warning
+
+`<details>` **CLI commands & legacy uninstall:**
+- Table: check-update, update, setup, doctor, uninstall, uninstall --purge
+- Legacy uninstall one-liners (macOS/Linux curl, Windows irm)
+
+### 5. How It Works
+
+**Heading:** `## ⚙️ How It Works`
+
+**Diagram:** `assets/how-it-works.png` (centered, width-constrained)
+
+**3 short paragraphs:**
+
+1. **Skills** = plain markdown on your machine. AI's playbook — what to check, preview, verify. You can open, read, edit them.
+
+2. **Relay** = small server on your HA box. Only thing that talks to HA directly. Keeps your token there — never on your laptop, never in a prompt.
+
+3. **The payoff:** New workflows = text file update. Relay doesn't change. No rebuild, no restart, no risk. And because the Relay sits next to HA, it can do things a remote client can't — like automatic backups of every automation change (coming soon).
+
+### 6. What's Next
+
+**Heading:** `## 🔮 What's Next`
+
+**Opener:**
+```
+HA NOVA is early — and that's the point.
+```
+
+**Bullet list (4 items, exciting first):**
+- **Automation backups** — snapshot every automation before a change, so you can always roll back
+- **Deeper reviews everywhere** — the full 40+ rule audit, expanding beyond automations
+- **Community skills** — write a workflow as a markdown file, share it with everyone
+- **Broader platform testing** — real-machine coverage for Linux and Windows
+
+**CTA (blockquote):**
+```
+> If you've ever wanted to shape how AI works with Home Assistant,
+> this is the stage where your input actually changes the product.
+```
+
+### 7. Skills
+
+**Heading:** `## 🧩 Skills`
+
+**Intro (1 line):**
+```
+11 skills, each a markdown file you can read and edit.
+```
+
+**Table (11 rows, emoji + bold name + benefit-oriented description max 12 words):**
+
+| Skill | What it does |
+|-------|-------------|
+| ✏️ **write** | Build and change automations with full preview and safety checks |
+| 📖 **read** | Inspect configs and debug why an automation didn't fire |
+| 🔍 **review** | Audit your setup for mistakes, conflicts, and reliability gaps |
+| 🧱 **dashboard** | Edit dashboards, cards, and Lovelace resources safely |
+| 🗂️ **organize** | Manage areas, floors, labels, and entity metadata |
+| 🕒 **history** | Query history, logbook timelines, and long-term stats |
+| 🎛️ **service-call** | Control lights, climate, covers, switches, and media players |
+| 🔎 **entity-discovery** | Find entities by name, room, area, or label |
+| 🧩 **helper** | Create and manage helpers: counters, timers, input booleans, more |
+| 🛡️ **fallback** | Safety net for blueprints, zones, energy, and advanced ops |
+| 🚀 **onboarding** | Diagnose setup issues and troubleshoot connections |
+
+**Link:** → CONTRIBUTING.md for adding new skills
+
+### 8. Supported Clients
+
+**Heading:** `## 🖥️ Supported Clients`
+
+**Table (5 rows):**
+
+| Client | Type |
+|--------|------|
+| Claude Code | Terminal |
+| Claude Desktop (Code tab) | Desktop app |
+| Codex CLI | Terminal |
+| OpenCode | Terminal |
+| Gemini CLI | Terminal |
+
+Client names linked to their repos.
+
+**Callout:**
+```
+> Not a terminal person? Claude Desktop gives you the same skills
+> in a regular app window.
+```
+
+**Platform support notes:** NOT here (already in Quick Start `<details>`).
+
+### 9. Contributing
+
+**Heading:** `## 🤝 Contributing`
+
+**Opener:** "HA NOVA is early. This is the best time to help shape it."
+
+**4 bullets:**
+- Write a skill — a new workflow in markdown, no server code needed
+- Test on your setup — edge cases from real installs make everything better
+- Improve docs — make HA NOVA clearer for the next person
+- Tackle an open issue (linked)
+
+**Link:** → CONTRIBUTING.md
+
+### 10. The Story
+
+**Heading:** `## 📖 The Story`
+
+**2 short paragraphs:**
+```
+I spent over a year building an 88K-line MCP server for Home Assistant.
+Kept adding features, never releasing. Others shipped theirs while mine
+sat on my machine.
+
+Then I realized the architecture was the problem. Instead of burying
+HA knowledge in a huge server, I could keep the server lean and write
+the workflows as plain text. HA NOVA is what came out of that.
+```
+
+**YouTube link:** "Here's an early demo from the MCP era." (linked)
+
+### 11. License + Acknowledgments
+
+**License:** MIT (linked)
+
+**Acknowledgments (1 flowing sentence):**
+Safety-rule ideas inspired by HALMark by Nathan Curtis. Automation patterns, helper guidance, and device-control patterns adapted from homeassistant-ai/skills by Sergey Kadentsev and Julien Lapointe.
+
+## What Gets Removed
+
+| Current section | Action |
+|----------------|--------|
+| "What is HA NOVA?" (8 lines) | Replaced by tagline + sub-tagline |
+| "Why People Use It" (4 bullets) | Duplicates capability + safety sections |
+| "Why Not Just Use a Generic MCP Server" (table + prose) | No MCP comparison at 2 stars |
+| "Why The Relay + Skills Split Matters" (separate section) | Merged into "How It Works" |
+| "Project Structure" (code block) | Moved to CONTRIBUTING.md |
+| Platform notes inline (30+ lines) | Collapsed into `<details>` |
+| Node.js badge | Removed (false prerequisite impression) |
+
+## What Gets Added
+
+| New element | Rationale |
+|-------------|-----------|
+| Navigation line under hero | Quick jumps for all personas |
+| Auto-discovery mention in Quick Start | Existing feature, undocumented, compelling |
+| "What's Next" roadmap section | Frames "early" as opportunity, teases backup feature |
+| Horizontal rules between sections | Breathing room, Apple-like visual flow |
+| Emoji ground rules in Safety | Scannability for the most important trust section |
+| Early access note moved below GIF | Show value before setting expectations |
+| Dashboard, organize, history in capability table | 3 new skills on main, unreleased but working |
+
+## Constraints
+
+- All text in English (international audience)
+- No claims that aren't backed by current project state
+- "40+ checks" only claimed for automations/scripts
+- Future features (backups) clearly marked as "coming soon"
+- No competitor names mentioned
+- URLs must be verified against actual repo paths before implementation
+- Existing asset files (demo.webp, how-it-works.png) referenced as-is
+
+## Target Metrics
+
+- Visible lines: ~140-150 (down from ~230)
+- Sections: 12 (down from 18)
+- Time to Quick Start: Screen 3 (down from Screen 7)
+- Time to Safety: Screen 2 (down from Screen 13)

--- a/nova/DOCS.md
+++ b/nova/DOCS.md
@@ -116,5 +116,5 @@ App logs are available in the **Log** tab above. Look for:
 ## Support
 
 - [GitHub Issues](https://github.com/markusleben/ha-nova/issues)
-- [Setup Guide](https://github.com/markusleben/ha-nova#quick-start)
+- [Setup Guide](https://github.com/markusleben/ha-nova#-get-started)
 - [Full Documentation](https://github.com/markusleben/ha-nova)

--- a/tests/onboarding/client-install-docs-contract.test.ts
+++ b/tests/onboarding/client-install-docs-contract.test.ts
@@ -26,19 +26,11 @@ describe("client install docs contract", () => {
     expect(readme).not.toContain("npm.cmd");
     expect(readme).not.toContain("WSL");
     expect(readme).not.toContain("5 tested clients");
-    expect(readme).toContain("Current validation matrix:");
     expect(readme).toContain("ha-nova uninstall --purge");
-    expect(readme).toContain("**Stable install (recommended)**");
     expect(readme).toContain("Copy the one-liner for your OS");
     expect(readme).toContain("https://github.com/markusleben/ha-nova/releases/latest");
-    expect(readme).toContain("HA NOVA itself does not need Node.js for normal use, but some AI clients do.");
     expect(readme).toContain("Git for Windows / Git Bash");
     expect(readme).toContain("Gemini CLI needs Node.js");
-    expect(readme).toContain("Default `ha-nova uninstall` is now a standard remove.");
-    expect(readme).toContain("Use `--purge` for the old full-cleanup behavior.");
-    expect(readme).toContain("at least one supported client is already installed and runnable");
-    expect(readme).toContain("no second terminal command is needed");
-    expect(readme).toContain("HA NOVA still installs locally and tells you which client prerequisite is still missing.");
     expect(readme).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.sh");
     expect(readme).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.ps1");
   });
@@ -117,8 +109,8 @@ describe("client install docs contract", () => {
   });
 
   it("keeps README and Windows client overlays aligned on prerequisites and validation depth", () => {
-    expect(readme).toContain("Claude currently has the deepest Windows validation.");
-    expect(readme).toContain("Gemini CLI has basic Windows validation for this release.");
+    expect(readme).toContain("Claude Code is the most tested client on Windows today");
+    expect(readme).toContain("Gemini CLI has basic validation");
     expect(geminiInstall).toContain("Gemini has basic Windows validation for this release.");
     expect(claudeInstall).toContain("Claude is the Windows path we have tested most for this release.");
   });


### PR DESCRIPTION
## Summary
- tighten Claude attach success so sync only succeeds when both marketplace registration and plugin attachment survive the install/update flow
- stop treating blank or unparseable Claude plugin registry state as a healthy attachment
- add regressions for marketplace-loss and broken Claude registry cases

## Testing
- cd cli && go test ./... -run 'TestInstallClaudePluginFailsWhenMarketplaceDisappearsAfterInstall|TestInstallClaudePluginFallsBackToInstallWhenUpdateStateIsStale|TestInstallClaudePluginFallbackInstallRestoresStateWhenMarketplaceDisappears|TestPostUpdateSyncRefreshesDetectedInstalledClientsWithoutState|TestPostUpdateSyncContinuesOtherClientsAfterClaudeFailure|TestRunUpdateAlreadyCurrentRetriesInstalledClientSync|TestClientAppearsInstalledForClaudeIgnoresStaleStateWithoutPluginRecord|TestClientAppearsInstalledForClaudeIgnoresBrokenInstallPathRecord|TestClientAppearsInstalledForClaudeIgnoresBlankInstallPathRecord|TestClientAppearsInstalledForClaudeIgnoresUnparseableRegistry|TestRunDoctorShowsRepairHintForDetachedConfiguredClaude|TestRunDoctorShowsDevSyncHintForDetachedConfiguredClaudeOnDevInstall' -count=1
- pre-push hook: typecheck, vitest run, build, docs fact-check
