### PR TITLE
feat: add Hermes client support

### DIFF
--- a/.claude/INSTALL.md
+++ b/.claude/INSTALL.md
@@ -78,3 +78,4 @@ On Windows, prefer the normal installed path or rerun `ha-nova setup claude` ins
 - Codex: `.codex/INSTALL.md`
 - OpenCode: `.opencode/INSTALL.md`
 - Gemini CLI: `.gemini/INSTALL.md`
+- Hermes Agent: `.hermes/INSTALL.md`

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -30,3 +30,4 @@ After setup, HA NOVA commands like `ha-nova:read`, `ha-nova:write`, and `ha-nova
 - Claude Code: `.claude/INSTALL.md`
 - OpenCode: `.opencode/INSTALL.md`
 - Gemini CLI: `.gemini/INSTALL.md`
+- Hermes Agent: `.hermes/INSTALL.md`

--- a/.gemini/INSTALL.md
+++ b/.gemini/INSTALL.md
@@ -45,3 +45,4 @@ After setup, HA NOVA commands like `ha-nova:read`, `ha-nova:write`, and `ha-nova
 - Claude Code: `.claude/INSTALL.md`
 - Codex: `.codex/INSTALL.md`
 - OpenCode: `.opencode/INSTALL.md`
+- Hermes Agent: `.hermes/INSTALL.md`

--- a/.github/ISSUE_TEMPLATE/hermes-platform-validation.yml
+++ b/.github/ISSUE_TEMPLATE/hermes-platform-validation.yml
@@ -1,0 +1,179 @@
+name: Hermes platform validation
+description: Share a real-machine Hermes + HA NOVA validation result
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for real validation results only.
+
+        Privacy rule:
+        - never paste Home Assistant long-lived access tokens
+        - never paste relay auth tokens
+        - never paste local keyring passwords
+        - never paste unredacted shell history
+        - redact hostnames, LAN IPs, local paths, and anything else private unless they are essential
+
+        Redact secrets before you submit anything.
+
+  - type: input
+    id: ha_nova_version
+    attributes:
+      label: HA NOVA version
+      placeholder: v0.4.0
+    validations:
+      required: true
+
+  - type: input
+    id: hermes_version
+    attributes:
+      label: Hermes version
+      placeholder: 0.0.x
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS native
+        - Linux native
+        - Windows native (unsupported today; use WSL2 for the supported path)
+        - Windows + WSL2
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_source
+    attributes:
+      label: Install source
+      options:
+        - latest public release
+        - release candidate or private bundle
+        - local checkout or local build
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: host_form
+    attributes:
+      label: Host form
+      options:
+        - real hardware
+        - virtual machine
+        - container or devcontainer
+        - remote CI-style environment
+        - other
+    validations:
+      required: true
+
+  - type: input
+    id: os_details
+    attributes:
+      label: OS / distro / version
+      placeholder: Ubuntu 24.04.1 LTS / macOS 15.x / Windows 11 24H2
+    validations:
+      required: true
+
+  - type: input
+    id: helper_or_overrides
+    attributes:
+      label: Helper script or `HA_NOVA_*` overrides used
+      description: Say `none` if you used the plain supported path. Redact hostnames, LAN IPs, and private paths.
+      placeholder: none / linux-headless-setup-check.sh + HA_NOVA_LIVE_SETUP_CMD / HA_NOVA_VERSION=...
+    validations:
+      required: true
+
+  - type: input
+    id: session_details
+    attributes:
+      label: Desktop environment / session type
+      placeholder: GNOME desktop session, KDE Plasma, SSH in same desktop user session, WSL shell
+    validations:
+      required: true
+
+  - type: input
+    id: secret_service_backend
+    attributes:
+      label: Secret Service backend if known
+      placeholder: GNOME Keyring / KWallet / none / unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: setup_path
+    attributes:
+      label: Setup path used
+      options:
+        - fresh install
+        - repair
+        - locked keyring recovery
+        - fresh-init keyring recovery
+        - update + repair
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: entrypoint_used
+    attributes:
+      label: Entry point used
+      options:
+        - public installer flow
+        - reran `ha-nova setup hermes`
+        - helper script driven setup
+        - local/manual install path
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: result
+    attributes:
+      label: Result
+      options:
+        - worked
+        - partial
+        - failed
+    validations:
+      required: true
+
+  - type: dropdown
+    id: hermes_skills_visible
+    attributes:
+      label: Did `hermes skills list` show `ha-nova*` skills?
+      options:
+        - yes
+        - partial
+        - no
+        - not checked
+    validations:
+      required: true
+
+  - type: textarea
+    id: where_stopped
+    attributes:
+      label: Where did it stop or what exactly worked?
+      description: Include the exact step, prompt, or command phase. Redact hostnames, LAN IPs, private paths, and secrets.
+      placeholder: Setup reached secure storage recovery, accepted password, then failed before token save...
+    validations:
+      required: true
+
+  - type: textarea
+    id: doctor_output
+    attributes:
+      label: Optional redacted `ha-nova doctor` output
+      description: Redact tokens, passwords, hostnames, and anything private before posting.
+      placeholder: Paste only the parts that matter, already redacted.
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra_notes
+    attributes:
+      label: Extra notes
+      description: Anything else that would help compare this environment against the validation matrix? Redact hostnames, LAN IPs, private paths, and secrets.
+    validations:
+      required: false

--- a/.hermes/INSTALL.md
+++ b/.hermes/INSTALL.md
@@ -2,6 +2,8 @@
 
 This page only covers Hermes-specific deltas.
 
+> **Release status:** Hermes support is implemented for the next HA NOVA release train, but it is not part of the current stable release until the final release PR, tag, and artifacts publish it. Until then, `README.md` remains the stable public product truth.
+
 For the stable installer, lifecycle commands, and general troubleshooting, use [README.md](../README.md) and the [latest GitHub release](https://github.com/markusleben/ha-nova/releases/latest).
 
 ## Setup Choice

--- a/.hermes/INSTALL.md
+++ b/.hermes/INSTALL.md
@@ -1,0 +1,84 @@
+# Hermes Agent Install Overlay
+
+This page only covers Hermes-specific deltas.
+
+For the stable installer, lifecycle commands, and general troubleshooting, use [README.md](../README.md) and the [latest GitHub release](https://github.com/markusleben/ha-nova/releases/latest).
+
+## Setup Choice
+
+- Use the normal HA NOVA installer flow.
+- In the setup wizard, choose `Hermes Agent`.
+- Install Hermes separately; HA NOVA handles the skills and onboarding, not the Hermes app itself.
+
+## What Supported Means Here
+
+Support status:
+- `Supported` means HA NOVA intentionally supports that Hermes route and keeps install docs plus product behavior aligned to it.
+- `Supported with limitation` means the route is real, but one UX slice is intentionally narrower today.
+- `Not supported` means the route is outside the current HA NOVA support model.
+
+Evidence status:
+- `Maintainer-validated` means the maintainer ran that exact path on a real machine recently.
+- `Community validation` is welcome and useful, but it is advisory only and does not replace maintainer release proof.
+- `Planned / not yet validated` means the path is part of the intended support model, but the current release cycle does not claim a fresh maintainer proof yet.
+
+## Platform Routing
+
+Current support/evidence truth lives in [docs/reference/hermes-platform-validation.md](../docs/reference/hermes-platform-validation.md).
+
+- macOS native Hermes follows the native macOS path.
+- Linux native Hermes is the current focus for inline secure-storage recovery; GNOME Keyring is the actively maintainer-validated path.
+- Linux non-GNOME Secret Service backends stay supported only when secure local storage already works; inline recovery is not claimed there yet.
+- Windows native Hermes is not supported. Use WSL2 instead.
+- Windows + WSL2 Hermes must run entirely inside the same WSL shell where `hermes --help` already works.
+
+## Network Model
+
+- Hermes is a local-first HA NOVA client, not a cloud-hosted control plane.
+- The simple path today is to run Hermes on a machine you control with direct private reachability to Home Assistant and the HA NOVA Relay.
+- In practice, that usually means the same home network or a private VPN/overlay route.
+- A generic public VPS is not the intended beginner path today. It changes the trust and networking model, and it is not the current maintainer-validated Hermes story.
+- If you want remote access later, the clean model is still local execution: a future remote entrypoint can forward requests into your trusted local Hermes + HA NOVA flow instead of moving execution onto a public server.
+- Do not expose the HA NOVA Relay directly to the public internet. If you need remote reachability, use a private tunnel or VPN path you control.
+
+## Linux Notes
+
+- On Linux, HA NOVA expects a working Secret Service session for secure local token storage.
+- If HA NOVA asks for a local Linux keyring password, it stays on this machine. HA NOVA only uses it to unlock or create local secure storage. It is not your Relay token, not your Home Assistant token, and it is not sent to the Relay, Home Assistant, Hermes, or any AI provider.
+- If no Secret Service provider is running, setup fails early with an explicit prerequisite message instead of raw `org.freedesktop.secrets` D-Bus errors.
+- If Linux is using GNOME Keyring and the default collection is locked or uninitialized, `ha-nova setup hermes` can guide recovery inline.
+- If Linux uses another Secret Service backend, keep the backend working first; HA NOVA does not pretend inline GNOME-only recovery exists there.
+- If you run setup or repair over SSH, use the same logged-in desktop user session that owns the user D-Bus / Secret Service session.
+
+## Updates and Repair
+
+- Run `ha-nova doctor` first. If Hermes is configured but not attached, doctor points you to `ha-nova setup hermes`.
+- Connect or repair with `ha-nova setup hermes`.
+- `ha-nova setup hermes` also repairs older Hermes installs whose bare sub-skill directory names could make `skills_list` and `skill_view` disagree.
+- On Windows with WSL2, run update and repair commands from the same WSL shell where Hermes is installed.
+- Validate the current route and proof status in [docs/reference/hermes-platform-validation.md](../docs/reference/hermes-platform-validation.md).
+- Validate the install with `ha-nova doctor`.
+- Hermes does not surface HA NOVA update notices automatically yet. Use `ha-nova check-update` or `ha-nova doctor` when you want to check manually.
+
+## Hermes-Specific Skill Layout
+
+- HA NOVA installs Hermes skills under `~/.hermes/skills/ha-nova/`.
+- The context skill stays `ha-nova`.
+- Hermes sub-skills are installed in matching namespaced directories such as `~/.hermes/skills/ha-nova/ha-nova-read/` and `~/.hermes/skills/ha-nova/ha-nova-review/`.
+- Each Hermes sub-skill keeps the same canonical identifier for both directory name and frontmatter `name:` to keep `skills_list` and `skill_view` aligned.
+
+## What You Get
+
+After setup, HA NOVA skills are available inside Hermes with the HA NOVA namespaced skill set.
+
+## Community Validation
+
+- If you validate Hermes on another macOS build, Linux distro, desktop session, or Secret Service backend, open the Hermes platform validation issue template and redact all tokens and secrets.
+- Community validation helps us expand the matrix faster, but maintainer-validated rows stay the release signoff source of truth.
+
+## Related
+
+- Claude Code: `.claude/INSTALL.md`
+- Codex: `.codex/INSTALL.md`
+- OpenCode: `.opencode/INSTALL.md`
+- Gemini CLI: `.gemini/INSTALL.md`

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -31,3 +31,4 @@ After setup, HA NOVA commands like `ha-nova:read`, `ha-nova:write`, and `ha-nova
 - Claude Code: `.claude/INSTALL.md`
 - Codex: `.codex/INSTALL.md`
 - Gemini CLI: `.gemini/INSTALL.md`
+- Hermes Agent: `.hermes/INSTALL.md`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@
 </p>
 
 <p align="center">
-  Works with <b>Claude Code</b> · <b>Claude Desktop</b> · <b>Codex CLI</b> · <b>OpenCode</b> · <b>Gemini CLI</b>
+  Works with <b>Claude Code</b> · <b>Claude Desktop</b> · <b>Codex CLI</b> · <b>OpenCode</b> · <b>Gemini CLI</b> · <b>Hermes Agent*</b>
+</p>
+
+<p align="center">
+  <sub>* Hermes follows the native macOS/Linux path and uses WSL2 on Windows. Current proof status: <a href="docs/reference/hermes-platform-validation.md">validation matrix</a>.</sub>
 </p>
 
 <p align="center">
@@ -94,8 +98,10 @@ Once it finishes, try: *"Show me all my automations."*
 - Claude Code is the most tested client on Windows today
 - Gemini CLI has basic validation
 - Codex and OpenCode are still early
+- Hermes Agent is supported through WSL2, not native Windows
+- If you use Hermes on Windows, open your WSL shell and run the Linux/WSL HA NOVA install plus `ha-nova setup hermes` there, not from native PowerShell
 - Native prerequisites: Claude Code needs Git for Windows / Git Bash; Gemini CLI needs Node.js
-- See [.claude/INSTALL.md](.claude/INSTALL.md) and [.gemini/INSTALL.md](.gemini/INSTALL.md)
+- See [.claude/INSTALL.md](.claude/INSTALL.md), [.gemini/INSTALL.md](.gemini/INSTALL.md), and [.hermes/INSTALL.md](.hermes/INSTALL.md)
 
 > Do not download the `ha-nova-installer-bundle-*.tar.gz` / `.zip` assets manually. Those archives are used by the installer behind the scenes. Always use the one-liner or `ha-nova update`.
 
@@ -185,6 +191,7 @@ Want to add a new capability? → [CONTRIBUTING.md](CONTRIBUTING.md)
 | [Codex CLI](https://github.com/openai/codex) | Terminal |
 | [OpenCode](https://github.com/opencode-ai/opencode) | Terminal |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Terminal |
+| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | Terminal (native macOS/Linux, WSL2 on Windows) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,7 @@
 </p>
 
 <p align="center">
-  Works with <b>Claude Code</b> · <b>Claude Desktop</b> · <b>Codex CLI</b> · <b>OpenCode</b> · <b>Gemini CLI</b> · <b>Hermes Agent*</b>
-</p>
-
-<p align="center">
-  <sub>* Hermes follows the native macOS/Linux path and uses WSL2 on Windows. Current proof status: <a href="docs/reference/hermes-platform-validation.md">validation matrix</a>.</sub>
+  Works with <b>Claude Code</b> · <b>Claude Desktop</b> · <b>Codex CLI</b> · <b>OpenCode</b> · <b>Gemini CLI</b>
 </p>
 
 <p align="center">
@@ -98,10 +94,8 @@ Once it finishes, try: *"Show me all my automations."*
 - Claude Code is the most tested client on Windows today
 - Gemini CLI has basic validation
 - Codex and OpenCode are still early
-- Hermes Agent is supported through WSL2, not native Windows
-- If you use Hermes on Windows, open your WSL shell and run the Linux/WSL HA NOVA install plus `ha-nova setup hermes` there, not from native PowerShell
 - Native prerequisites: Claude Code needs Git for Windows / Git Bash; Gemini CLI needs Node.js
-- See [.claude/INSTALL.md](.claude/INSTALL.md), [.gemini/INSTALL.md](.gemini/INSTALL.md), and [.hermes/INSTALL.md](.hermes/INSTALL.md)
+- See [.claude/INSTALL.md](.claude/INSTALL.md) and [.gemini/INSTALL.md](.gemini/INSTALL.md)
 
 > Do not download the `ha-nova-installer-bundle-*.tar.gz` / `.zip` assets manually. Those archives are used by the installer behind the scenes. Always use the one-liner or `ha-nova update`.
 
@@ -191,7 +185,6 @@ Want to add a new capability? → [CONTRIBUTING.md](CONTRIBUTING.md)
 | [Codex CLI](https://github.com/openai/codex) | Terminal |
 | [OpenCode](https://github.com/opencode-ai/opencode) | Terminal |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Terminal |
-| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | Terminal (native macOS/Linux, WSL2 on Windows) |
 
 ---
 

--- a/cli/client_availability_test.go
+++ b/cli/client_availability_test.go
@@ -22,8 +22,8 @@ func TestBuildSetupClientChoicesDisablesMissingRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildSetupClientChoices() error: %v", err)
 	}
-	if len(choices) != 5 {
-		t.Fatalf("expected 5 setup choices, got %d", len(choices))
+	if len(choices) != 6 {
+		t.Fatalf("expected 6 setup choices, got %d", len(choices))
 	}
 	for _, choice := range choices {
 		if !choice.Disabled {
@@ -52,18 +52,26 @@ func TestBuildSetupClientChoicesShowsAvailableClientsBeforeDisabledOnes(t *testi
 	for _, choice := range choices {
 		gotValues = append(gotValues, choice.Value)
 	}
-	wantValues := []string{"claude", "gemini", "codex", "opencode", "all"}
+	wantValues := []string{"claude", "gemini", "codex", "opencode", "hermes", "all"}
 	if strings.Join(gotValues, ",") != strings.Join(wantValues, ",") {
 		t.Fatalf("choice order = %v, want %v", gotValues, wantValues)
 	}
 	if choices[0].Disabled || choices[1].Disabled {
 		t.Fatalf("expected available clients first, got %+v", choices)
 	}
-	if !choices[2].Disabled || !choices[3].Disabled {
-		t.Fatalf("expected disabled clients after available ones, got %+v", choices)
+	for _, choice := range choices[2:5] {
+		if !choice.Disabled {
+			t.Fatalf("expected disabled clients after available ones, got %+v", choices)
+		}
 	}
-	if choices[4].Number != "5" {
-		t.Fatalf("expected all-choice numbering to be recomputed, got %q", choices[4].Number)
+	if choices[5].Disabled {
+		t.Fatalf("expected all choice to stay available when at least one client is available, got %+v", choices)
+	}
+	if choices[5].Value != "all" {
+		t.Fatalf("expected all choice to stay last, got %+v", choices)
+	}
+	if choices[5].Number != "6" {
+		t.Fatalf("expected all-choice numbering to be recomputed, got %q", choices[5].Number)
 	}
 }
 
@@ -84,8 +92,8 @@ func TestResolveSetupClientsForAllReturnsOnlyAvailableClients(t *testing.T) {
 	if len(resolved) != 1 || resolved[0] != "claude" {
 		t.Fatalf("expected all to resolve only Claude, got %+v", resolved)
 	}
-	if len(skipped) != 3 {
-		t.Fatalf("expected three skipped clients, got %+v", skipped)
+	if len(skipped) != 4 {
+		t.Fatalf("expected four skipped clients, got %+v", skipped)
 	}
 }
 

--- a/cli/client_detection.go
+++ b/cli/client_detection.go
@@ -15,6 +15,12 @@ func detectInstalledClients(paths runtimePaths) ([]string, error) {
 			}
 			continue
 		}
+		if entry.ID == "hermes" {
+			if status.RuntimeDetected && (status.Attached || hermesLegacyBundlePresent(paths.Home)) {
+				clients = append(clients, entry.ID)
+			}
+			continue
+		}
 		if status.Attached && status.RuntimeDetected {
 			clients = append(clients, entry.ID)
 		}

--- a/cli/client_gemini.go
+++ b/cli/client_gemini.go
@@ -26,7 +26,7 @@ func installGeminiClient(home, sourceRoot string) error {
 		return err
 	}
 
-	subSkills, err := geminiSourceSubSkills(sourceRoot)
+	subSkills, err := sourceSubSkills(sourceRoot)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func installGeminiClient(home, sourceRoot string) error {
 	return nil
 }
 
-func geminiSourceSubSkills(sourceRoot string) ([]string, error) {
+func sourceSubSkills(sourceRoot string) ([]string, error) {
 	entries, err := os.ReadDir(filepath.Join(sourceRoot, "skills"))
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cli/client_hermes.go
+++ b/cli/client_hermes.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var hermesRequiredSkillDirs = []string{
+	"ha-nova",
+	"ha-nova-dashboard",
+	"ha-nova-entity-discovery",
+	"ha-nova-fallback",
+	"ha-nova-helper",
+	"ha-nova-history",
+	"ha-nova-onboarding",
+	"ha-nova-organize",
+	"ha-nova-read",
+	"ha-nova-review",
+	"ha-nova-service-call",
+	"ha-nova-write",
+}
+
+var hermesLegacyRequiredSkillDirs = []string{
+	"ha-nova",
+	"dashboard",
+	"entity-discovery",
+	"fallback",
+	"helper",
+	"history",
+	"onboarding",
+	"organize",
+	"read",
+	"review",
+	"service-call",
+	"write",
+}
+
+func hermesInstalledSkillName(skillName string) string {
+	if strings.TrimSpace(skillName) == "" || skillName == "ha-nova" {
+		return "ha-nova"
+	}
+	return "ha-nova-" + skillName
+}
+
+func hermesBundlePresent(home string) bool {
+	bundleRoot := filepath.Join(home, ".hermes", "skills", "ha-nova")
+	for _, skillDir := range hermesRequiredSkillDirs {
+		if !fileExists(filepath.Join(bundleRoot, skillDir, "SKILL.md")) {
+			return false
+		}
+	}
+	return true
+}
+
+func hermesLegacyBundlePresent(home string) bool {
+	bundleRoot := filepath.Join(home, ".hermes", "skills", "ha-nova")
+	for _, skillDir := range hermesLegacyRequiredSkillDirs {
+		if !fileExists(filepath.Join(bundleRoot, skillDir, "SKILL.md")) {
+			return false
+		}
+	}
+	return true
+}
+
+func installHermesClient(home, sourceRoot string) error {
+	bundleRoot := filepath.Join(home, ".hermes", "skills", "ha-nova")
+	if err := os.RemoveAll(bundleRoot); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(bundleRoot, 0o755); err != nil {
+		return err
+	}
+
+	subSkills, err := sourceSubSkills(sourceRoot)
+	if err != nil {
+		return err
+	}
+
+	if err := writeHermesSkill(filepath.Join(sourceRoot, "skills"), "ha-nova", filepath.Join(bundleRoot, "ha-nova"), sourceRoot, subSkills); err != nil {
+		return err
+	}
+	for _, skill := range subSkills {
+		if err := writeHermesSkill(filepath.Join(sourceRoot, "skills"), skill, filepath.Join(bundleRoot, hermesInstalledSkillName(skill)), sourceRoot, subSkills); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeHermesSkill(skillsRoot, skillName, destDir, sourceRoot string, subSkills []string) error {
+	sourceDir := filepath.Join(skillsRoot, skillName)
+	if _, err := os.Stat(filepath.Join(sourceDir, "SKILL.md")); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("missing Hermes source skill: %s", filepath.Join(sourceDir, "SKILL.md"))
+		}
+		return err
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(sourceDir, entry.Name()))
+		if err != nil {
+			return err
+		}
+		rewritten := rewriteHermesMarkdown(skillName, string(data), sourceDir, sourceRoot, subSkills)
+		if err := os.WriteFile(filepath.Join(destDir, entry.Name()), []byte(rewritten), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rewriteHermesMarkdown(skillName, content, sourceDir, sourceRoot string, subSkills []string) string {
+	entries, err := os.ReadDir(sourceDir)
+	if err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") || entry.Name() == "SKILL.md" {
+				continue
+			}
+			from := fmt.Sprintf("`skills/%s/%s`", skillName, entry.Name())
+			to := fmt.Sprintf("`%s`", entry.Name())
+			content = strings.ReplaceAll(content, from, to)
+		}
+	}
+
+	content = docsRefPattern.ReplaceAllStringFunc(content, func(match string) string {
+		parts := docsRefPattern.FindStringSubmatch(match)
+		return fmt.Sprintf("`%s`", filepath.Join(sourceRoot, "docs", "reference", parts[1]))
+	})
+	content = sharedSkillRefPattern.ReplaceAllStringFunc(content, func(match string) string {
+		if sameSkillRefPattern.MatchString(match) {
+			return match
+		}
+		parts := sharedSkillRefPattern.FindStringSubmatch(match)
+		return fmt.Sprintf("`%s`", filepath.Join(sourceRoot, "skills", parts[1]))
+	})
+	content = rewriteHermesSkillDispatchRefs(content, subSkills)
+	content = rewriteHermesSkillFrontmatter(skillName, content)
+	return content
+}
+
+func rewriteHermesSkillDispatchRefs(content string, subSkills []string) string {
+	for _, skill := range subSkills {
+		content = strings.ReplaceAll(content, "ha-nova:"+skill, hermesInstalledSkillName(skill))
+	}
+	return content
+}
+
+func rewriteHermesSkillFrontmatter(skillName, content string) string {
+	if strings.TrimSpace(skillName) == "" || skillName == "ha-nova" {
+		return content
+	}
+	short := "name: " + skillName
+	full := "name: " + hermesInstalledSkillName(skillName)
+	return strings.Replace(content, short, full, 1)
+}

--- a/cli/client_install.go
+++ b/cli/client_install.go
@@ -48,6 +48,8 @@ func installClient(paths runtimePaths, sourceRoot, client string) (string, error
 			return installTreeClient(filepath.Join(paths.Home, ".agents", "skills"), filepath.Join(sourceRoot, "skills"), preferSymlinkForCurrentOS())
 		case "opencode":
 			return installTreeClient(filepath.Join(paths.Home, ".config", "opencode", "skills"), filepath.Join(sourceRoot, "skills"), preferSymlinkForCurrentOS())
+		case "hermes":
+			return "copy", installHermesClient(paths.Home, sourceRoot)
 		default:
 			return "", fmt.Errorf("unsupported skill-tree client: %s", client)
 		}

--- a/cli/client_status.go
+++ b/cli/client_status.go
@@ -37,6 +37,9 @@ func evaluateClientStatus(paths runtimePaths, state installState, client clientR
 	if client.ID == "claude" && (claudeSnapshot.MarketplaceFound || claudeSnapshot.PluginFound) {
 		status.Configured = true
 	}
+	if client.ID == "hermes" && hermesLegacyBundlePresent(paths.Home) {
+		status.Configured = true
+	}
 	status.RuntimeDetected = clientRuntimeDetectedForStatus(client.ID)
 	status.Ready = status.SupportedOnOS && status.RuntimeDetected && status.Attached
 	status.Reason = clientStatusReason(client.ID, status)
@@ -62,6 +65,8 @@ func clientRuntimeCommand(client string) string {
 		return "opencode"
 	case "gemini":
 		return "gemini"
+	case "hermes":
+		return "hermes"
 	default:
 		return ""
 	}
@@ -76,6 +81,8 @@ func clientAttachmentPresent(paths runtimePaths, state installState, client stri
 	case "gemini":
 		return fileExists(filepath.Join(paths.Home, ".gemini", "skills", "ha-nova", "SKILL.md")) &&
 			fileExists(filepath.Join(paths.Home, ".gemini", "skills", "ha-nova-review", "SKILL.md"))
+	case "hermes":
+		return hermesBundlePresent(paths.Home)
 	case "claude":
 		return inspectClaudeInstallSnapshot(paths, state).Attached
 	default:
@@ -117,6 +124,8 @@ func clientStatusReason(client string, status clientStatus) string {
 		return "install OpenCode first"
 	case "gemini":
 		return "install Gemini CLI first"
+	case "hermes":
+		return "install Hermes Agent first"
 	default:
 		return "install this client first"
 	}

--- a/cli/client_status_test_helpers_test.go
+++ b/cli/client_status_test_helpers_test.go
@@ -24,6 +24,7 @@ func withAllClientRuntimesAvailable(t *testing.T) {
 		"codex":    true,
 		"opencode": true,
 		"gemini":   true,
+		"hermes":   true,
 	})
 }
 

--- a/cli/client_uninstall.go
+++ b/cli/client_uninstall.go
@@ -14,8 +14,11 @@ func removeInstalledClients(paths runtimePaths, state installState) error {
 
 func removeInstalledClientsWithReport(paths runtimePaths, state installState, report *uninstallReport) error {
 	clients := append([]string{}, state.InstalledClients...)
+	if hermesBundlePresent(paths.Home) || hermesLegacyBundlePresent(paths.Home) {
+		clients = normalizeClients(append(clients, "hermes"))
+	}
 	if len(clients) == 0 {
-		clients = []string{"claude", "codex", "opencode", "gemini"}
+		clients = []string{"claude", "codex", "opencode", "gemini", "hermes"}
 	}
 	sort.Strings(clients)
 	for _, client := range clients {
@@ -85,6 +88,10 @@ func removeInstalledClientsWithReport(paths runtimePaths, state installState, re
 			}
 		case "gemini":
 			if err := removeSkillEntriesWithReport(filepath.Join(paths.Home, ".gemini", "skills"), report); err != nil {
+				return err
+			}
+		case "hermes":
+			if err := removeSkillEntriesWithReport(filepath.Join(paths.Home, ".hermes", "skills"), report); err != nil {
 				return err
 			}
 		}

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -254,7 +254,7 @@ func normalizeSetupArgs(args []string) []string {
 
 func isSetupTarget(value string) bool {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "all", "claude", "codex", "opencode", "gemini":
+	case "all", "claude", "codex", "opencode", "gemini", "hermes":
 		return true
 	default:
 		return false

--- a/cli/hermes_install_test.go
+++ b/cli/hermes_install_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallHermesClientKeepsHermesDirectoryNamesAlignedWithFrontmatterNames(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := filepath.Join(t.TempDir(), "source")
+	skillsRoot := filepath.Join(sourceRoot, "skills")
+	for _, skill := range []string{
+		"ha-nova",
+		"dashboard",
+		"organize",
+		"history",
+		"write",
+		"read",
+		"helper",
+		"entity-discovery",
+		"onboarding",
+		"service-call",
+		"review",
+		"fallback",
+	} {
+		dir := filepath.Join(skillsRoot, skill)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", skill, err)
+		}
+		content := "name: " + skill + "\n"
+		if skill == "ha-nova" {
+			content += "use ha-nova:entity-discovery\n"
+			content += "use ha-nova:review\n"
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s skill: %v", skill, err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".hermes", "skills", "ha-nova", "review"), 0o755); err != nil {
+		t.Fatalf("mkdir legacy Hermes review skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".hermes", "skills", "ha-nova", "review", "SKILL.md"), []byte("name: review\n"), 0o644); err != nil {
+		t.Fatalf("write legacy Hermes review skill: %v", err)
+	}
+
+	if err := installHermesClient(home, sourceRoot); err != nil {
+		t.Fatalf("installHermesClient() error: %v", err)
+	}
+
+	for _, skill := range []string{
+		"ha-nova",
+		"ha-nova-dashboard",
+		"ha-nova-organize",
+		"ha-nova-history",
+		"ha-nova-write",
+		"ha-nova-read",
+		"ha-nova-helper",
+		"ha-nova-entity-discovery",
+		"ha-nova-onboarding",
+		"ha-nova-service-call",
+		"ha-nova-review",
+		"ha-nova-fallback",
+	} {
+		if _, err := os.Stat(filepath.Join(home, ".hermes", "skills", "ha-nova", skill, "SKILL.md")); err != nil {
+			t.Fatalf("expected Hermes skill %s to exist: %v", skill, err)
+		}
+	}
+
+	entityDiscovery, err := os.ReadFile(filepath.Join(home, ".hermes", "skills", "ha-nova", "ha-nova-entity-discovery", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read Hermes entity-discovery skill: %v", err)
+	}
+	if !strings.Contains(string(entityDiscovery), "name: ha-nova-entity-discovery") {
+		t.Fatalf("expected Hermes entity-discovery skill to use namespaced frontmatter name, got %q", string(entityDiscovery))
+	}
+
+	contextSkill, err := os.ReadFile(filepath.Join(home, ".hermes", "skills", "ha-nova", "ha-nova", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read Hermes context skill: %v", err)
+	}
+	if !strings.Contains(string(contextSkill), "use ha-nova-entity-discovery") {
+		t.Fatalf("expected Hermes context skill to rewrite dispatch refs, got %q", string(contextSkill))
+	}
+	if !strings.Contains(string(contextSkill), "use ha-nova-review") {
+		t.Fatalf("expected Hermes context skill to rewrite additional dispatch refs, got %q", string(contextSkill))
+	}
+	if !strings.Contains(string(contextSkill), "name: ha-nova") {
+		t.Fatalf("expected Hermes context skill to keep the root skill name, got %q", string(contextSkill))
+	}
+	if _, err := os.Stat(filepath.Join(home, ".hermes", "skills", "ha-nova", "entity-discovery")); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy bare Hermes directory to be absent, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".hermes", "skills", "ha-nova", "review")); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy bare Hermes directory to be absent, got err=%v", err)
+	}
+}
+
+func TestInstallHermesClientFailsWhenContextSkillIsMissing(t *testing.T) {
+	home := t.TempDir()
+	sourceRoot := filepath.Join(t.TempDir(), "source")
+	if err := os.MkdirAll(filepath.Join(sourceRoot, "skills", "read"), 0o755); err != nil {
+		t.Fatalf("mkdir read skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "skills", "read", "SKILL.md"), []byte("name: read\n"), 0o644); err != nil {
+		t.Fatalf("write read skill: %v", err)
+	}
+
+	err := installHermesClient(home, sourceRoot)
+	if err == nil || !strings.Contains(err.Error(), "missing Hermes source skill") {
+		t.Fatalf("expected missing Hermes context skill error, got %v", err)
+	}
+}

--- a/cli/setup_ui.go
+++ b/cli/setup_ui.go
@@ -235,6 +235,8 @@ func setupClientLabel(client string) string {
 		return "OpenCode"
 	case "gemini":
 		return "Gemini CLI"
+	case "hermes":
+		return "Hermes Agent"
 	case "all":
 		return "your available AI assistants"
 	default:

--- a/cli/setup_ui_test.go
+++ b/cli/setup_ui_test.go
@@ -15,7 +15,8 @@ func testSetupClientChoices() []setupClientChoice {
 		{Number: "2", Value: "codex", Label: "Codex CLI", Resolved: []string{"codex"}},
 		{Number: "3", Value: "opencode", Label: "OpenCode", Resolved: []string{"opencode"}},
 		{Number: "4", Value: "gemini", Label: "Gemini CLI", Resolved: []string{"gemini"}},
-		{Number: "5", Value: "all", Label: "All available clients", Resolved: []string{"claude", "codex", "opencode", "gemini"}},
+		{Number: "5", Value: "hermes", Label: "Hermes Agent", Resolved: []string{"hermes"}},
+		{Number: "6", Value: "all", Label: "All available clients", Resolved: []string{"claude", "codex", "opencode", "gemini", "hermes"}},
 	}
 }
 
@@ -38,8 +39,9 @@ func TestPromptSetupClientShowsLegacyListAndDefaultsToClaude(t *testing.T) {
 		"2) Codex CLI",
 		"3) OpenCode",
 		"4) Gemini CLI",
-		"5) All available clients",
-		"Enter [1-5] (default 1, or type 'exit'): ",
+		"5) Hermes Agent",
+		"6) All available clients",
+		"Enter [1-6] (default 1, or type 'exit'): ",
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("prompt output missing %q:\n%s", want, rendered)

--- a/clients/registry.json
+++ b/clients/registry.json
@@ -23,6 +23,12 @@
       "label": "Gemini CLI",
       "adapter_kind": "skill_flat",
       "supported_os": ["macos", "linux", "windows"]
+    },
+    {
+      "id": "hermes",
+      "label": "Hermes Agent",
+      "adapter_kind": "skill_tree",
+      "supported_os": ["macos", "linux"]
     }
   ]
 }

--- a/docs/reference/documentation-governance.md
+++ b/docs/reference/documentation-governance.md
@@ -24,7 +24,7 @@ Use these files as the current sources of truth:
   - HA transport/routing truth
 - `docs/reference/skill-architecture.md`
   - skill topology and contributor index
-- `.claude/INSTALL.md`, `.codex/INSTALL.md`, `.gemini/INSTALL.md`, `.opencode/INSTALL.md`
+- `.claude/INSTALL.md`, `.codex/INSTALL.md`, `.gemini/INSTALL.md`, `.opencode/INSTALL.md`, `.hermes/INSTALL.md`
   - client-specific install overlays; derived active docs that cover client deltas only and must point back to `README.md` for the shared install contract
 - `nova/DOCS.md`
   - Home Assistant App / relay operator truth
@@ -86,6 +86,7 @@ Active paths:
 - `.codex/INSTALL.md`
 - `.gemini/INSTALL.md`
 - `.opencode/INSTALL.md`
+- `.hermes/INSTALL.md`
 - `nova/DOCS.md`
 - `nova/README.md`
 - `skills/**/SKILL.md`

--- a/docs/reference/hermes-platform-validation.md
+++ b/docs/reference/hermes-platform-validation.md
@@ -2,6 +2,8 @@
 
 This is the active truth source for Hermes support evidence in HA NOVA.
 
+> **Release status:** This matrix tracks the next release train. Hermes support is not part of the current stable release until the final release PR publishes matching README claims, release notes, tag, and artifacts.
+
 Use it to answer two separate questions cleanly:
 
 - Is this route part of the intended supported product path?

--- a/docs/reference/hermes-platform-validation.md
+++ b/docs/reference/hermes-platform-validation.md
@@ -1,0 +1,49 @@
+# Hermes Platform Validation
+
+This is the active truth source for Hermes support evidence in HA NOVA.
+
+Use it to answer two separate questions cleanly:
+
+- Is this route part of the intended supported product path?
+- Has the maintainer actually re-proved that exact route on a real machine recently?
+
+## Support Status
+
+- `Supported`: HA NOVA intentionally supports the route and keeps docs plus product behavior aligned to it.
+- `Supported with limitation`: the route is real, but one UX slice is intentionally narrower today.
+- `Not supported`: the route is outside the current HA NOVA support model.
+
+## Evidence Status
+
+- `Maintainer-validated`: the maintainer ran this exact route on a real machine recently enough to cite it for release confidence.
+- `Community validation`: a user reported a real result for this route. Helpful signal; not release signoff on its own.
+- `Planned / not yet validated`: the route belongs to the support model, but does not yet have a fresh maintainer proof in this matrix.
+
+## Current Matrix
+
+| Platform | OS / distro / version | Session / DE | Secret Service backend | Support status | Evidence status | Hermes runtime detected | HA NOVA skills attached | `ha-nova setup hermes` | `ha-nova doctor` | Inline recovery available | Last proof date | Notes |
+|:---------|:----------------------|:-------------|:------------------------|:---------------|:----------------|:------------------------|:------------------------|:-----------------------|:-----------------|:--------------------------|:----------------|:------|
+| Linux native | Ubuntu 24.04.1 LTS | Logged-in desktop session | GNOME Keyring | Supported | Maintainer-validated | Yes | Yes | Yes | Yes | Yes | 2026-04-18 | Current real-machine Hermes/Linux proof. Also validated over SSH inside the same logged-in desktop user session. |
+| macOS native | macOS native path | Local terminal session | n/a | Supported | Planned / not yet validated | n/a | n/a | n/a | n/a | n/a | n/a | Native Hermes is part of the intended support model. Fresh maintainer release proof still needs to be recorded here. |
+| Linux native | Distribution varies | Desktop session with non-GNOME Secret Service backend | Secret Service backend other than GNOME Keyring | Supported with limitation | Planned / not yet validated | Depends on local backend health | Depends on local backend health | Depends on local backend health | Depends on local backend health | Not claimed | n/a | Supported only when secure local storage already works. Locked/fresh-init inline recovery is currently GNOME Keyring only. |
+| Windows native | Windows 10 / 11 | PowerShell / Windows Terminal | Windows Credential Manager is not the Hermes target path | Not supported | n/a | No | No | No | No | Not claimed | n/a | Native Windows Hermes is not part of the HA NOVA support model. Use WSL2 instead. |
+| Windows + WSL2 | Windows host + supported WSL distro | WSL shell | Unknown / not yet validated | Supported | Planned / not yet validated | n/a | n/a | n/a | n/a | Not claimed | n/a | Run Hermes and HA NOVA entirely inside the same WSL shell. Fresh maintainer release proof still pending. |
+
+## Repair Check
+
+- `ha-nova doctor` is the first repair surface for Hermes.
+- If Hermes is installed but HA NOVA is still on an older mismatched skill layout, `doctor` should report that Hermes is configured but not attached and point to `ha-nova setup hermes`.
+- `ha-nova setup hermes` is the supported repair path.
+- After repair, `ha-nova doctor` should report `Hermes Agent ready now`.
+
+## Community Validation Rules
+
+- Community reports are advisory only. They help expand the matrix, but they do not replace maintainer-validated release proof.
+- Never paste Home Assistant long-lived access tokens, relay auth tokens, keyring passwords, or unredacted shell history into an issue.
+- Prefer structured reports through the Hermes platform validation issue template so distro, session, and backend details stay comparable.
+
+## Current Practical Read
+
+- Best current maintainer proof: Ubuntu 24.04.1 LTS desktop session with GNOME Keyring.
+- Best current Windows guidance: WSL2 is the supported Windows route; fresh maintainer proof is still pending, and native Windows Hermes is not supported.
+- Best current Linux caveat: inline secure-storage recovery is GNOME Keyring only; other Secret Service backends must already be healthy.

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -8,6 +8,7 @@ The repo skill tree is the single source of truth. Client installers adapt that 
 - Claude: plugin marketplace payload
 - Codex / OpenCode: nested skill tree
 - Gemini: flat copied skill directories
+- Hermes: namespaced nested copied skill tree with directory names aligned to installed skill IDs
 
 Installed skill tree:
 ```
@@ -45,6 +46,7 @@ The canonical skill entrypoints remain `skills/*/SKILL.md`.
 - Codex and OpenCode load the nested `ha-nova` skill tree directly.
 - Gemini receives flat copied skill directories because it only supports one skill level.
 - Gemini sub-skills are installed with namespaced identifiers such as `ha-nova-entity-discovery` so the flat folder names and activation names stay aligned.
+- Hermes receives a nested copied `ha-nova` bundle under `~/.hermes/skills/ha-nova`, with namespaced sub-skill directories such as `ha-nova-entity-discovery/` whose directory names and frontmatter names stay identical.
 
 The context skill (`ha-nova`) stays the stable entrypoint; sub-skills remain independently discoverable by description and naming.
 
@@ -289,8 +291,9 @@ It handles repo-local skill refreshes for development and validation:
   - **Codex CLI:** symlink on Unix, copy fallback on Windows at `~/.agents/skills/ha-nova`
   - **OpenCode:** symlink on Unix, copy fallback on Windows at `~/.config/opencode/skills/ha-nova`
   - **Gemini CLI:** Flat copy `~/.gemini/skills/ha-nova-*/SKILL.md` (1-level limit), with namespaced sub-skill names matching those folder names
+  - **Hermes Agent:** Namespaced nested copy under `~/.hermes/skills/ha-nova/ha-nova-*`, with sub-skill directory names and frontmatter names both using the same `ha-nova-*` identifier
 - cleans up legacy flat skill directories (old `ha-nova-*` prefixed dirs)
-- supports targets: `codex`, `claude`, `opencode`, `gemini`, `all`
+- supports targets: `codex`, `claude`, `opencode`, `gemini`, `hermes`, `all`
 
 The other helper roles are intentionally smaller:
 - `scripts/onboarding/bin/ha-nova` forwards repo-local setup/update/check-update calls into the Go runtime

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -177,7 +177,7 @@ macOS self-managed lifecycle:
 Linux real-machine onboarding:
 Helper:
 - use `scripts/smoke/linux-headless-setup-check.sh` as the executable assistant for the SSH/headless Linux lane; pass the host and install command via env, never hardcode host-specific details in the repo
-- by default the helper runs `HA_NOVA_NO_BROWSER=1 ha-nova setup`
+- by default the helper runs `HA_NOVA_NO_BROWSER=1 ha-nova setup`; for Hermes-specific proof, set `HA_NOVA_LIVE_SETUP_CMD='HA_NOVA_NO_BROWSER=1 ha-nova setup hermes'`
 - `HA_NOVA_LIVE_SKIP_INSTALL=1` is for repair/debug passes only; it does not satisfy the full release-bound fresh-install proof for this lane
 1. use a real Linux host with a desktop user session; when validating the SSH/headless recovery path, use an SSH shell inside that same logged-in user session
 2. fresh stable install via the public `install.sh` flow
@@ -188,7 +188,10 @@ Helper:
 7. confirm a wrong local keyring password keeps the user on the locked recovery step with a clear local secure-storage error, and confirm a correct password unlocks the keyring and resumes setup
 8. confirm the fresh-init recovery path can create the default GNOME Keyring collection over SSH and then resumes setup without sending the user to a desktop GUI
 9. finish setup, then run `ha-nova doctor`
-10. confirm the relay token is saved and can be reused by a second `ha-nova setup` / `ha-nova doctor` invocation without repeating recovery
+10. if the lane includes Hermes or a pre-fix Hermes bundle, confirm `ha-nova doctor` reports a repairable Hermes mismatch instead of silently hiding it
+11. run `ha-nova setup hermes` and confirm the Hermes route repairs cleanly
+12. re-run `ha-nova doctor` and confirm it reports `Hermes Agent ready now`
+13. confirm the relay token is saved and can be reused by a second `ha-nova setup` / `ha-nova doctor` invocation without repeating recovery
 
 Windows self-managed:
 1. on fresh-profile runs, preinstall at least one supported client and verify it already runs on that exact machine/session

--- a/docs/work/2026-04-24-hermes-release-claim-gating.md
+++ b/docs/work/2026-04-24-hermes-release-claim-gating.md
@@ -1,0 +1,30 @@
+# Hermes Release Claim Gating
+
+Status: active
+
+## Goal
+
+Ship Hermes Agent support in the next HA NOVA release without letting the public `README.md` claim stable Hermes support before the release commit, tag, artifacts, and live proof are aligned.
+
+## Scope
+
+- Keep the Hermes implementation, registry entry, installer behavior, tests, `.hermes/INSTALL.md`, and validation matrix in the Hermes support PR.
+- Keep public `README.md` release-conservative until the final release PR.
+- Use a final release PR to flip the public README support claim after the release-bound proof matrix is complete.
+
+## Rules
+
+- `README.md` is stable public product truth.
+- `.hermes/INSTALL.md` is the Hermes overlay for the unreleased next release while this work is still in-flight.
+- `docs/reference/hermes-platform-validation.md` is the proof matrix and must record the strongest current evidence without overstating unvalidated routes.
+- The final release PR must either:
+  - restore the public Hermes claim in `README.md`, if release proof is complete, or
+  - keep Hermes absent from the public support list, if proof is incomplete.
+
+## Release Blockers Before Public README Claim
+
+- Hermes filesystem install uses namespaced directories and matching frontmatter.
+- `ha-nova doctor` reports the expected Hermes state.
+- `skills_list(category="ha-nova")` and `skill_view("<listed-name>")` agree on a real Hermes install.
+- Linux secure-storage recovery proof covers the current release-bound matrix.
+- Windows messaging stays explicit: native Windows Hermes is unsupported; WSL2 is the intended Windows route.

--- a/scripts/dev/macos-private-rc-client.sh
+++ b/scripts/dev/macos-private-rc-client.sh
@@ -12,7 +12,7 @@ RELAY_TOKEN="${RELAY_TOKEN:-test-relay-token}"
 CLIENT="${1:-}"
 
 if [[ -z "${CLIENT}" ]]; then
-  echo "Usage: $0 <claude|codex|opencode|gemini>" >&2
+  echo "Usage: $0 <claude|codex|opencode|gemini|hermes>" >&2
   exit 1
 fi
 
@@ -135,6 +135,12 @@ case "${CLIENT}" in
     test -f "${TMP_HOME}/.gemini/skills/ha-nova/SKILL.md"
     test -f "${TMP_HOME}/.gemini/skills/ha-nova-review/SKILL.md"
     ;;
+  hermes)
+    command -v hermes >/dev/null 2>&1
+    test -f "${TMP_HOME}/.hermes/skills/ha-nova/ha-nova/SKILL.md"
+    test -f "${TMP_HOME}/.hermes/skills/ha-nova/ha-nova-read/SKILL.md"
+    grep -Fq 'name: ha-nova-read' "${TMP_HOME}/.hermes/skills/ha-nova/ha-nova-read/SKILL.md"
+    ;;
   claude)
     command -v claude >/dev/null 2>&1
     grep -Fq '"ha-nova@ha-nova"' "${TMP_HOME}/.claude/plugins/installed_plugins.json"
@@ -152,6 +158,9 @@ test ! -e "${TMP_HOME}/.local/share/ha-nova"
 test -e "${TMP_HOME}/.config/ha-nova/config.json"
 test ! -e "${TMP_HOME}/.config/ha-nova/state.json"
 test ! -e "${TMP_HOME}/.cache/ha-nova"
+if [[ "${CLIENT}" == "hermes" ]]; then
+  test ! -e "${TMP_HOME}/.hermes/skills/ha-nova"
+fi
 if [[ "${CLIENT}" == "claude" ]]; then
   if [[ -f "${TMP_HOME}/.claude/plugins/installed_plugins.json" ]]; then
     ! grep -Fq '"ha-nova@ha-nova"' "${TMP_HOME}/.claude/plugins/installed_plugins.json"

--- a/scripts/dev/macos-private-rc-suite.sh
+++ b/scripts/dev/macos-private-rc-suite.sh
@@ -61,4 +61,5 @@ bash scripts/dev/macos-private-rc-setup-all.sh
 bash scripts/dev/macos-private-rc-client.sh codex
 bash scripts/dev/macos-private-rc-client.sh opencode
 bash scripts/dev/macos-private-rc-client.sh gemini
+bash scripts/dev/macos-private-rc-client.sh hermes
 bash scripts/dev/macos-private-rc-client.sh claude

--- a/scripts/onboarding/install-local-skills.sh
+++ b/scripts/onboarding/install-local-skills.sh
@@ -8,6 +8,7 @@ Usage:
   bash scripts/onboarding/install-local-skills.sh claude
   bash scripts/onboarding/install-local-skills.sh opencode
   bash scripts/onboarding/install-local-skills.sh gemini
+  bash scripts/onboarding/install-local-skills.sh hermes
   bash scripts/onboarding/install-local-skills.sh all
 
 Targets:
@@ -15,7 +16,8 @@ Targets:
   claude   -> stage local Claude marketplace + install ha-nova@ha-nova
   opencode -> link/copy ~/.config/opencode/skills/ha-nova -> repo skills
   gemini   -> flat copy ~/.gemini/skills/ha-nova-*/SKILL.md (+ local companion .md files)
-  all      -> install for codex + claude + opencode + gemini
+  hermes   -> namespaced copy ~/.hermes/skills/ha-nova/ha-nova-*
+  all      -> install for codex + claude + opencode + gemini + hermes (non-Windows)
 USAGE
 }
 
@@ -106,6 +108,95 @@ copy_flat_skill_markdown() {
   done
 }
 
+hermes_installed_skill_name() {
+  local skill_name="$1"
+  if [[ -z "${skill_name}" || "${skill_name}" == "ha-nova" ]]; then
+    printf 'ha-nova'
+    return
+  fi
+  printf 'ha-nova-%s' "${skill_name}"
+}
+
+rewrite_hermes_markdown() {
+  local skill_name="$1"
+  local source_dir="$2"
+  local src="$3"
+  local dest="$4"
+  local content
+  local installed_skill_name
+
+  installed_skill_name="$(hermes_installed_skill_name "${skill_name}")"
+  content="$(cat "${src}")"
+
+  for companion in "${source_dir}"/*.md; do
+    local companion_name
+    companion_name="$(basename "${companion}")"
+    [[ "${companion_name}" == "SKILL.md" ]] && continue
+    local same_skill_ref same_skill_local
+    printf -v same_skill_ref '`skills/%s/%s`' "${skill_name}" "${companion_name}"
+    printf -v same_skill_local '`%s`' "${companion_name}"
+    content="${content//${same_skill_ref}/${same_skill_local}}"
+  done
+
+  content="$(
+    printf '%s' "${content}" | HA_NOVA_ROOT="${REPO_ROOT}" perl -0pe '
+      s{`docs/reference/([^`]+)`}{sprintf("`%s/docs/reference/%s`", $ENV{HA_NOVA_ROOT}, $1)}ge;
+      s{`skills/([^`]+)`}{sprintf("`%s/skills/%s`", $ENV{HA_NOVA_ROOT}, $1)}ge;
+    '
+  )"
+
+  for sub_skill in "${GEMINI_SUB_SKILLS[@]}"; do
+    content="${content//ha-nova:${sub_skill}/ha-nova-${sub_skill}}"
+  done
+
+  if [[ "${skill_name}" != "ha-nova" ]]; then
+    content="$(
+      printf '%s' "${content}" | SKILL_NAME="${skill_name}" INSTALLED_SKILL_NAME="${installed_skill_name}" perl -0pe '
+        s/^name:\s*\Q$ENV{SKILL_NAME}\E$/name: $ENV{INSTALLED_SKILL_NAME}/m;
+      '
+    )"
+  fi
+
+  printf '%s' "${content}" > "${dest}"
+}
+
+copy_hermes_skill_markdown() {
+  local skill_name="$1"
+  local source_dir="${SOURCE_SKILLS_DIR}/${skill_name}"
+  local dest_dir="$2"
+
+  mkdir -p "${dest_dir}"
+  find "${dest_dir}" -maxdepth 1 -type f -name '*.md' -exec rm -f {} +
+
+  if [[ -f "${source_dir}/SKILL.md" ]]; then
+    rewrite_hermes_markdown "${skill_name}" "${source_dir}" "${source_dir}/SKILL.md" "${dest_dir}/SKILL.md"
+  fi
+
+  for companion in "${source_dir}"/*.md; do
+    local companion_name
+    companion_name="$(basename "${companion}")"
+    [[ "${companion_name}" == "SKILL.md" ]] && continue
+    rewrite_hermes_markdown "${skill_name}" "${source_dir}" "${companion}" "${dest_dir}/${companion_name}"
+  done
+}
+
+install_hermes_tree() {
+  local target_root="${HOME}/.hermes/skills/ha-nova"
+
+  [[ "${CURRENT_PLATFORM_ID}" == "windows" ]] && die "[hermes] Hermes Agent is supported through WSL2, not native Windows"
+  command -v hermes >/dev/null 2>&1 || die "[hermes] Hermes Agent not found in PATH"
+
+  rm -rf "${target_root}"
+  mkdir -p "${target_root}"
+
+  copy_hermes_skill_markdown "ha-nova" "${target_root}/ha-nova"
+  for skill_name in "${GEMINI_SUB_SKILLS[@]}"; do
+    copy_hermes_skill_markdown "${skill_name}" "${target_root}/$(hermes_installed_skill_name "${skill_name}")"
+  done
+
+  log "[hermes] Copied namespaced skill tree: ${target_root}"
+}
+
 install_symlink_tree() {
   local target="$1"
   local user_skills_dir="$2"
@@ -176,6 +267,9 @@ install_target() {
     gemini)
       install_gemini_flat
       ;;
+    hermes)
+      install_hermes_tree
+      ;;
     *)
       die "Unsupported target: ${target}"
       ;;
@@ -195,7 +289,7 @@ main() {
   fi
 
   case "${target}" in
-    codex|claude|opencode|gemini)
+    codex|claude|opencode|gemini|hermes)
       install_target "${target}"
       ;;
     all)
@@ -203,6 +297,9 @@ main() {
       install_target "gemini"
       install_target "claude"
       install_target "opencode"
+      if [[ "${CURRENT_PLATFORM_ID}" != "windows" ]]; then
+        install_target "hermes"
+      fi
       ;;
     -h|--help|help)
       usage

--- a/scripts/smoke/linux-headless-setup-check.sh
+++ b/scripts/smoke/linux-headless-setup-check.sh
@@ -19,6 +19,8 @@ Important:
 Optional env:
   HA_NOVA_LIVE_SETUP_CMD   Interactive setup command to run remotely
                            default: HA_NOVA_NO_BROWSER=1 ha-nova setup
+                           Hermes proof override:
+                           HA_NOVA_LIVE_SETUP_CMD='HA_NOVA_NO_BROWSER=1 ha-nova setup hermes'
   HA_NOVA_LIVE_SKIP_INSTALL=1
                            Skip the remote install command and run setup only
                            repair/debug only; not a full release-lane proof

--- a/tests/onboarding/_helpers.ts
+++ b/tests/onboarding/_helpers.ts
@@ -34,7 +34,7 @@ export interface MockHomeOpts {
   /** Create a fake keychain token file (since we mock `security`) */
   keychainToken?: string;
   /** Pre-install skills for this client */
-  skills?: "codex" | "gemini" | "opencode" | "claude" | "all";
+  skills?: "codex" | "gemini" | "opencode" | "claude" | "hermes" | "all";
 }
 
 /**
@@ -226,6 +226,8 @@ exit 0
 `,
     { mode: 0o755 },
   );
+
+  writeFileSync(join(binDir, "hermes"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
 
   return binDir;
 }

--- a/tests/onboarding/client-install-docs-contract.test.ts
+++ b/tests/onboarding/client-install-docs-contract.test.ts
@@ -20,17 +20,19 @@ describe("client install docs contract", () => {
   const codexInstall = readFileSync(".codex/INSTALL.md", "utf8");
   const geminiInstall = readFileSync(".gemini/INSTALL.md", "utf8");
   const opencodeInstall = readFileSync(".opencode/INSTALL.md", "utf8");
+  const hermesInstall = readFileSync(".hermes/INSTALL.md", "utf8");
 
   it("keeps the README at product level, not client-migration level", () => {
     expect(readme).not.toContain("claude install");
     expect(readme).not.toContain("npm.cmd");
-    expect(readme).not.toContain("WSL");
     expect(readme).not.toContain("5 tested clients");
     expect(readme).toContain("ha-nova uninstall --purge");
     expect(readme).toContain("Copy the one-liner for your OS");
     expect(readme).toContain("https://github.com/markusleben/ha-nova/releases/latest");
     expect(readme).toContain("Git for Windows / Git Bash");
     expect(readme).toContain("Gemini CLI needs Node.js");
+    expect(readme).toContain("Hermes Agent is supported through WSL2, not native Windows");
+    expect(readme).toContain("docs/reference/hermes-platform-validation.md");
     expect(readme).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.sh");
     expect(readme).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.ps1");
   });
@@ -40,6 +42,7 @@ describe("client install docs contract", () => {
     expectOverlayToPointBackToReadme(codexInstall);
     expectOverlayToPointBackToReadme(geminiInstall);
     expectOverlayToPointBackToReadme(opencodeInstall);
+    expectOverlayToPointBackToReadme(hermesInstall);
   });
 
   it("documents Claude-specific setup, Windows caveats, and local marketplace behavior", () => {
@@ -70,7 +73,7 @@ describe("client install docs contract", () => {
     expect(claudeInstall).not.toContain("ha-nova setup opencode");
   });
 
-  it("documents Codex, Gemini, and OpenCode deltas without inheriting Claude-only behavior", () => {
+  it("documents Codex, Gemini, OpenCode, and Hermes deltas without inheriting Claude-only behavior", () => {
     expect(codexInstall).toContain("Codex CLI");
     expect(codexInstall).toContain("Install the Codex client separately");
     expect(codexInstall).toContain("ha-nova setup codex");
@@ -96,13 +99,31 @@ describe("client install docs contract", () => {
     expect(opencodeInstall).toContain("WSL");
     expect(opencodeInstall).toContain("still early and not fully tested yet");
 
+    expect(hermesInstall).toContain("Hermes Agent");
+    expect(hermesInstall).toContain("ha-nova setup hermes");
+    expect(hermesInstall).toContain("ha-nova check-update");
+    expect(hermesInstall).toContain("What Supported Means Here");
+    expect(hermesInstall).toContain("Platform Routing");
+    expect(hermesInstall).toContain("Network Model");
+    expect(hermesInstall).toContain("GNOME Keyring");
+    expect(hermesInstall).toContain("WSL2");
+    expect(hermesInstall).toContain("Windows native");
+    expect(hermesInstall).toContain("~/.hermes/skills/ha-nova/");
+    expect(hermesInstall).toContain("ha-nova-read");
+    expect(hermesInstall).toContain("skills_list");
+    expect(hermesInstall).toContain("skill_view");
+
     expect(codexInstall).not.toContain("HA_NOVA_CLAUDE_MARKETPLACE_LOCAL=1");
     expect(geminiInstall).not.toContain("HA_NOVA_CLAUDE_MARKETPLACE_LOCAL=1");
     expect(opencodeInstall).not.toContain("HA_NOVA_CLAUDE_MARKETPLACE_LOCAL=1");
+    expect(hermesInstall).not.toContain("HA_NOVA_CLAUDE_MARKETPLACE_LOCAL=1");
+    expect(hermesInstall).not.toContain("CLAUDE_CODE_GIT_BASH_PATH");
+    expect(hermesInstall).not.toContain("ha-nova setup claude");
+    expect(hermesInstall).not.toContain("Git Bash");
   });
 
   it("classifies per-client install docs as active derived install overlays", () => {
-    expect(governance).toContain("`.claude/INSTALL.md`, `.codex/INSTALL.md`, `.gemini/INSTALL.md`, `.opencode/INSTALL.md`");
+    expect(governance).toContain("`.claude/INSTALL.md`, `.codex/INSTALL.md`, `.gemini/INSTALL.md`, `.opencode/INSTALL.md`, `.hermes/INSTALL.md`");
     expect(governance).toContain("client-specific install overlays");
     expect(governance).toContain("cover client deltas only");
     expect(governance).toContain("point back to `README.md`");

--- a/tests/onboarding/client-install-docs-contract.test.ts
+++ b/tests/onboarding/client-install-docs-contract.test.ts
@@ -21,6 +21,7 @@ describe("client install docs contract", () => {
   const geminiInstall = readFileSync(".gemini/INSTALL.md", "utf8");
   const opencodeInstall = readFileSync(".opencode/INSTALL.md", "utf8");
   const hermesInstall = readFileSync(".hermes/INSTALL.md", "utf8");
+  const hermesReleaseGate = readFileSync("docs/work/2026-04-24-hermes-release-claim-gating.md", "utf8");
 
   it("keeps the README at product level, not client-migration level", () => {
     expect(readme).not.toContain("claude install");
@@ -31,8 +32,8 @@ describe("client install docs contract", () => {
     expect(readme).toContain("https://github.com/markusleben/ha-nova/releases/latest");
     expect(readme).toContain("Git for Windows / Git Bash");
     expect(readme).toContain("Gemini CLI needs Node.js");
-    expect(readme).toContain("Hermes Agent is supported through WSL2, not native Windows");
-    expect(readme).toContain("docs/reference/hermes-platform-validation.md");
+    expect(readme).not.toContain("Hermes Agent");
+    expect(readme).not.toContain("docs/reference/hermes-platform-validation.md");
     expect(readme).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.sh");
     expect(readme).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.ps1");
   });
@@ -100,6 +101,7 @@ describe("client install docs contract", () => {
     expect(opencodeInstall).toContain("still early and not fully tested yet");
 
     expect(hermesInstall).toContain("Hermes Agent");
+    expect(hermesInstall).toContain("not part of the current stable release");
     expect(hermesInstall).toContain("ha-nova setup hermes");
     expect(hermesInstall).toContain("ha-nova check-update");
     expect(hermesInstall).toContain("What Supported Means Here");
@@ -134,5 +136,13 @@ describe("client install docs contract", () => {
     expect(readme).toContain("Gemini CLI has basic validation");
     expect(geminiInstall).toContain("Gemini has basic Windows validation for this release.");
     expect(claudeInstall).toContain("Claude is the Windows path we have tested most for this release.");
+  });
+
+  it("keeps Hermes in the release train without promoting the public README claim early", () => {
+    expect(hermesReleaseGate).toContain("Status: active");
+    expect(hermesReleaseGate).toContain("Keep public `README.md` release-conservative until the final release PR.");
+    expect(hermesReleaseGate).toContain("restore the public Hermes claim in `README.md`, if release proof is complete");
+    expect(hermesInstall).toContain("not part of the current stable release until the final release PR");
+    expect(readme).not.toContain("Hermes Agent");
   });
 });

--- a/tests/onboarding/desktop-validation-contract.test.ts
+++ b/tests/onboarding/desktop-validation-contract.test.ts
@@ -118,6 +118,7 @@ describe("desktop validation helpers contract", () => {
     expect(macosSuite).toContain("macos-private-rc-smoke.sh");
     expect(macosSuite).toContain("macos-private-rc-setup-all.sh");
     expect(macosSuite).toContain("macos-private-rc-client.sh claude");
+    expect(macosSuite).toContain("macos-private-rc-client.sh hermes");
   });
 
   it("keeps the mock server intentionally tiny and dependency-free", () => {
@@ -164,7 +165,7 @@ describe("desktop validation helpers contract", () => {
   });
 
   it("keeps the macOS per-client lane explicit about expected client artifacts", () => {
-    expect(macosClient).toContain("Usage: $0 <claude|codex|opencode|gemini>");
+    expect(macosClient).toContain("Usage: $0 <claude|codex|opencode|gemini|hermes>");
     expect(macosClient).toContain("HA_NOVA_KEYRING_SERVICE");
     expect(macosClient).toContain("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING=1");
     expect(macosClient).toContain("HA_NOVA_TEST_KEYRING_FILE");
@@ -178,6 +179,9 @@ describe("desktop validation helpers contract", () => {
     expect(macosClient).toContain(".agents/skills/ha-nova/ha-nova/SKILL.md");
     expect(macosClient).toContain(".config/opencode/skills/ha-nova/ha-nova/SKILL.md");
     expect(macosClient).toContain(".gemini/skills/ha-nova/SKILL.md");
+    expect(macosClient).toContain(".hermes/skills/ha-nova/ha-nova/SKILL.md");
+    expect(macosClient).toContain(".hermes/skills/ha-nova/ha-nova-read/SKILL.md");
+    expect(macosClient).toContain("name: ha-nova-read");
     expect(macosClient).toContain(".claude/plugins/installed_plugins.json");
     expect(macosClient).toContain(".claude/plugins/known_marketplaces.json");
     expect(macosClient).toContain('claude_marketplace_points_to_root "${TMP_HOME}/.claude/plugins/known_marketplaces.json"');
@@ -186,6 +190,7 @@ describe("desktop validation helpers contract", () => {
     expect(macosClient).toContain('test -e "${TMP_HOME}/.config/ha-nova/config.json"');
     expect(macosClient).toContain('test ! -e "${TMP_HOME}/.config/ha-nova/state.json"');
     expect(macosClient).toContain('test ! -e "${TMP_HOME}/.cache/ha-nova"');
+    expect(macosClient).toContain('test ! -e "${TMP_HOME}/.hermes/skills/ha-nova"');
   });
 
   it("keeps the Windows cleanup helper scoped to HA NOVA-owned paths", () => {

--- a/tests/onboarding/install-skills-per-client.test.ts
+++ b/tests/onboarding/install-skills-per-client.test.ts
@@ -146,6 +146,54 @@ describe("S-4: client-specific skill installation", () => {
     }
   });
 
+  it("installs hermes skills with directory names aligned to their namespaced skill IDs", () => {
+    const { home, result } = installSkills("hermes");
+    expect(result.status).toBe(0);
+
+    const hermesRoot = join(home, ".hermes/skills/ha-nova");
+    const context = readFileSync(join(hermesRoot, "ha-nova", "SKILL.md"), "utf8");
+    expect(context).toContain("name: ha-nova");
+    expect(context).toContain("ha-nova-entity-discovery");
+
+    for (const src of SOURCE_SUB_SKILLS) {
+      const installedName = `ha-nova-${src}`;
+      const content = readFileSync(join(hermesRoot, installedName, "SKILL.md"), "utf8");
+      expect(content).toContain(`name: ha-nova-${src}`);
+      expectRepoRefsRewritten(content);
+    }
+
+    const checks = readFileSync(join(hermesRoot, "ha-nova-review", "checks.md"), "utf8");
+    expect(checks).toContain("Canonical path: `checks.md`");
+    expect(checks).not.toContain("skills/review/checks.md");
+    expect(existsSync(join(hermesRoot, "review"))).toBe(false);
+  });
+
+  it("fails loudly for hermes on native Windows", () => {
+    const { result } = installSkills("hermes", { HA_NOVA_PLATFORM_OVERRIDE: "windows" });
+    expect(result.status).not.toBe(0);
+    expect(String(result.stderr) + String(result.stdout)).toContain("Hermes Agent is supported through WSL2, not native Windows");
+  });
+
+  it("fails loudly when Hermes Agent is missing from PATH", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-skill-hermes-missing-"));
+    const result = spawnSync(
+      "bash",
+      ["scripts/onboarding/install-local-skills.sh", "hermes"],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        timeout: 20000,
+        env: {
+          ...mockEnv(home, "", {}),
+          PATH: "/usr/bin:/bin",
+        },
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr + result.stdout).toContain("Hermes Agent not found in PATH");
+  });
+
   it("installs claude skills via plugin system", () => {
     const { home, result } = installSkills("claude");
     expect(result.status).toBe(0);
@@ -467,6 +515,10 @@ describe("S-5: multi-client 'all' installation", () => {
 
     expect(() =>
       statSync(join(home, ".gemini/skills", "ha-nova-review", "checks.md")),
+    ).not.toThrow();
+
+    expect(() =>
+      statSync(join(home, ".hermes/skills/ha-nova/ha-nova/SKILL.md")),
     ).not.toThrow();
   });
 

--- a/tests/onboarding/project-docs-contract.test.ts
+++ b/tests/onboarding/project-docs-contract.test.ts
@@ -10,6 +10,8 @@ describe("project docs contract", () => {
   const novaDocs = readFileSync("nova/DOCS.md", "utf8");
   const bridgeArchitecture = readFileSync("docs/reference/bridge-architecture.md", "utf8");
   const governance = readFileSync("docs/reference/documentation-governance.md", "utf8");
+  const hermesValidation = readFileSync("docs/reference/hermes-platform-validation.md", "utf8");
+  const hermesValidationIssue = readFileSync(".github/ISSUE_TEMPLATE/hermes-platform-validation.yml", "utf8");
 
   it("keeps PROJECT.md scoped to internal product context instead of public install truth", () => {
     expect(project).toContain("This file is internal product context only.");
@@ -80,11 +82,46 @@ describe("project docs contract", () => {
   it("defines a canonical active work-doc path and keeps breadcrumbs short/current", () => {
     expect(governance).toContain("keep active work docs under `docs/work/`");
     expect(governance).toContain("`docs/work/`");
-    expect(governance).toContain("`.claude/INSTALL.md`, `.codex/INSTALL.md`, `.gemini/INSTALL.md`, `.opencode/INSTALL.md`");
+    expect(governance).toContain("`.claude/INSTALL.md`, `.codex/INSTALL.md`, `.gemini/INSTALL.md`, `.opencode/INSTALL.md`, `.hermes/INSTALL.md`");
     expect(governance).toContain("`SUPPORT.md`");
     expect(governance).toContain("`CODE_OF_CONDUCT.md`");
     expect(governance).toContain("`nova/README.md`");
     expect(governance).toContain("`docs/archive/breadcrumbs.md` is the long historical breadcrumb ledger");
     expect(governance).toContain("keep the root `docs/breadcrumbs.md` short and current only");
+  });
+
+  it("tracks Hermes support evidence in a dedicated active reference doc", () => {
+    expect(hermesValidation).toContain("This is the active truth source for Hermes support evidence in HA NOVA.");
+    expect(hermesValidation).toContain("## Support Status");
+    expect(hermesValidation).toContain("Supported with limitation");
+    expect(hermesValidation).toContain("Not supported");
+    expect(hermesValidation).toContain("## Evidence Status");
+    expect(hermesValidation).toContain("Maintainer-validated");
+    expect(hermesValidation).toContain("Community validation");
+    expect(hermesValidation).toContain("Planned / not yet validated");
+    expect(hermesValidation).toContain("## Repair Check");
+    expect(hermesValidation).toContain("configured but not attached");
+    expect(hermesValidation).toContain("Hermes Agent ready now");
+    expect(hermesValidation).toContain("GNOME Keyring");
+    expect(hermesValidation).toContain("WSL2");
+    expect(hermesValidation).toContain("Native Windows Hermes is not part of the HA NOVA support model.");
+  });
+
+  it("keeps community validation intake structured and privacy-safe", () => {
+    expect(hermesValidationIssue).toContain("Hermes platform validation");
+    expect(hermesValidationIssue).toContain("never paste Home Assistant long-lived access tokens");
+    expect(hermesValidationIssue).toContain("never paste relay auth tokens");
+    expect(hermesValidationIssue).toContain("never paste local keyring passwords");
+    expect(hermesValidationIssue).toContain("Windows native (unsupported today; use WSL2 for the supported path)");
+    expect(hermesValidationIssue).toContain("Install source");
+    expect(hermesValidationIssue).toContain("Host form");
+    expect(hermesValidationIssue).toContain("Helper script or `HA_NOVA_*` overrides used");
+    expect(hermesValidationIssue).toContain("Entry point used");
+    expect(hermesValidationIssue).toContain("Redact hostnames, LAN IPs, private paths, and secrets");
+    expect(hermesValidationIssue).toContain("hermes skills list");
+    expect(hermesValidationIssue).toContain("ha-nova*");
+    expect(hermesValidationIssue).toContain("Optional redacted `ha-nova doctor` output");
+    expect(hermesValidationIssue).toContain("session");
+    expect(hermesValidationIssue).toContain("Secret Service backend");
   });
 });


### PR DESCRIPTION
## Summary
- add Hermes Agent as a supported HA NOVA client with registry, setup/status/doctor/uninstall support
- install Hermes skills under a namespaced layout and repair older mismatched layouts
- add Hermes overlay docs, validation matrix, issue template, and onboarding contract coverage

## Verification
- npm run verify
- go test ./... (cli)
- npx vitest run tests/onboarding/install-skills-per-client.test.ts tests/onboarding/client-install-docs-contract.test.ts tests/onboarding/project-docs-contract.test.ts tests/onboarding/desktop-validation-contract.test.ts