### PR TITLE
chore: prep v0.4.1 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/docs/work/2026-04-14-v0.4.1-release-body.md
+++ b/docs/work/2026-04-14-v0.4.1-release-body.md
@@ -1,0 +1,22 @@
+## Bug Fixes
+
+- HA NOVA now catches Claude installs that still leave files behind but are no longer fully attached.
+- `ha-nova doctor` now flags missing Claude marketplace state instead of showing a false healthy Claude setup.
+- Claude drift capture and repair now preserve pinned marketplace refs and keep working even when registry files are broken.
+
+## Install
+
+**macOS / Linux**
+```sh
+curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/v0.4.1/install.sh | HA_NOVA_VERSION=v0.4.1 bash
+```
+
+**Windows (PowerShell)**
+```powershell
+$env:HA_NOVA_VERSION = 'v0.4.1'
+irm https://raw.githubusercontent.com/markusleben/ha-nova/v0.4.1/install.ps1 | iex
+```
+
+## Already Installed?
+
+Run `ha-nova check-update` or `ha-nova update`.

--- a/docs/work/2026-04-14-v0.4.1-release-prep-spec.md
+++ b/docs/work/2026-04-14-v0.4.1-release-prep-spec.md
@@ -1,0 +1,21 @@
+## Goal
+
+Prepare `v0.4.1` as the first patch release after `v0.4.0`.
+
+## Release Delta
+
+- `#169` tighten Claude attachment verification
+- `#170` detect missing Claude marketplace in `doctor`
+- `#171` add Claude drift evidence capture tooling and harden the helper around pinned refs and broken registry paths
+
+## Open PR Preflight
+
+- `#166` separate later
+- `#163` separate later
+- `#156` separate later
+
+## Release Notes Shape
+
+- no `New Features`
+- selective `Bug Fixes` only
+- keep `Install` and `Already Installed?`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.4.0",
+  "skill_version": "0.4.1",
   "min_relay_version": "0.1.0"
 }


### PR DESCRIPTION
## Summary
- bump release metadata to 0.4.1
- add the short v0.4.1 release body draft
- capture release preflight notes for the Claude patch release

## Verification
- npm run verify:next-release-version -- v0.4.1
- npm run verify:release-metadata
- npm run verify:release-contracts
- npx vitest run tests/onboarding/bump-version.test.ts tests/onboarding/release-contract.test.ts
- pre-push hook: typecheck, full vitest, build, docs fact-check