### PR TITLE
fix: add Claude drift evidence capture tooling

### DIFF
--- a/docs/work/2026-04-14-claude-drift-helper-followup-spec.md
+++ b/docs/work/2026-04-14-claude-drift-helper-followup-spec.md
@@ -1,0 +1,9 @@
+## Goal
+
+Close the last Codex findings on PR `#171` without widening scope.
+
+## Changes
+
+- Preserve pinned marketplace refs when reading structured Claude marketplace sources.
+- Make Claude drift snapshots degrade cleanly when a tracked registry path is unreadable or is a directory.
+- Add regression coverage for both cases.

--- a/nova/package-lock.json
+++ b/nova/package-lock.json
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1198,9 +1198,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "dev:install:opencode-skill": "bash scripts/onboarding/install-local-skills.sh opencode",
     "dev:install:gemini-skill": "bash scripts/onboarding/install-local-skills.sh gemini",
     "dev:install:skills": "bash scripts/onboarding/install-local-skills.sh all",
+    "dev:watch:claude-state": "bash scripts/dev/watch-claude-state.sh",
     "dev:validation:harness": "bash scripts/dev/start-local-validation-harness.sh",
     "seed:llat": "node scripts/dev-seed-ha-llat.mjs",
     "dev:app:bootstrap": "bash scripts/dev/ha-app-bootstrap.sh",

--- a/scripts/dev/claude-plugin-state.mjs
+++ b/scripts/dev/claude-plugin-state.mjs
@@ -43,17 +43,44 @@ function fileSummary(path) {
     };
   }
 
-  const raw = readFileSync(resolved);
-  const stat = statSync(resolved);
+  let stat;
+  try {
+    stat = statSync(resolved);
+  } catch (error) {
+    return {
+      path: resolved,
+      exists: true,
+      parseable: false,
+      size: 0,
+      mtimeMs: 0,
+      sha256: "",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
   const summary = {
     path: resolved,
     exists: true,
     parseable: false,
     size: stat.size,
     mtimeMs: stat.mtimeMs,
-    sha256: createHash("sha256").update(raw).digest("hex"),
+    sha256: "",
     error: "",
   };
+
+  if (!stat.isFile()) {
+    summary.error = "not a file";
+    return summary;
+  }
+
+  let raw;
+  try {
+    raw = readFileSync(resolved);
+  } catch (error) {
+    summary.error = error instanceof Error ? error.message : String(error);
+    return summary;
+  }
+  summary.sha256 = createHash("sha256").update(raw).digest("hex");
 
   try {
     parseJsonText(raw.toString("utf8"));
@@ -310,15 +337,40 @@ function findMarketplaceEntry(raw) {
   return null;
 }
 
+function sourceCommandFromObject(source) {
+  const ref = typeof source.ref === "string" ? source.ref.trim() : "";
+  if (typeof source.url === "string" && source.url.trim()) {
+    const url = source.url.trim();
+    return ref ? `${url}#${ref}` : url;
+  }
+  if (typeof source.path === "string" && source.path.trim()) {
+    return source.path.trim();
+  }
+  if (typeof source.repo === "string" && source.repo.trim()) {
+    const repo = source.repo.trim().replace(/\.git$/u, "").replace(/^\/+/u, "");
+    if (typeof source.source === "string" && source.source.trim().toLowerCase() === "github") {
+      return ref ? `${repo}#${ref}` : repo;
+    }
+    return ref ? `${repo}#${ref}` : repo;
+  }
+  if (typeof source.source === "string") {
+    const value = source.source.trim();
+    if (value && value.toLowerCase() !== "github") {
+      return value;
+    }
+  }
+  return "";
+}
+
 function readMarketplaceSource(path) {
   const raw = readJson(path);
   const entry = findMarketplaceEntry(raw);
   if (!entry) {
     return "";
   }
-  let source = entry.source;
-  if (source && typeof source === "object") {
-    source = source.url ?? source.path ?? source.repo ?? "";
+  const source = entry.source;
+  if (source && typeof source === "object" && !Array.isArray(source)) {
+    return sourceCommandFromObject(source);
   }
   return typeof source === "string" ? source.trim() : "";
 }

--- a/scripts/dev/claude-plugin-state.mjs
+++ b/scripts/dev/claude-plugin-state.mjs
@@ -164,6 +164,7 @@ function readPluginSnapshot(path) {
   if (!summary.exists || !summary.parseable) {
     return {
       recordPresent: false,
+      usableInstallPath: false,
       installPath: "",
       version: "",
       entries: 0,
@@ -180,7 +181,8 @@ function readPluginSnapshot(path) {
     .find((value) => typeof value === "string" && value.trim()) ?? "";
 
   return {
-    recordPresent: installPath !== "",
+    recordPresent: entries.length > 0,
+    usableInstallPath: installPath !== "",
     installPath,
     version,
     entries: entries.length,
@@ -404,9 +406,10 @@ function buildSnapshot(home) {
   return {
     capturedAt: new Date().toISOString(),
     home: resolvedHome,
-    attached: plugin.recordPresent && marketplace.source !== "",
+    attached: plugin.usableInstallPath && marketplace.source !== "",
     plugin: {
       recordPresent: plugin.recordPresent,
+      usableInstallPath: plugin.usableInstallPath,
       installPath: plugin.installPath,
       version: plugin.version,
       entries: plugin.entries,
@@ -461,6 +464,7 @@ function buildChangeSet(previous, next) {
   const fields = [
     "attached",
     "plugin.recordPresent",
+    "plugin.usableInstallPath",
     "plugin.installPath",
     "plugin.version",
     "marketplace.present",

--- a/scripts/dev/claude-plugin-state.mjs
+++ b/scripts/dev/claude-plugin-state.mjs
@@ -1,17 +1,25 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { dirname, resolve } from "node:path";
 
 const PLUGIN_ID = "ha-nova@ha-nova";
+const MARKETPLACE_ID = "ha-nova";
 
 function fail(message) {
   console.error(message);
   process.exit(1);
 }
 
+function parseJsonText(text) {
+  const normalized = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+  return JSON.parse(normalized);
+}
+
 function readJson(path) {
   try {
-    return JSON.parse(readFileSync(path, "utf8"));
+    return parseJsonText(readFileSync(path, "utf8"));
   } catch (error) {
     fail(error instanceof Error ? error.message : String(error));
   }
@@ -21,23 +29,116 @@ function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+function fileSummary(path) {
+  const resolved = resolve(path);
+  if (!existsSync(resolved)) {
+    return {
+      path: resolved,
+      exists: false,
+      parseable: false,
+      size: 0,
+      mtimeMs: 0,
+      sha256: "",
+      error: "missing",
+    };
+  }
+
+  const raw = readFileSync(resolved);
+  const stat = statSync(resolved);
+  const summary = {
+    path: resolved,
+    exists: true,
+    parseable: false,
+    size: stat.size,
+    mtimeMs: stat.mtimeMs,
+    sha256: createHash("sha256").update(raw).digest("hex"),
+    error: "",
+  };
+
+  try {
+    parseJsonText(raw.toString("utf8"));
+    summary.parseable = true;
+    return summary;
+  } catch (error) {
+    summary.error = error instanceof Error ? error.message : String(error);
+    return summary;
+  }
+}
+
+function hasPluginIdentity(value) {
+  return [value.name, value.id, value.plugin].some((entry) => entry === PLUGIN_ID);
+}
+
+function normalizePluginEntries(value, options = {}) {
+  const { keyedPluginRecord = false } = options;
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => normalizePluginEntries(entry, options));
+  }
+  if (value === PLUGIN_ID) {
+    return [{ kind: "string", raw: value }];
+  }
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  if (hasPluginIdentity(value) || (keyedPluginRecord && (typeof value.installPath === "string" || typeof value.version === "string"))) {
+    return [{ kind: "record", raw: value }];
+  }
+  return [];
+}
+
+function findPluginEntries(raw) {
+  if (!raw || typeof raw !== "object") {
+    return [];
+  }
+
+  const directEntries = Object.prototype.hasOwnProperty.call(raw, PLUGIN_ID)
+    ? normalizePluginEntries(raw[PLUGIN_ID], { keyedPluginRecord: true })
+    : [];
+  if (directEntries.length > 0) {
+    return directEntries;
+  }
+
+  const plugins = raw.plugins;
+  if (plugins && typeof plugins === "object" && !Array.isArray(plugins)) {
+    if (Object.prototype.hasOwnProperty.call(plugins, PLUGIN_ID)) {
+      return normalizePluginEntries(plugins[PLUGIN_ID], { keyedPluginRecord: true });
+    }
+  }
+
+  if (Array.isArray(plugins)) {
+    return plugins.flatMap((entry) => normalizePluginEntries(entry));
+  }
+
+  return [];
+}
+
 function findPluginEntry(raw) {
   if (!raw || typeof raw !== "object") {
     return null;
   }
 
-  if (
-    Object.prototype.hasOwnProperty.call(raw, PLUGIN_ID) &&
-    raw[PLUGIN_ID] &&
-    typeof raw[PLUGIN_ID] === "object" &&
-    !Array.isArray(raw[PLUGIN_ID])
-  ) {
-    return { kind: "top-level-record", record: raw[PLUGIN_ID] };
+  if (Object.prototype.hasOwnProperty.call(raw, PLUGIN_ID)) {
+    const direct = raw[PLUGIN_ID];
+    if (Array.isArray(direct)) {
+      const index = direct.findIndex((entry) => normalizePluginEntries(entry, { keyedPluginRecord: true }).length > 0);
+      if (index >= 0) {
+        return { kind: "top-level-record-array", index, parent: direct, record: direct[index] };
+      }
+    }
+    if (direct && typeof direct === "object" && !Array.isArray(direct)) {
+      return { kind: "top-level-record", record: direct };
+    }
   }
 
   const plugins = raw.plugins;
   if (plugins && typeof plugins === "object" && !Array.isArray(plugins)) {
     const record = plugins[PLUGIN_ID];
+    if (Array.isArray(record)) {
+      const index = record.findIndex((entry) => normalizePluginEntries(entry, { keyedPluginRecord: true }).length > 0);
+      if (index >= 0) {
+        return { kind: "plugins-map-record-array", index, parent: record, record: record[index] };
+      }
+    }
     if (record && typeof record === "object" && !Array.isArray(record)) {
       return { kind: "plugins-map-record", record };
     }
@@ -49,11 +150,7 @@ function findPluginEntry(raw) {
       if (entry === PLUGIN_ID) {
         return { kind: "plugins-list-string", index, record: null };
       }
-      if (
-        entry &&
-        typeof entry === "object" &&
-        [entry.name, entry.id, entry.plugin].includes(PLUGIN_ID)
-      ) {
+      if (entry && typeof entry === "object" && hasPluginIdentity(entry)) {
         return { kind: "plugins-list-record", index, record: entry };
       }
     }
@@ -62,19 +159,40 @@ function findPluginEntry(raw) {
   return null;
 }
 
-function inspectInstalledPlugin(path) {
-  const raw = readJson(path);
-  const entry = findPluginEntry(raw);
-  const installPath = entry?.record && typeof entry.record.installPath === "string"
-    ? entry.record.installPath
-    : "";
-  const version = entry?.record && typeof entry.record.version === "string"
-    ? entry.record.version
-    : "";
+function readPluginSnapshot(path) {
+  const summary = fileSummary(path);
+  if (!summary.exists || !summary.parseable) {
+    return {
+      recordPresent: false,
+      installPath: "",
+      version: "",
+      entries: 0,
+    };
+  }
 
-  console.log(`installed=${entry ? "1" : "0"}`);
-  console.log(`install_path=${installPath}`);
-  console.log(`version=${version}`);
+  const raw = readJson(path);
+  const entries = findPluginEntries(raw);
+  const installPath = entries
+    .map((entry) => entry.raw?.installPath)
+    .find((value) => typeof value === "string" && value.trim()) ?? "";
+  const version = entries
+    .map((entry) => entry.raw?.version)
+    .find((value) => typeof value === "string" && value.trim()) ?? "";
+
+  return {
+    recordPresent: installPath !== "",
+    installPath,
+    version,
+    entries: entries.length,
+  };
+}
+
+function inspectInstalledPlugin(path) {
+  const snapshot = readPluginSnapshot(path);
+
+  console.log(`installed=${snapshot.recordPresent ? "1" : "0"}`);
+  console.log(`install_path=${snapshot.installPath}`);
+  console.log(`version=${snapshot.version}`);
 }
 
 function removePluginRecord(path) {
@@ -139,7 +257,7 @@ function repairPluginRecord(path, installPath, version) {
     return;
   }
 
-  if (!entry.record) {
+  if (!entry.record || typeof entry.record !== "object" || Array.isArray(entry.record)) {
     return;
   }
 
@@ -158,46 +276,237 @@ function repairPluginRecord(path, installPath, version) {
   }
 }
 
-function* iterateMarketplaceEntries(value) {
-  if (Array.isArray(value)) {
-    yield* value;
-    return;
+function findMarketplaceEntry(raw) {
+  if (!raw || typeof raw !== "object") {
+    return null;
   }
 
-  if (!value || typeof value !== "object") {
-    return;
+  if (Object.prototype.hasOwnProperty.call(raw, MARKETPLACE_ID)) {
+    const entry = raw[MARKETPLACE_ID];
+    return entry && typeof entry === "object" ? entry : null;
   }
 
-  if (Object.prototype.hasOwnProperty.call(value, "ha-nova")) {
-    yield value["ha-nova"];
-    return;
+  const marketplaces = raw.marketplaces;
+  if (marketplaces && typeof marketplaces === "object" && !Array.isArray(marketplaces)) {
+    if (Object.prototype.hasOwnProperty.call(marketplaces, MARKETPLACE_ID)) {
+      const entry = marketplaces[MARKETPLACE_ID];
+      return entry && typeof entry === "object" ? entry : null;
+    }
   }
 
-  yield* Object.values(value);
+  const values = Array.isArray(raw)
+    ? raw
+    : Array.isArray(marketplaces)
+      ? marketplaces
+      : Object.values(raw);
+
+  for (const entry of values) {
+    if (entry && typeof entry === "object" && entry.name === MARKETPLACE_ID) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+function readMarketplaceSource(path) {
+  const raw = readJson(path);
+  const entry = findMarketplaceEntry(raw);
+  if (!entry) {
+    return "";
+  }
+  let source = entry.source;
+  if (source && typeof source === "object") {
+    source = source.url ?? source.path ?? source.repo ?? "";
+  }
+  return typeof source === "string" ? source.trim() : "";
+}
+
+function readMarketplaceSnapshot(path) {
+  const summary = fileSummary(path);
+  if (!summary.exists || !summary.parseable) {
+    return {
+      present: false,
+      source: "",
+    };
+  }
+
+  const source = readMarketplaceSource(path);
+  return {
+    present: source !== "",
+    source,
+  };
 }
 
 function readKnownMarketplaceSource(path) {
-  const raw = readJson(path);
-
-  for (const entry of iterateMarketplaceEntries(raw)) {
-    if (!entry || typeof entry !== "object") {
-      continue;
-    }
-    const name = entry.name;
-    if (name && name !== "ha-nova") {
-      continue;
-    }
-
-    let source = entry.source;
-    if (source && typeof source === "object") {
-      source = source.url ?? source.path;
-    }
-
-    if (typeof source === "string" && source.trim()) {
-      console.log(source.trim());
-      return;
-    }
+  const source = readMarketplaceSource(path);
+  if (source) {
+    console.log(source);
   }
+}
+
+function readSettingsAttachment(path) {
+  const summary = fileSummary(path);
+  if (!summary.exists || !summary.parseable) {
+    return {
+      pluginEnabled: false,
+      marketplacePresent: false,
+      marketplacePath: "",
+    };
+  }
+
+  const raw = readJson(path);
+  const enabledPlugins = raw.enabledPlugins;
+  const extraKnownMarketplaces = raw.extraKnownMarketplaces;
+  const pluginEnabled = Boolean(
+    enabledPlugins &&
+      typeof enabledPlugins === "object" &&
+      !Array.isArray(enabledPlugins) &&
+      enabledPlugins[PLUGIN_ID] === true,
+  );
+  const marketplaceEntry =
+    extraKnownMarketplaces &&
+    typeof extraKnownMarketplaces === "object" &&
+    !Array.isArray(extraKnownMarketplaces)
+      ? extraKnownMarketplaces[MARKETPLACE_ID]
+      : undefined;
+
+  let marketplacePath = "";
+  if (typeof marketplaceEntry === "string") {
+    marketplacePath = marketplaceEntry.trim();
+  } else if (marketplaceEntry && typeof marketplaceEntry === "object") {
+    marketplacePath = String(
+      marketplaceEntry.path ??
+        marketplaceEntry.url ??
+        marketplaceEntry.repo ??
+        "",
+    ).trim();
+  }
+
+  return {
+    pluginEnabled,
+    marketplacePresent: marketplacePath !== "",
+    marketplacePath,
+  };
+}
+
+function buildSnapshot(home) {
+  const resolvedHome = resolve(home);
+  const installedPath = `${resolvedHome}/.claude/plugins/installed_plugins.json`;
+  const knownPath = `${resolvedHome}/.claude/plugins/known_marketplaces.json`;
+  const settingsPath = `${resolvedHome}/.claude/settings.json`;
+  const settingsLocalPath = `${resolvedHome}/.claude/settings.local.json`;
+
+  const plugin = readPluginSnapshot(installedPath);
+  const marketplace = readMarketplaceSnapshot(knownPath);
+  const settings = readSettingsAttachment(settingsPath);
+  const settingsLocal = readSettingsAttachment(settingsLocalPath);
+
+  return {
+    capturedAt: new Date().toISOString(),
+    home: resolvedHome,
+    attached: plugin.recordPresent && marketplace.source !== "",
+    plugin: {
+      recordPresent: plugin.recordPresent,
+      installPath: plugin.installPath,
+      version: plugin.version,
+      entries: plugin.entries,
+    },
+    marketplace,
+    settings: {
+      pluginEnabled: settings.pluginEnabled,
+      marketplacePresent: settings.marketplacePresent,
+      marketplacePath: settings.marketplacePath,
+    },
+    settingsLocal: {
+      pluginEnabled: settingsLocal.pluginEnabled,
+      marketplacePresent: settingsLocal.marketplacePresent,
+      marketplacePath: settingsLocal.marketplacePath,
+    },
+    files: {
+      installedPlugins: fileSummary(installedPath),
+      knownMarketplaces: fileSummary(knownPath),
+      settings: fileSummary(settingsPath),
+      settingsLocal: fileSummary(settingsLocalPath),
+    },
+  };
+}
+
+function snapshotHome(home) {
+  console.log(JSON.stringify(buildSnapshot(home), null, 2));
+}
+
+function readSnapshotFile(path) {
+  const resolved = resolve(path);
+  if (!existsSync(resolved)) {
+    return null;
+  }
+
+  try {
+    return parseJsonText(readFileSync(resolved, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function buildChangeSet(previous, next) {
+  if (!previous) {
+    return {
+      initialized: {
+        from: null,
+        to: true,
+      },
+    };
+  }
+
+  const fields = [
+    "attached",
+    "plugin.recordPresent",
+    "plugin.installPath",
+    "plugin.version",
+    "marketplace.present",
+    "marketplace.source",
+    "settings.pluginEnabled",
+    "settings.marketplacePresent",
+    "settings.marketplacePath",
+    "settingsLocal.pluginEnabled",
+    "settingsLocal.marketplacePresent",
+    "settingsLocal.marketplacePath",
+    "files.installedPlugins.parseable",
+    "files.knownMarketplaces.parseable",
+    "files.settings.parseable",
+    "files.settingsLocal.parseable",
+  ];
+  const changes = {};
+
+  for (const field of fields) {
+    const previousValue = field.split(".").reduce((value, key) => value?.[key], previous);
+    const nextValue = field.split(".").reduce((value, key) => value?.[key], next);
+    if (JSON.stringify(previousValue) === JSON.stringify(nextValue)) {
+      continue;
+    }
+    changes[field] = {
+      from: previousValue ?? null,
+      to: nextValue ?? null,
+    };
+  }
+
+  return changes;
+}
+
+function writeWatchEvent(home, changedPath, eventLogPath, latestPath) {
+  const previous = readSnapshotFile(latestPath);
+  const snapshot = buildSnapshot(home);
+  const event = {
+    capturedAt: snapshot.capturedAt,
+    triggerPath: changedPath === "__startup__" ? "__startup__" : resolve(changedPath),
+    context: process.env.HA_NOVA_CLAUDE_AUDIT_CONTEXT?.trim() || "",
+    changes: buildChangeSet(previous, snapshot),
+    snapshot,
+  };
+  mkdirSync(dirname(resolve(eventLogPath)), { recursive: true });
+  mkdirSync(dirname(resolve(latestPath)), { recursive: true });
+  appendFileSync(resolve(eventLogPath), `${JSON.stringify(event)}\n`);
+  writeFileSync(resolve(latestPath), `${JSON.stringify(snapshot, null, 2)}\n`);
 }
 
 const [command, ...args] = process.argv.slice(2);
@@ -226,6 +535,18 @@ switch (command) {
       fail("usage: read-known-marketplace-source <known_marketplaces.json>");
     }
     readKnownMarketplaceSource(args[0]);
+    break;
+  case "snapshot-home":
+    if (args.length !== 1) {
+      fail("usage: snapshot-home <home>");
+    }
+    snapshotHome(args[0]);
+    break;
+  case "write-watch-event":
+    if (args.length !== 4) {
+      fail("usage: write-watch-event <home> <changed_path> <event_log_path> <latest_path>");
+    }
+    writeWatchEvent(args[0], args[1], args[2], args[3]);
     break;
   default:
     fail("unknown command");

--- a/scripts/dev/watch-claude-state.sh
+++ b/scripts/dev/watch-claude-state.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+STATE_TOOL="${REPO_ROOT}/scripts/dev/claude-plugin-state.mjs"
+HOME_ROOT="${1:-${HOME}}"
+CACHE_ROOT_DEFAULT="${HOME_ROOT}/Library/Caches/ha-nova/claude-drift-audit"
+if [[ ! -d "${HOME_ROOT}/Library/Caches" ]]; then
+  CACHE_ROOT_DEFAULT="${HOME_ROOT}/.cache/ha-nova/claude-drift-audit"
+fi
+OUT_DIR="${HA_NOVA_CLAUDE_AUDIT_DIR:-${CACHE_ROOT_DEFAULT}}"
+EVENT_LOG="${OUT_DIR}/events.jsonl"
+LATEST_JSON="${OUT_DIR}/latest.json"
+CLAUDE_DIR="${HOME_ROOT}/.claude"
+PLUGIN_DIR="${CLAUDE_DIR}/plugins"
+INSTALLED_PLUGINS_JSON="${PLUGIN_DIR}/installed_plugins.json"
+KNOWN_MARKETPLACES_JSON="${PLUGIN_DIR}/known_marketplaces.json"
+SETTINGS_JSON="${CLAUDE_DIR}/settings.json"
+SETTINGS_LOCAL_JSON="${CLAUDE_DIR}/settings.local.json"
+
+require_cmd() {
+  local name="$1"
+  shift
+  local candidate
+
+  if candidate="$(command -v "${name}" 2>/dev/null)"; then
+    printf '%s\n' "${candidate}"
+    return 0
+  fi
+
+  for candidate in "$@"; do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  echo "[claude-audit] Missing command: ${name}" >&2
+  exit 1
+}
+
+NODE_BIN="$(require_cmd node /opt/homebrew/bin/node /usr/local/bin/node)"
+FSWATCH_BIN="$(require_cmd fswatch /opt/homebrew/bin/fswatch /usr/local/bin/fswatch)"
+[[ -f "${STATE_TOOL}" ]] || {
+  echo "[claude-audit] Missing helper: ${STATE_TOOL}" >&2
+  exit 1
+}
+
+mkdir -p "${OUT_DIR}"
+
+WATCH_PATHS=(
+  "${PLUGIN_DIR}"
+  "${INSTALLED_PLUGINS_JSON}"
+  "${KNOWN_MARKETPLACES_JSON}"
+  "${SETTINGS_JSON}"
+  "${SETTINGS_LOCAL_JSON}"
+)
+
+normalize_trigger_path() {
+  local changed_path="$1"
+  case "${changed_path}" in
+    "${INSTALLED_PLUGINS_JSON}") echo "${INSTALLED_PLUGINS_JSON}" ;;
+    "${KNOWN_MARKETPLACES_JSON}") echo "${KNOWN_MARKETPLACES_JSON}" ;;
+    "${SETTINGS_JSON}") echo "${SETTINGS_JSON}" ;;
+    "${SETTINGS_LOCAL_JSON}") echo "${SETTINGS_LOCAL_JSON}" ;;
+    "${PLUGIN_DIR}/installed_plugins.json") echo "${INSTALLED_PLUGINS_JSON}" ;;
+    "${PLUGIN_DIR}/known_marketplaces.json") echo "${KNOWN_MARKETPLACES_JSON}" ;;
+    *) return 1 ;;
+  esac
+}
+
+capture_event() {
+  local trigger_path="$1"
+  if ! "${NODE_BIN}" "${STATE_TOOL}" write-watch-event "${HOME_ROOT}" "${trigger_path}" "${EVENT_LOG}" "${LATEST_JSON}"; then
+    echo "[claude-audit] helper failed for: ${trigger_path}" >&2
+    return 1
+  fi
+}
+
+capture_event "__startup__"
+echo "[claude-audit] Watching Claude registry state"
+echo "[claude-audit] Output dir: ${OUT_DIR}"
+
+"${FSWATCH_BIN}" -0 "${WATCH_PATHS[@]}" | while IFS= read -r -d '' changed_path; do
+  if ! trigger_path="$(normalize_trigger_path "${changed_path}")"; then
+    continue
+  fi
+  if capture_event "${trigger_path}"; then
+    echo "[claude-audit] captured: ${trigger_path}"
+  fi
+done

--- a/tests/onboarding/claude-plugin-state-helper.test.ts
+++ b/tests/onboarding/claude-plugin-state-helper.test.ts
@@ -1,0 +1,259 @@
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { REPO_ROOT } from "./_helpers";
+
+const helperPath = join(REPO_ROOT, "scripts/dev/claude-plugin-state.mjs");
+
+function runHelper(args: string[]) {
+  return spawnSync("node", [helperPath, ...args], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+}
+
+describe("Claude plugin state helper", () => {
+  it("captures a full Claude attachment snapshot from home", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-claude-state-"));
+    const installPath = join(home, ".claude", "plugins", "cache", "ha-nova", "ha-nova", "0.4.0");
+    mkdirSync(installPath, { recursive: true });
+    mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "plugins", "installed_plugins.json"),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          "ha-nova@ha-nova": [
+            {
+              scope: "user",
+              installPath,
+              version: "0.4.0",
+            },
+          ],
+        },
+      }, null, 2) + "\n",
+    );
+    writeFileSync(
+      join(home, ".claude", "plugins", "known_marketplaces.json"),
+      JSON.stringify({
+        "ha-nova": {
+          source: {
+            source: "directory",
+            path: join(home, ".config", "ha-nova", "claude-marketplace"),
+          },
+        },
+      }, null, 2) + "\n",
+    );
+    writeFileSync(
+      join(home, ".claude", "settings.json"),
+      JSON.stringify({
+        enabledPlugins: {
+          "ha-nova@ha-nova": true,
+        },
+        extraKnownMarketplaces: {
+          "ha-nova": {
+            path: join(home, ".config", "ha-nova", "claude-marketplace"),
+          },
+        },
+      }, null, 2) + "\n",
+    );
+
+    const result = runHelper(["snapshot-home", home]);
+    expect(result.status).toBe(0);
+
+    const snapshot = JSON.parse(result.stdout);
+    expect(snapshot.attached).toBe(true);
+    expect(snapshot.plugin.recordPresent).toBe(true);
+    expect(snapshot.plugin.installPath).toBe(installPath);
+    expect(snapshot.plugin.version).toBe("0.4.0");
+    expect(snapshot.marketplace.present).toBe(true);
+    expect(snapshot.settings.pluginEnabled).toBe(true);
+    expect(snapshot.files.installedPlugins.exists).toBe(true);
+    expect(snapshot.files.knownMarketplaces.exists).toBe(true);
+    expect(snapshot.files.installedPlugins.sha256.length).toBe(64);
+  });
+
+  it("does not treat another plugin record as HA NOVA", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-claude-other-plugin-"));
+    mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "plugins", "installed_plugins.json"),
+      JSON.stringify({
+        version: 2,
+        plugins: [
+          {
+            name: "other-plugin",
+            installPath: "/tmp/other",
+            version: "1.0.0",
+          },
+        ],
+      }, null, 2) + "\n",
+    );
+    writeFileSync(
+      join(home, ".claude", "plugins", "known_marketplaces.json"),
+      JSON.stringify({
+        "other-marketplace": {
+          source: {
+            source: "directory",
+            path: "/tmp/other-marketplace",
+          },
+        },
+      }, null, 2) + "\n",
+    );
+
+    const inspect = runHelper([
+      "inspect-installed-plugin",
+      join(home, ".claude", "plugins", "installed_plugins.json"),
+    ]);
+    expect(inspect.status).toBe(0);
+    expect(inspect.stdout).toContain("installed=0");
+
+    const snapshotResult = runHelper(["snapshot-home", home]);
+    expect(snapshotResult.status).toBe(0);
+
+    const snapshot = JSON.parse(snapshotResult.stdout);
+    expect(snapshot.attached).toBe(false);
+    expect(snapshot.plugin.recordPresent).toBe(false);
+    expect(snapshot.marketplace.present).toBe(false);
+  });
+
+  it("records watch events and latest snapshot", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-claude-watch-"));
+    mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "plugins", "installed_plugins.json"),
+      JSON.stringify({ version: 2, plugins: {} }, null, 2) + "\n",
+    );
+
+    const outDir = join(home, ".config", "ha-nova", "claude-drift-audit");
+    const eventLog = join(outDir, "events.jsonl");
+    const latest = join(outDir, "latest.json");
+
+    const result = runHelper([
+      "write-watch-event",
+      home,
+      join(home, ".claude", "plugins", "installed_plugins.json"),
+      eventLog,
+      latest,
+    ]);
+    expect(result.status).toBe(0);
+    expect(existsSync(eventLog)).toBe(true);
+    expect(existsSync(latest)).toBe(true);
+
+    const eventLine = readFileSync(eventLog, "utf8").trim();
+    const event = JSON.parse(eventLine);
+    const latestSnapshot = JSON.parse(readFileSync(latest, "utf8"));
+
+    expect(event.triggerPath).toBe(join(home, ".claude", "plugins", "installed_plugins.json"));
+    expect(event.context).toBe("");
+    expect(event.changes.initialized).toEqual({ from: null, to: true });
+    expect(event.snapshot.home).toBe(home);
+    expect(latestSnapshot.home).toBe(home);
+    expect(latestSnapshot.plugin.recordPresent).toBe(false);
+    expect(latestSnapshot.files.installedPlugins.exists).toBe(true);
+  });
+
+  it("does not call a blank install path attached", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-claude-blank-install-"));
+    mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "plugins", "installed_plugins.json"),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          "ha-nova@ha-nova": [
+            {
+              scope: "user",
+              installPath: "",
+              version: "0.4.0",
+            },
+          ],
+        },
+      }, null, 2) + "\n",
+    );
+    writeFileSync(
+      join(home, ".claude", "plugins", "known_marketplaces.json"),
+      JSON.stringify({
+        "ha-nova": {
+          source: {
+            source: "directory",
+            path: join(home, ".config", "ha-nova", "claude-marketplace"),
+          },
+        },
+      }, null, 2) + "\n",
+    );
+
+    const result = runHelper(["snapshot-home", home]);
+    expect(result.status).toBe(0);
+
+    const snapshot = JSON.parse(result.stdout);
+    expect(snapshot.plugin.recordPresent).toBe(false);
+    expect(snapshot.plugin.installPath).toBe("");
+    expect(snapshot.attached).toBe(false);
+  });
+
+  it("treats BOM-prefixed JSON as parseable", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-claude-bom-"));
+    mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "plugins", "installed_plugins.json"),
+      `\uFEFF${JSON.stringify({ version: 2, plugins: {} }, null, 2)}\n`,
+    );
+
+    const result = runHelper(["snapshot-home", home]);
+    expect(result.status).toBe(0);
+
+    const snapshot = JSON.parse(result.stdout);
+    expect(snapshot.files.installedPlugins.parseable).toBe(true);
+    expect(snapshot.files.installedPlugins.error).toBe("");
+  });
+
+  it("treats BOM-prefixed known marketplaces json as parseable", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-claude-known-bom-"));
+    mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "plugins", "known_marketplaces.json"),
+      `\uFEFF${JSON.stringify({
+        "ha-nova": {
+          source: {
+            source: "directory",
+            path: join(home, ".config", "ha-nova", "claude-marketplace"),
+          },
+        },
+      }, null, 2)}\n`,
+    );
+
+    const result = runHelper(["snapshot-home", home]);
+    expect(result.status).toBe(0);
+
+    const snapshot = JSON.parse(result.stdout);
+    expect(snapshot.marketplace.present).toBe(true);
+    expect(snapshot.files.knownMarketplaces.parseable).toBe(true);
+    expect(snapshot.files.knownMarketplaces.error).toBe("");
+  });
+
+  it("keeps snapshot output when known marketplaces json is invalid", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-claude-invalid-known-"));
+    mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "plugins", "installed_plugins.json"),
+      JSON.stringify({ version: 2, plugins: {} }, null, 2) + "\n",
+    );
+    writeFileSync(
+      join(home, ".claude", "plugins", "known_marketplaces.json"),
+      "{\n",
+    );
+
+    const result = runHelper(["snapshot-home", home]);
+    expect(result.status).toBe(0);
+
+    const snapshot = JSON.parse(result.stdout);
+    expect(snapshot.marketplace.present).toBe(false);
+    expect(snapshot.marketplace.source).toBe("");
+    expect(snapshot.files.knownMarketplaces.parseable).toBe(false);
+    expect(snapshot.files.knownMarketplaces.error.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/onboarding/claude-plugin-state-helper.test.ts
+++ b/tests/onboarding/claude-plugin-state-helper.test.ts
@@ -266,6 +266,30 @@ describe("Claude plugin state helper", () => {
     expect(snapshot.files.knownMarketplaces.error).toBe("");
   });
 
+  it("preserves pinned GitHub refs in marketplace source output", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-claude-known-pinned-"));
+    mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "plugins", "known_marketplaces.json"),
+      JSON.stringify({
+        "ha-nova": {
+          source: {
+            source: "github",
+            repo: "markusleben/ha-nova",
+            ref: "v0.2.2",
+          },
+        },
+      }, null, 2) + "\n",
+    );
+
+    const result = runHelper(["snapshot-home", home]);
+    expect(result.status).toBe(0);
+
+    const snapshot = JSON.parse(result.stdout);
+    expect(snapshot.marketplace.present).toBe(true);
+    expect(snapshot.marketplace.source).toBe("markusleben/ha-nova#v0.2.2");
+  });
+
   it("keeps snapshot output when known marketplaces json is invalid", () => {
     const home = mkdtempSync(join(tmpdir(), "ha-nova-claude-invalid-known-"));
     mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
@@ -284,6 +308,20 @@ describe("Claude plugin state helper", () => {
     const snapshot = JSON.parse(result.stdout);
     expect(snapshot.marketplace.present).toBe(false);
     expect(snapshot.marketplace.source).toBe("");
+    expect(snapshot.files.knownMarketplaces.parseable).toBe(false);
+    expect(snapshot.files.knownMarketplaces.error.length).toBeGreaterThan(0);
+  });
+
+  it("keeps snapshot output when a tracked registry path is a directory", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-claude-dir-known-"));
+    mkdirSync(join(home, ".claude", "plugins", "known_marketplaces.json"), { recursive: true });
+
+    const result = runHelper(["snapshot-home", home]);
+    expect(result.status).toBe(0);
+
+    const snapshot = JSON.parse(result.stdout);
+    expect(snapshot.marketplace.present).toBe(false);
+    expect(snapshot.files.knownMarketplaces.exists).toBe(true);
     expect(snapshot.files.knownMarketplaces.parseable).toBe(false);
     expect(snapshot.files.knownMarketplaces.error.length).toBeGreaterThan(0);
   });

--- a/tests/onboarding/claude-plugin-state-helper.test.ts
+++ b/tests/onboarding/claude-plugin-state-helper.test.ts
@@ -67,6 +67,7 @@ describe("Claude plugin state helper", () => {
     const snapshot = JSON.parse(result.stdout);
     expect(snapshot.attached).toBe(true);
     expect(snapshot.plugin.recordPresent).toBe(true);
+    expect(snapshot.plugin.usableInstallPath).toBe(true);
     expect(snapshot.plugin.installPath).toBe(installPath);
     expect(snapshot.plugin.version).toBe("0.4.0");
     expect(snapshot.marketplace.present).toBe(true);
@@ -117,6 +118,7 @@ describe("Claude plugin state helper", () => {
     const snapshot = JSON.parse(snapshotResult.stdout);
     expect(snapshot.attached).toBe(false);
     expect(snapshot.plugin.recordPresent).toBe(false);
+    expect(snapshot.plugin.usableInstallPath).toBe(false);
     expect(snapshot.marketplace.present).toBe(false);
   });
 
@@ -153,6 +155,7 @@ describe("Claude plugin state helper", () => {
     expect(event.snapshot.home).toBe(home);
     expect(latestSnapshot.home).toBe(home);
     expect(latestSnapshot.plugin.recordPresent).toBe(false);
+    expect(latestSnapshot.plugin.usableInstallPath).toBe(false);
     expect(latestSnapshot.files.installedPlugins.exists).toBe(true);
   });
 
@@ -190,8 +193,36 @@ describe("Claude plugin state helper", () => {
     expect(result.status).toBe(0);
 
     const snapshot = JSON.parse(result.stdout);
-    expect(snapshot.plugin.recordPresent).toBe(false);
+    expect(snapshot.plugin.recordPresent).toBe(true);
+    expect(snapshot.plugin.usableInstallPath).toBe(false);
     expect(snapshot.plugin.installPath).toBe("");
+    expect(snapshot.attached).toBe(false);
+  });
+
+  it("treats a legacy string entry as installed but not attached", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-claude-legacy-string-"));
+    mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "plugins", "installed_plugins.json"),
+      JSON.stringify({
+        version: 2,
+        plugins: ["ha-nova@ha-nova"],
+      }, null, 2) + "\n",
+    );
+
+    const inspect = runHelper([
+      "inspect-installed-plugin",
+      join(home, ".claude", "plugins", "installed_plugins.json"),
+    ]);
+    expect(inspect.status).toBe(0);
+    expect(inspect.stdout).toContain("installed=1");
+
+    const snapshotResult = runHelper(["snapshot-home", home]);
+    expect(snapshotResult.status).toBe(0);
+
+    const snapshot = JSON.parse(snapshotResult.stdout);
+    expect(snapshot.plugin.recordPresent).toBe(true);
+    expect(snapshot.plugin.usableInstallPath).toBe(false);
     expect(snapshot.attached).toBe(false);
   });
 

--- a/tests/onboarding/claude-plugin-state-helper.test.ts
+++ b/tests/onboarding/claude-plugin-state-helper.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { REPO_ROOT } from "./_helpers";
+import { REPO_ROOT } from "./_helpers.js";
 
 const helperPath = join(REPO_ROOT, "scripts/dev/claude-plugin-state.mjs");
 


### PR DESCRIPTION
## Summary
- add a small Claude registry snapshot helper for detach forensics
- add a local watcher script that records file-level drift events without changing product runtime
- add focused regressions for BOM, invalid JSON, foreign plugin false positives, and blank install paths

## Testing
- npx vitest run tests/onboarding/claude-plugin-state-helper.test.ts
- (cd cli && go test -run 'TestDoctor|Test.*Claude.*' -count=1)