### PR TITLE
fix: pin Claude to local release snapshots

### DIFF
--- a/.claude/INSTALL.md
+++ b/.claude/INSTALL.md
@@ -48,7 +48,7 @@ npm.cmd uninstall -g @anthropic-ai/claude-code
 ## Updates and Repair
 
 - Connect or repair with `ha-nova setup claude`.
-- Shipped installs use the Claude marketplace files that came with your installed HA NOVA version.
+- Shipped installs use a local HA NOVA release snapshot under `~/.config/ha-nova/claude-marketplace/releases/vX.Y.Z`.
 - HA NOVA itself shows Claude update notices. When you see one, run `ha-nova update` and then restart Claude.
 - If the Claude path looks broken, run `ha-nova setup claude` and then `ha-nova doctor`.
 

--- a/cli/claude_marketplace.go
+++ b/cli/claude_marketplace.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 )
 
-const defaultClaudeMarketplaceURL = "https://github.com/markusleben/ha-nova"
-
 type claudeLocalRestoreState struct {
 	source          claudeMarketplaceSource
 	hasSource       bool
@@ -26,37 +24,31 @@ type claudeMarketplaceSource struct {
 
 func resolveClaudeMarketplaceSource(paths runtimePaths, sourceRoot string) (string, error) {
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("HA_NOVA_CLAUDE_MARKETPLACE_LOCAL")), "1") {
-		return prepareClaudeMarketplaceRoot(paths, sourceRoot)
+		return prepareClaudeMarketplaceRoot(paths, sourceRoot, claudeMarketplaceDevRoot(paths))
 	}
 
 	switch detectInstallSource(paths, loadStateOrDefault(paths)) {
 	case installSourceDev:
-		return prepareClaudeMarketplaceRoot(paths, sourceRoot)
-	case installSourceBundle:
-		if shippedClaudeMarketplacePresentOnDisk(sourceRoot) {
-			return prepareClaudeMarketplaceRoot(paths, sourceRoot)
-		}
-		if bundleInstallPresentOnDisk(sourceRoot) {
-			return "", fmt.Errorf("installed Claude payload missing from shipped bundle runtime")
-		}
-		return defaultClaudeMarketplaceURL, nil
+		return prepareClaudeMarketplaceRoot(paths, sourceRoot, claudeMarketplaceDevRoot(paths))
 	default:
-		return defaultClaudeMarketplaceURL, nil
+		if !shippedClaudeMarketplacePresentOnDisk(sourceRoot) {
+			return "", fmt.Errorf("Claude release snapshot payload missing from installed bundle")
+		}
+		version, err := claudeMarketplaceVersionForSourceRoot(paths, sourceRoot)
+		if err != nil {
+			return "", err
+		}
+		targetRoot, err := claudeMarketplaceReleaseRoot(paths, version)
+		if err != nil {
+			return "", err
+		}
+		return prepareClaudeMarketplaceRoot(paths, sourceRoot, targetRoot)
 	}
 }
 
 func useLocalClaudeMarketplace(paths runtimePaths, sourceRoot string) bool {
-	if strings.EqualFold(strings.TrimSpace(os.Getenv("HA_NOVA_CLAUDE_MARKETPLACE_LOCAL")), "1") {
-		return true
-	}
-	switch detectInstallSource(paths, loadStateOrDefault(paths)) {
-	case installSourceDev:
-		return true
-	case installSourceBundle:
-		return shippedClaudeMarketplacePresentOnDisk(sourceRoot)
-	default:
-		return false
-	}
+	source, err := resolveClaudeMarketplaceSource(paths, sourceRoot)
+	return err == nil && !strings.Contains(claudeMarketplaceCompareKey(source), "github:")
 }
 
 func shippedClaudeMarketplacePresentOnDisk(sourceRoot string) bool {
@@ -87,15 +79,14 @@ func shippedClaudeMarketplacePresentOnDisk(sourceRoot string) bool {
 	return true
 }
 
-func prepareClaudeMarketplaceRoot(paths runtimePaths, sourceRoot string) (string, error) {
+func prepareClaudeMarketplaceRoot(paths runtimePaths, sourceRoot string, targetRoot string) (string, error) {
 	absSourceRoot, err := filepath.Abs(sourceRoot)
 	if err != nil {
 		return "", err
 	}
 
-	targetRoot := filepath.Join(paths.ConfigDir, "claude-marketplace")
 	localSource := "./ha-nova"
-	if err := os.MkdirAll(paths.ConfigDir, 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(targetRoot), 0o755); err != nil {
 		return "", err
 	}
 	stageRoot, err := os.MkdirTemp(paths.ConfigDir, "claude-marketplace-stage-")
@@ -210,6 +201,9 @@ func ensureClaudeMarketplaceRegistration(home, desiredSource string) error {
 		return err
 	}
 	if hasCurrentSource && sameClaudeMarketplaceSource(currentSource, desiredSource) {
+		if !strings.Contains(claudeMarketplaceCompareKey(desiredSource), "github:") {
+			return verifyClaudeMarketplaceRegistration(home, desiredSource)
+		}
 		if err := updateClaudeMarketplaceRegistration(); err != nil {
 			return err
 		}
@@ -338,6 +332,11 @@ func verifyClaudeMarketplaceRegistration(home, desiredSource string) error {
 		return fmt.Errorf("Claude marketplace ha-nova source mismatch after sync")
 	}
 	return nil
+}
+
+func claudeMarketplaceRegistered(home string) bool {
+	_, hasCurrentSource, err := readClaudeMarketplaceSource(home)
+	return err == nil && hasCurrentSource
 }
 
 func clearClaudeMarketplaceRegistration(home string) error {

--- a/cli/claude_marketplace_test.go
+++ b/cli/claude_marketplace_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestInstallClaudePluginMigratesGitHubMarketplaceToLocalStagedSource(t *testing.T) {
+func TestInstallClaudePluginMigratesFloatingGitHubMarketplaceToVersionedLocalSnapshot(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -41,15 +41,18 @@ func TestInstallClaudePluginMigratesGitHubMarketplaceToLocalStagedSource(t *test
 		t.Fatalf("read log: %v", err)
 	}
 	log := string(logData)
-	marketplaceRoot := filepath.Join(paths.ConfigDir, "claude-marketplace")
-	if !strings.Contains(log, "plugin validate "+marketplaceRoot) {
-		t.Fatalf("expected staged marketplace validation before migration:\n%s", log)
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
 	}
 	if !strings.Contains(log, "plugin marketplace remove ha-nova") {
-		t.Fatalf("expected legacy GitHub marketplace removal before local re-add:\n%s", log)
+		t.Fatalf("expected floating GitHub marketplace to be replaced with a local release snapshot:\n%s", log)
 	}
-	if !strings.Contains(log, "plugin marketplace add "+marketplaceRoot) {
-		t.Fatalf("expected staged local marketplace re-add:\n%s", log)
+	if !strings.Contains(log, "plugin validate ") {
+		t.Fatalf("expected floating GitHub marketplace migration to validate a staged local release snapshot:\n%s", log)
+	}
+	if !strings.Contains(log, "plugin marketplace add "+expectedRoot) {
+		t.Fatalf("expected local release snapshot after replacement:\n%s", log)
 	}
 	if !strings.Contains(log, "plugin install ha-nova@ha-nova") {
 		t.Fatalf("expected plugin install to continue, got:\n%s", log)
@@ -85,13 +88,16 @@ func TestInstallClaudePluginAcceptsBOMPrefixedMarketplaceRegistry(t *testing.T) 
 	if err != nil {
 		t.Fatalf("read log: %v", err)
 	}
-	marketplaceRoot := filepath.Join(paths.ConfigDir, "claude-marketplace")
-	if !strings.Contains(string(logData), "plugin marketplace add "+marketplaceRoot) {
-		t.Fatalf("expected BOM-prefixed registry to migrate to staged local marketplace, got:\n%s", string(logData))
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
+	}
+	if !strings.Contains(string(logData), "plugin marketplace add "+expectedRoot) {
+		t.Fatalf("expected BOM-prefixed registry to migrate to the local release snapshot, got:\n%s", string(logData))
 	}
 }
 
-func TestInstallClaudePluginAcceptsStructuredGitHubMarketplaceSource(t *testing.T) {
+func TestInstallClaudePluginMigratesStructuredGitHubMarketplaceSourceToVersionedLocalSnapshot(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -124,19 +130,19 @@ func TestInstallClaudePluginAcceptsStructuredGitHubMarketplaceSource(t *testing.
 		t.Fatalf("read log: %v", err)
 	}
 	log := string(logData)
-	marketplaceRoot := filepath.Join(paths.ConfigDir, "claude-marketplace")
-	if !strings.Contains(log, "plugin marketplace add "+marketplaceRoot) {
-		t.Fatalf("expected structured GitHub marketplace to migrate to staged local source:\n%s", log)
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
 	}
 	if !strings.Contains(log, "plugin marketplace remove ha-nova") {
-		t.Fatalf("expected structured GitHub marketplace removal before local add:\n%s", log)
+		t.Fatalf("expected structured GitHub marketplace to be replaced with a local release snapshot:\n%s", log)
 	}
-	if strings.Contains(log, "plugin marketplace add https://github.com/markusleben/ha-nova") {
-		t.Fatalf("did not expect structured GitHub marketplace to remain on floating GitHub:\n%s", log)
+	if !strings.Contains(log, "plugin marketplace add "+expectedRoot) {
+		t.Fatalf("expected structured GitHub marketplace to migrate to the local release snapshot:\n%s", log)
 	}
 }
 
-func TestInstallClaudePluginReplacesPinnedGitHubMarketplaceRef(t *testing.T) {
+func TestInstallClaudePluginReplacesPinnedGitHubMarketplaceRefWithVersionedLocalSnapshot(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -169,12 +175,15 @@ func TestInstallClaudePluginReplacesPinnedGitHubMarketplaceRef(t *testing.T) {
 		t.Fatalf("read log: %v", err)
 	}
 	log := string(logData)
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
+	}
 	if !strings.Contains(log, "plugin marketplace remove ha-nova") {
 		t.Fatalf("expected pinned marketplace removal before re-add:\n%s", log)
 	}
-	marketplaceRoot := filepath.Join(paths.ConfigDir, "claude-marketplace")
-	if !strings.Contains(log, "plugin marketplace add "+marketplaceRoot) {
-		t.Fatalf("expected pinned marketplace to be replaced with staged local source:\n%s", log)
+	if !strings.Contains(log, "plugin marketplace add "+expectedRoot) {
+		t.Fatalf("expected pinned marketplace to be replaced with the current local release snapshot:\n%s", log)
 	}
 	if strings.Contains(log, "plugin marketplace update ha-nova") {
 		t.Fatalf("did not expect pinned marketplace to be treated as a matching source:\n%s", log)
@@ -202,13 +211,17 @@ func TestInstallClaudePluginRestoresPinnedGitHubMarketplaceRefWhenReplaceFails(t
 	}
 
 	logPath := filepath.Join(home, "claude.log")
-	failCommand := "plugin marketplace add " + filepath.Join(paths.ConfigDir, "claude-marketplace")
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
+	}
+	failCommand := "plugin marketplace add " + expectedRoot
 	t.Setenv("PATH", installClaudeMarketplaceMock(t, logPath, failCommand)+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	writeClaudeMarketplaceFixture(t, paths.InstallRoot)
 	err = installClaudePlugin(paths, paths.InstallRoot)
 	if err == nil {
-		t.Fatal("expected installClaudePlugin() to fail when staged local marketplace add fails")
+		t.Fatal("expected installClaudePlugin() to fail when local release snapshot replace fails")
 	}
 
 	logData, readErr := os.ReadFile(logPath)
@@ -242,13 +255,17 @@ func TestInstallClaudePluginRestoresPinnedGitURLMarketplaceRefWhenReplaceFails(t
 	}
 
 	logPath := filepath.Join(home, "claude.log")
-	failCommand := "plugin marketplace add " + filepath.Join(paths.ConfigDir, "claude-marketplace")
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
+	}
+	failCommand := "plugin marketplace add " + expectedRoot
 	t.Setenv("PATH", installClaudeMarketplaceMock(t, logPath, failCommand)+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	writeClaudeMarketplaceFixture(t, paths.InstallRoot)
 	err = installClaudePlugin(paths, paths.InstallRoot)
 	if err == nil {
-		t.Fatal("expected installClaudePlugin() to fail when staged local marketplace add fails")
+		t.Fatal("expected installClaudePlugin() to fail when local release snapshot replace fails")
 	}
 
 	logData, readErr := os.ReadFile(logPath)
@@ -261,7 +278,7 @@ func TestInstallClaudePluginRestoresPinnedGitURLMarketplaceRefWhenReplaceFails(t
 	}
 }
 
-func TestInstallClaudePluginFallsBackToGitHubMarketplaceWithoutInstalledBundlePayload(t *testing.T) {
+func TestInstallClaudePluginFailsWithoutInstalledBundlePayload(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -280,27 +297,16 @@ func TestInstallClaudePluginFallsBackToGitHubMarketplaceWithoutInstalledBundlePa
 	logPath := filepath.Join(home, "claude.log")
 	t.Setenv("PATH", installClaudeMarketplaceMock(t, logPath, "")+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	if err := installClaudePlugin(paths, paths.InstallRoot); err != nil {
-		t.Fatalf("installClaudePlugin() error: %v", err)
+	err = installClaudePlugin(paths, paths.InstallRoot)
+	if err == nil {
+		t.Fatal("expected installClaudePlugin() to fail when the installed bundle payload is missing")
 	}
-
-	logData, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("read log: %v", err)
-	}
-	log := string(logData)
-	if !strings.Contains(log, "plugin marketplace add https://github.com/markusleben/ha-nova") {
-		t.Fatalf("expected GitHub marketplace fallback when no installed Claude payload exists:\n%s", log)
-	}
-	if strings.Contains(log, "plugin validate ") {
-		t.Fatalf("did not expect local marketplace validation without an installed Claude payload:\n%s", log)
-	}
-	if strings.Contains(log, "plugin marketplace add "+filepath.Join(paths.ConfigDir, "claude-marketplace")) {
-		t.Fatalf("did not expect local staged marketplace add without an installed Claude payload:\n%s", log)
+	if !strings.Contains(err.Error(), "Claude release snapshot payload missing") {
+		t.Fatalf("expected missing release snapshot payload error, got %v", err)
 	}
 }
 
-func TestInstallClaudePluginFallsBackToGitHubMarketplaceWithoutStageableClaudePayload(t *testing.T) {
+func TestInstallClaudePluginFailsWithoutStageableClaudePayload(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -333,22 +339,10 @@ func TestInstallClaudePluginFallsBackToGitHubMarketplaceWithoutStageableClaudePa
 
 	err = installClaudePlugin(paths, paths.InstallRoot)
 	if err == nil {
-		t.Fatal("expected installClaudePlugin() to fail when a shipped bundle payload is incomplete")
+		t.Fatal("expected installClaudePlugin() to fail when the shipped Claude payload is incomplete")
 	}
-	if !strings.Contains(err.Error(), "installed Claude payload missing from shipped bundle runtime") {
-		t.Fatalf("expected shipped bundle payload error, got: %v", err)
-	}
-
-	logData, readErr := os.ReadFile(logPath)
-	if readErr != nil && !os.IsNotExist(readErr) {
-		t.Fatalf("read log: %v", readErr)
-	}
-	log := string(logData)
-	if strings.Contains(log, "plugin marketplace add https://github.com/markusleben/ha-nova") {
-		t.Fatalf("did not expect shipped bundle fallback to floating GitHub:\n%s", log)
-	}
-	if strings.Contains(log, "plugin validate ") || strings.Contains(log, "plugin marketplace add "+filepath.Join(paths.ConfigDir, "claude-marketplace")) {
-		t.Fatalf("did not expect local staging commands for incomplete shipped bundle payload:\n%s", log)
+	if !strings.Contains(err.Error(), "Claude release snapshot payload missing") {
+		t.Fatalf("expected incomplete payload to fail with missing release snapshot payload error, got %v", err)
 	}
 }
 
@@ -364,7 +358,7 @@ func TestSameClaudeMarketplaceSourceTreatsPinnedGitHubRefsAsDistinct(t *testing.
 	}
 }
 
-func TestInstallClaudePluginReplacesStaleMarketplaceWithLocalStagedSource(t *testing.T) {
+func TestInstallClaudePluginReplacesStaleMarketplaceWithVersionedLocalSnapshot(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -397,12 +391,15 @@ func TestInstallClaudePluginReplacesStaleMarketplaceWithLocalStagedSource(t *tes
 		t.Fatalf("read log: %v", err)
 	}
 	log := string(logData)
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
+	}
 	if !strings.Contains(log, "plugin marketplace remove ha-nova") {
 		t.Fatalf("expected stale marketplace removal before local re-add:\n%s", log)
 	}
-	marketplaceRoot := filepath.Join(paths.ConfigDir, "claude-marketplace")
-	if !strings.Contains(log, "plugin marketplace add "+marketplaceRoot) {
-		t.Fatalf("expected staged local marketplace re-add after stale marketplace removal:\n%s", log)
+	if !strings.Contains(log, "plugin marketplace add "+expectedRoot) {
+		t.Fatalf("expected stale marketplace to be replaced with the local release snapshot:\n%s", log)
 	}
 }
 
@@ -427,7 +424,11 @@ func TestInstallClaudePluginRestoresExistingMarketplaceWhenLocalReplaceFails(t *
 	}
 
 	logPath := filepath.Join(home, "claude.log")
-	failCommand := "plugin marketplace add " + filepath.Join(paths.ConfigDir, "claude-marketplace")
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
+	}
+	failCommand := "plugin marketplace add " + expectedRoot
 	t.Setenv("PATH", installClaudeMarketplaceMock(t, logPath, failCommand)+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	writeClaudeMarketplaceFixture(t, paths.InstallRoot)
@@ -452,6 +453,7 @@ func TestInstallClaudePluginRestoresExistingMarketplaceWhenLocalReplaceFails(t *
 func TestInstallClaudePluginKeepsExistingLocalMarketplaceWhenValidationFails(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_CLAUDE_MARKETPLACE_LOCAL", "1")
 
 	paths, err := detectPaths()
 	if err != nil {
@@ -494,6 +496,7 @@ func TestInstallClaudePluginKeepsExistingLocalMarketplaceWhenValidationFails(t *
 func TestInstallClaudePluginRestoresExistingLocalMarketplaceWhenInstallFailsAfterCutover(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_CLAUDE_MARKETPLACE_LOCAL", "1")
 
 	paths, err := detectPaths()
 	if err != nil {

--- a/cli/claude_snapshot.go
+++ b/cli/claude_snapshot.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type claudeInstallSnapshot struct {
+	ExpectedSource    string
+	MarketplaceSource claudeMarketplaceSource
+	MarketplaceFound  bool
+	PluginFound       bool
+	UsableInstallPath bool
+	Attached          bool
+	MismatchReason    string
+}
+
+func claudeMarketplaceBaseRoot(paths runtimePaths) string {
+	return filepath.Join(paths.ConfigDir, "claude-marketplace")
+}
+
+func claudeMarketplaceDevRoot(paths runtimePaths) string {
+	return claudeMarketplaceBaseRoot(paths)
+}
+
+func claudeMarketplaceReleaseRoot(paths runtimePaths, version string) (string, error) {
+	version = strings.TrimPrefix(strings.TrimSpace(version), "v")
+	if version == "" || version == "dev" {
+		return "", fmt.Errorf("Claude release snapshot requires a stable version")
+	}
+	return filepath.Join(claudeMarketplaceBaseRoot(paths), "releases", "v"+version), nil
+}
+
+func claudeMarketplaceVersionForSourceRoot(paths runtimePaths, sourceRoot string) (string, error) {
+	bundlePath := filepath.Join(strings.TrimSpace(sourceRoot), "bundle.json")
+	if meta, err := loadBundleMetadataFile(bundlePath); err == nil && strings.TrimSpace(meta.Version) != "" {
+		version := strings.TrimPrefix(strings.TrimSpace(meta.Version), "v")
+		if version != "" && version != "dev" {
+			return version, nil
+		}
+	}
+	version := strings.TrimPrefix(strings.TrimSpace(localVersion(paths)), "v")
+	if version == "" || version == "dev" {
+		return "", fmt.Errorf("cannot determine Claude release snapshot version")
+	}
+	return version, nil
+}
+
+func expectedClaudeMarketplaceSource(paths runtimePaths, state installState) (string, error) {
+	if normalizeInstallSource(detectInstallSource(paths, state)) == installSourceDev ||
+		strings.EqualFold(strings.TrimSpace(os.Getenv("HA_NOVA_CLAUDE_MARKETPLACE_LOCAL")), "1") {
+		return claudeMarketplaceDevRoot(paths), nil
+	}
+	version, err := claudeMarketplaceVersionForSourceRoot(paths, paths.InstallRoot)
+	if err != nil {
+		return "", err
+	}
+	return claudeMarketplaceReleaseRoot(paths, version)
+}
+
+func inspectClaudeInstallSnapshot(paths runtimePaths, state installState) claudeInstallSnapshot {
+	snapshot := claudeInstallSnapshot{}
+	expectedSource, err := expectedClaudeMarketplaceSource(paths, state)
+	if err == nil {
+		snapshot.ExpectedSource = expectedSource
+	}
+	currentSource, hasCurrentSource, err := readClaudeMarketplaceSource(paths.Home)
+	if err == nil && hasCurrentSource {
+		snapshot.MarketplaceSource = currentSource
+		snapshot.MarketplaceFound = true
+	}
+	snapshot.PluginFound, snapshot.UsableInstallPath = readClaudePluginInstallSnapshot(paths.Home)
+
+	switch {
+	case !snapshot.MarketplaceFound:
+		snapshot.MismatchReason = "marketplace missing"
+	case snapshot.ExpectedSource != "" && !sameClaudeMarketplaceSource(snapshot.MarketplaceSource, snapshot.ExpectedSource):
+		snapshot.MismatchReason = "marketplace source mismatch"
+	case !snapshot.PluginFound:
+		snapshot.MismatchReason = "plugin missing"
+	case !snapshot.UsableInstallPath:
+		snapshot.MismatchReason = "plugin installPath missing"
+	default:
+		snapshot.Attached = true
+	}
+	return snapshot
+}
+
+func readClaudePluginInstallSnapshot(home string) (bool, bool) {
+	if strings.TrimSpace(home) == "" {
+		return false, false
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))
+	if err != nil {
+		return false, false
+	}
+	var raw map[string]any
+	if err := unmarshalClaudeJSON(data, &raw); err != nil {
+		return false, false
+	}
+	return claudePluginInstallSnapshotFromValue(raw["plugins"])
+}
+
+func claudePluginInstallSnapshotFromValue(value any) (bool, bool) {
+	switch typed := value.(type) {
+	case []any:
+		recordFound := len(typed) > 0
+		usableInstallPath := false
+		for _, entry := range typed {
+			_, usable := claudePluginInstallSnapshotFromValue(entry)
+			usableInstallPath = usableInstallPath || usable
+		}
+		return recordFound, usableInstallPath
+	case map[string]any:
+		if pluginValue, ok := typed["ha-nova@ha-nova"]; ok {
+			return true, claudePluginInstallValuePresent(pluginValue)
+		}
+		if !claudePluginRecordMatches(typed) {
+			return false, false
+		}
+		installPath, _ := typed["installPath"].(string)
+		installPath = strings.TrimSpace(installPath)
+		if installPath == "" {
+			return true, false
+		}
+		return true, fileExists(installPath)
+	case string:
+		return strings.TrimSpace(typed) == "ha-nova@ha-nova", false
+	default:
+		return false, false
+	}
+}

--- a/cli/claude_snapshot.go
+++ b/cli/claude_snapshot.go
@@ -106,10 +106,11 @@ func readClaudePluginInstallSnapshot(home string) (bool, bool) {
 func claudePluginInstallSnapshotFromValue(value any) (bool, bool) {
 	switch typed := value.(type) {
 	case []any:
-		recordFound := len(typed) > 0
+		recordFound := false
 		usableInstallPath := false
 		for _, entry := range typed {
-			_, usable := claudePluginInstallSnapshotFromValue(entry)
+			found, usable := claudePluginInstallSnapshotFromValue(entry)
+			recordFound = recordFound || found
 			usableInstallPath = usableInstallPath || usable
 		}
 		return recordFound, usableInstallPath

--- a/cli/client_claude.go
+++ b/cli/client_claude.go
@@ -17,7 +17,6 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 		return fmt.Errorf("Claude CLI not found in PATH; install Claude Code first")
 	}
 
-	localMode := useLocalClaudeMarketplace(paths, sourceRoot)
 	restoreState, err := captureClaudeLocalRestoreState(paths.Home)
 	if err != nil {
 		return err
@@ -26,6 +25,7 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 	if err != nil {
 		return err
 	}
+	localMode := !strings.Contains(claudeMarketplaceCompareKey(marketplaceRoot), "github:")
 	restoreMarketplace := func(cause error) error {
 		if localMode {
 			if restoreErr := restoreClaudeMarketplaceBackup(marketplaceRoot); restoreErr != nil {
@@ -58,26 +58,24 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 
 	cmd := exec.Command("claude", refreshArgs...)
 	if output, err := cmd.CombinedOutput(); err != nil {
+		commandErr := fmt.Errorf("claude plugin command failed: %s (%s)", strings.Join(refreshArgs, " "), strings.TrimSpace(string(output)))
 		if localMode {
-			return restoreMarketplace(fmt.Errorf("claude plugin command failed: %s (%s)", strings.Join(refreshArgs, " "), strings.TrimSpace(string(output))))
+			return restoreMarketplace(commandErr)
 		}
 		if alreadyInstalled {
 			text := strings.TrimSpace(string(output))
 			if strings.Contains(strings.ToLower(text), "not found") || strings.Contains(strings.ToLower(text), "not installed") {
 				installCmd := exec.Command("claude", "plugin", "install", "ha-nova@ha-nova")
 				if installOutput, installErr := installCmd.CombinedOutput(); installErr == nil {
-					if err := verifyClaudePluginAttachment(paths.Home, marketplaceRoot); err != nil {
-						return restoreMarketplace(err)
-					}
-					return nil
+					return verifyClaudePluginInstalled(paths.Home, marketplaceRoot)
 				} else {
-					return fmt.Errorf("claude plugin command failed: %s (%s)", strings.Join(installCmd.Args[1:], " "), strings.TrimSpace(string(installOutput)))
+					return restoreMarketplace(fmt.Errorf("claude plugin command failed: %s (%s)", strings.Join(installCmd.Args[1:], " "), strings.TrimSpace(string(installOutput))))
 				}
 			}
 		}
-		return fmt.Errorf("claude plugin command failed: %s (%s)", strings.Join(refreshArgs, " "), strings.TrimSpace(string(output)))
+		return restoreMarketplace(commandErr)
 	}
-	if err := verifyClaudePluginAttachment(paths.Home, marketplaceRoot); err != nil {
+	if err := verifyClaudePluginInstalled(paths.Home, marketplaceRoot); err != nil {
 		return restoreMarketplace(err)
 	}
 	if localMode {
@@ -88,12 +86,23 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 	return nil
 }
 
-func verifyClaudePluginAttachment(home, desiredMarketplaceSource string) error {
-	if err := verifyClaudeMarketplaceRegistration(home, desiredMarketplaceSource); err != nil {
+func verifyClaudePluginInstalled(home, desiredSource string) error {
+	pluginPresent, usableInstallPath := readClaudePluginInstallSnapshot(home)
+	if !pluginPresent {
+		return fmt.Errorf("Claude plugin ha-nova@ha-nova not found after sync")
+	}
+	if !usableInstallPath {
+		return fmt.Errorf("Claude plugin ha-nova@ha-nova installPath missing after sync")
+	}
+	currentSource, hasCurrentSource, err := readClaudeMarketplaceSource(home)
+	if err != nil {
 		return err
 	}
-	if !claudePluginInstalled(home) {
-		return fmt.Errorf("Claude plugin ha-nova@ha-nova not found after sync")
+	if !hasCurrentSource {
+		return fmt.Errorf("Claude marketplace ha-nova not found after sync")
+	}
+	if !sameClaudeMarketplaceSource(currentSource, desiredSource) {
+		return fmt.Errorf("Claude marketplace ha-nova source mismatch after sync")
 	}
 	return nil
 }

--- a/cli/client_detection.go
+++ b/cli/client_detection.go
@@ -8,6 +8,13 @@ func detectInstalledClients(paths runtimePaths) ([]string, error) {
 	}
 	for _, entry := range entries {
 		status := evaluateClientStatus(paths, installState{}, entry)
+		if entry.ID == "claude" {
+			snapshot := inspectClaudeInstallSnapshot(paths, installState{})
+			if status.RuntimeDetected && (status.Attached || snapshot.MarketplaceFound || snapshot.PluginFound) {
+				clients = append(clients, entry.ID)
+			}
+			continue
+		}
 		if status.Attached && status.RuntimeDetected {
 			clients = append(clients, entry.ID)
 		}

--- a/cli/client_status.go
+++ b/cli/client_status.go
@@ -28,8 +28,15 @@ func evaluateClientStatus(paths runtimePaths, state installState, client clientR
 		Label:         client.Label,
 		SupportedOnOS: clientSupportedOnCurrentOS(client),
 	}
-	status.Attached = clientAttachmentPresentForStatus(paths, client.ID)
+	claudeSnapshot := claudeInstallSnapshot{}
+	if client.ID == "claude" {
+		claudeSnapshot = inspectClaudeInstallSnapshot(paths, state)
+	}
+	status.Attached = clientAttachmentPresentForStatus(paths, state, client.ID)
 	status.Configured = containsClient(state.InstalledClients, client.ID) || status.Attached
+	if client.ID == "claude" && (claudeSnapshot.MarketplaceFound || claudeSnapshot.PluginFound) {
+		status.Configured = true
+	}
 	status.RuntimeDetected = clientRuntimeDetectedForStatus(client.ID)
 	status.Ready = status.SupportedOnOS && status.RuntimeDetected && status.Attached
 	status.Reason = clientStatusReason(client.ID, status)
@@ -60,7 +67,7 @@ func clientRuntimeCommand(client string) string {
 	}
 }
 
-func clientAttachmentPresent(paths runtimePaths, client string) bool {
+func clientAttachmentPresent(paths runtimePaths, state installState, client string) bool {
 	switch client {
 	case "codex":
 		return fileExists(filepath.Join(paths.Home, ".agents", "skills", "ha-nova", "ha-nova", "SKILL.md"))
@@ -70,7 +77,7 @@ func clientAttachmentPresent(paths runtimePaths, client string) bool {
 		return fileExists(filepath.Join(paths.Home, ".gemini", "skills", "ha-nova", "SKILL.md")) &&
 			fileExists(filepath.Join(paths.Home, ".gemini", "skills", "ha-nova-review", "SKILL.md"))
 	case "claude":
-		return claudePluginAttached(paths.Home)
+		return inspectClaudeInstallSnapshot(paths, state).Attached
 	default:
 		return false
 	}

--- a/cli/client_status_test_helpers_test.go
+++ b/cli/client_status_test_helpers_test.go
@@ -31,7 +31,7 @@ func withClientAttachmentPresence(t *testing.T, attached map[string]bool) {
 	t.Helper()
 
 	original := clientAttachmentPresentForStatus
-	clientAttachmentPresentForStatus = func(paths runtimePaths, client string) bool {
+	clientAttachmentPresentForStatus = func(paths runtimePaths, _ installState, client string) bool {
 		if value, ok := attached[client]; ok {
 			return value
 		}

--- a/cli/clients_test.go
+++ b/cli/clients_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestInstallClaudePluginUsesLocalMarketplaceByDefaultForInstalledBundle(t *testing.T) {
+func TestInstallClaudePluginUsesVersionedLocalMarketplaceByDefaultForInstalledBundle(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -31,15 +31,21 @@ func TestInstallClaudePluginUsesLocalMarketplaceByDefaultForInstalledBundle(t *t
 		t.Fatalf("read log: %v", err)
 	}
 	log := string(logData)
-	marketplaceRoot := filepath.Join(paths.ConfigDir, "claude-marketplace")
-	if !strings.Contains(log, "plugin validate "+marketplaceRoot) {
-		t.Fatalf("expected staged marketplace validation before install, got:\n%s", log)
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
 	}
-	if !strings.Contains(log, "plugin marketplace add "+marketplaceRoot) {
-		t.Fatalf("expected marketplace add to use staged local marketplace by default, got:\n%s", log)
+	if !strings.Contains(log, "plugin validate ") {
+		t.Fatalf("expected staged marketplace validation before registering the release snapshot, got:\n%s", log)
+	}
+	if !strings.Contains(log, "plugin marketplace add "+expectedRoot) {
+		t.Fatalf("expected marketplace add to use the exact local release snapshot, got:\n%s", log)
 	}
 	if !strings.Contains(log, "plugin install ha-nova@ha-nova") {
 		t.Fatalf("expected plugin install command, got:\n%s", log)
+	}
+	if strings.Contains(log, "github.com/markusleben/ha-nova.git") {
+		t.Fatalf("did not expect bundle install to use a GitHub source, got:\n%s", log)
 	}
 }
 
@@ -124,6 +130,7 @@ func TestInstallClaudePluginStagesDevMarketplaceOutsideRepoRoot(t *testing.T) {
 	t.Setenv("PATH", installClaudeMock(t, home, logPath)+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	sourceRoot := filepath.Join(t.TempDir(), "repo")
+	t.Setenv("HA_NOVA_DEV_ROOT", sourceRoot)
 	writeClaudeMarketplaceFixture(t, sourceRoot)
 	if err := installClaudePlugin(paths, sourceRoot); err != nil {
 		t.Fatalf("installClaudePlugin() error: %v", err)
@@ -187,18 +194,21 @@ func TestInstallClaudePluginUpdatesExistingPlugin(t *testing.T) {
 		t.Fatalf("read log: %v", err)
 	}
 	log := string(logData)
-	marketplaceRoot := filepath.Join(paths.ConfigDir, "claude-marketplace")
-	if !strings.Contains(log, "plugin marketplace add "+marketplaceRoot) {
-		t.Fatalf("expected local marketplace registration for existing plugin, got:\n%s", log)
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
+	}
+	if !strings.Contains(log, "plugin marketplace add "+expectedRoot) {
+		t.Fatalf("expected local release marketplace registration for existing plugin, got:\n%s", log)
 	}
 	if !strings.Contains(log, "plugin remove ha-nova@ha-nova") {
-		t.Fatalf("expected local marketplace sync to reset plugin first, got:\n%s", log)
+		t.Fatalf("expected local release sync to reset plugin first, got:\n%s", log)
 	}
 	if !strings.Contains(log, "plugin install ha-nova@ha-nova") {
-		t.Fatalf("expected local marketplace sync to install fresh plugin, got:\n%s", log)
+		t.Fatalf("expected local release sync to use a fresh install, got:\n%s", log)
 	}
 	if strings.Contains(log, "plugin update ha-nova@ha-nova") {
-		t.Fatalf("did not expect local marketplace sync to use update, got:\n%s", log)
+		t.Fatalf("did not expect local release sync to use plugin update, got:\n%s", log)
 	}
 }
 
@@ -443,11 +453,18 @@ func TestInstallClaudePluginFallsBackToInstallWhenUpdateStateIsStale(t *testing.
 		t.Fatalf("read log: %v", err)
 	}
 	log := string(logData)
-	if !strings.Contains(log, "plugin remove ha-nova@ha-nova") {
-		t.Fatalf("expected stale local plugin reset before reinstall, got:\n%s", log)
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
 	}
 	if !strings.Contains(log, "plugin install ha-nova@ha-nova") {
-		t.Fatalf("expected fresh install for local marketplace sync, got:\n%s", log)
+		t.Fatalf("expected stale update fallback to install fresh plugin, got:\n%s", log)
+	}
+	if !strings.Contains(log, "plugin marketplace add "+expectedRoot) {
+		t.Fatalf("expected stale update fallback to keep the local release snapshot source, got:\n%s", log)
+	}
+	if !strings.Contains(log, "plugin remove ha-nova@ha-nova") {
+		t.Fatalf("expected stale update fallback to reset the plugin first, got:\n%s", log)
 	}
 }
 

--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -99,7 +99,11 @@ func runDoctor(paths runtimePaths, _ []string) int {
 				printHumanWarn("%s", doctorClientRepairHint(client, installSource))
 				status = 1
 			case !client.Attached:
-				printHumanWarn("%s configured, but HA NOVA is not attached", client.Label)
+				if client.ID == "claude" {
+					printHumanWarn("%s is not attached correctly", client.Label)
+				} else {
+					printHumanWarn("%s configured, but HA NOVA is not attached", client.Label)
+				}
 				printHumanWarn("%s", doctorClientRepairHint(client, installSource))
 				status = 1
 			}

--- a/cli/doctor_test.go
+++ b/cli/doctor_test.go
@@ -180,7 +180,7 @@ func TestRunDoctorShowsRepairHintForDetachedConfiguredClaude(t *testing.T) {
 	if exitCode == 0 {
 		t.Fatalf("expected doctor to degrade for detached Claude:\n%s", output)
 	}
-	if !strings.Contains(output, "Claude Code configured, but HA NOVA is not attached") {
+	if !strings.Contains(output, "Claude Code is not attached correctly") {
 		t.Fatalf("expected detached Claude warning:\n%s", output)
 	}
 	if !strings.Contains(output, "Repair: run `ha-nova setup claude`.") {
@@ -271,7 +271,7 @@ func TestRunDoctorShowsRepairHintWhenClaudeMarketplaceMissing(t *testing.T) {
 	if exitCode == 0 {
 		t.Fatalf("expected doctor to degrade when Claude marketplace is missing:\n%s", output)
 	}
-	if !strings.Contains(output, "Claude Code configured, but HA NOVA is not attached") {
+	if !strings.Contains(output, "Claude Code is not attached correctly") {
 		t.Fatalf("expected detached Claude warning for missing marketplace:\n%s", output)
 	}
 	if !strings.Contains(output, "Repair: run `ha-nova setup claude`.") {

--- a/cli/setup_state_test.go
+++ b/cli/setup_state_test.go
@@ -331,3 +331,41 @@ func TestClientAppearsInstalledForClaudeRejectsLegacyFlatMarketplaceRoot(t *test
 		t.Fatal("expected legacy flat Claude marketplace root to count as not installed")
 	}
 }
+
+func TestClientAppearsInstalledForClaudeIgnoresForeignPluginArrayEntries(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "plugins"), 0o755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"), []byte(`{
+  "plugins": [
+    {
+      "name": "context7@claude-plugins-official",
+      "installPath": "/tmp/context7"
+    }
+  ]
+}`), 0o644); err != nil {
+		t.Fatalf("write installed_plugins.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "plugins", "known_marketplaces.json"), []byte(`{"ha-nova":{"source":"https://github.com/markusleben/ha-nova"}}`), 0o644); err != nil {
+		t.Fatalf("write known_marketplaces.json: %v", err)
+	}
+
+	entry, ok, err := findRegistryClient(paths, "claude")
+	if err != nil {
+		t.Fatalf("findRegistryClient() error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected claude registry entry")
+	}
+	if evaluateClientStatus(paths, installState{}, entry).Ready {
+		t.Fatal("expected foreign Claude plugin array entries to count as not installed")
+	}
+}

--- a/cli/setup_state_test.go
+++ b/cli/setup_state_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -229,6 +230,9 @@ func TestClientAppearsInstalledForClaudeIgnoresBlankInstallPathRecord(t *testing
 }`), 0o644); err != nil {
 		t.Fatalf("write installed_plugins.json: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "plugins", "known_marketplaces.json"), []byte(`{"ha-nova":{"source":"https://github.com/markusleben/ha-nova"}}`), 0o644); err != nil {
+		t.Fatalf("write known_marketplaces.json: %v", err)
+	}
 
 	entry, ok, err := findRegistryClient(paths, "claude")
 	if err != nil {
@@ -267,5 +271,63 @@ func TestClientAppearsInstalledForClaudeIgnoresUnparseableRegistry(t *testing.T)
 	}
 	if evaluateClientStatus(paths, installState{}, entry).Ready {
 		t.Fatal("expected unparseable Claude registry to count as not installed")
+		t.Fatal("expected unparseable Claude registry to count as not installed")
+	}
+}
+
+func TestClientAppearsInstalledForClaudeRequiresMarketplaceRecord(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "plugins"), 0o755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	writeInstalledClaudePluginFixture(t, home)
+
+	entry, ok, err := findRegistryClient(paths, "claude")
+	if err != nil {
+		t.Fatalf("findRegistryClient() error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected claude registry entry")
+	}
+	if evaluateClientStatus(paths, installState{}, entry).Ready {
+		t.Fatal("expected missing Claude marketplace record to count as not installed")
+	}
+}
+
+func TestClientAppearsInstalledForClaudeRejectsLegacyFlatMarketplaceRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "plugins"), 0o755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	writeClaudeMarketplaceFixture(t, paths.InstallRoot)
+	writeInstalledClaudePluginFixture(t, home)
+	legacyRoot := filepath.Join(home, ".config", "ha-nova", "claude-marketplace")
+	if err := os.WriteFile(filepath.Join(home, ".claude", "plugins", "known_marketplaces.json"), []byte(fmt.Sprintf(`{"ha-nova":{"source":%q}}`, legacyRoot)), 0o644); err != nil {
+		t.Fatalf("write known_marketplaces.json: %v", err)
+	}
+
+	entry, ok, err := findRegistryClient(paths, "claude")
+	if err != nil {
+		t.Fatalf("findRegistryClient() error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected claude registry entry")
+	}
+	if evaluateClientStatus(paths, installState{}, entry).Ready {
+		t.Fatal("expected legacy flat Claude marketplace root to count as not installed")
 	}
 }

--- a/cli/update_sync_test.go
+++ b/cli/update_sync_test.go
@@ -22,7 +22,9 @@ func TestPostUpdateSyncRefreshesDetectedInstalledClientsWithoutState(t *testing.
 		t.Fatalf("mkdir plugins: %v", err)
 	}
 	writeInstalledClaudePluginFixture(t, home)
-	writeClaudeMarketplaceRegistrationFixture(t, home, filepath.Join(paths.ConfigDir, "claude-marketplace"))
+	if err := os.WriteFile(filepath.Join(home, ".claude", "plugins", "known_marketplaces.json"), []byte(`{"ha-nova":{"source":"https://github.com/markusleben/ha-nova"}}`), 0o644); err != nil {
+		t.Fatalf("write known marketplaces: %v", err)
+	}
 	writeClaudeMarketplaceFixture(t, paths.InstallRoot)
 
 	logPath := filepath.Join(home, "claude.log")
@@ -36,14 +38,18 @@ func TestPostUpdateSyncRefreshesDetectedInstalledClientsWithoutState(t *testing.
 	if err != nil {
 		t.Fatalf("read log: %v", err)
 	}
-	if !strings.Contains(string(logData), "plugin remove ha-nova@ha-nova") {
-		t.Fatalf("expected detected Claude install to be reset before reinstall, got:\n%s", string(logData))
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
 	}
 	if !strings.Contains(string(logData), "plugin install ha-nova@ha-nova") {
-		t.Fatalf("expected detected Claude install to be reinstalled from the local staged payload, got:\n%s", string(logData))
+		t.Fatalf("expected detected Claude install to be reinstalled from the release snapshot, got:\n%s", string(logData))
 	}
-	if !strings.Contains(string(logData), "plugin marketplace add ") && !strings.Contains(string(logData), "plugin marketplace update ha-nova") {
-		t.Fatalf("expected Claude marketplace to be added or refreshed, got:\n%s", string(logData))
+	if !strings.Contains(string(logData), "plugin marketplace add "+expectedRoot) {
+		t.Fatalf("expected Claude marketplace to point at the exact local release snapshot, got:\n%s", string(logData))
+	}
+	if strings.Contains(string(logData), "github.com/markusleben/ha-nova.git") {
+		t.Fatalf("did not expect update sync to use GitHub for bundle installs, got:\n%s", string(logData))
 	}
 
 	state, err := loadState(paths)
@@ -52,6 +58,52 @@ func TestPostUpdateSyncRefreshesDetectedInstalledClientsWithoutState(t *testing.
 	}
 	if !containsClient(state.InstalledClients, "claude") {
 		t.Fatalf("expected saved state to include detected Claude install, got %+v", state.InstalledClients)
+	}
+}
+
+func TestPostUpdateSyncRepairsConfiguredClaudeWhenMarketplaceRecordIsMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "plugins"), 0o755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	writeInstalledClaudePluginFixture(t, home)
+	writeClaudeMarketplaceFixture(t, paths.InstallRoot)
+
+	logPath := filepath.Join(home, "claude.log")
+	t.Setenv("PATH", installClaudeMock(t, home, logPath)+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	state := installState{
+		SchemaVersion:    stateSchemaVersion,
+		InstalledClients: []string{"claude"},
+	}
+	if err := saveState(paths, state); err != nil {
+		t.Fatalf("saveState() error: %v", err)
+	}
+
+	if err := postUpdateSync(paths); err != nil {
+		t.Fatalf("postUpdateSync() error: %v", err)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	expectedRoot, err := claudeMarketplaceReleaseRoot(paths, "0.1.12")
+	if err != nil {
+		t.Fatalf("claudeMarketplaceReleaseRoot() error: %v", err)
+	}
+	if !strings.Contains(string(logData), "plugin marketplace add "+expectedRoot) {
+		t.Fatalf("expected configured Claude repair to restore the exact local release snapshot, got:\n%s", string(logData))
+	}
+	if !strings.Contains(string(logData), "plugin install ha-nova@ha-nova") {
+		t.Fatalf("expected configured Claude repair to reinstall the plugin, got:\n%s", string(logData))
 	}
 }
 
@@ -80,7 +132,9 @@ func TestPostUpdateSyncRefreshesAllDetectedClients(t *testing.T) {
 		t.Fatalf("mkdir Claude plugins: %v", err)
 	}
 	writeInstalledClaudePluginFixture(t, home)
-	writeClaudeMarketplaceRegistrationFixture(t, home, filepath.Join(paths.ConfigDir, "claude-marketplace"))
+	if err := os.WriteFile(filepath.Join(home, ".claude", "plugins", "known_marketplaces.json"), []byte(`{"ha-nova":{"source":"https://github.com/markusleben/ha-nova"}}`), 0o644); err != nil {
+		t.Fatalf("write known marketplaces: %v", err)
+	}
 
 	if err := os.MkdirAll(filepath.Join(home, ".agents", "skills", "ha-nova", "ha-nova"), 0o755); err != nil {
 		t.Fatalf("mkdir Codex attachment: %v", err)
@@ -123,8 +177,12 @@ func TestPostUpdateSyncRefreshesAllDetectedClients(t *testing.T) {
 	if !strings.Contains(string(logData), "plugin install ha-nova@ha-nova") {
 		t.Fatalf("expected detected Claude install to be refreshed, got:\n%s", string(logData))
 	}
-	if !strings.Contains(string(logData), "plugin marketplace add ") && !strings.Contains(string(logData), "plugin marketplace update ha-nova") {
-		t.Fatalf("expected Claude marketplace to be added or refreshed, got:\n%s", string(logData))
+	expectedRoot := claudeMarketplaceDevRoot(paths)
+	if !strings.Contains(string(logData), "plugin marketplace add "+expectedRoot) {
+		t.Fatalf("expected detected Claude install to use the dev marketplace root, got:\n%s", string(logData))
+	}
+	if strings.Contains(string(logData), "github.com/markusleben/ha-nova.git") {
+		t.Fatalf("did not expect detected Claude install to use GitHub for bundle installs, got:\n%s", string(logData))
 	}
 
 	state, err := loadState(paths)
@@ -182,6 +240,7 @@ func TestPostUpdateSyncContinuesOtherClientsAfterClaudeFailure(t *testing.T) {
 
 	logPath := filepath.Join(home, "claude.log")
 	t.Setenv("PATH", installClaudeMock(t, home, logPath)+string(os.PathListSeparator)+os.Getenv("PATH"))
+	writeInstalledClaudePluginFixture(t, home)
 
 	state := installState{
 		SchemaVersion:    stateSchemaVersion,
@@ -241,6 +300,7 @@ func TestRunUpdateAlreadyCurrentRetriesInstalledClientSync(t *testing.T) {
 	logPath := filepath.Join(home, "claude.log")
 	t.Setenv("PATH", installClaudeMock(t, home, logPath)+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("HA_NOVA_TEST_CLAUDE_INSTALL_FAIL", "1")
+	writeInstalledClaudePluginFixture(t, home)
 
 	state := installState{
 		SchemaVersion:    stateSchemaVersion,

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -50,7 +50,7 @@ The context skill (`ha-nova`) stays the stable entrypoint; sub-skills remain ind
 
 ## Repo-local Hook Note
 
-`hooks/session-start` still exists as a repo-local development helper, but it is **not** the production installation model for Claude. Production Claude installs use the GitHub-backed marketplace path pinned to the installed HA NOVA version. The local staged marketplace layout stays a repo-local development tool only.
+`hooks/session-start` still exists as a repo-local development helper, but it is **not** the production installation model for Claude. Production Claude installs use a versioned local release snapshot under `~/.config/ha-nova/claude-marketplace/releases/vX.Y.Z`. The flat local staged marketplace layout stays a repo-local development tool only.
 
 ## Agent vs Inline Decision Rule
 

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -50,7 +50,7 @@ The context skill (`ha-nova`) stays the stable entrypoint; sub-skills remain ind
 
 ## Repo-local Hook Note
 
-`hooks/session-start` still exists as a repo-local development helper, but it is **not** the production installation model for Claude. Production Claude installs come from the plugin marketplace path, and HA NOVA intentionally keeps the local marketplace layout anchored to `source: "./"` inside the plugin bundle.
+`hooks/session-start` still exists as a repo-local development helper, but it is **not** the production installation model for Claude. Production Claude installs use the GitHub-backed marketplace path pinned to the installed HA NOVA version. The local staged marketplace layout stays a repo-local development tool only.
 
 ## Agent vs Inline Decision Rule
 
@@ -285,7 +285,7 @@ Rules for this helper family:
 It handles repo-local skill refreshes for development and validation:
 - source skill tree: `skills/` (repo-local, flat layout)
 - client-specific install strategies:
-  - **Claude Code:** stages a local marketplace root under `~/.config/ha-nova/claude-marketplace`, registers it with `claude plugin marketplace add`, then installs/reinstalls `ha-nova@ha-nova`
+  - **Claude Code:** for repo-local development only, stages a local marketplace root under `~/.config/ha-nova/claude-marketplace`, registers it with `claude plugin marketplace add`, then installs/reinstalls `ha-nova@ha-nova`
   - **Codex CLI:** symlink on Unix, copy fallback on Windows at `~/.agents/skills/ha-nova`
   - **OpenCode:** symlink on Unix, copy fallback on Windows at `~/.config/opencode/skills/ha-nova`
   - **Gemini CLI:** Flat copy `~/.gemini/skills/ha-nova-*/SKILL.md` (1-level limit), with namespaced sub-skill names matching those folder names
@@ -300,6 +300,7 @@ The other helper roles are intentionally smaller:
 The end-user installer contract is:
 - `install.sh` / `install.ps1` bootstrap the runtime, handle legacy gating, and hand off into `ha-nova setup`
 - `ha-nova setup` owns product setup, migration, and client attachment
+- bundled Claude installs attach to a versioned local release snapshot under `~/.config/ha-nova/claude-marketplace/releases/vX.Y.Z`; the flat `~/.config/ha-nova/claude-marketplace` root stays repo/dev-only
 
 ## Skill Section Template
 

--- a/docs/work/2026-03-27-breadcrumbs.md
+++ b/docs/work/2026-03-27-breadcrumbs.md
@@ -154,3 +154,39 @@ Historical breadcrumb log:
 - Run the targeted review-live contract suite
 - Commit the post-merge follow-up fix on a new branch
 - Open a small follow-up PR and wait for a fresh clean Codex result before merging
+
+## 2026-04-14: Claude Release Snapshot Implementation
+
+### Completed
+- Replaced the Claude production default with an exact versioned local release snapshot under `~/.config/ha-nova/claude-marketplace/releases/vX.Y.Z`
+- Kept the flat local marketplace root for dev / explicit override only
+- Removed the bundle-path fallback to floating GitHub; missing or incomplete Claude payload now fails loudly
+- Tightened Claude attach truth so healthy state requires:
+  - marketplace record present
+  - plugin record present
+  - usable `installPath`
+  - expected marketplace source match
+- Added regression coverage for:
+  - bundle install -> versioned local snapshot
+  - legacy GitHub source migration -> versioned local snapshot
+  - missing marketplace repair on same-version update
+  - old flat local root no longer counting as healthy
+  - bundle payload missing -> loud failure
+- Proved the behavior on macOS both in:
+  - an isolated temp-`HOME`
+  - the real user profile after backup + deliberate marketplace removal
+
+### Verification
+- `cd cli && go test ./... -run 'TestInstallClaudePlugin|TestPostUpdateSync|TestClientAppearsInstalledForClaude|TestRunDoctor'`
+- `npx vitest run tests/onboarding/install-skills-per-client.test.ts tests/onboarding/dev-sync-behavior.test.ts tests/onboarding/desktop-validation-contract.test.ts tests/onboarding/client-install-docs-contract.test.ts tests/onboarding/dev-sync-contract.test.ts`
+- `git diff --check`
+- Real macOS checks:
+  - `go run . doctor`
+  - `claude plugin list`
+  - `claude plugin marketplace list`
+  - deliberate marketplace removal -> same-version `update --version 0.4.1` repair back to the versioned local snapshot
+
+### Next
+- Open a focused PR for the Claude release-snapshot fix
+- Wait for CI + Codex on the exact PR SHA
+- Merge and ship as a small patch release so all users get the same production attach model

--- a/docs/work/2026-03-27-choices.md
+++ b/docs/work/2026-03-27-choices.md
@@ -1508,3 +1508,17 @@ Superseded in structure by the 2026-03-12 catalog split below. Keep the threshol
 
 - **Review-live shell network rule:** detect multiline Python network commands by checking interpreter and client-library tokens independently within the same `command_execution` payload.
 - **Reason:** heredoc-based commands split across newlines bypass single-regex same-line matching and can produce false-passing local-only review harness runs.
+
+## 2026-04-14
+
+- **Claude production release-snapshot rule:** normal bundle installs must attach Claude to a versioned local release snapshot under `~/.config/ha-nova/claude-marketplace/releases/vX.Y.Z`, not to GitHub and not to the flat local root.
+- **Reason:** GitHub-backed marketplace sources still risk release drift, while the old flat local root was too reusable and fragile; the versioned local snapshot is the smallest model that keeps Claude on the exact shipped release.
+
+- **Claude bundle-no-fallback rule:** if the bundle-local Claude payload cannot produce the exact release snapshot, fail loudly instead of falling back to GitHub.
+- **Reason:** a silent remote fallback would reintroduce the same release-drift problem the snapshot model is meant to prevent.
+
+- **Claude proof-before-ship rule:** do not call the release-snapshot model done until it passes both an isolated temp-`HOME` run and a real-profile macOS repair run.
+- **Reason:** this bug sits in Claude's own registry files; repo tests prove contract, but only real CLI state proves attach, repair, and relaunch behavior.
+
+- **Claude repair-source rule:** same-version `ha-nova update` must rebuild Claude from the exact local release snapshot and restore the marketplace record to that same versioned directory.
+- **Reason:** the real-profile test showed the missing-marketplace drift can be repaired cleanly without changing the installed HA NOVA version.

--- a/docs/work/2026-04-14-claude-release-snapshot-implementation-spec.md
+++ b/docs/work/2026-04-14-claude-release-snapshot-implementation-spec.md
@@ -1,0 +1,50 @@
+# Claude Release Snapshot Implementation Spec
+
+Date: 2026-04-14
+
+## Problem
+
+The earlier Claude fix path moved bundle installs to GitHub-backed marketplace sources.
+
+That reduced one detach trigger, but it did not solve the user's original release-integrity requirement:
+
+- the installed Claude source could still drift away from the shipped HA NOVA release
+- later `main` commits could become visible through the marketplace source shape
+- the old flat local root and the new GitHub path did not give one exact release snapshot target
+
+## Decision
+
+Bundle installs now treat Claude like a release-pinned local artifact again, but not through the old flat root.
+
+Production target:
+- `~/.config/ha-nova/claude-marketplace/releases/vX.Y.Z`
+
+Dev-only target:
+- `~/.config/ha-nova/claude-marketplace`
+
+Legacy GitHub marketplace forms remain supported only as migration inputs.
+
+## Implementation
+
+1. Bundle installs build and register the exact versioned local snapshot path.
+2. Dev installs and explicit `HA_NOVA_CLAUDE_MARKETPLACE_LOCAL=1` continue to use the flat dev root.
+3. Claude health now requires:
+   - marketplace record present
+   - plugin record present
+   - usable `installPath`
+   - expected marketplace source match
+4. Detection and repair treat legacy GitHub or flat-local Claude states as repairable, not healthy.
+5. Bundle installs no longer fall back to GitHub when the local Claude payload is missing; that is now a loud failure.
+
+## Verification
+
+- Go regressions cover:
+  - bundle default -> versioned local snapshot
+  - legacy GitHub migration -> versioned local snapshot
+  - configured-Claude repair when marketplace record is missing
+  - bundle payload missing -> hard failure
+  - old flat local marketplace root -> not healthy
+- Vitest contract lanes cover:
+  - repo/dev Claude path still uses the flat local root
+  - dev sync still repairs Claude
+  - desktop validation contract still reflects explicit local override for private RC/dev flows


### PR DESCRIPTION
## Summary
- pin production Claude installs to exact local release snapshots under `~/.config/ha-nova/claude-marketplace/releases/vX.Y.Z`
- remove the bundle fallback to floating GitHub and require marketplace + plugin + usable install path for a healthy Claude attach
- add migration/repair coverage plus notes for the isolated and real-mac proof runs

## Why
Claude was detaching and the old fallback path could drift to `main`. This keeps production Claude on the exact shipped release and makes same-version repair rebuild from that same local snapshot.

## Testing
- `cd cli && go test ./... -run 'TestInstallClaudePlugin|TestPostUpdateSync|TestClientAppearsInstalledForClaude|TestRunDoctor'`
- `npx vitest run tests/onboarding/install-skills-per-client.test.ts tests/onboarding/dev-sync-behavior.test.ts tests/onboarding/desktop-validation-contract.test.ts tests/onboarding/client-install-docs-contract.test.ts tests/onboarding/dev-sync-contract.test.ts`
- `git diff --check`
- isolated temp-`HOME` macOS proof for `setup claude`, deliberate marketplace removal, and same-version `update --version 0.4.1` repair
- real-profile macOS proof with backup, deliberate marketplace removal, and same-version repair back to `/Users/markus/.config/ha-nova/claude-marketplace/releases/v0.4.1`
