### PR TITLE
chore: prep v0.4.2 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.4.1"
+    "version": "0.4.2"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/docs/work/2026-03-27-breadcrumbs.md
+++ b/docs/work/2026-03-27-breadcrumbs.md
@@ -190,3 +190,26 @@ Historical breadcrumb log:
 - Open a focused PR for the Claude release-snapshot fix
 - Wait for CI + Codex on the exact PR SHA
 - Merge and ship as a small patch release so all users get the same production attach model
+
+## 2026-04-15
+
+### Release Prep
+- Started isolated `v0.4.2` release prep in fresh clone `/tmp/ha-nova-v042-prep` because the main workspace is dirty and behind/ahead of `origin/main`.
+- Confirmed release delta from `v0.4.1..main` is only the merged Claude release-snapshot fix in `#173`.
+- Wrote minimal release prep spec:
+  - `docs/work/2026-04-15-v0.4.2-release-prep-spec.md`
+- Drafted release body:
+  - `docs/work/2026-04-15-v0.4.2-release-body.md`
+- Bumped release metadata to `0.4.2` in:
+  - `version.json`
+  - `package.json`
+  - `package-lock.json`
+  - `.claude-plugin/plugin.json`
+  - `.claude-plugin/marketplace.json`
+- Verified release prep locally:
+  - `npm run verify:next-release-version -- v0.4.2`
+  - `npm run verify:release-metadata`
+  - `npm run verify:release-contracts`
+  - `npx vitest run tests/onboarding/bump-version.test.ts tests/onboarding/release-contract.test.ts`
+  - `cd cli && go test ./... -run 'TestInstallClaudePlugin|TestPostUpdateSync|TestClientAppearsInstalledForClaude|TestRunDoctor'`
+  - `git diff --check`

--- a/docs/work/2026-03-27-choices.md
+++ b/docs/work/2026-03-27-choices.md
@@ -1522,3 +1522,8 @@ Superseded in structure by the 2026-03-12 catalog split below. Keep the threshol
 
 - **Claude repair-source rule:** same-version `ha-nova update` must rebuild Claude from the exact local release snapshot and restore the marketplace record to that same versioned directory.
 - **Reason:** the real-profile test showed the missing-marketplace drift can be repaired cleanly without changing the installed HA NOVA version.
+
+## 2026-04-15
+
+- **Release-worthiness rule for `v0.4.2`:** ship the Claude release-snapshot fix as a patch release immediately instead of batching it.
+- **Reason:** the bug affects the live Claude attach model in the published product, and the fix is already merged, reviewed, and proven on a real macOS profile.

--- a/docs/work/2026-04-15-v0.4.2-release-body.md
+++ b/docs/work/2026-04-15-v0.4.2-release-body.md
@@ -1,0 +1,22 @@
+## Bug Fixes
+
+- Claude Code now stays attached to the exact installed HA NOVA release instead of drifting to a floating source.
+- Same-version Claude repair now rebuilds the exact local release snapshot and reattaches Claude to that same release.
+- `ha-nova doctor` now treats Claude as healthy only when the expected snapshot source, marketplace state, plugin record, and install path all line up.
+
+## Install
+
+**macOS / Linux**
+```sh
+curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/v0.4.2/install.sh | HA_NOVA_VERSION=v0.4.2 bash
+```
+
+**Windows (PowerShell)**
+```powershell
+$env:HA_NOVA_VERSION = 'v0.4.2'
+irm https://raw.githubusercontent.com/markusleben/ha-nova/v0.4.2/install.ps1 | iex
+```
+
+## Already Installed?
+
+Run `ha-nova check-update` or `ha-nova update`.

--- a/docs/work/2026-04-15-v0.4.2-release-prep-spec.md
+++ b/docs/work/2026-04-15-v0.4.2-release-prep-spec.md
@@ -1,0 +1,20 @@
+## Goal
+
+Prepare `v0.4.2` as the patch release after `v0.4.1`.
+
+## Release Delta
+
+- `#173` pin Claude production installs to exact local release snapshots
+- same-version Claude repair now restores the exact installed release snapshot instead of drifting to a floating source
+- `doctor` and status checks now require the expected Claude snapshot source, marketplace record, plugin record, and usable install path together
+
+## Open PR Preflight
+
+- no open blocker-now PRs should be pulled into this release after `#173`
+- release scope stays limited to the Claude snapshot fix already merged in `main`
+
+## Release Notes Shape
+
+- no `New Features`
+- selective `Bug Fixes` only
+- keep `Install` and `Already Installed?`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.4.1",
+  "skill_version": "0.4.2",
   "min_relay_version": "0.1.0"
 }


### PR DESCRIPTION
## Summary
- bump release metadata to 0.4.2
- add the v0.4.2 release prep spec and release body
- ship the Claude release-snapshot fix from main as a focused patch release

## Verification
- npm run verify:next-release-version -- v0.4.2
- npm run verify:release-metadata
- npm run verify:release-contracts
- npx vitest run tests/onboarding/bump-version.test.ts tests/onboarding/release-contract.test.ts
- cd cli && go test ./... -run 'TestInstallClaudePlugin|TestPostUpdateSync|TestClientAppearsInstalledForClaude|TestRunDoctor'\n- git diff --check