### PR TITLE
fix: recover Linux secure storage during setup

### DIFF
--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+var readRelayAuthTokenForDoctor = readRelayAuthToken
+
 func runDoctor(paths runtimePaths, _ []string) int {
 	if recovery := inspectWindowsUninstallStatus(paths); recovery.Kind != windowsUninstallStatusKindNone {
 		switch recovery.Kind {
@@ -25,7 +27,7 @@ func runDoctor(paths runtimePaths, _ []string) int {
 	}
 
 	cfg, cfgErr := loadConfig(paths)
-	token, tokenErr := readRelayAuthToken()
+	token, tokenErr := readRelayAuthTokenForDoctor()
 	state := loadStateOrDefault(paths)
 	status := 0
 
@@ -40,6 +42,9 @@ func runDoctor(paths runtimePaths, _ []string) int {
 		printHumanInfo("Relay auth token present in secure storage")
 	} else {
 		printHumanErr("%s", relayAuthTokenProblemMessage(tokenErr))
+		if hint := setupSecureStorageRecoveryHint(tokenErr); hint != "" {
+			printHumanWarn("%s", hint)
+		}
 		return 1
 	}
 

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -79,12 +79,23 @@ func runSetup(paths runtimePaths, args []string) int {
 		cfg.RelayBaseURL = "http://" + cfg.HAHost + ":8791"
 	}
 
+	tokenStoragePreflightErr := relayAuthTokenSetupPreflightForSetup()
 	token := strings.TrimSpace(*relayToken)
 	if token == "" {
+		if tokenStoragePreflightErr != nil {
+			printHumanErr("%s", relayAuthTokenProblemMessage(tokenStoragePreflightErr))
+			if hint := setupSecureStorageRecoveryHint(tokenStoragePreflightErr); hint != "" {
+				printHumanWarn("%s", hint)
+			}
+			return 1
+		}
 		if existing, err := readRelayAuthToken(); err == nil {
 			token = existing
 		} else if !isMissingRelayAuthTokenError(err) {
 			printHumanErr("%s", relayAuthTokenProblemMessage(err))
+			if hint := setupSecureStorageRecoveryHint(err); hint != "" {
+				printHumanWarn("%s", hint)
+			}
 			return 1
 		}
 	}
@@ -101,6 +112,13 @@ func runSetup(paths runtimePaths, args []string) int {
 		return 1
 	}
 
+	if tokenStoragePreflightErr != nil {
+		printHumanErr("%s", relayAuthTokenSetupSaveError(tokenStoragePreflightErr))
+		if hint := setupSecureStorageRecoveryHint(tokenStoragePreflightErr); hint != "" {
+			printHumanWarn("%s", hint)
+		}
+		return 1
+	}
 	previousToken, tokenErr := readRelayAuthToken()
 	hadPreviousToken := tokenErr == nil && strings.TrimSpace(previousToken) != ""
 	tokenChanged := !hadPreviousToken || previousToken != token
@@ -116,8 +134,18 @@ func runSetup(paths runtimePaths, args []string) int {
 		return 1
 	}
 	if tokenChanged {
+		if err := relayAuthTokenSetupPreflightForSetup(); err != nil {
+			printHumanErr("%s", relayAuthTokenSetupSaveError(err))
+			if hint := setupSecureStorageRecoveryHint(err); hint != "" {
+				printHumanWarn("%s", hint)
+			}
+			return 1
+		}
 		if err := writeRelayAuthTokenForSetup(token); err != nil {
-			printHumanErr("cannot save relay token: %s", err)
+			printHumanErr("%s", relayAuthTokenSetupSaveError(err))
+			if hint := setupSecureStorageRecoveryHint(err); hint != "" {
+				printHumanWarn("%s", hint)
+			}
 			return 1
 		}
 	}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,6 +3,7 @@ module github.com/markusleben/ha-nova/cli
 go 1.24.0
 
 require (
+	github.com/godbus/dbus/v5 v5.1.0
 	github.com/itchyny/gojq v0.12.18
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/sys v0.39.0
@@ -12,6 +13,5 @@ require (
 require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	github.com/danieljoos/wincred v1.2.2 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.7 // indirect
 )

--- a/cli/keyring_error_classify_linux.go
+++ b/cli/keyring_error_classify_linux.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+package main
+
+import "strings"
+
+var inspectLinuxSecureStorageStateForClassification = inspectLinuxSecureStorageState
+
+func classifyAmbiguousDesktopKeyringSetupError(err error) error {
+	if err == nil {
+		return nil
+	}
+	message := strings.ToLower(err.Error())
+	if !strings.Contains(message, "failed to unlock correct collection") {
+		return nil
+	}
+
+	state, inspectErr := inspectLinuxSecureStorageStateForClassification()
+	if inspectErr != nil {
+		return nil
+	}
+	switch state.kind {
+	case linuxSecureStorageStateNeedsInit:
+		return desktopKeyringInitializationRequiredError(err.Error())
+	case linuxSecureStorageStateLocked:
+		return desktopKeyringLockedError(err.Error())
+	default:
+		return nil
+	}
+}

--- a/cli/keyring_error_classify_other.go
+++ b/cli/keyring_error_classify_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package main
+
+func classifyAmbiguousDesktopKeyringSetupError(err error) error {
+	_ = err
+	return nil
+}

--- a/cli/keyring_linux.go
+++ b/cli/keyring_linux.go
@@ -9,6 +9,10 @@ import (
 	"github.com/zalando/go-keyring"
 )
 
+var keyringGetWithService = keyring.Get
+var keyringSetWithService = keyring.Set
+var keyringDeleteWithService = keyring.Delete
+
 func readRelayAuthToken() (string, error) {
 	if token, overridden, err := readRelayAuthTokenOverride(); overridden {
 		if err != nil {
@@ -19,20 +23,7 @@ func readRelayAuthToken() (string, error) {
 		}
 		return token, nil
 	}
-	u, err := user.Current()
-	if err != nil {
-		return "", fmt.Errorf("cannot determine current user: %w", err)
-	}
-	service := relayAuthTokenServiceName()
-
-	token, err := keyring.Get(service, u.Username)
-	if err != nil {
-		if err == keyring.ErrNotFound {
-			return "", missingRelayAuthTokenError(service)
-		}
-		return "", relayAuthTokenReadError(service, err)
-	}
-	return token, nil
+	return readSecretWithService(relayAuthTokenServiceName())
 }
 
 func writeRelayAuthToken(token string) error {
@@ -42,11 +33,7 @@ func writeRelayAuthToken(token string) error {
 		}
 		return nil
 	}
-	u, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("cannot determine current user: %w", err)
-	}
-	return keyring.Set(relayAuthTokenServiceName(), u.Username, token)
+	return writeSecretWithService(relayAuthTokenServiceName(), token)
 }
 
 func deleteRelayAuthToken() error {
@@ -56,12 +43,48 @@ func deleteRelayAuthToken() error {
 		}
 		return nil
 	}
+	return deleteSecretWithService(relayAuthTokenServiceName())
+}
+
+func currentKeyringUsername() (string, error) {
 	u, err := user.Current()
 	if err != nil {
-		return fmt.Errorf("cannot determine current user: %w", err)
+		return "", fmt.Errorf("cannot determine current user: %w", err)
 	}
-	if err := keyring.Delete(relayAuthTokenServiceName(), u.Username); err != nil && err != keyring.ErrNotFound {
+	return u.Username, nil
+}
+
+func readSecretWithService(service string) (string, error) {
+	username, err := currentKeyringUsername()
+	if err != nil {
+		return "", err
+	}
+
+	token, err := keyringGetWithService(service, username)
+	if err != nil {
+		if err == keyring.ErrNotFound {
+			return "", missingRelayAuthTokenError(service)
+		}
+		return "", relayAuthTokenReadError(service, normalizeLinuxKeyringError(err))
+	}
+	return token, nil
+}
+
+func writeSecretWithService(service, token string) error {
+	username, err := currentKeyringUsername()
+	if err != nil {
 		return err
+	}
+	return normalizeLinuxKeyringError(keyringSetWithService(service, username, token))
+}
+
+func deleteSecretWithService(service string) error {
+	username, err := currentKeyringUsername()
+	if err != nil {
+		return err
+	}
+	if err := keyringDeleteWithService(service, username); err != nil && err != keyring.ErrNotFound {
+		return normalizeLinuxKeyringError(err)
 	}
 	return nil
 }

--- a/cli/keyring_linux_secure_storage.go
+++ b/cli/keyring_linux_secure_storage.go
@@ -1,0 +1,313 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	dbus "github.com/godbus/dbus/v5"
+)
+
+const (
+	secretCollectionDBusInterface        = "org.freedesktop.Secret.Collection"
+	dbusIntrospectableInterface          = "org.freedesktop.DBus.Introspectable"
+	secretServicePropertiesInterface     = "org.freedesktop.DBus.Properties"
+	secretServiceDefaultCollectionAlias  = "default"
+	secretServiceDefaultCollectionLabel  = "Login"
+	secretServiceContentType             = "text/plain; charset=utf8"
+	gnomeKeyringInternalDBusInterface    = "org.gnome.keyring.InternalUnsupportedGuiltRiddenInterface"
+	gnomeKeyringCreateWithPasswordMethod = gnomeKeyringInternalDBusInterface + ".CreateWithMasterPassword"
+	gnomeKeyringUnlockWithPasswordMethod = gnomeKeyringInternalDBusInterface + ".UnlockWithMasterPassword"
+)
+
+type linuxSecureStorageStateKind string
+
+const (
+	linuxSecureStorageStateWritable  linuxSecureStorageStateKind = "writable"
+	linuxSecureStorageStateLocked    linuxSecureStorageStateKind = "locked"
+	linuxSecureStorageStateNeedsInit linuxSecureStorageStateKind = "needs-init"
+)
+
+type linuxSecureStorageState struct {
+	kind              linuxSecureStorageStateKind
+	defaultCollection dbus.ObjectPath
+}
+
+type secretServiceOwnerProcess struct {
+	comm    string
+	exePath string
+}
+
+type secretServiceSecret struct {
+	Session     dbus.ObjectPath
+	Parameters  []byte
+	Value       []byte
+	ContentType string `dbus:"content_type"`
+}
+
+var secureStorageRecoveryReadFile = os.ReadFile
+var secureStorageRecoveryReadLink = os.Readlink
+var secureStorageRecoveryStat = os.Stat
+var secureStorageRecoverySupportsGNOMEMethods = secretServiceSupportsGNOMERecoveryMethods
+
+func inspectLinuxSecureStorageState() (linuxSecureStorageState, error) {
+	conn, err := relayAuthTokenPreflightSessionBusWithTimeout(relayAuthTokenPreflightTimeout)
+	if err != nil {
+		if isDesktopKeyringSessionUnavailableError(err) {
+			return linuxSecureStorageState{}, desktopKeyringSessionUnavailableError(err.Error())
+		}
+		if errorsIsContextDeadlineExceeded(err) {
+			return linuxSecureStorageState{}, desktopKeyringUnavailableError("Secret Service preflight timed out")
+		}
+		return linuxSecureStorageState{}, err
+	}
+	return inspectLinuxSecureStorageStateWithConn(conn)
+}
+
+func inspectLinuxSecureStorageStateWithConn(conn *dbus.Conn) (linuxSecureStorageState, error) {
+	defaultCollection, err := readSecretServiceDefaultCollection(conn)
+	if err != nil {
+		return linuxSecureStorageState{}, err
+	}
+	if strings.TrimSpace(string(defaultCollection)) == "" || defaultCollection == dbus.ObjectPath("/") {
+		return linuxSecureStorageState{kind: linuxSecureStorageStateNeedsInit}, nil
+	}
+
+	locked, err := secretServiceCollectionLocked(conn, defaultCollection)
+	if err != nil {
+		if isDesktopKeyringInitializationRequiredError(err) {
+			return linuxSecureStorageState{kind: linuxSecureStorageStateNeedsInit}, nil
+		}
+		return linuxSecureStorageState{}, err
+	}
+	if locked {
+		return linuxSecureStorageState{
+			kind:              linuxSecureStorageStateLocked,
+			defaultCollection: defaultCollection,
+		}, nil
+	}
+
+	return linuxSecureStorageState{
+		kind:              linuxSecureStorageStateWritable,
+		defaultCollection: defaultCollection,
+	}, nil
+}
+
+func readSecretServiceDefaultCollection(conn *dbus.Conn) (dbus.ObjectPath, error) {
+	service := conn.Object(secretServiceDBusName, dbus.ObjectPath(secretServiceDBusPath))
+	ctx, cancel := context.WithTimeout(context.Background(), relayAuthTokenPreflightTimeout)
+	defer cancel()
+
+	var defaultCollection dbus.ObjectPath
+	if err := service.CallWithContext(ctx, secretServiceDBusInterface+".ReadAlias", 0, secretServiceDefaultCollectionAlias).Store(&defaultCollection); err != nil {
+		return "", normalizeLinuxKeyringErrorWithoutAmbiguousClassification(err)
+	}
+	return defaultCollection, nil
+}
+
+func secretServiceCollectionLocked(conn *dbus.Conn, collection dbus.ObjectPath) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), relayAuthTokenPreflightTimeout)
+	defer cancel()
+
+	var locked dbus.Variant
+	err := conn.Object(secretServiceDBusName, collection).CallWithContext(
+		ctx,
+		secretServicePropertiesInterface+".Get",
+		0,
+		secretCollectionDBusInterface,
+		"Locked",
+	).Store(&locked)
+	if err != nil {
+		return false, normalizeLinuxKeyringErrorWithoutAmbiguousClassification(err)
+	}
+
+	value, ok := locked.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("Secret Service returned invalid collection lock state")
+	}
+	return value, nil
+}
+
+func openSecretServiceSession(conn *dbus.Conn) (dbus.ObjectPath, func(), error) {
+	ctx, cancel := context.WithTimeout(context.Background(), relayAuthTokenPreflightTimeout)
+	var output dbus.Variant
+	var session dbus.ObjectPath
+	err := conn.Object(secretServiceDBusName, dbus.ObjectPath(secretServiceDBusPath)).
+		CallWithContext(ctx, secretServiceDBusInterface+".OpenSession", 0, "plain", dbus.MakeVariant("")).
+		Store(&output, &session)
+	cancel()
+	if err != nil {
+		return "", func() {}, normalizeLinuxKeyringErrorWithoutAmbiguousClassification(err)
+	}
+
+	closeSession := func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), relayAuthTokenPreflightTimeout)
+		defer closeCancel()
+		_ = conn.Object(secretServiceDBusName, session).CallWithContext(closeCtx, "org.freedesktop.Secret.Session.Close", 0).Err
+	}
+	return session, closeSession, nil
+}
+
+func newSecretServiceSecret(session dbus.ObjectPath, secret []byte) secretServiceSecret {
+	return secretServiceSecret{
+		Session:     session,
+		Parameters:  []byte{},
+		Value:       append([]byte(nil), secret...),
+		ContentType: secretServiceContentType,
+	}
+}
+
+func initializeLinuxSecureStorage(conn *dbus.Conn, secret []byte) error {
+	session, closeSession, err := openSecretServiceSession(conn)
+	if err != nil {
+		return err
+	}
+	defer closeSession()
+	payload := newSecretServiceSecret(session, secret)
+	defer zeroSecretBytes(payload.Value)
+
+	properties := map[string]dbus.Variant{
+		secretCollectionDBusInterface + ".Label": dbus.MakeVariant(secretServiceDefaultCollectionLabel),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), secureStorageUnlockTimeout)
+	defer cancel()
+
+	var collection dbus.ObjectPath
+	err = conn.Object(secretServiceDBusName, dbus.ObjectPath(secretServiceDBusPath)).
+		CallWithContext(ctx, gnomeKeyringCreateWithPasswordMethod, 0, properties, payload).
+		Store(&collection)
+	if err != nil {
+		return normalizeLinuxKeyringErrorWithoutAmbiguousClassification(err)
+	}
+	if strings.TrimSpace(string(collection)) == "" || collection == dbus.ObjectPath("/") {
+		return desktopKeyringInitializationRequiredError("GNOME Keyring did not create a default collection")
+	}
+
+	if err := conn.Object(secretServiceDBusName, dbus.ObjectPath(secretServiceDBusPath)).
+		CallWithContext(ctx, secretServiceDBusInterface+".SetAlias", 0, secretServiceDefaultCollectionAlias, collection).Err; err != nil {
+		return normalizeLinuxKeyringErrorWithoutAmbiguousClassification(err)
+	}
+	return nil
+}
+
+func unlockLinuxSecureStorage(conn *dbus.Conn, collection dbus.ObjectPath, secret []byte) error {
+	session, closeSession, err := openSecretServiceSession(conn)
+	if err != nil {
+		return err
+	}
+	defer closeSession()
+	payload := newSecretServiceSecret(session, secret)
+	defer zeroSecretBytes(payload.Value)
+
+	ctx, cancel := context.WithTimeout(context.Background(), secureStorageUnlockTimeout)
+	defer cancel()
+
+	err = conn.Object(secretServiceDBusName, dbus.ObjectPath(secretServiceDBusPath)).
+		CallWithContext(ctx, gnomeKeyringUnlockWithPasswordMethod, 0, collection, payload).Err
+	if err != nil {
+		if isGNOMEKeyringInvalidPasswordError(err) {
+			return localSecureStoragePasswordRejectedError()
+		}
+		return normalizeLinuxKeyringErrorWithoutAmbiguousClassification(err)
+	}
+	return nil
+}
+
+func isGNOMEKeyringInvalidPasswordError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "password was invalid")
+}
+
+func detectSecretServiceOwnerProcessForRecovery() (secretServiceOwnerProcess, error) {
+	conn, err := relayAuthTokenPreflightSessionBusWithTimeout(relayAuthTokenPreflightTimeout)
+	if err != nil {
+		if isDesktopKeyringSessionUnavailableError(err) {
+			return secretServiceOwnerProcess{}, desktopKeyringSessionUnavailableError(err.Error())
+		}
+		if errorsIsContextDeadlineExceeded(err) {
+			return secretServiceOwnerProcess{}, desktopKeyringUnavailableError("Secret Service preflight timed out")
+		}
+		return secretServiceOwnerProcess{}, err
+	}
+	return secretServiceOwnerInfo(conn)
+}
+
+func secretServiceOwnerInfo(conn *dbus.Conn) (secretServiceOwnerProcess, error) {
+	bus := conn.Object(dbusServiceName, dbus.ObjectPath(dbusServicePath))
+
+	var owner string
+	if err := bus.Call(dbusServiceInterface+".GetNameOwner", 0, secretServiceDBusName).Store(&owner); err != nil {
+		return secretServiceOwnerProcess{}, normalizeLinuxKeyringError(err)
+	}
+	if owner == "" {
+		return secretServiceOwnerProcess{}, desktopKeyringUnavailableError("Secret Service owner unavailable")
+	}
+
+	var pid uint32
+	if err := bus.Call(dbusServiceInterface+".GetConnectionUnixProcessID", 0, owner).Store(&pid); err != nil {
+		return secretServiceOwnerProcess{}, err
+	}
+	if pid == 0 {
+		return secretServiceOwnerProcess{}, fmt.Errorf("Secret Service owner pid unavailable")
+	}
+
+	process := secretServiceOwnerProcess{}
+	if comm, err := secureStorageRecoveryReadFile(filepath.Join("/proc", fmt.Sprintf("%d", pid), "comm")); err == nil {
+		process.comm = strings.TrimSpace(string(comm))
+	}
+	if exePath, err := secureStorageRecoveryReadLink(filepath.Join("/proc", fmt.Sprintf("%d", pid), "exe")); err == nil {
+		process.exePath = exePath
+	}
+	if process.comm == "" && process.exePath == "" {
+		return secretServiceOwnerProcess{}, fmt.Errorf("Secret Service owner process details unavailable")
+	}
+	return process, nil
+}
+
+func (process secretServiceOwnerProcess) supportsGNOMEKeyringRecovery() bool {
+	if !isGNOMEKeyringProcessName(process.comm) && !isGNOMEKeyringProcessName(filepath.Base(process.exePath)) {
+		return false
+	}
+	if !filepath.IsAbs(process.exePath) {
+		return false
+	}
+	info, err := secureStorageRecoveryStat(process.exePath)
+	if err != nil {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return stat.Uid == 0
+}
+
+func secretServiceSupportsGNOMERecoveryMethods(conn *dbus.Conn) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), relayAuthTokenPreflightTimeout)
+	defer cancel()
+
+	var xml string
+	err := conn.Object(secretServiceDBusName, dbus.ObjectPath(secretServiceDBusPath)).
+		CallWithContext(ctx, dbusIntrospectableInterface+".Introspect", 0).
+		Store(&xml)
+	if err != nil {
+		return false, normalizeLinuxKeyringError(err)
+	}
+
+	return strings.Contains(xml, gnomeKeyringInternalDBusInterface) &&
+		strings.Contains(xml, "CreateWithMasterPassword") &&
+		strings.Contains(xml, "UnlockWithMasterPassword"), nil
+}
+
+func isGNOMEKeyringProcessName(name string) bool {
+	name = strings.TrimSpace(strings.ToLower(name))
+	return name == gnomeKeyringComm || strings.HasPrefix(name, "gnome-keyring")
+}

--- a/cli/keyring_linux_secure_storage.go
+++ b/cli/keyring_linux_secure_storage.go
@@ -244,17 +244,23 @@ func secretServiceOwnerInfo(conn *dbus.Conn) (secretServiceOwnerProcess, error) 
 	bus := conn.Object(dbusServiceName, dbus.ObjectPath(dbusServicePath))
 
 	var owner string
-	if err := bus.Call(dbusServiceInterface+".GetNameOwner", 0, secretServiceDBusName).Store(&owner); err != nil {
+	ownerCtx, ownerCancel := context.WithTimeout(context.Background(), relayAuthTokenPreflightTimeout)
+	if err := bus.CallWithContext(ownerCtx, dbusServiceInterface+".GetNameOwner", 0, secretServiceDBusName).Store(&owner); err != nil {
+		ownerCancel()
 		return secretServiceOwnerProcess{}, normalizeLinuxKeyringError(err)
 	}
+	ownerCancel()
 	if owner == "" {
 		return secretServiceOwnerProcess{}, desktopKeyringUnavailableError("Secret Service owner unavailable")
 	}
 
 	var pid uint32
-	if err := bus.Call(dbusServiceInterface+".GetConnectionUnixProcessID", 0, owner).Store(&pid); err != nil {
-		return secretServiceOwnerProcess{}, err
+	pidCtx, pidCancel := context.WithTimeout(context.Background(), relayAuthTokenPreflightTimeout)
+	if err := bus.CallWithContext(pidCtx, dbusServiceInterface+".GetConnectionUnixProcessID", 0, owner).Store(&pid); err != nil {
+		pidCancel()
+		return secretServiceOwnerProcess{}, normalizeLinuxKeyringError(err)
 	}
+	pidCancel()
 	if pid == 0 {
 		return secretServiceOwnerProcess{}, fmt.Errorf("Secret Service owner pid unavailable")
 	}

--- a/cli/keyring_linux_secure_storage.go
+++ b/cli/keyring_linux_secure_storage.go
@@ -175,13 +175,12 @@ func initializeLinuxSecureStorage(conn *dbus.Conn, secret []byte) error {
 		secretCollectionDBusInterface + ".Label": dbus.MakeVariant(secretServiceDefaultCollectionLabel),
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), secureStorageUnlockTimeout)
-	defer cancel()
-
 	var collection dbus.ObjectPath
+	createCtx, createCancel := context.WithTimeout(context.Background(), secureStorageUnlockTimeout)
 	err = conn.Object(secretServiceDBusName, dbus.ObjectPath(secretServiceDBusPath)).
-		CallWithContext(ctx, gnomeKeyringCreateWithPasswordMethod, 0, properties, payload).
+		CallWithContext(createCtx, gnomeKeyringCreateWithPasswordMethod, 0, properties, payload).
 		Store(&collection)
+	createCancel()
 	if err != nil {
 		return normalizeLinuxKeyringErrorWithoutAmbiguousClassification(err)
 	}
@@ -189,10 +188,13 @@ func initializeLinuxSecureStorage(conn *dbus.Conn, secret []byte) error {
 		return desktopKeyringInitializationRequiredError("GNOME Keyring did not create a default collection")
 	}
 
+	aliasCtx, aliasCancel := context.WithTimeout(context.Background(), secureStorageUnlockTimeout)
 	if err := conn.Object(secretServiceDBusName, dbus.ObjectPath(secretServiceDBusPath)).
-		CallWithContext(ctx, secretServiceDBusInterface+".SetAlias", 0, secretServiceDefaultCollectionAlias, collection).Err; err != nil {
+		CallWithContext(aliasCtx, secretServiceDBusInterface+".SetAlias", 0, secretServiceDefaultCollectionAlias, collection).Err; err != nil {
+		aliasCancel()
 		return normalizeLinuxKeyringErrorWithoutAmbiguousClassification(err)
 	}
+	aliasCancel()
 	return nil
 }
 

--- a/cli/keyring_preflight.go
+++ b/cli/keyring_preflight.go
@@ -1,0 +1,11 @@
+package main
+
+var relayAuthTokenSetupPreflightForSetup = relayAuthTokenSetupPreflight
+var relayAuthTokenPlatformSetupPreflight = relayAuthTokenPlatformSetupPreflightImpl
+
+func relayAuthTokenSetupPreflight() error {
+	if relayAuthTokenTestFile() != "" {
+		return nil
+	}
+	return relayAuthTokenPlatformSetupPreflight()
+}

--- a/cli/keyring_preflight_linux.go
+++ b/cli/keyring_preflight_linux.go
@@ -25,10 +25,9 @@ type relayAuthTokenPreflightSessionBusResult struct {
 }
 
 type relayAuthTokenPreflightSessionBusCall struct {
-	done     chan struct{}
-	result   relayAuthTokenPreflightSessionBusResult
-	waiters  int
-	consumed bool
+	done    chan struct{}
+	result  relayAuthTokenPreflightSessionBusResult
+	waiters int
 }
 
 var relayAuthTokenPreflightSessionBusState struct {
@@ -80,25 +79,13 @@ func runRelayAuthTokenPreflightSessionBusCall(call *relayAuthTokenPreflightSessi
 		relayAuthTokenPreflightSessionBusState.current = nil
 	}
 	close(call.done)
-	shouldClose := call.waiters == 0 && conn != nil
 	relayAuthTokenPreflightSessionBusState.Unlock()
-
-	if shouldClose {
-		_ = conn.Close()
-	}
 }
 
 func finishRelayAuthTokenPreflightSessionBusCall(call *relayAuthTokenPreflightSessionBusCall) (*dbus.Conn, error) {
 	relayAuthTokenPreflightSessionBusState.Lock()
 	outcome := call.result
 	call.waiters--
-	if outcome.conn != nil {
-		if call.consumed {
-			relayAuthTokenPreflightSessionBusState.Unlock()
-			return nil, context.DeadlineExceeded
-		}
-		call.consumed = true
-	}
 	relayAuthTokenPreflightSessionBusState.Unlock()
 	return outcome.conn, outcome.err
 }
@@ -108,22 +95,7 @@ func releaseRelayAuthTokenPreflightSessionBusCall(call *relayAuthTokenPreflightS
 	if call.waiters > 0 {
 		call.waiters--
 	}
-	done := false
-	select {
-	case <-call.done:
-		done = true
-	default:
-	}
-	var conn *dbus.Conn
-	if done && call.waiters == 0 && !call.consumed && call.result.conn != nil {
-		conn = call.result.conn
-		call.result.conn = nil
-	}
 	relayAuthTokenPreflightSessionBusState.Unlock()
-
-	if conn != nil {
-		_ = conn.Close()
-	}
 }
 
 func relayAuthTokenPlatformSetupPreflightImpl() error {

--- a/cli/keyring_preflight_linux.go
+++ b/cli/keyring_preflight_linux.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	dbus "github.com/godbus/dbus/v5"
@@ -18,23 +19,110 @@ const (
 var relayAuthTokenPreflightSessionBus = dbus.SessionBus
 var relayAuthTokenPreflightTimeout = 2 * time.Second
 
+type relayAuthTokenPreflightSessionBusResult struct {
+	conn *dbus.Conn
+	err  error
+}
+
+type relayAuthTokenPreflightSessionBusCall struct {
+	done     chan struct{}
+	result   relayAuthTokenPreflightSessionBusResult
+	waiters  int
+	consumed bool
+}
+
+var relayAuthTokenPreflightSessionBusState struct {
+	sync.Mutex
+	current *relayAuthTokenPreflightSessionBusCall
+}
+
 func relayAuthTokenPreflightSessionBusWithTimeout(timeout time.Duration) (*dbus.Conn, error) {
-	type result struct {
-		conn *dbus.Conn
-		err  error
+	if timeout <= 0 {
+		timeout = relayAuthTokenPreflightTimeout
 	}
+	call := beginRelayAuthTokenPreflightSessionBusCall()
 
-	done := make(chan result, 1)
-	go func() {
-		conn, err := relayAuthTokenPreflightSessionBus()
-		done <- result{conn: conn, err: err}
-	}()
-
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
-	case outcome := <-done:
-		return outcome.conn, outcome.err
-	case <-time.After(timeout):
+	case <-call.done:
+		return finishRelayAuthTokenPreflightSessionBusCall(call)
+	case <-timer.C:
+		releaseRelayAuthTokenPreflightSessionBusCall(call)
 		return nil, context.DeadlineExceeded
+	}
+}
+
+func beginRelayAuthTokenPreflightSessionBusCall() *relayAuthTokenPreflightSessionBusCall {
+	relayAuthTokenPreflightSessionBusState.Lock()
+	call := relayAuthTokenPreflightSessionBusState.current
+	start := false
+	if call == nil {
+		call = &relayAuthTokenPreflightSessionBusCall{done: make(chan struct{})}
+		relayAuthTokenPreflightSessionBusState.current = call
+		start = true
+	}
+	call.waiters++
+	relayAuthTokenPreflightSessionBusState.Unlock()
+
+	if start {
+		go runRelayAuthTokenPreflightSessionBusCall(call)
+	}
+	return call
+}
+
+func runRelayAuthTokenPreflightSessionBusCall(call *relayAuthTokenPreflightSessionBusCall) {
+	conn, err := relayAuthTokenPreflightSessionBus()
+
+	relayAuthTokenPreflightSessionBusState.Lock()
+	call.result = relayAuthTokenPreflightSessionBusResult{conn: conn, err: err}
+	if relayAuthTokenPreflightSessionBusState.current == call {
+		relayAuthTokenPreflightSessionBusState.current = nil
+	}
+	close(call.done)
+	shouldClose := call.waiters == 0 && conn != nil
+	relayAuthTokenPreflightSessionBusState.Unlock()
+
+	if shouldClose {
+		_ = conn.Close()
+	}
+}
+
+func finishRelayAuthTokenPreflightSessionBusCall(call *relayAuthTokenPreflightSessionBusCall) (*dbus.Conn, error) {
+	relayAuthTokenPreflightSessionBusState.Lock()
+	outcome := call.result
+	call.waiters--
+	if outcome.conn != nil {
+		if call.consumed {
+			relayAuthTokenPreflightSessionBusState.Unlock()
+			return nil, context.DeadlineExceeded
+		}
+		call.consumed = true
+	}
+	relayAuthTokenPreflightSessionBusState.Unlock()
+	return outcome.conn, outcome.err
+}
+
+func releaseRelayAuthTokenPreflightSessionBusCall(call *relayAuthTokenPreflightSessionBusCall) {
+	relayAuthTokenPreflightSessionBusState.Lock()
+	if call.waiters > 0 {
+		call.waiters--
+	}
+	done := false
+	select {
+	case <-call.done:
+		done = true
+	default:
+	}
+	var conn *dbus.Conn
+	if done && call.waiters == 0 && !call.consumed && call.result.conn != nil {
+		conn = call.result.conn
+		call.result.conn = nil
+	}
+	relayAuthTokenPreflightSessionBusState.Unlock()
+
+	if conn != nil {
+		_ = conn.Close()
 	}
 }
 

--- a/cli/keyring_preflight_linux.go
+++ b/cli/keyring_preflight_linux.go
@@ -1,0 +1,55 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"time"
+
+	dbus "github.com/godbus/dbus/v5"
+)
+
+const (
+	secretServiceDBusName      = "org.freedesktop.secrets"
+	secretServiceDBusPath      = "/org/freedesktop/secrets"
+	secretServiceDBusInterface = "org.freedesktop.Secret.Service"
+)
+
+var relayAuthTokenPreflightSessionBus = dbus.SessionBus
+var relayAuthTokenPreflightTimeout = 2 * time.Second
+
+func relayAuthTokenPreflightSessionBusWithTimeout(timeout time.Duration) (*dbus.Conn, error) {
+	type result struct {
+		conn *dbus.Conn
+		err  error
+	}
+
+	done := make(chan result, 1)
+	go func() {
+		conn, err := relayAuthTokenPreflightSessionBus()
+		done <- result{conn: conn, err: err}
+	}()
+
+	select {
+	case outcome := <-done:
+		return outcome.conn, outcome.err
+	case <-time.After(timeout):
+		return nil, context.DeadlineExceeded
+	}
+}
+
+func relayAuthTokenPlatformSetupPreflightImpl() error {
+	state, err := inspectLinuxSecureStorageState()
+	if err != nil {
+		return err
+	}
+
+	switch state.kind {
+	case linuxSecureStorageStateNeedsInit:
+		return desktopKeyringInitializationRequiredError("no default Secret Service collection configured")
+	case linuxSecureStorageStateLocked:
+		return desktopKeyringLockedError("default Secret Service collection is locked")
+	default:
+		return normalizeLinuxKeyringError(probeLinuxKeyringWritable())
+	}
+}

--- a/cli/keyring_preflight_linux_test.go
+++ b/cli/keyring_preflight_linux_test.go
@@ -1,0 +1,75 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	dbus "github.com/godbus/dbus/v5"
+)
+
+func TestRelayAuthTokenPreflightSessionBusWithTimeoutReusesHungProbe(t *testing.T) {
+	originalSessionBus := relayAuthTokenPreflightSessionBus
+	defer func() {
+		relayAuthTokenPreflightSessionBus = originalSessionBus
+		resetRelayAuthTokenPreflightSessionBusStateForTest()
+	}()
+	resetRelayAuthTokenPreflightSessionBusStateForTest()
+
+	started := make(chan struct{}, 1)
+	unblock := make(chan struct{})
+	var calls atomic.Int32
+	relayAuthTokenPreflightSessionBus = func() (*dbus.Conn, error) {
+		calls.Add(1)
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-unblock
+		return nil, context.Canceled
+	}
+
+	if conn, err := relayAuthTokenPreflightSessionBusWithTimeout(time.Millisecond); !errors.Is(err, context.DeadlineExceeded) || conn != nil {
+		t.Fatalf("expected first probe to time out, got conn=%v err=%v", conn, err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("expected first probe to start")
+	}
+
+	if conn, err := relayAuthTokenPreflightSessionBusWithTimeout(time.Millisecond); !errors.Is(err, context.DeadlineExceeded) || conn != nil {
+		t.Fatalf("expected second probe to time out, got conn=%v err=%v", conn, err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected timeout retry to reuse the in-flight probe, got %d SessionBus calls", got)
+	}
+
+	close(unblock)
+	waitForRelayAuthTokenPreflightSessionBusIdleForTest(t)
+}
+
+func resetRelayAuthTokenPreflightSessionBusStateForTest() {
+	relayAuthTokenPreflightSessionBusState.Lock()
+	relayAuthTokenPreflightSessionBusState.current = nil
+	relayAuthTokenPreflightSessionBusState.Unlock()
+}
+
+func waitForRelayAuthTokenPreflightSessionBusIdleForTest(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		relayAuthTokenPreflightSessionBusState.Lock()
+		idle := relayAuthTokenPreflightSessionBusState.current == nil
+		relayAuthTokenPreflightSessionBusState.Unlock()
+		if idle {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("timed out waiting for SessionBus probe to finish")
+}

--- a/cli/keyring_preflight_other.go
+++ b/cli/keyring_preflight_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package main
+
+func relayAuthTokenPlatformSetupPreflightImpl() error {
+	return nil
+}

--- a/cli/keyring_service.go
+++ b/cli/keyring_service.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -9,6 +10,11 @@ import (
 )
 
 var errRelayAuthTokenMissing = errors.New("relay auth token missing")
+var errDesktopKeyringSessionUnavailable = errors.New("desktop keyring session unavailable")
+var errDesktopKeyringUnavailable = errors.New("desktop keyring unavailable")
+var errDesktopKeyringSetupRequired = errors.New("desktop keyring setup required")
+var errDesktopKeyringLocked = errors.New("desktop keyring locked")
+var errDesktopKeyringInitializationRequired = errors.New("desktop keyring initialization required")
 
 func relayAuthTokenServiceName() string {
 	if override := strings.TrimSpace(os.Getenv("HA_NOVA_KEYRING_SERVICE")); override != "" {
@@ -50,6 +56,34 @@ func relayAuthTokenReadError(service string, err error) error {
 	return fmt.Errorf("cannot read relay auth token (%s): %w", service, err)
 }
 
+func wrapDesktopKeyringError(kind error, detail string) error {
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return kind
+	}
+	return fmt.Errorf("%w: %s", kind, detail)
+}
+
+func desktopKeyringSessionUnavailableError(detail string) error {
+	return wrapDesktopKeyringError(errDesktopKeyringSessionUnavailable, detail)
+}
+
+func desktopKeyringUnavailableError(detail string) error {
+	return wrapDesktopKeyringError(errDesktopKeyringUnavailable, detail)
+}
+
+func desktopKeyringSetupRequiredError(detail string) error {
+	return wrapDesktopKeyringError(errDesktopKeyringSetupRequired, detail)
+}
+
+func desktopKeyringLockedError(detail string) error {
+	return wrapDesktopKeyringError(errDesktopKeyringLocked, detail)
+}
+
+func desktopKeyringInitializationRequiredError(detail string) error {
+	return wrapDesktopKeyringError(errDesktopKeyringInitializationRequired, detail)
+}
+
 func isMissingRelayAuthTokenError(err error) bool {
 	return errors.Is(err, errRelayAuthTokenMissing)
 }
@@ -61,6 +95,21 @@ func relayAuthTokenProblemMessage(err error) string {
 	if isMissingRelayAuthTokenError(err) {
 		return "relay auth token missing; run: ha-nova setup"
 	}
+	if isDesktopKeyringSessionUnavailableError(err) {
+		return "secure storage unavailable in this Linux session; run HA NOVA from a terminal inside the Linux desktop session on this machine, and then run: ha-nova setup"
+	}
+	if isDesktopKeyringUnavailableError(err) {
+		return "secure storage unavailable on this Linux machine; start a Secret Service provider (for example GNOME Keyring or KWallet Secrets) and then run: ha-nova setup"
+	}
+	if isDesktopKeyringInitializationRequiredError(err) {
+		return "secure storage is present but not initialized on this Linux machine; initialize the default keyring and then run: ha-nova setup"
+	}
+	if isDesktopKeyringLockedError(err) {
+		return "secure storage is present but locked on this Linux machine; unlock the default keyring and then run: ha-nova setup"
+	}
+	if isDesktopKeyringSetupRequiredError(err) {
+		return "secure storage is present but not ready on this Linux machine; rerun `ha-nova setup` interactively to finish local secure storage setup"
+	}
 	return fmt.Sprintf("relay auth token unavailable: %s", err)
 }
 
@@ -68,9 +117,165 @@ func isDesktopKeyringUnavailableError(err error) bool {
 	if err == nil {
 		return false
 	}
+	if errors.Is(err, errDesktopKeyringUnavailable) {
+		return true
+	}
 	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "org.freedesktop.secrets") &&
-		(strings.Contains(message, "not provided") || strings.Contains(message, "serviceunknown"))
+	return (strings.Contains(message, "org.freedesktop.secrets") &&
+		(strings.Contains(message, "not provided") || strings.Contains(message, "serviceunknown"))) ||
+		strings.Contains(message, "secret service preflight timed out")
+}
+
+func isDesktopKeyringSessionUnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errDesktopKeyringSessionUnavailable) {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "couldn't determine address of session bus") ||
+		(strings.Contains(message, "dbus-launch") && strings.Contains(message, "not found"))
+}
+
+func isDesktopKeyringSetupRequiredError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isDesktopKeyringLockedError(err) || isDesktopKeyringInitializationRequiredError(err) {
+		return true
+	}
+	if errors.Is(err, errDesktopKeyringSetupRequired) {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "failed to unlock correct collection") ||
+		strings.Contains(message, "secure storage is present but not ready on this linux machine") ||
+		(strings.Contains(message, "object does not exist at path") &&
+			(strings.Contains(message, "/org/freedesktop/secrets/collection/login") ||
+				strings.Contains(message, "/org/freedesktop/secrets/aliases/default"))) ||
+		strings.Contains(message, "no such secret collection")
+}
+
+func isDesktopKeyringLockedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errDesktopKeyringLocked) {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "default secret service collection is locked") ||
+		strings.Contains(message, "secure storage is present but locked on this linux machine") ||
+		strings.Contains(message, "local secure storage is still locked on this linux machine") ||
+		strings.Contains(message, "password was invalid")
+}
+
+func isDesktopKeyringInitializationRequiredError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errDesktopKeyringInitializationRequired) {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "no default secret service collection configured") ||
+		strings.Contains(message, "secure storage is present but not initialized on this linux machine") ||
+		strings.Contains(message, "local secure storage still needs one-time setup on this linux machine") ||
+		(strings.Contains(message, "object does not exist at path") &&
+			(strings.Contains(message, "/org/freedesktop/secrets/collection/login") ||
+				strings.Contains(message, "/org/freedesktop/secrets/aliases/default"))) ||
+		strings.Contains(message, "no such secret collection")
+}
+
+func errorsIsContextDeadlineExceeded(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "context deadline exceeded")
+}
+
+func relayAuthTokenSetupSaveError(err error) error {
+	return relayAuthTokenSetupOperationError("save relay token", err)
+}
+
+func relayAuthTokenSetupReadError(err error) error {
+	return relayAuthTokenSetupOperationError("access saved relay token", err)
+}
+
+func relayAuthTokenSetupOperationError(action string, err error) error {
+	if isDesktopKeyringSessionUnavailableError(err) {
+		return fmt.Errorf("cannot %s: secure storage unavailable in this Linux session. Run HA NOVA from a terminal inside the Linux desktop session on this machine, and rerun `ha-nova setup`", action)
+	}
+	if isDesktopKeyringUnavailableError(err) {
+		return fmt.Errorf("cannot %s: secure storage unavailable on this Linux machine. Start a Secret Service provider (for example GNOME Keyring or KWallet Secrets) and rerun `ha-nova setup`", action)
+	}
+	if isDesktopKeyringInitializationRequiredError(err) {
+		return fmt.Errorf("cannot %s: secure storage is present but not initialized on this Linux machine. Initialize the default keyring and rerun `ha-nova setup`", action)
+	}
+	if isDesktopKeyringLockedError(err) {
+		return fmt.Errorf("cannot %s: secure storage is present but locked on this Linux machine. Unlock the default keyring and rerun `ha-nova setup`", action)
+	}
+	if isDesktopKeyringSetupRequiredError(err) {
+		return fmt.Errorf("cannot %s: secure storage is present but not ready on this Linux machine. Rerun `ha-nova setup` interactively to finish local secure storage setup", action)
+	}
+	return fmt.Errorf("cannot %s: %s", action, err)
+}
+
+func localSecureStorageRecoveryError(err error) error {
+	if errors.Is(err, errLocalSecureStoragePasswordRejected) {
+		return err
+	}
+	err = normalizeLinuxKeyringError(err)
+	if isDesktopKeyringSessionUnavailableError(err) {
+		return desktopKeyringSessionUnavailableError("local secure storage is unavailable in this Linux session")
+	}
+	if isDesktopKeyringUnavailableError(err) {
+		return desktopKeyringUnavailableError("local secure storage backend is unavailable on this Linux machine")
+	}
+	if isDesktopKeyringInitializationRequiredError(err) {
+		return desktopKeyringInitializationRequiredError("local secure storage still needs one-time setup on this Linux machine")
+	}
+	if isDesktopKeyringLockedError(err) {
+		return desktopKeyringLockedError("local secure storage is still locked on this Linux machine")
+	}
+	if isDesktopKeyringSetupRequiredError(err) {
+		return desktopKeyringSetupRequiredError("local secure storage is still not ready on this Linux machine")
+	}
+	return fmt.Errorf("local secure storage verification failed: %s", err)
+}
+
+func normalizeLinuxKeyringError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if classified := classifyAmbiguousDesktopKeyringSetupError(err); classified != nil {
+		return classified
+	}
+	return normalizeLinuxKeyringErrorWithoutAmbiguousClassification(err)
+}
+
+func normalizeLinuxKeyringErrorWithoutAmbiguousClassification(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case isDesktopKeyringSessionUnavailableError(err):
+		return desktopKeyringSessionUnavailableError(err.Error())
+	case isDesktopKeyringUnavailableError(err):
+		return desktopKeyringUnavailableError(err.Error())
+	case isDesktopKeyringInitializationRequiredError(err):
+		return desktopKeyringInitializationRequiredError(err.Error())
+	case isDesktopKeyringLockedError(err):
+		return desktopKeyringLockedError(err.Error())
+	case isDesktopKeyringSetupRequiredError(err):
+		return desktopKeyringSetupRequiredError(err.Error())
+	default:
+		return err
+	}
 }
 
 func writeRelayAuthTokenOverride(token string) (bool, error) {

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -15,6 +15,58 @@ var probeHTTPForSetup = probeHTTP
 var fetchRelayHealthForSetup = fetchRelayHealth
 var detectDefaultHAHostForSetup = detectDefaultHAHost
 var probeRelayWSPingForSetup = probeRelayWSPing
+var readRelayAuthTokenForSetup = readRelayAuthToken
+
+func printRelayTokenStorageSetupWarning(err error) {
+	switch {
+	case isDesktopKeyringSessionUnavailableError(err):
+		printHumanWarn("secure storage unavailable in this Linux session; run HA NOVA from a terminal inside the Linux desktop session on this machine so local secure storage is available")
+	case isDesktopKeyringUnavailableError(err):
+		printHumanWarn("secure storage unavailable on this Linux machine; start a Secret Service provider (for example GNOME Keyring or KWallet Secrets) before finishing setup")
+	case isDesktopKeyringInitializationRequiredError(err):
+		printHumanWarn("secure storage is present but not initialized on this Linux machine; finish local secure storage setup before finishing setup")
+	case isDesktopKeyringLockedError(err):
+		printHumanWarn("secure storage is present but locked on this Linux machine; unlock the default keyring before finishing setup")
+	case isDesktopKeyringSetupRequiredError(err):
+		printHumanWarn("secure storage is present but not ready on this Linux machine; finish local secure storage setup before finishing setup")
+	case err != nil:
+		printHumanWarn("%s", relayAuthTokenProblemMessage(err))
+	}
+}
+
+func maybeHandleInteractiveSetupCurrentState(reader *bufio.Reader, out io.Writer, paths runtimePaths, cfg runtimeConfig, current setupState, overrideApplied bool) (bool, int) {
+	if !(current.ConfigOK || current.TokenOK || current.RelayOK || current.WSOK || current.SkillsOK) {
+		return false, 0
+	}
+
+	renderSetupHeader(out)
+	renderSetupStatusSummary(out, current)
+	if current.IsComplete() {
+		if overrideApplied {
+			if err := saveConfig(paths, cfg); err != nil {
+				printHumanErr("cannot save config: %s", err)
+				return true, 1
+			}
+		}
+		renderSetupAlreadyDoneBanner(out)
+		return true, 0
+	}
+	if summary := current.SkipSummary(); summary != "" {
+		fmt.Fprintf(out, "  Already done: %s\n\n", summary)
+	}
+	if writerSupportsTTYForSetup(out) {
+		_, err := promptWizardLineFromReader(reader, out, "Press Enter to continue setup", "")
+		if err == errSetupExit {
+			printHumanInfo("Setup cancelled")
+			return true, 0
+		}
+		if err != nil && err != errSetupBack {
+			printHumanErr("%s", err)
+			return true, 1
+		}
+	}
+	return false, 0
+}
 
 func promptYesNoFromReader(reader *bufio.Reader, out io.Writer, label string, defaultYes bool) (bool, error) {
 	return promptYesNoWithOptions(reader, out, label, defaultYes, false)
@@ -42,6 +94,7 @@ func maskSecretHint(value string) string {
 func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState, target string, hostFlag, haURLFlag, relayURLFlag, relayTokenFlag string) int {
 	const (
 		setupStageClient = iota
+		setupStageSecureStorageRecovery
 		setupStageHost
 		setupStageRelayInstall
 		setupStageToken
@@ -59,20 +112,13 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 	}
 	selectedClients := []string{}
 	skippedClients := []string{}
+	secureStorageRecovery := setupSecureStorageRecoveryState{}
 
 	savedTokenBeforeSetup := ""
 	hadSavedTokenBeforeSetup := false
-	if savedToken, err := readRelayAuthToken(); err == nil && strings.TrimSpace(savedToken) != "" {
-		savedTokenBeforeSetup = strings.TrimSpace(savedToken)
-		hadSavedTokenBeforeSetup = true
-	} else if err != nil && !isMissingRelayAuthTokenError(err) {
-		printHumanWarn("secure storage unavailable: %s", err)
-	}
-
+	tokenStoragePreflightErr := error(nil)
+	tokenStorageRecoveryReadBlocked := false
 	existingToken := strings.TrimSpace(relayTokenFlag)
-	if existingToken == "" {
-		existingToken = savedTokenBeforeSetup
-	}
 
 	promptedClient := false
 	if target == "" {
@@ -107,6 +153,27 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 		}
 	}
 
+	tokenStoragePreflightErr = relayAuthTokenSetupPreflightForSetup()
+	if tokenStoragePreflightErr == nil {
+		if savedToken, err := readRelayAuthTokenForSetup(); err == nil && strings.TrimSpace(savedToken) != "" {
+			savedTokenBeforeSetup = strings.TrimSpace(savedToken)
+			hadSavedTokenBeforeSetup = true
+		} else if err != nil && setupSecureStorageRecoveryAvailableNow(err) {
+			tokenStoragePreflightErr = err
+			tokenStorageRecoveryReadBlocked = true
+		} else if err != nil && !isMissingRelayAuthTokenError(err) {
+			printRelayTokenStorageSetupWarning(err)
+		}
+	} else if !setupSecureStorageRecoveryAvailableNow(tokenStoragePreflightErr) {
+		printRelayTokenStorageSetupWarning(tokenStoragePreflightErr)
+		printHumanErr("%s", relayAuthTokenSetupSaveError(tokenStoragePreflightErr))
+		return 1
+	}
+
+	if existingToken == "" {
+		existingToken = savedTokenBeforeSetup
+	}
+
 	overrideApplied := strings.TrimSpace(hostFlag) != "" || strings.TrimSpace(haURLFlag) != "" || strings.TrimSpace(relayURLFlag) != ""
 	skipLLATWalkthrough := strings.TrimSpace(hostFlag) != "" && strings.TrimSpace(relayTokenFlag) != ""
 	if overrideApplied {
@@ -118,39 +185,19 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 		}
 	}
 
-	current := detectSetupState(paths, cfg, state, target)
-	if current.ConfigOK || current.TokenOK || current.RelayOK || current.WSOK || current.SkillsOK {
-		renderSetupHeader(os.Stdout)
-		renderSetupStatusSummary(os.Stdout, current)
-		if current.IsComplete() {
-			if overrideApplied {
-				if err := saveConfig(paths, cfg); err != nil {
-					printHumanErr("cannot save config: %s", err)
-					return 1
-				}
-			}
-			renderSetupAlreadyDoneBanner(os.Stdout)
-			return 0
-		}
-		if summary := current.SkipSummary(); summary != "" {
-			fmt.Fprintf(os.Stdout, "  Already done: %s\n\n", summary)
-		}
-		if writerSupportsTTYForSetup(os.Stdout) {
-			_, err := promptWizardLineFromReader(reader, os.Stdout, "Press Enter to continue setup", "")
-			if err == errSetupExit {
-				printHumanInfo("Setup cancelled")
-				return 0
-			}
-			if err != nil && err != errSetupBack {
-				printHumanErr("%s", err)
-				return 1
-			}
+	current := detectSetupStateWithToken(paths, cfg, state, target, savedTokenBeforeSetup, hadSavedTokenBeforeSetup)
+	if tokenStoragePreflightErr == nil {
+		if handled, code := maybeHandleInteractiveSetupCurrentState(reader, os.Stdout, paths, cfg, current, overrideApplied); handled {
+			return code
 		}
 	}
 
 	stage := setupStageHost
+	if tokenStoragePreflightErr != nil {
+		stage = setupStageSecureStorageRecovery
+	}
 	verifyFirstReuseFlow := false
-	if cfg.HAHost != "" && cfg.HAURL != "" {
+	if stage != setupStageSecureStorageRecovery && cfg.HAHost != "" && cfg.HAURL != "" {
 		switch {
 		case existingToken != "" && current.RelayOK && !current.WSOK:
 			stage = setupStageVerify
@@ -193,7 +240,88 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				printHumanErr("%s", err)
 				return 1
 			}
+			if tokenStoragePreflightErr != nil {
+				stage = setupStageSecureStorageRecovery
+			} else {
+				stage = setupStageHost
+			}
+
+		case setupStageSecureStorageRecovery:
+			result, err := runSetupSecureStorageRecoveryFlow(reader, os.Stdout, tokenStoragePreflightErr, &secureStorageRecovery, setupSecureStorageRecoveryInitialAttempt)
+			if err == errSetupBack {
+				if promptedClient {
+					stage = setupStageClient
+					continue
+				}
+				printHumanInfo("Setup cancelled")
+				return 0
+			}
+			if err == errSetupExit {
+				printHumanInfo("Setup cancelled")
+				return 0
+			}
+			if err != nil {
+				printHumanErr("%s", err)
+				return 1
+			}
+			if result != setupSecureStorageRecoveryRecovered {
+				if tokenStorageRecoveryReadBlocked {
+					printHumanErr("%s", relayAuthTokenSetupReadError(tokenStoragePreflightErr))
+				} else {
+					printHumanErr("%s", relayAuthTokenSetupSaveError(tokenStoragePreflightErr))
+				}
+				return 1
+			}
+
+			tokenStoragePreflightErr = relayAuthTokenSetupPreflightForSetup()
+			if tokenStoragePreflightErr != nil {
+				printRelayTokenStorageSetupWarning(tokenStoragePreflightErr)
+				printHumanErr("%s", relayAuthTokenSetupSaveError(tokenStoragePreflightErr))
+				return 1
+			}
+			tokenStorageRecoveryReadBlocked = false
+			savedTokenBeforeSetup = ""
+			hadSavedTokenBeforeSetup = false
+			if savedToken, err := readRelayAuthTokenForSetup(); err == nil && strings.TrimSpace(savedToken) != "" {
+				savedTokenBeforeSetup = strings.TrimSpace(savedToken)
+				hadSavedTokenBeforeSetup = true
+			} else if err != nil && !isMissingRelayAuthTokenError(err) {
+				printHumanErr("%s", relayAuthTokenSetupReadError(err))
+				return 1
+			}
+			if strings.TrimSpace(relayTokenFlag) == "" {
+				existingToken = savedTokenBeforeSetup
+			}
+			current = detectSetupStateWithToken(paths, cfg, state, target, savedTokenBeforeSetup, hadSavedTokenBeforeSetup)
+			if current.IsComplete() {
+				if overrideApplied {
+					if err := saveConfig(paths, cfg); err != nil {
+						printHumanErr("cannot save config: %s", err)
+						return 1
+					}
+				}
+				renderSetupAlreadyDoneBanner(os.Stdout)
+				return 0
+			}
 			stage = setupStageHost
+			verifyFirstReuseFlow = false
+			if cfg.HAHost != "" && cfg.HAURL != "" {
+				switch {
+				case existingToken != "" && current.RelayOK && !current.WSOK:
+					stage = setupStageVerify
+					verifyFirstReuseFlow = true
+				case existingToken != "":
+					if relayTokenFlag != "" {
+						stage = setupStageToken
+					} else {
+						stage = setupStageVerify
+						verifyFirstReuseFlow = true
+					}
+				default:
+					stage = setupStageToken
+				}
+			}
+			continue
 
 		case setupStageHost:
 			defaultHost, _ := detectDefaultHAHostWithFeedback(os.Stdout, cfg)
@@ -264,12 +392,10 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			stage = setupStageToken
 
 		case setupStageToken:
-			current = detectSetupState(paths, cfg, state, target)
+			current = detectSetupStateWithToken(paths, cfg, state, target, savedTokenBeforeSetup, hadSavedTokenBeforeSetup)
 			existingToken = ""
-			if relayTokenFlag == "" {
-				if existing, err := readRelayAuthToken(); err == nil {
-					existingToken = strings.TrimSpace(existing)
-				}
+			if relayTokenFlag == "" && hadSavedTokenBeforeSetup {
+				existingToken = savedTokenBeforeSetup
 			}
 			if relayTokenFlag != "" {
 				token = strings.TrimSpace(relayTokenFlag)
@@ -432,14 +558,14 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				return 1
 			}
 			if !ok {
-				if err := persistInteractiveSetupState(paths, cfg, &state, savedTokenBeforeSetup, hadSavedTokenBeforeSetup, token); err != nil {
+				if err := persistInteractiveSetupStateWithRecovery(reader, os.Stdout, paths, cfg, &state, savedTokenBeforeSetup, hadSavedTokenBeforeSetup, token, &secureStorageRecovery); err != nil {
 					printHumanErr("%s", err)
 					return 1
 				}
 				renderSetupIncompleteBanner(os.Stdout, issue)
 				return 1
 			}
-			if err := persistInteractiveSetupState(paths, cfg, &state, savedTokenBeforeSetup, hadSavedTokenBeforeSetup, token); err != nil {
+			if err := persistInteractiveSetupStateWithRecovery(reader, os.Stdout, paths, cfg, &state, savedTokenBeforeSetup, hadSavedTokenBeforeSetup, token, &secureStorageRecovery); err != nil {
 				printHumanErr("%s", err)
 				return 1
 			}
@@ -469,4 +595,27 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			return 0
 		}
 	}
+}
+
+func persistInteractiveSetupStateWithRecovery(reader *bufio.Reader, out io.Writer, paths runtimePaths, cfg runtimeConfig, state *installState, previousToken string, hadPreviousToken bool, token string, recovery *setupSecureStorageRecoveryState) error {
+	err := persistInteractiveSetupState(paths, cfg, state, previousToken, hadPreviousToken, token)
+	if err == nil {
+		return nil
+	}
+	if !isDesktopKeyringSetupRequiredError(err) || recovery == nil || recovery.saveRetryAttempted || !setupSecureStorageRecoveryAvailableNow(err) {
+		return err
+	}
+
+	result, recoveryErr := runSetupSecureStorageRecoveryFlow(reader, out, err, recovery, setupSecureStorageRecoverySaveRetryAttempt)
+	if recoveryErr != nil {
+		if recoveryErr == errSetupExit || recoveryErr == errSetupBack {
+			return relayAuthTokenSetupSaveError(err)
+		}
+		return recoveryErr
+	}
+	if result != setupSecureStorageRecoveryRecovered {
+		return relayAuthTokenSetupSaveError(err)
+	}
+
+	return persistInteractiveSetupState(paths, cfg, state, previousToken, hadPreviousToken, token)
 }

--- a/cli/setup_persistence.go
+++ b/cli/setup_persistence.go
@@ -19,7 +19,7 @@ func persistInteractiveSetupState(paths runtimePaths, cfg runtimeConfig, state *
 	tokenChanged := token != previousToken
 	if tokenChanged {
 		if err := writeRelayAuthTokenForSetupPersistence(token); err != nil {
-			return fmt.Errorf("cannot save relay token: %s", err)
+			return relayAuthTokenSetupSaveError(err)
 		}
 	}
 	if err := saveConfigForSetupPersistence(paths, cfg); err != nil {

--- a/cli/setup_secure_storage_recovery.go
+++ b/cli/setup_secure_storage_recovery.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+type setupSecureStorageRecoveryResult string
+type setupSecureStorageRecoveryAttempt string
+type platformSecureStorageRecoveryAction string
+
+type platformSecureStorageRecoveryPlan struct {
+	action             platformSecureStorageRecoveryAction
+	title              string
+	paragraphs         []string
+	prompt             string
+	secretLabel        string
+	confirmSecretLabel string
+	successMessage     string
+	hint               string
+}
+
+const (
+	setupSecureStorageRecoveryRecovered setupSecureStorageRecoveryResult = "recovered"
+	setupSecureStorageRecoveryDeclined  setupSecureStorageRecoveryResult = "declined"
+
+	setupSecureStorageRecoveryInitialAttempt   setupSecureStorageRecoveryAttempt = "initial"
+	setupSecureStorageRecoverySaveRetryAttempt setupSecureStorageRecoveryAttempt = "save-retry"
+
+	platformSecureStorageRecoveryUnlock     platformSecureStorageRecoveryAction = "unlock"
+	platformSecureStorageRecoveryInitialize platformSecureStorageRecoveryAction = "initialize"
+)
+
+type setupSecureStorageRecoveryState struct {
+	initialAttempted   bool
+	saveRetryAttempted bool
+}
+
+var errLocalSecureStoragePasswordRejected = errors.New("local secure storage password rejected")
+
+var detectPlatformSecureStorageRecoverySupportForSetup = detectPlatformSecureStorageRecoverySupport
+var inferPlatformSecureStorageRecoveryActionForSetup = inferPlatformSecureStorageRecoveryAction
+var runPlatformSecureStorageRecoveryForSetup = runPlatformSecureStorageRecovery
+var readSetupSecretInputForSetup = term.ReadPassword
+
+func inferBasicSetupSecureStorageRecoveryAction(err error) platformSecureStorageRecoveryAction {
+	switch {
+	case isDesktopKeyringInitializationRequiredError(err):
+		return platformSecureStorageRecoveryInitialize
+	case isDesktopKeyringLockedError(err):
+		return platformSecureStorageRecoveryUnlock
+	default:
+		return ""
+	}
+}
+
+func setupSecureStorageRecoveryHint(err error) string {
+	plan, available, supportErr := resolveSetupSecureStorageRecoveryPlan(err)
+	if supportErr != nil || !available {
+		return ""
+	}
+	return fmt.Sprintf("Recovery: run `ha-nova setup` interactively to %s.", plan.hint)
+}
+
+func setupSecureStorageRecoveryAvailableNow(err error) bool {
+	if !uiInputSupportsTTY() || !writerSupportsTTYForSetup(os.Stdout) {
+		return false
+	}
+	_, available, supportErr := resolveSetupSecureStorageRecoveryPlan(err)
+	return supportErr == nil && available
+}
+
+func promptSetupSecretInput(out io.Writer, label string) ([]byte, error) {
+	if !uiInputSupportsTTY() || !writerSupportsTTYForSetup(out) {
+		return nil, fmt.Errorf("secure storage recovery requires an interactive terminal")
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "  %s: ", label)
+	secret, err := readSetupSecretInputForSetup(int(os.Stdin.Fd()))
+	fmt.Fprintln(out)
+	if err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
+func zeroSecretBytes(secret []byte) {
+	for i := range secret {
+		secret[i] = 0
+	}
+}
+
+func markSetupSecureStorageRecoveryAttempt(state *setupSecureStorageRecoveryState, attempt setupSecureStorageRecoveryAttempt) {
+	switch attempt {
+	case setupSecureStorageRecoverySaveRetryAttempt:
+		state.saveRetryAttempted = true
+	default:
+		state.initialAttempted = true
+	}
+}
+
+func isRetryableSetupSecureStorageRecoveryError(err error) bool {
+	if errors.Is(err, errLocalSecureStoragePasswordRejected) {
+		return true
+	}
+	if isDesktopKeyringLockedError(err) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "local secure storage is still locked on this linux machine")
+}
+
+func localSecureStoragePasswordRejectedError() error {
+	return fmt.Errorf("%w: local Linux keyring password was rejected", errLocalSecureStoragePasswordRejected)
+}
+
+func runSetupSecureStorageRecoveryFlow(reader *bufio.Reader, out io.Writer, triggerErr error, state *setupSecureStorageRecoveryState, attempt setupSecureStorageRecoveryAttempt) (setupSecureStorageRecoveryResult, error) {
+	if state == nil {
+		return "", errors.New("secure storage recovery state missing")
+	}
+
+	plan, available, err := resolveSetupSecureStorageRecoveryPlan(triggerErr)
+	if !available {
+		if err == nil {
+			err = errors.New("local secure storage recovery is unavailable")
+		}
+		return "", err
+	}
+
+	for {
+		renderSetupSecureStorageRecoveryPage(out, plan)
+		unlockNow, err := promptWizardYesNoFromReader(reader, out, plan.prompt, true)
+		if err != nil {
+			return "", err
+		}
+		markSetupSecureStorageRecoveryAttempt(state, attempt)
+		if !unlockNow {
+			return setupSecureStorageRecoveryDeclined, nil
+		}
+
+		secret, err := promptSetupSecretInput(out, plan.secretLabel)
+		if err != nil {
+			return "", err
+		}
+		if len(secret) == 0 {
+			zeroSecretBytes(secret)
+			renderSetupErrorLine(out, "No password entered.")
+			continue
+		}
+		if plan.confirmSecretLabel != "" {
+			confirmSecret, confirmErr := promptSetupSecretInput(out, plan.confirmSecretLabel)
+			if confirmErr != nil {
+				zeroSecretBytes(secret)
+				return "", confirmErr
+			}
+			if len(confirmSecret) == 0 {
+				zeroSecretBytes(secret)
+				zeroSecretBytes(confirmSecret)
+				renderSetupErrorLine(out, "No password entered.")
+				continue
+			}
+			if !bytes.Equal(secret, confirmSecret) {
+				zeroSecretBytes(secret)
+				zeroSecretBytes(confirmSecret)
+				renderSetupErrorLine(out, "Passwords did not match.")
+				continue
+			}
+			zeroSecretBytes(confirmSecret)
+		}
+
+		runErr := runPlatformSecureStorageRecoveryForSetup(plan.action, secret)
+		zeroSecretBytes(secret)
+		if runErr == nil {
+			renderSetupSuccessLine(out, "%s", plan.successMessage)
+			return setupSecureStorageRecoveryRecovered, nil
+		}
+		if !isRetryableSetupSecureStorageRecoveryError(runErr) {
+			return "", runErr
+		}
+
+		renderSetupErrorLine(out, "%s", runErr)
+	}
+}
+
+func resolveSetupSecureStorageRecoveryPlan(err error) (platformSecureStorageRecoveryPlan, bool, error) {
+	if !isDesktopKeyringSetupRequiredError(err) {
+		return platformSecureStorageRecoveryPlan{}, false, nil
+	}
+	supported, supportErr := detectPlatformSecureStorageRecoverySupportForSetup()
+	if supportErr != nil || !supported {
+		return platformSecureStorageRecoveryPlan{}, false, supportErr
+	}
+	action, actionErr := inferPlatformSecureStorageRecoveryActionForSetup(err)
+	if actionErr != nil {
+		return platformSecureStorageRecoveryPlan{}, false, actionErr
+	}
+	if action == "" {
+		action = inferBasicSetupSecureStorageRecoveryAction(err)
+	}
+	if action == "" {
+		return platformSecureStorageRecoveryPlan{}, false, nil
+	}
+	return secureStorageRecoveryPlanForAction(action), true, nil
+}
+
+func renderSetupSecureStorageRecoveryPage(out io.Writer, plan platformSecureStorageRecoveryPlan) {
+	renderSetupSectionTitle(out, plan.title)
+	renderSetupParagraph(out, plan.paragraphs...)
+}
+
+func secureStorageRecoveryPlanForAction(action platformSecureStorageRecoveryAction) platformSecureStorageRecoveryPlan {
+	switch action {
+	case platformSecureStorageRecoveryInitialize:
+		return platformSecureStorageRecoveryPlan{
+			action: platformSecureStorageRecoveryInitialize,
+			title:  "Local secure storage needs setup",
+			paragraphs: []string{
+				"HA NOVA needs local secure storage before it can save the Relay Auth Token on this Linux machine.",
+				"This step creates the local Linux keyring password this computer will ask for when the keyring needs to be unlocked later, not the Relay token or the Home Assistant token.",
+				"It stays only on this Linux machine. HA NOVA, NOVA Relay, and Home Assistant never receive it.",
+			},
+			prompt:             "Set up local secure storage now",
+			secretLabel:        "New local Linux keyring password",
+			confirmSecretLabel: "Repeat local Linux keyring password",
+			successMessage:     "Local secure storage is ready.",
+			hint:               "set up local secure storage on this Linux machine",
+		}
+	default:
+		return platformSecureStorageRecoveryPlan{
+			action: platformSecureStorageRecoveryUnlock,
+			title:  "Local secure storage is locked",
+			paragraphs: []string{
+				"HA NOVA needs local secure storage before it can save the Relay Auth Token on this Linux machine.",
+				"This is the existing local Linux keyring password on this computer, not the Relay token or the Home Assistant token.",
+				"It stays only on this Linux machine. HA NOVA, NOVA Relay, and Home Assistant never receive it.",
+			},
+			prompt:         "Unlock local secure storage now",
+			secretLabel:    "Local Linux keyring password",
+			successMessage: "Local secure storage is ready.",
+			hint:           "unlock local secure storage on this Linux machine",
+		}
+	}
+}

--- a/cli/setup_secure_storage_recovery.go
+++ b/cli/setup_secure_storage_recovery.go
@@ -125,15 +125,16 @@ func runSetupSecureStorageRecoveryFlow(reader *bufio.Reader, out io.Writer, trig
 		return "", errors.New("secure storage recovery state missing")
 	}
 
-	plan, available, err := resolveSetupSecureStorageRecoveryPlan(triggerErr)
-	if !available {
-		if err == nil {
-			err = errors.New("local secure storage recovery is unavailable")
-		}
-		return "", err
-	}
-
+	recoveryErr := triggerErr
 	for {
+		plan, available, err := resolveSetupSecureStorageRecoveryPlan(recoveryErr)
+		if !available {
+			if err == nil {
+				err = errors.New("local secure storage recovery is unavailable")
+			}
+			return "", err
+		}
+
 		renderSetupSecureStorageRecoveryPage(out, plan)
 		unlockNow, err := promptWizardYesNoFromReader(reader, out, plan.prompt, true)
 		if err != nil {
@@ -182,6 +183,9 @@ func runSetupSecureStorageRecoveryFlow(reader *bufio.Reader, out io.Writer, trig
 		}
 		if !isRetryableSetupSecureStorageRecoveryError(runErr) {
 			return "", runErr
+		}
+		if isDesktopKeyringSetupRequiredError(runErr) {
+			recoveryErr = runErr
 		}
 
 		renderSetupErrorLine(out, "%s", runErr)

--- a/cli/setup_secure_storage_recovery_linux.go
+++ b/cli/setup_secure_storage_recovery_linux.go
@@ -1,0 +1,147 @@
+//go:build linux
+
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+const (
+	dbusServiceName            = "org.freedesktop.DBus"
+	dbusServicePath            = "/org/freedesktop/DBus"
+	dbusServiceInterface       = "org.freedesktop.DBus"
+	gnomeKeyringComm           = "gnome-keyring-daemon"
+	secureStorageUnlockTimeout = 3 * time.Second
+)
+
+var secureStorageRecoveryOwnerProcess = detectSecretServiceOwnerProcessForRecovery
+var secureStorageRecoveryProbe = probeLinuxKeyringWritable
+var secureStorageRecoverySessionBusWithTimeout = relayAuthTokenPreflightSessionBusWithTimeout
+var inspectLinuxSecureStorageStateForRecovery = inspectLinuxSecureStorageState
+var inspectLinuxSecureStorageStateWithConnForRecovery = inspectLinuxSecureStorageStateWithConn
+var initializeLinuxSecureStorageForRecovery = initializeLinuxSecureStorage
+var unlockLinuxSecureStorageForRecovery = unlockLinuxSecureStorage
+
+func detectPlatformSecureStorageRecoverySupport() (bool, error) {
+	owner, err := secureStorageRecoveryOwnerProcess()
+	if err != nil {
+		return false, err
+	}
+	if !owner.supportsGNOMEKeyringRecovery() {
+		return false, nil
+	}
+	conn, err := secureStorageRecoverySessionBusWithTimeout(relayAuthTokenPreflightTimeout)
+	if err != nil {
+		return false, err
+	}
+	return secureStorageRecoverySupportsGNOMEMethods(conn)
+}
+
+func inferPlatformSecureStorageRecoveryAction(err error) (platformSecureStorageRecoveryAction, error) {
+	switch {
+	case isDesktopKeyringInitializationRequiredError(err):
+		return platformSecureStorageRecoveryInitialize, nil
+	case isDesktopKeyringLockedError(err):
+		return platformSecureStorageRecoveryUnlock, nil
+	}
+
+	state, inspectErr := inspectLinuxSecureStorageStateForRecovery()
+	if inspectErr != nil {
+		return "", inspectErr
+	}
+	switch state.kind {
+	case linuxSecureStorageStateNeedsInit:
+		return platformSecureStorageRecoveryInitialize, nil
+	case linuxSecureStorageStateLocked:
+		return platformSecureStorageRecoveryUnlock, nil
+	default:
+		return "", desktopKeyringSetupRequiredError("local secure storage does not need interactive recovery")
+	}
+}
+
+func runPlatformSecureStorageRecovery(action platformSecureStorageRecoveryAction, secret []byte) error {
+	if len(secret) == 0 {
+		return localSecureStorageRecoveryError(desktopKeyringSetupRequiredError("local secure storage password missing"))
+	}
+
+	owner, err := secureStorageRecoveryOwnerProcess()
+	if err != nil {
+		return localSecureStorageRecoveryError(err)
+	}
+	if !owner.supportsGNOMEKeyringRecovery() {
+		return localSecureStorageRecoveryError(desktopKeyringUnavailableError("GNOME Keyring recovery is unavailable"))
+	}
+
+	conn, err := secureStorageRecoverySessionBusWithTimeout(relayAuthTokenPreflightTimeout)
+	if err != nil {
+		return localSecureStorageRecoveryError(err)
+	}
+
+	switch action {
+	case platformSecureStorageRecoveryInitialize:
+		if err := initializeLinuxSecureStorageForRecovery(conn, secret); err != nil {
+			return localSecureStorageRecoveryError(err)
+		}
+	default:
+		state, err := inspectLinuxSecureStorageStateWithConnForRecovery(conn)
+		if err != nil {
+			return localSecureStorageRecoveryError(err)
+		}
+		if state.kind == linuxSecureStorageStateNeedsInit {
+			return localSecureStorageRecoveryError(desktopKeyringInitializationRequiredError("no default Secret Service collection configured"))
+		}
+		if state.kind == linuxSecureStorageStateLocked {
+			if err := unlockLinuxSecureStorageForRecovery(conn, state.defaultCollection, secret); err != nil {
+				return localSecureStorageRecoveryError(err)
+			}
+		}
+		if err := secureStorageRecoveryProbe(); err != nil {
+			return localSecureStorageRecoveryError(err)
+		}
+		return nil
+	}
+
+	if err := secureStorageRecoveryProbe(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func probeLinuxKeyringWritable() error {
+	serviceSuffix := make([]byte, 8)
+	if _, err := rand.Read(serviceSuffix); err != nil {
+		return fmt.Errorf("cannot verify local secure storage: %w", err)
+	}
+	secret := make([]byte, 16)
+	if _, err := rand.Read(secret); err != nil {
+		return fmt.Errorf("cannot verify local secure storage: %w", err)
+	}
+	service := fmt.Sprintf("%s.recovery-probe.%s", relayAuthTokenServiceName(), hex.EncodeToString(serviceSuffix))
+	probeSecret := hex.EncodeToString(secret)
+
+	if err := writeSecretWithService(service, probeSecret); err != nil {
+		return localSecureStorageRecoveryError(err)
+	}
+	readBack, err := readSecretWithService(service)
+	if err != nil {
+		deleteErr := deleteSecretWithService(service)
+		if deleteErr != nil {
+			return localSecureStorageRecoveryError(deleteErr)
+		}
+		return localSecureStorageRecoveryError(err)
+	}
+	if readBack != probeSecret {
+		deleteErr := deleteSecretWithService(service)
+		if deleteErr != nil {
+			return localSecureStorageRecoveryError(deleteErr)
+		}
+		return fmt.Errorf("cannot verify local secure storage: saved verification secret did not match")
+	}
+	if err := deleteSecretWithService(service); err != nil {
+		return localSecureStorageRecoveryError(err)
+	}
+	return nil
+}

--- a/cli/setup_secure_storage_recovery_linux_test.go
+++ b/cli/setup_secure_storage_recovery_linux_test.go
@@ -1,0 +1,477 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	dbus "github.com/godbus/dbus/v5"
+)
+
+type fakeFileInfo struct {
+	sys any
+}
+
+func (fakeFileInfo) Name() string       { return "gnome-keyring-daemon" }
+func (fakeFileInfo) Size() int64        { return 0 }
+func (fakeFileInfo) Mode() os.FileMode  { return 0o755 }
+func (fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any         { return f.sys }
+
+func TestDetectPlatformSecureStorageRecoverySupportRequiresTrustedOwner(t *testing.T) {
+	originalOwner := secureStorageRecoveryOwnerProcess
+	originalStat := secureStorageRecoveryStat
+	originalBus := secureStorageRecoverySessionBusWithTimeout
+	originalMethods := secureStorageRecoverySupportsGNOMEMethods
+	defer func() {
+		secureStorageRecoveryOwnerProcess = originalOwner
+		secureStorageRecoveryStat = originalStat
+		secureStorageRecoverySessionBusWithTimeout = originalBus
+		secureStorageRecoverySupportsGNOMEMethods = originalMethods
+	}()
+
+	secureStorageRecoveryOwnerProcess = func() (secretServiceOwnerProcess, error) {
+		return secretServiceOwnerProcess{
+			comm:    "gnome-keyring-daemon",
+			exePath: "/usr/bin/gnome-keyring-daemon",
+		}, nil
+	}
+	secureStorageRecoveryStat = func(string) (os.FileInfo, error) {
+		return fakeFileInfo{sys: &syscall.Stat_t{Uid: 0}}, nil
+	}
+	secureStorageRecoverySessionBusWithTimeout = func(time.Duration) (*dbus.Conn, error) {
+		return &dbus.Conn{}, nil
+	}
+	secureStorageRecoverySupportsGNOMEMethods = func(*dbus.Conn) (bool, error) {
+		return true, nil
+	}
+
+	supported, err := detectPlatformSecureStorageRecoverySupport()
+	if err != nil {
+		t.Fatalf("detectPlatformSecureStorageRecoverySupport() error = %v", err)
+	}
+	if !supported {
+		t.Fatal("expected GNOME Keyring recovery support for a trusted root-owned daemon")
+	}
+}
+
+func TestDetectPlatformSecureStorageRecoverySupportRejectsUntrustedOwner(t *testing.T) {
+	originalOwner := secureStorageRecoveryOwnerProcess
+	originalStat := secureStorageRecoveryStat
+	originalMethods := secureStorageRecoverySupportsGNOMEMethods
+	defer func() {
+		secureStorageRecoveryOwnerProcess = originalOwner
+		secureStorageRecoveryStat = originalStat
+		secureStorageRecoverySupportsGNOMEMethods = originalMethods
+	}()
+
+	secureStorageRecoveryOwnerProcess = func() (secretServiceOwnerProcess, error) {
+		return secretServiceOwnerProcess{
+			comm:    "gnome-keyring-daemon",
+			exePath: "/tmp/gnome-keyring-daemon",
+		}, nil
+	}
+	secureStorageRecoveryStat = func(string) (os.FileInfo, error) {
+		return fakeFileInfo{sys: &syscall.Stat_t{Uid: 1000}}, nil
+	}
+	secureStorageRecoverySupportsGNOMEMethods = func(*dbus.Conn) (bool, error) {
+		t.Fatal("did not expect method check for untrusted owner")
+		return false, nil
+	}
+
+	supported, err := detectPlatformSecureStorageRecoverySupport()
+	if err != nil {
+		t.Fatalf("detectPlatformSecureStorageRecoverySupport() error = %v", err)
+	}
+	if supported {
+		t.Fatal("expected recovery support to reject non-root-owned executables")
+	}
+}
+
+func TestDetectPlatformSecureStorageRecoverySupportRequiresGNOMEMethods(t *testing.T) {
+	originalOwner := secureStorageRecoveryOwnerProcess
+	originalStat := secureStorageRecoveryStat
+	originalBus := secureStorageRecoverySessionBusWithTimeout
+	originalMethods := secureStorageRecoverySupportsGNOMEMethods
+	defer func() {
+		secureStorageRecoveryOwnerProcess = originalOwner
+		secureStorageRecoveryStat = originalStat
+		secureStorageRecoverySessionBusWithTimeout = originalBus
+		secureStorageRecoverySupportsGNOMEMethods = originalMethods
+	}()
+
+	secureStorageRecoveryOwnerProcess = func() (secretServiceOwnerProcess, error) {
+		return secretServiceOwnerProcess{comm: "gnome-keyring-daemon", exePath: "/usr/bin/gnome-keyring-daemon"}, nil
+	}
+	secureStorageRecoveryStat = func(string) (os.FileInfo, error) {
+		return fakeFileInfo{sys: &syscall.Stat_t{Uid: 0}}, nil
+	}
+	secureStorageRecoverySessionBusWithTimeout = func(time.Duration) (*dbus.Conn, error) {
+		return &dbus.Conn{}, nil
+	}
+	secureStorageRecoverySupportsGNOMEMethods = func(*dbus.Conn) (bool, error) {
+		return false, nil
+	}
+
+	supported, err := detectPlatformSecureStorageRecoverySupport()
+	if err != nil {
+		t.Fatalf("detectPlatformSecureStorageRecoverySupport() error = %v", err)
+	}
+	if supported {
+		t.Fatal("expected recovery support to stay disabled when GNOME recovery methods are unavailable")
+	}
+}
+
+func TestInferPlatformSecureStorageRecoveryActionUsesLiveStateForAmbiguousError(t *testing.T) {
+	originalInspect := inspectLinuxSecureStorageStateForRecovery
+	defer func() {
+		inspectLinuxSecureStorageStateForRecovery = originalInspect
+	}()
+
+	inspectLinuxSecureStorageStateForRecovery = func() (linuxSecureStorageState, error) {
+		return linuxSecureStorageState{kind: linuxSecureStorageStateNeedsInit}, nil
+	}
+	action, err := inferPlatformSecureStorageRecoveryAction(desktopKeyringSetupRequiredError("generic setup required"))
+	if err != nil {
+		t.Fatalf("inferPlatformSecureStorageRecoveryAction() error = %v", err)
+	}
+	if action != platformSecureStorageRecoveryInitialize {
+		t.Fatalf("expected initialize action, got %q", action)
+	}
+
+	inspectLinuxSecureStorageStateForRecovery = func() (linuxSecureStorageState, error) {
+		return linuxSecureStorageState{kind: linuxSecureStorageStateLocked}, nil
+	}
+	action, err = inferPlatformSecureStorageRecoveryAction(desktopKeyringSetupRequiredError("generic setup required"))
+	if err != nil {
+		t.Fatalf("inferPlatformSecureStorageRecoveryAction() error = %v", err)
+	}
+	if action != platformSecureStorageRecoveryUnlock {
+		t.Fatalf("expected unlock action, got %q", action)
+	}
+}
+
+func TestClassifyAmbiguousDesktopKeyringSetupErrorUsesLiveState(t *testing.T) {
+	originalInspect := inspectLinuxSecureStorageStateForClassification
+	defer func() {
+		inspectLinuxSecureStorageStateForClassification = originalInspect
+	}()
+
+	rawErr := errors.New("failed to unlock correct collection '/org/freedesktop/secrets/aliases/default'")
+
+	inspectLinuxSecureStorageStateForClassification = func() (linuxSecureStorageState, error) {
+		return linuxSecureStorageState{kind: linuxSecureStorageStateNeedsInit}, nil
+	}
+	classified := classifyAmbiguousDesktopKeyringSetupError(rawErr)
+	if !isDesktopKeyringInitializationRequiredError(classified) {
+		t.Fatalf("expected initialization-required classification, got %v", classified)
+	}
+
+	inspectLinuxSecureStorageStateForClassification = func() (linuxSecureStorageState, error) {
+		return linuxSecureStorageState{kind: linuxSecureStorageStateLocked}, nil
+	}
+	classified = classifyAmbiguousDesktopKeyringSetupError(rawErr)
+	if !isDesktopKeyringLockedError(classified) {
+		t.Fatalf("expected locked classification, got %v", classified)
+	}
+}
+
+func TestClassifyAmbiguousDesktopKeyringSetupErrorStopsWhenInspectionIsStillAmbiguous(t *testing.T) {
+	originalInspect := inspectLinuxSecureStorageStateForClassification
+	defer func() {
+		inspectLinuxSecureStorageStateForClassification = originalInspect
+	}()
+
+	rawErr := errors.New("failed to unlock correct collection '/org/freedesktop/secrets/aliases/default'")
+	inspectLinuxSecureStorageStateForClassification = func() (linuxSecureStorageState, error) {
+		return linuxSecureStorageState{}, rawErr
+	}
+
+	if classified := classifyAmbiguousDesktopKeyringSetupError(rawErr); classified != nil {
+		t.Fatalf("expected no classification when state inspection stays ambiguous, got %v", classified)
+	}
+}
+
+func TestRunPlatformSecureStorageRecoveryInitializesWhenDefaultCollectionMissing(t *testing.T) {
+	originalOwner := secureStorageRecoveryOwnerProcess
+	originalStat := secureStorageRecoveryStat
+	originalBus := secureStorageRecoverySessionBusWithTimeout
+	originalMethods := secureStorageRecoverySupportsGNOMEMethods
+	originalInitialize := initializeLinuxSecureStorageForRecovery
+	originalProbe := secureStorageRecoveryProbe
+	defer func() {
+		secureStorageRecoveryOwnerProcess = originalOwner
+		secureStorageRecoveryStat = originalStat
+		secureStorageRecoverySessionBusWithTimeout = originalBus
+		secureStorageRecoverySupportsGNOMEMethods = originalMethods
+		initializeLinuxSecureStorageForRecovery = originalInitialize
+		secureStorageRecoveryProbe = originalProbe
+	}()
+
+	secureStorageRecoveryOwnerProcess = func() (secretServiceOwnerProcess, error) {
+		return secretServiceOwnerProcess{comm: "gnome-keyring-daemon", exePath: "/usr/bin/gnome-keyring-daemon"}, nil
+	}
+	secureStorageRecoveryStat = func(string) (os.FileInfo, error) {
+		return fakeFileInfo{sys: &syscall.Stat_t{Uid: 0}}, nil
+	}
+	secureStorageRecoverySessionBusWithTimeout = func(time.Duration) (*dbus.Conn, error) {
+		return &dbus.Conn{}, nil
+	}
+	secureStorageRecoverySupportsGNOMEMethods = func(*dbus.Conn) (bool, error) {
+		return true, nil
+	}
+
+	var gotSecret string
+	initializeLinuxSecureStorageForRecovery = func(_ *dbus.Conn, secret []byte) error {
+		gotSecret = string(secret)
+		return nil
+	}
+	secureStorageRecoveryProbe = func() error { return nil }
+
+	if err := runPlatformSecureStorageRecovery(platformSecureStorageRecoveryInitialize, []byte("linux-local-keyring")); err != nil {
+		t.Fatalf("runPlatformSecureStorageRecovery() error = %v", err)
+	}
+	if gotSecret != "linux-local-keyring" {
+		t.Fatalf("initialize secret = %q", gotSecret)
+	}
+}
+
+func TestRunPlatformSecureStorageRecoveryUnlocksExistingCollection(t *testing.T) {
+	originalOwner := secureStorageRecoveryOwnerProcess
+	originalStat := secureStorageRecoveryStat
+	originalBus := secureStorageRecoverySessionBusWithTimeout
+	originalMethods := secureStorageRecoverySupportsGNOMEMethods
+	originalInspect := inspectLinuxSecureStorageStateWithConnForRecovery
+	originalUnlock := unlockLinuxSecureStorageForRecovery
+	originalProbe := secureStorageRecoveryProbe
+	defer func() {
+		secureStorageRecoveryOwnerProcess = originalOwner
+		secureStorageRecoveryStat = originalStat
+		secureStorageRecoverySessionBusWithTimeout = originalBus
+		secureStorageRecoverySupportsGNOMEMethods = originalMethods
+		inspectLinuxSecureStorageStateWithConnForRecovery = originalInspect
+		unlockLinuxSecureStorageForRecovery = originalUnlock
+		secureStorageRecoveryProbe = originalProbe
+	}()
+
+	secureStorageRecoveryOwnerProcess = func() (secretServiceOwnerProcess, error) {
+		return secretServiceOwnerProcess{comm: "gnome-keyring-daemon", exePath: "/usr/bin/gnome-keyring-daemon"}, nil
+	}
+	secureStorageRecoveryStat = func(string) (os.FileInfo, error) {
+		return fakeFileInfo{sys: &syscall.Stat_t{Uid: 0}}, nil
+	}
+	secureStorageRecoverySessionBusWithTimeout = func(time.Duration) (*dbus.Conn, error) {
+		return &dbus.Conn{}, nil
+	}
+	secureStorageRecoverySupportsGNOMEMethods = func(*dbus.Conn) (bool, error) {
+		return true, nil
+	}
+	inspectLinuxSecureStorageStateWithConnForRecovery = func(*dbus.Conn) (linuxSecureStorageState, error) {
+		return linuxSecureStorageState{
+			kind:              linuxSecureStorageStateLocked,
+			defaultCollection: dbus.ObjectPath("/org/freedesktop/secrets/collection/Login"),
+		}, nil
+	}
+
+	var gotSecret string
+	var gotCollection dbus.ObjectPath
+	unlockLinuxSecureStorageForRecovery = func(_ *dbus.Conn, collection dbus.ObjectPath, secret []byte) error {
+		gotCollection = collection
+		gotSecret = string(secret)
+		return nil
+	}
+	secureStorageRecoveryProbe = func() error { return nil }
+
+	if err := runPlatformSecureStorageRecovery(platformSecureStorageRecoveryUnlock, []byte("linux-local-keyring")); err != nil {
+		t.Fatalf("runPlatformSecureStorageRecovery() error = %v", err)
+	}
+	if gotCollection != dbus.ObjectPath("/org/freedesktop/secrets/collection/Login") {
+		t.Fatalf("unlock collection = %q", gotCollection)
+	}
+	if gotSecret != "linux-local-keyring" {
+		t.Fatalf("unlock secret = %q", gotSecret)
+	}
+}
+
+func TestRunPlatformSecureStorageRecoveryPreservesPasswordRejected(t *testing.T) {
+	originalOwner := secureStorageRecoveryOwnerProcess
+	originalStat := secureStorageRecoveryStat
+	originalBus := secureStorageRecoverySessionBusWithTimeout
+	originalMethods := secureStorageRecoverySupportsGNOMEMethods
+	originalInspect := inspectLinuxSecureStorageStateWithConnForRecovery
+	originalUnlock := unlockLinuxSecureStorageForRecovery
+	defer func() {
+		secureStorageRecoveryOwnerProcess = originalOwner
+		secureStorageRecoveryStat = originalStat
+		secureStorageRecoverySessionBusWithTimeout = originalBus
+		secureStorageRecoverySupportsGNOMEMethods = originalMethods
+		inspectLinuxSecureStorageStateWithConnForRecovery = originalInspect
+		unlockLinuxSecureStorageForRecovery = originalUnlock
+	}()
+
+	secureStorageRecoveryOwnerProcess = func() (secretServiceOwnerProcess, error) {
+		return secretServiceOwnerProcess{comm: "gnome-keyring-daemon", exePath: "/usr/bin/gnome-keyring-daemon"}, nil
+	}
+	secureStorageRecoveryStat = func(string) (os.FileInfo, error) {
+		return fakeFileInfo{sys: &syscall.Stat_t{Uid: 0}}, nil
+	}
+	secureStorageRecoverySessionBusWithTimeout = func(time.Duration) (*dbus.Conn, error) {
+		return &dbus.Conn{}, nil
+	}
+	secureStorageRecoverySupportsGNOMEMethods = func(*dbus.Conn) (bool, error) {
+		return true, nil
+	}
+	inspectLinuxSecureStorageStateWithConnForRecovery = func(*dbus.Conn) (linuxSecureStorageState, error) {
+		return linuxSecureStorageState{
+			kind:              linuxSecureStorageStateLocked,
+			defaultCollection: dbus.ObjectPath("/org/freedesktop/secrets/collection/Login"),
+		}, nil
+	}
+	unlockLinuxSecureStorageForRecovery = func(*dbus.Conn, dbus.ObjectPath, []byte) error {
+		return localSecureStoragePasswordRejectedError()
+	}
+
+	err := runPlatformSecureStorageRecovery(platformSecureStorageRecoveryUnlock, []byte("linux-local-keyring"))
+	if !errors.Is(err, errLocalSecureStoragePasswordRejected) {
+		t.Fatalf("expected password rejection, got %v", err)
+	}
+}
+
+func TestProbeLinuxKeyringWritableRoundTripsAndCleansUp(t *testing.T) {
+	originalSet := keyringSetWithService
+	originalGet := keyringGetWithService
+	originalDelete := keyringDeleteWithService
+	defer func() {
+		keyringSetWithService = originalSet
+		keyringGetWithService = originalGet
+		keyringDeleteWithService = originalDelete
+	}()
+
+	storage := map[string]string{}
+	setCalls := 0
+	getCalls := 0
+	deleteCalls := 0
+	keyringSetWithService = func(service, username, secret string) error {
+		setCalls++
+		storage[service+"|"+username] = secret
+		return nil
+	}
+	keyringGetWithService = func(service, username string) (string, error) {
+		getCalls++
+		value, ok := storage[service+"|"+username]
+		if !ok {
+			return "", errors.New("missing probe secret")
+		}
+		return value, nil
+	}
+	keyringDeleteWithService = func(service, username string) error {
+		deleteCalls++
+		delete(storage, service+"|"+username)
+		return nil
+	}
+
+	if err := probeLinuxKeyringWritable(); err != nil {
+		t.Fatalf("probeLinuxKeyringWritable() error = %v", err)
+	}
+	if setCalls != 1 || getCalls != 1 || deleteCalls != 1 {
+		t.Fatalf("expected one set/get/delete probe cycle, got set=%d get=%d delete=%d", setCalls, getCalls, deleteCalls)
+	}
+	if len(storage) != 0 {
+		t.Fatalf("expected probe cleanup to remove the temporary secret, remaining=%d", len(storage))
+	}
+}
+
+func TestRunPlatformSecureStorageRecoveryFailsWhenPostInitProbeStillFails(t *testing.T) {
+	originalOwner := secureStorageRecoveryOwnerProcess
+	originalStat := secureStorageRecoveryStat
+	originalBus := secureStorageRecoverySessionBusWithTimeout
+	originalMethods := secureStorageRecoverySupportsGNOMEMethods
+	originalInitialize := initializeLinuxSecureStorageForRecovery
+	originalProbe := secureStorageRecoveryProbe
+	defer func() {
+		secureStorageRecoveryOwnerProcess = originalOwner
+		secureStorageRecoveryStat = originalStat
+		secureStorageRecoverySessionBusWithTimeout = originalBus
+		secureStorageRecoverySupportsGNOMEMethods = originalMethods
+		initializeLinuxSecureStorageForRecovery = originalInitialize
+		secureStorageRecoveryProbe = originalProbe
+	}()
+
+	secureStorageRecoveryOwnerProcess = func() (secretServiceOwnerProcess, error) {
+		return secretServiceOwnerProcess{comm: "gnome-keyring-daemon", exePath: "/usr/bin/gnome-keyring-daemon"}, nil
+	}
+	secureStorageRecoveryStat = func(string) (os.FileInfo, error) {
+		return fakeFileInfo{sys: &syscall.Stat_t{Uid: 0}}, nil
+	}
+	secureStorageRecoverySessionBusWithTimeout = func(time.Duration) (*dbus.Conn, error) {
+		return &dbus.Conn{}, nil
+	}
+	secureStorageRecoverySupportsGNOMEMethods = func(*dbus.Conn) (bool, error) {
+		return true, nil
+	}
+	initializeLinuxSecureStorageForRecovery = func(*dbus.Conn, []byte) error { return nil }
+	secureStorageRecoveryProbe = func() error {
+		return localSecureStorageRecoveryError(desktopKeyringInitializationRequiredError("local secure storage still needs one-time setup on this Linux machine"))
+	}
+
+	err := runPlatformSecureStorageRecovery(platformSecureStorageRecoveryInitialize, []byte("linux-local-keyring"))
+	if !isDesktopKeyringInitializationRequiredError(err) {
+		t.Fatalf("expected initialization-required probe failure, got %v", err)
+	}
+}
+
+func TestRunPlatformSecureStorageRecoveryReprobesUnlockedCollection(t *testing.T) {
+	originalOwner := secureStorageRecoveryOwnerProcess
+	originalStat := secureStorageRecoveryStat
+	originalBus := secureStorageRecoverySessionBusWithTimeout
+	originalMethods := secureStorageRecoverySupportsGNOMEMethods
+	originalInspect := inspectLinuxSecureStorageStateWithConnForRecovery
+	originalUnlock := unlockLinuxSecureStorageForRecovery
+	originalProbe := secureStorageRecoveryProbe
+	defer func() {
+		secureStorageRecoveryOwnerProcess = originalOwner
+		secureStorageRecoveryStat = originalStat
+		secureStorageRecoverySessionBusWithTimeout = originalBus
+		secureStorageRecoverySupportsGNOMEMethods = originalMethods
+		inspectLinuxSecureStorageStateWithConnForRecovery = originalInspect
+		unlockLinuxSecureStorageForRecovery = originalUnlock
+		secureStorageRecoveryProbe = originalProbe
+	}()
+
+	secureStorageRecoveryOwnerProcess = func() (secretServiceOwnerProcess, error) {
+		return secretServiceOwnerProcess{comm: "gnome-keyring-daemon", exePath: "/usr/bin/gnome-keyring-daemon"}, nil
+	}
+	secureStorageRecoveryStat = func(string) (os.FileInfo, error) {
+		return fakeFileInfo{sys: &syscall.Stat_t{Uid: 0}}, nil
+	}
+	secureStorageRecoverySessionBusWithTimeout = func(time.Duration) (*dbus.Conn, error) {
+		return &dbus.Conn{}, nil
+	}
+	secureStorageRecoverySupportsGNOMEMethods = func(*dbus.Conn) (bool, error) {
+		return true, nil
+	}
+	inspectLinuxSecureStorageStateWithConnForRecovery = func(*dbus.Conn) (linuxSecureStorageState, error) {
+		return linuxSecureStorageState{kind: linuxSecureStorageStateWritable}, nil
+	}
+	unlockLinuxSecureStorageForRecovery = func(*dbus.Conn, dbus.ObjectPath, []byte) error {
+		t.Fatal("did not expect unlock when the collection is already writable")
+		return nil
+	}
+	probeCalls := 0
+	secureStorageRecoveryProbe = func() error {
+		probeCalls++
+		return nil
+	}
+
+	if err := runPlatformSecureStorageRecovery(platformSecureStorageRecoveryUnlock, []byte("linux-local-keyring")); err != nil {
+		t.Fatalf("runPlatformSecureStorageRecovery() error = %v", err)
+	}
+	if probeCalls != 1 {
+		t.Fatalf("expected one post-recovery probe, got %d", probeCalls)
+	}
+}

--- a/cli/setup_secure_storage_recovery_other.go
+++ b/cli/setup_secure_storage_recovery_other.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+package main
+
+func detectPlatformSecureStorageRecoverySupport() (bool, error) {
+	return false, nil
+}
+
+func inferPlatformSecureStorageRecoveryAction(err error) (platformSecureStorageRecoveryAction, error) {
+	_ = err
+	return "", nil
+}
+
+func runPlatformSecureStorageRecovery(action platformSecureStorageRecoveryAction, secret []byte) error {
+	_ = action
+	_ = secret
+	return nil
+}

--- a/cli/setup_secure_storage_recovery_test.go
+++ b/cli/setup_secure_storage_recovery_test.go
@@ -1,0 +1,742 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunSetupSecureStorageRecoveryFlowStopsOnFatalError(t *testing.T) {
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	originalReadSecret := readSetupSecretInputForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+		readSetupSecretInputForSetup = originalReadSecret
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) { return true, nil }
+	runPlatformSecureStorageRecoveryForSetup = func(platformSecureStorageRecoveryAction, []byte) error {
+		return errors.New("local secure storage backend disappeared")
+	}
+	readSetupSecretInputForSetup = func(int) ([]byte, error) {
+		return []byte("linux-local-keyring"), nil
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	state := setupSecureStorageRecoveryState{}
+	_, err := runSetupSecureStorageRecoveryFlow(bufio.NewReader(strings.NewReader("\n")), io.Discard, desktopKeyringLockedError("default Secret Service collection is locked"), &state, setupSecureStorageRecoveryInitialAttempt)
+	if err == nil || err.Error() != "local secure storage backend disappeared" {
+		t.Fatalf("expected fatal recovery error, got %v", err)
+	}
+	if !state.initialAttempted {
+		t.Fatal("expected initial recovery attempt to be recorded")
+	}
+}
+
+func TestRunSetupSecureStorageRecoveryFlowRetriesOnlyOnRetryableError(t *testing.T) {
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	originalReadSecret := readSetupSecretInputForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+		readSetupSecretInputForSetup = originalReadSecret
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) { return true, nil }
+	runCalls := 0
+	runPlatformSecureStorageRecoveryForSetup = func(platformSecureStorageRecoveryAction, []byte) error {
+		runCalls++
+		if runCalls == 1 {
+			return localSecureStoragePasswordRejectedError()
+		}
+		return nil
+	}
+	readCalls := 0
+	readSetupSecretInputForSetup = func(int) ([]byte, error) {
+		readCalls++
+		if readCalls == 1 {
+			return []byte("wrong-password"), nil
+		}
+		return []byte("correct-password"), nil
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	var out bytes.Buffer
+	state := setupSecureStorageRecoveryState{}
+	result, err := runSetupSecureStorageRecoveryFlow(bufio.NewReader(strings.NewReader("\n\n")), &out, desktopKeyringLockedError("default Secret Service collection is locked"), &state, setupSecureStorageRecoveryInitialAttempt)
+	if err != nil {
+		t.Fatalf("expected retryable recovery flow to succeed, got %v", err)
+	}
+	if result != setupSecureStorageRecoveryRecovered {
+		t.Fatalf("expected recovered result, got %q", result)
+	}
+	if !strings.Contains(out.String(), "local Linux keyring password was rejected") {
+		t.Fatalf("expected explicit wrong-password wording, got:\n%s", out.String())
+	}
+	if runCalls != 2 {
+		t.Fatalf("expected two recovery attempts, got %d", runCalls)
+	}
+}
+
+func TestRunSetupSecureStorageRecoveryFlowBackDoesNotConsumeAttempt(t *testing.T) {
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) { return true, nil }
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	state := setupSecureStorageRecoveryState{}
+	_, err := runSetupSecureStorageRecoveryFlow(bufio.NewReader(strings.NewReader("back\n")), io.Discard, desktopKeyringLockedError("default Secret Service collection is locked"), &state, setupSecureStorageRecoveryInitialAttempt)
+	if err != errSetupBack {
+		t.Fatalf("expected back navigation, got %v", err)
+	}
+	if state.initialAttempted {
+		t.Fatal("expected back navigation not to consume the initial recovery attempt")
+	}
+}
+
+func TestRunSetupSecureStorageRecoveryFlowInitializationConfirmsPassword(t *testing.T) {
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	originalReadSecret := readSetupSecretInputForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+		readSetupSecretInputForSetup = originalReadSecret
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) { return true, nil }
+	runCalls := 0
+	runPlatformSecureStorageRecoveryForSetup = func(action platformSecureStorageRecoveryAction, secret []byte) error {
+		runCalls++
+		if action != platformSecureStorageRecoveryInitialize {
+			t.Fatalf("unexpected recovery action %q", action)
+		}
+		if string(secret) != "correct-password" {
+			t.Fatalf("unexpected recovery secret %q", string(secret))
+		}
+		return nil
+	}
+	secretReads := 0
+	readSetupSecretInputForSetup = func(int) ([]byte, error) {
+		secretReads++
+		switch secretReads {
+		case 1:
+			return []byte("first-password"), nil
+		case 2:
+			return []byte("different-password"), nil
+		default:
+			return []byte("correct-password"), nil
+		}
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	var out bytes.Buffer
+	state := setupSecureStorageRecoveryState{}
+	result, err := runSetupSecureStorageRecoveryFlow(
+		bufio.NewReader(strings.NewReader("\n\n")),
+		&out,
+		desktopKeyringInitializationRequiredError("no default Secret Service collection configured"),
+		&state,
+		setupSecureStorageRecoveryInitialAttempt,
+	)
+	if err != nil {
+		t.Fatalf("expected initialization recovery flow to succeed, got %v", err)
+	}
+	if result != setupSecureStorageRecoveryRecovered {
+		t.Fatalf("expected recovered result, got %q", result)
+	}
+	if !strings.Contains(out.String(), "Passwords did not match.") {
+		t.Fatalf("expected mismatch guidance, got:\n%s", out.String())
+	}
+	if runCalls != 1 {
+		t.Fatalf("expected one successful recovery call after confirmation, got %d", runCalls)
+	}
+}
+
+func TestInteractiveSetupRecoveryBackDoesNotBypassGate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	defer relayServer.Close()
+
+	originalPreflight := relayAuthTokenSetupPreflightForSetup
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	originalReadSecret := readSetupSecretInputForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		relayAuthTokenSetupPreflightForSetup = originalPreflight
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+		readSetupSecretInputForSetup = originalReadSecret
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	preflightCalls := 0
+	relayAuthTokenSetupPreflightForSetup = func() error {
+		preflightCalls++
+		if preflightCalls == 1 {
+			return desktopKeyringSetupRequiredError("no default Secret Service collection configured")
+		}
+		return nil
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return true, nil
+	}
+	recoveryCalls := 0
+	runPlatformSecureStorageRecoveryForSetup = func(action platformSecureStorageRecoveryAction, secret []byte) error {
+		recoveryCalls++
+		if action != platformSecureStorageRecoveryInitialize {
+			t.Fatalf("unexpected recovery action %q", action)
+		}
+		if string(secret) != "linux-local-keyring" {
+			t.Fatalf("unexpected recovery secret %q", string(secret))
+		}
+		return nil
+	}
+	readSetupSecretInputForSetup = func(int) ([]byte, error) {
+		return []byte("linux-local-keyring"), nil
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	input := joinSetupInputs(
+		[]string{"4", "back", "4", "", haServer.URL},
+		setupWizardRelayInstallPrompts(),
+		setupWizardGenerateRelayTokenPrompts(),
+		setupWizardLLATPrompts(),
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	if strings.Count(output, "Local secure storage needs setup") != 2 {
+		t.Fatalf("expected recovery page twice after backing out once:\n%s", output)
+	}
+	if recoveryCalls != 1 {
+		t.Fatalf("expected one successful recovery call after returning, got %d", recoveryCalls)
+	}
+}
+
+func TestInteractiveSetupRecoversWhenSavedTokenReadNeedsRecovery(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	defer relayServer.Close()
+
+	originalPreflight := relayAuthTokenSetupPreflightForSetup
+	originalReadToken := readRelayAuthTokenForSetup
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	originalReadSecret := readSetupSecretInputForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		relayAuthTokenSetupPreflightForSetup = originalPreflight
+		readRelayAuthTokenForSetup = originalReadToken
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+		readSetupSecretInputForSetup = originalReadSecret
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	relayAuthTokenSetupPreflightForSetup = func() error { return nil }
+	readCalls := 0
+	readRelayAuthTokenForSetup = func() (string, error) {
+		readCalls++
+		if readCalls == 1 {
+			return "", desktopKeyringLockedError("default Secret Service collection is locked")
+		}
+		return "", missingRelayAuthTokenError(relayAuthTokenServiceName())
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return true, nil
+	}
+	runPlatformSecureStorageRecoveryForSetup = func(action platformSecureStorageRecoveryAction, secret []byte) error {
+		if action != platformSecureStorageRecoveryUnlock {
+			t.Fatalf("unexpected recovery action %q", action)
+		}
+		if string(secret) != "linux-local-keyring" {
+			t.Fatalf("unexpected recovery secret %q", string(secret))
+		}
+		return nil
+	}
+	readSetupSecretInputForSetup = func(int) ([]byte, error) {
+		return []byte("linux-local-keyring"), nil
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	input := joinSetupInputs(
+		[]string{"4", "", haServer.URL},
+		setupWizardRelayInstallPrompts(),
+		setupWizardGenerateRelayTokenPrompts(),
+		setupWizardLLATPrompts(),
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	recoveryIdx := strings.Index(output, "Local secure storage is locked")
+	hostIdx := strings.Index(output, "Home Assistant address (IP, hostname, or URL)")
+	if recoveryIdx == -1 || hostIdx == -1 || recoveryIdx > hostIdx {
+		t.Fatalf("expected saved-token recovery before host prompt:\n%s", output)
+	}
+}
+
+func TestInteractiveSetupReusesSavedTokenAfterReadRecovery(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	defer relayServer.Close()
+
+	originalPreflight := relayAuthTokenSetupPreflightForSetup
+	originalReadToken := readRelayAuthTokenForSetup
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	originalReadSecret := readSetupSecretInputForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		relayAuthTokenSetupPreflightForSetup = originalPreflight
+		readRelayAuthTokenForSetup = originalReadToken
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+		readSetupSecretInputForSetup = originalReadSecret
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	relayAuthTokenSetupPreflightForSetup = func() error { return nil }
+	readCalls := 0
+	readRelayAuthTokenForSetup = func() (string, error) {
+		readCalls++
+		if readCalls == 1 {
+			return "", desktopKeyringLockedError("default Secret Service collection is locked")
+		}
+		return "saved-relay-token", nil
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return true, nil
+	}
+	runPlatformSecureStorageRecoveryForSetup = func(action platformSecureStorageRecoveryAction, secret []byte) error {
+		if action != platformSecureStorageRecoveryUnlock {
+			t.Fatalf("unexpected recovery action %q", action)
+		}
+		if string(secret) != "linux-local-keyring" {
+			t.Fatalf("unexpected recovery secret %q", string(secret))
+		}
+		return nil
+	}
+	readSetupSecretInputForSetup = func(int) ([]byte, error) {
+		return []byte("linux-local-keyring"), nil
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	input := joinSetupInputs(
+		[]string{"4", "", haServer.URL},
+		setupWizardRelayInstallPrompts(),
+		setupWizardLLATPrompts(),
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	if !strings.Contains(output, "Existing relay token found") {
+		t.Fatalf("expected saved token reuse after recovery:\n%s", output)
+	}
+	if strings.Contains(output, "Here is your relay token (generated automatically)") {
+		t.Fatalf("did not expect a new relay token to be generated after recovery:\n%s", output)
+	}
+}
+
+func TestInteractiveSetupDeclinedReadRecoveryMentionsSavedTokenAccess(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	originalPreflight := relayAuthTokenSetupPreflightForSetup
+	originalReadToken := readRelayAuthTokenForSetup
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		relayAuthTokenSetupPreflightForSetup = originalPreflight
+		readRelayAuthTokenForSetup = originalReadToken
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	relayAuthTokenSetupPreflightForSetup = func() error { return nil }
+	readRelayAuthTokenForSetup = func() (string, error) {
+		return "", desktopKeyringLockedError("default Secret Service collection is locked")
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return true, nil
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, joinSetupInputs([]string{"4", "n"}), func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", "http://relay.test:8791", "")
+		return exitCode
+	})
+	if exitCode != 1 {
+		t.Fatalf("interactiveSetup() exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	if !strings.Contains(output, "cannot access saved relay token") {
+		t.Fatalf("expected saved-token access wording when recovery is declined:\n%s", output)
+	}
+}
+
+func TestInteractiveSetupRetriesSaveTimeRecoveryInline(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	defer relayServer.Close()
+
+	originalPreflight := relayAuthTokenSetupPreflightForSetup
+	originalWrite := writeRelayAuthTokenForSetupPersistence
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	originalReadSecret := readSetupSecretInputForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		relayAuthTokenSetupPreflightForSetup = originalPreflight
+		writeRelayAuthTokenForSetupPersistence = originalWrite
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+		readSetupSecretInputForSetup = originalReadSecret
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	relayAuthTokenSetupPreflightForSetup = func() error { return nil }
+	writeCalls := 0
+	writeRelayAuthTokenForSetupPersistence = func(token string) error {
+		writeCalls++
+		if writeCalls == 1 {
+			return desktopKeyringLockedError("default Secret Service collection is locked")
+		}
+		return originalWrite(token)
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return true, nil
+	}
+	recoveryCalls := 0
+	runPlatformSecureStorageRecoveryForSetup = func(action platformSecureStorageRecoveryAction, secret []byte) error {
+		recoveryCalls++
+		if action != platformSecureStorageRecoveryUnlock {
+			t.Fatalf("unexpected recovery action %q", action)
+		}
+		if string(secret) != "linux-local-keyring" {
+			t.Fatalf("unexpected recovery secret %q", string(secret))
+		}
+		return nil
+	}
+	readSetupSecretInputForSetup = func(int) ([]byte, error) {
+		return []byte("linux-local-keyring"), nil
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	input := joinSetupInputs(
+		[]string{"4", haServer.URL},
+		setupWizardRelayInstallPrompts(),
+		setupWizardGenerateRelayTokenPrompts(),
+		setupWizardLLATPrompts(),
+		[]string{""},
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	if !strings.Contains(output, "Verifying connection") || !strings.Contains(output, "Local secure storage is locked") {
+		t.Fatalf("expected verify stage followed by inline recovery:\n%s", output)
+	}
+	if recoveryCalls != 1 {
+		t.Fatalf("expected one save-time recovery call, got %d", recoveryCalls)
+	}
+	if writeCalls != 2 {
+		t.Fatalf("expected one failed save plus one retry, got %d writes", writeCalls)
+	}
+}
+
+func TestInteractiveSetupRetriesSaveTimeInitializationRecoveryInline(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	defer relayServer.Close()
+
+	originalPreflight := relayAuthTokenSetupPreflightForSetup
+	originalWrite := writeRelayAuthTokenForSetupPersistence
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	originalReadSecret := readSetupSecretInputForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		relayAuthTokenSetupPreflightForSetup = originalPreflight
+		writeRelayAuthTokenForSetupPersistence = originalWrite
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+		readSetupSecretInputForSetup = originalReadSecret
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	relayAuthTokenSetupPreflightForSetup = func() error { return nil }
+	writeCalls := 0
+	writeRelayAuthTokenForSetupPersistence = func(token string) error {
+		writeCalls++
+		if writeCalls == 1 {
+			return desktopKeyringInitializationRequiredError("no default Secret Service collection configured")
+		}
+		return originalWrite(token)
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return true, nil
+	}
+	recoveryCalls := 0
+	runPlatformSecureStorageRecoveryForSetup = func(action platformSecureStorageRecoveryAction, secret []byte) error {
+		recoveryCalls++
+		if action != platformSecureStorageRecoveryInitialize {
+			t.Fatalf("unexpected recovery action %q", action)
+		}
+		if string(secret) != "linux-local-keyring" {
+			t.Fatalf("unexpected recovery secret %q", string(secret))
+		}
+		return nil
+	}
+	readSetupSecretInputForSetup = func(int) ([]byte, error) {
+		return []byte("linux-local-keyring"), nil
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	input := joinSetupInputs(
+		[]string{"4", haServer.URL},
+		setupWizardRelayInstallPrompts(),
+		setupWizardGenerateRelayTokenPrompts(),
+		setupWizardLLATPrompts(),
+		[]string{""},
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	if !strings.Contains(output, "Verifying connection") || !strings.Contains(output, "Local secure storage needs setup") {
+		t.Fatalf("expected verify stage followed by inline initialization recovery:\n%s", output)
+	}
+	if !strings.Contains(output, "Set up local secure storage now") {
+		t.Fatalf("expected initialization recovery prompt:\n%s", output)
+	}
+	if !strings.Contains(output, "Setup complete!") {
+		t.Fatalf("expected setup to complete after inline initialization recovery:\n%s", output)
+	}
+	if recoveryCalls != 1 {
+		t.Fatalf("expected one save-time initialization recovery call, got %d", recoveryCalls)
+	}
+	if writeCalls != 2 {
+		t.Fatalf("expected one failed save plus one retry, got %d writes", writeCalls)
+	}
+}

--- a/cli/setup_secure_storage_recovery_test.go
+++ b/cli/setup_secure_storage_recovery_test.go
@@ -97,6 +97,78 @@ func TestRunSetupSecureStorageRecoveryFlowRetriesOnlyOnRetryableError(t *testing
 	}
 }
 
+func TestRunSetupSecureStorageRecoveryFlowRecomputesPlanAfterRetryableKeyringError(t *testing.T) {
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalInfer := inferPlatformSecureStorageRecoveryActionForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	originalReadSecret := readSetupSecretInputForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		inferPlatformSecureStorageRecoveryActionForSetup = originalInfer
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+		readSetupSecretInputForSetup = originalReadSecret
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) { return true, nil }
+	inferPlatformSecureStorageRecoveryActionForSetup = func(err error) (platformSecureStorageRecoveryAction, error) {
+		switch {
+		case isDesktopKeyringInitializationRequiredError(err):
+			return platformSecureStorageRecoveryInitialize, nil
+		case isDesktopKeyringLockedError(err):
+			return platformSecureStorageRecoveryUnlock, nil
+		default:
+			return "", nil
+		}
+	}
+
+	var actions []platformSecureStorageRecoveryAction
+	runPlatformSecureStorageRecoveryForSetup = func(action platformSecureStorageRecoveryAction, _ []byte) error {
+		actions = append(actions, action)
+		if len(actions) == 1 {
+			return desktopKeyringLockedError("default Secret Service collection is locked")
+		}
+		return nil
+	}
+	secretReads := 0
+	readSetupSecretInputForSetup = func(int) ([]byte, error) {
+		secretReads++
+		switch secretReads {
+		case 1, 2:
+			return []byte("new-keyring-password"), nil
+		default:
+			return []byte("existing-keyring-password"), nil
+		}
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	var out bytes.Buffer
+	state := setupSecureStorageRecoveryState{}
+	result, err := runSetupSecureStorageRecoveryFlow(
+		bufio.NewReader(strings.NewReader("\n\n")),
+		&out,
+		desktopKeyringInitializationRequiredError("no default Secret Service collection configured"),
+		&state,
+		setupSecureStorageRecoveryInitialAttempt,
+	)
+	if err != nil {
+		t.Fatalf("expected recomputed recovery flow to succeed, got %v", err)
+	}
+	if result != setupSecureStorageRecoveryRecovered {
+		t.Fatalf("expected recovered result, got %q", result)
+	}
+	if len(actions) != 2 || actions[0] != platformSecureStorageRecoveryInitialize || actions[1] != platformSecureStorageRecoveryUnlock {
+		t.Fatalf("expected initialize then unlock actions, got %v", actions)
+	}
+	if !strings.Contains(out.String(), "Local secure storage is locked") {
+		t.Fatalf("expected retry to show the recomputed unlock copy, got:\n%s", out.String())
+	}
+}
+
 func TestRunSetupSecureStorageRecoveryFlowBackDoesNotConsumeAttempt(t *testing.T) {
 	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
 	originalTTY := writerSupportsTTYForSetup

--- a/cli/setup_state.go
+++ b/cli/setup_state.go
@@ -38,13 +38,17 @@ func (s setupState) SkipSummary() string {
 }
 
 func detectSetupState(paths runtimePaths, cfg runtimeConfig, state installState, target string) setupState {
+	token, err := readRelayAuthToken()
+	return detectSetupStateWithToken(paths, cfg, state, target, token, err == nil && strings.TrimSpace(token) != "")
+}
+
+func detectSetupStateWithToken(paths runtimePaths, cfg runtimeConfig, state installState, target, token string, tokenOK bool) setupState {
 	current := setupState{
 		ConfigOK: cfg.HAHost != "" && cfg.HAURL != "" && cfg.RelayBaseURL != "",
 		SkillsOK: clientsAppearInstalled(paths, target, state),
 	}
 
-	token, err := readRelayAuthToken()
-	if err == nil && strings.TrimSpace(token) != "" {
+	if tokenOK && strings.TrimSpace(token) != "" {
 		current.TokenOK = true
 	}
 	if !current.ConfigOK || !current.TokenOK {

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -174,6 +174,22 @@ macOS self-managed lifecycle:
 11. reinstall the runtime, then run `ha-nova uninstall --yes --purge`
 12. confirm purge removed runtime/config/state/cache and deleted the relay auth token
 
+Linux real-machine onboarding:
+Helper:
+- use `scripts/smoke/linux-headless-setup-check.sh` as the executable assistant for the SSH/headless Linux lane; pass the host and install command via env, never hardcode host-specific details in the repo
+- by default the helper runs `HA_NOVA_NO_BROWSER=1 ha-nova setup`
+- `HA_NOVA_LIVE_SKIP_INSTALL=1` is for repair/debug passes only; it does not satisfy the full release-bound fresh-install proof for this lane
+1. use a real Linux host with a desktop user session; when validating the SSH/headless recovery path, use an SSH shell inside that same logged-in user session
+2. fresh stable install via the public `install.sh` flow
+3. if secure storage is unavailable because no Secret Service provider is running, confirm setup fails with the explicit provider prerequisite message instead of raw `org.freedesktop.secrets` D-Bus text
+4. if secure storage is present but the default collection is still locked or uninitialized and the active Secret Service owner is GNOME Keyring, confirm interactive `ha-nova setup` offers the built-in local secure-storage recovery step before host/token work
+5. if the same locked/uninitialized state exists on a non-GNOME Secret Service backend, confirm setup stays fail-loud with the explicit prerequisite guidance and does not pretend inline recovery is available
+6. confirm the locked-flow copy asks for the existing local Linux keyring password, while the uninitialized-flow copy asks the user to create and confirm a new local Linux keyring password
+7. confirm a wrong local keyring password keeps the user on the locked recovery step with a clear local secure-storage error, and confirm a correct password unlocks the keyring and resumes setup
+8. confirm the fresh-init recovery path can create the default GNOME Keyring collection over SSH and then resumes setup without sending the user to a desktop GUI
+9. finish setup, then run `ha-nova doctor`
+10. confirm the relay token is saved and can be reused by a second `ha-nova setup` / `ha-nova doctor` invocation without repeating recovery
+
 Windows self-managed:
 1. on fresh-profile runs, preinstall at least one supported client and verify it already runs on that exact machine/session
 2. fresh stable install via `install.ps1` from a local PowerShell console or Windows Terminal session
@@ -204,6 +220,7 @@ Rules:
 - `scripts/dev/windows-desktop-setup.ps1` proves same-version update smoke plus standard/purge uninstall semantics; the cross-version background replace path is still covered by the manual RC/stable matrix above
 - do not present any package-manager alternative as an equal public path
 - keep the matrix small but explicit; do not replace the commands above with vague "relevant tests" wording
+- when Linux setup or secure-storage behavior changes, the release-bound manual matrix must include the Linux real-machine onboarding lane above; macOS/Windows proofs are not a substitute for it
 
 ### macOS Public Onboarding Lane
 

--- a/scripts/smoke/linux-headless-setup-check.sh
+++ b/scripts/smoke/linux-headless-setup-check.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  HA_NOVA_LIVE_SSH_HOST=user@host \
+  HA_NOVA_LIVE_INSTALL_CMD='curl -fsSL https://your-bundle-host.example/install.sh | bash' \
+  ./scripts/smoke/linux-headless-setup-check.sh
+
+Required env:
+  HA_NOVA_LIVE_SSH_HOST    SSH target for the real Linux host
+  HA_NOVA_LIVE_INSTALL_CMD Install command to run remotely before setup
+
+Important:
+  For SSH/headless Linux recovery proof, connect to the same logged-in desktop
+  user session that owns the user D-Bus / Secret Service session.
+
+Optional env:
+  HA_NOVA_LIVE_SETUP_CMD   Interactive setup command to run remotely
+                           default: HA_NOVA_NO_BROWSER=1 ha-nova setup
+  HA_NOVA_LIVE_SKIP_INSTALL=1
+                           Skip the remote install command and run setup only
+                           repair/debug only; not a full release-lane proof
+
+What this helper does:
+  1. Verifies SSH connectivity to the Linux host
+  2. Captures a small keyring/session preflight snapshot on the remote host
+  3. Runs the provided install command unless HA_NOVA_LIVE_SKIP_INSTALL=1
+  4. Hands off into an interactive remote `ha-nova setup ...` session
+
+What this helper does not do:
+  - store hostnames, tokens, or passwords in the repo
+  - bypass the interactive Linux secure-storage prompts
+  - mutate your release docs; it is only a live validation helper
+EOF
+}
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "[linux-live-check] missing required env: ${name}" >&2
+    usage >&2
+    exit 1
+  fi
+}
+
+run_remote() {
+  local command="$1"
+  ssh "${HA_NOVA_LIVE_SSH_HOST}" "bash -lc $(printf '%q' "$command")"
+}
+
+run_remote_tty() {
+  local command="$1"
+  ssh -tt "${HA_NOVA_LIVE_SSH_HOST}" "bash -lc $(printf '%q' "$command")"
+}
+
+if [[ "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+require_env "HA_NOVA_LIVE_SSH_HOST"
+if [[ "${HA_NOVA_LIVE_SKIP_INSTALL:-0}" != "1" ]]; then
+  require_env "HA_NOVA_LIVE_INSTALL_CMD"
+fi
+
+setup_cmd="${HA_NOVA_LIVE_SETUP_CMD:-HA_NOVA_NO_BROWSER=1 ha-nova setup}"
+
+echo "[linux-live-check] SSH target: ${HA_NOVA_LIVE_SSH_HOST}"
+echo "[linux-live-check] checking remote session..."
+run_remote 'set -euo pipefail; whoami >/dev/null; uname -srm'
+
+echo "[linux-live-check] capturing remote secure-storage preflight..."
+preflight_output="$(run_remote '
+set -euo pipefail
+echo "[remote] DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS:-<unset>}"
+if command -v gdbus >/dev/null 2>&1; then
+  echo "[remote] Secret Service default alias:"
+  gdbus call --session \
+    --dest org.freedesktop.secrets \
+    --object-path /org/freedesktop/secrets \
+    --method org.freedesktop.Secret.Service.ReadAlias default || true
+else
+  echo "[remote] gdbus not installed"
+fi
+if command -v ha-nova >/dev/null 2>&1; then
+  echo "[remote] installed ha-nova version:"
+  ha-nova version || true
+else
+  echo "[remote] ha-nova not installed yet"
+fi
+')"
+printf '%s\n' "${preflight_output}"
+
+if [[ "${preflight_output}" == *"DBUS_SESSION_BUS_ADDRESS=<unset>"* ]]; then
+  echo "[linux-live-check] warning: remote user D-Bus session looks unset; reconnect inside the same logged-in desktop user session before treating this as a release proof." >&2
+fi
+
+if [[ "${preflight_output}" == *"[remote] gdbus not installed"* ]]; then
+  echo "[linux-live-check] warning: remote gdbus is missing; Secret Service preflight evidence is incomplete and this usually is not a valid release-proof state." >&2
+fi
+
+if [[ "${HA_NOVA_LIVE_SKIP_INSTALL:-0}" != "1" ]]; then
+  echo "[linux-live-check] running remote install command..."
+  run_remote_tty "${HA_NOVA_LIVE_INSTALL_CMD}"
+fi
+
+echo "[linux-live-check] starting interactive remote setup..."
+echo "[linux-live-check] complete the Linux secure-storage prompts, then finish the normal setup flow."
+run_remote_tty "${setup_cmd}"

--- a/tests/onboarding/desktop-validation-contract.test.ts
+++ b/tests/onboarding/desktop-validation-contract.test.ts
@@ -10,6 +10,7 @@ describe("desktop validation helpers contract", () => {
   const macosSmoke = readFileSync("scripts/dev/macos-private-rc-smoke.sh", "utf8");
   const macosSetupAll = readFileSync("scripts/dev/macos-private-rc-setup-all.sh", "utf8");
   const macosClient = readFileSync("scripts/dev/macos-private-rc-client.sh", "utf8");
+  const linuxHeadless = readFileSync("scripts/smoke/linux-headless-setup-check.sh", "utf8");
   const validationCommon = readFileSync("scripts/dev/lib/validation-common.sh", "utf8");
   const mockServer = readFileSync("scripts/dev/mock-ha-relay.py", "utf8");
   const windowsCleanup = readFileSync("scripts/dev/windows-clean-test-state.ps1", "utf8");
@@ -24,6 +25,7 @@ describe("desktop validation helpers contract", () => {
       "scripts/dev/macos-private-rc-setup-all.sh",
       "scripts/dev/macos-private-rc-client.sh",
       "scripts/dev/start-local-validation-harness.sh",
+      "scripts/smoke/linux-headless-setup-check.sh",
     ]) {
       const stats = statSync(path);
       expect((stats.mode & constants.S_IXUSR) !== 0).toBe(true);
@@ -67,6 +69,21 @@ describe("desktop validation helpers contract", () => {
     expect(releasing).toContain("file-based test keyring override");
     expect(releasing).toContain("Windows Credential Manager interop stays covered");
     expect(releasing).toContain("open a new shell and run `ha-nova doctor`");
+    expect(releasing).toContain("Linux real-machine onboarding");
+    expect(releasing).toContain("scripts/smoke/linux-headless-setup-check.sh");
+    expect(releasing).toContain("same logged-in user session");
+    expect(releasing).toContain("explicit provider prerequisite message instead of raw `org.freedesktop.secrets` D-Bus text");
+    expect(releasing).toContain("local Linux keyring password");
+  });
+
+  it("keeps the Linux headless helper explicit and privacy-safe", () => {
+    expect(linuxHeadless).toContain("HA_NOVA_LIVE_SSH_HOST");
+    expect(linuxHeadless).toContain("HA_NOVA_LIVE_INSTALL_CMD");
+    expect(linuxHeadless).toContain("DBUS_SESSION_BUS_ADDRESS");
+    expect(linuxHeadless).toContain("org.freedesktop.Secret.Service.ReadAlias default");
+    expect(linuxHeadless).toContain("HA_NOVA_NO_BROWSER=1 ha-nova setup");
+    expect(linuxHeadless).toContain("store hostnames, tokens, or passwords");
+    expect(linuxHeadless).toContain("same logged-in desktop");
   });
 
   it("ships a single local validation harness entrypoint", () => {

--- a/tests/onboarding/linux-keyring-contract.test.ts
+++ b/tests/onboarding/linux-keyring-contract.test.ts
@@ -4,14 +4,51 @@ import { describe, expect, it } from "vitest";
 
 describe("linux keyring contract", () => {
   const content = readFileSync("cli/keyring_linux.go", "utf8");
+  const preflight = readFileSync("cli/keyring_preflight_linux.go", "utf8");
+  const recovery = readFileSync("cli/setup_secure_storage_recovery.go", "utf8");
+  const recoveryLinux = readFileSync("cli/setup_secure_storage_recovery_linux.go", "utf8");
+  const secureStorage = readFileSync("cli/keyring_linux_secure_storage.go", "utf8");
 
-  it("keeps Linux on the go-keyring Secret Service path", () => {
+  it("keeps Linux on the go-keyring Secret Service path behind testable wrappers", () => {
     expect(content).toContain('//go:build linux');
     expect(content).toContain('github.com/zalando/go-keyring');
-    expect(content).toContain("keyring.Get(service, u.Username)");
-    expect(content).toContain("keyring.Set(relayAuthTokenServiceName(), u.Username, token)");
-    expect(content).toContain("keyring.Delete(relayAuthTokenServiceName(), u.Username)");
+    expect(content).toContain("var keyringGetWithService = keyring.Get");
+    expect(content).toContain("var keyringSetWithService = keyring.Set");
+    expect(content).toContain("var keyringDeleteWithService = keyring.Delete");
+    expect(content).toContain("readSecretWithService(relayAuthTokenServiceName())");
+    expect(content).toContain("writeSecretWithService(relayAuthTokenServiceName(), token)");
+    expect(content).toContain("deleteSecretWithService(relayAuthTokenServiceName())");
     expect(content).toContain("relayAuthTokenReadError");
     expect(content).toContain("missingRelayAuthTokenError");
+  });
+
+  it("preflights Secret Service before setup writes tokens", () => {
+    expect(preflight).toContain("inspectLinuxSecureStorageState()");
+    expect(preflight).toContain("linuxSecureStorageStateNeedsInit");
+    expect(preflight).toContain("desktopKeyringInitializationRequiredError");
+    expect(preflight).toContain("linuxSecureStorageStateLocked");
+    expect(preflight).toContain("desktopKeyringLockedError");
+    expect(preflight).toContain("probeLinuxKeyringWritable()");
+  });
+
+  it("keeps inline recovery limited to explicit local Linux keyring copy", () => {
+    expect(recovery).toContain("local Linux keyring password");
+    expect(recovery).toContain("not the Relay token or the Home Assistant token");
+    expect(recovery).toContain("HA NOVA, NOVA Relay, and Home Assistant never receive it.");
+    expect(recovery).toContain("Passwords did not match.");
+    expect(recovery).toContain("local Linux keyring password was rejected");
+    expect(recoveryLinux).toContain("supportsGNOMEKeyringRecovery()");
+    expect(recoveryLinux).toContain("secureStorageRecoverySupportsGNOMEMethods");
+    expect(recoveryLinux).toContain("platformSecureStorageRecoveryInitialize");
+    expect(recoveryLinux).toContain("platformSecureStorageRecoveryUnlock");
+  });
+
+  it("uses bounded D-Bus inspection instead of surfacing raw Secret Service failures", () => {
+    expect(secureStorage).toContain("context.WithTimeout");
+    expect(secureStorage).toContain("ReadAlias");
+    expect(secureStorage).toContain("CreateWithMasterPassword");
+    expect(secureStorage).toContain("UnlockWithMasterPassword");
+    expect(secureStorage).toContain("normalizeLinuxKeyringErrorWithoutAmbiguousClassification");
+    expect(secureStorage).toContain("Secret Service preflight timed out");
   });
 });


### PR DESCRIPTION
## Summary
- add Linux Secret Service / GNOME Keyring preflight and recovery paths
- surface setup/doctor messaging without raw D-Bus errors
- add regression tests plus a live smoke helper for Linux secure-storage paths

## Verification
- go test ./...
- npx vitest run tests/onboarding/linux-keyring-contract.test.ts tests/onboarding/desktop-validation-contract.test.ts
- git diff --check origin/main..HEAD
- pre-push hook: typecheck, safe tests, build, docs fact-check

## Notes
- PR 2 of the stabilization stack. README/UX release wording is intentionally not included here.