### PR TITLE
fix: harden installer cleanup and discovery

### DIFF
--- a/cli/setup_discovery.go
+++ b/cli/setup_discovery.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"net"
 	"os/exec"
 	"regexp"
 	"runtime"
@@ -17,6 +18,7 @@ var runMDNSBrowseForDiscovery = runMDNSBrowse
 var runMDNSLookupForDiscovery = runMDNSLookup
 var mdnsAvailableForDiscovery = defaultMDNSDiscoveryAvailable
 var setupDiscoveryOverallTimeout = 20 * time.Second
+var setupDiscoveryPlatformOS = runtime.GOOS
 
 func detectDefaultHAHost(cfg runtimeConfig) string {
 	host, _ := detectDefaultHAHostChoice(cfg)
@@ -37,7 +39,16 @@ func detectDefaultHAHostChoice(cfg runtimeConfig) (string, bool) {
 			return candidate, true
 		}
 	}
-	return "homeassistant.local", false
+	return preferredUnverifiedHAHost(cfg), false
+}
+
+func preferredUnverifiedHAHost(cfg runtimeConfig) string {
+	for _, candidate := range []string{cfg.HAHost, cfg.HAURL, cfg.RelayBaseURL} {
+		if host := normalizeHostInput(candidate); host != "" {
+			return host
+		}
+	}
+	return ""
 }
 
 func collectCandidateHosts(cfg runtimeConfig) []string {
@@ -77,6 +88,9 @@ func discoverHAViaMDNS() string {
 	instanceOut, err := runMDNSBrowseForDiscovery()
 	if err != nil {
 		return ""
+	}
+	if setupDiscoveryPlatformOS == "linux" {
+		return parseAvahiBrowseHost(instanceOut)
 	}
 	instance := parseMDNSBrowseInstance(instanceOut)
 	if instance == "" {
@@ -148,15 +162,28 @@ func parseARPHosts(output string) []string {
 }
 
 func defaultMDNSDiscoveryAvailable() bool {
-	if runtime.GOOS != "darwin" {
+	var binary string
+	switch setupDiscoveryPlatformOS {
+	case "darwin":
+		binary = "dns-sd"
+	case "linux":
+		binary = "avahi-browse"
+	default:
 		return false
 	}
-	_, err := exec.LookPath("dns-sd")
+	_, err := exec.LookPath(binary)
 	return err == nil
 }
 
 func runMDNSBrowse() (string, error) {
-	return runCommandAllowingTimeoutOutput(3*time.Second, "dns-sd", "-B", "_home-assistant._tcp", "local")
+	switch setupDiscoveryPlatformOS {
+	case "darwin":
+		return runCommandAllowingTimeoutOutput(3*time.Second, "dns-sd", "-B", "_home-assistant._tcp", "local")
+	case "linux":
+		return runCommandAllowingTimeoutOutput(3*time.Second, "avahi-browse", "-rt", "_home-assistant._tcp")
+	default:
+		return "", exec.ErrNotFound
+	}
 }
 
 func runMDNSLookup(instance string) (string, error) {
@@ -197,6 +224,31 @@ func parseMDNSLookupHost(output string) string {
 			value = strings.Fields(value)[0]
 			return normalizeHostInput(value)
 		}
+	}
+	return ""
+}
+
+func parseAvahiBrowseHost(output string) string {
+	urlPattern := regexp.MustCompile(`(?:internal_url|base_url)=([^"\s]+)`)
+	if match := urlPattern.FindStringSubmatch(output); len(match) >= 2 {
+		return normalizeHostInput(match[1])
+	}
+
+	addressPattern := regexp.MustCompile(`(?m)^\s*address = \[([^\]]+)\]\s*$`)
+	matches := addressPattern.FindAllStringSubmatch(output, -1)
+	for _, match := range matches {
+		candidate := strings.TrimSpace(match[1])
+		if ip := net.ParseIP(candidate); ip != nil && ip.To4() != nil {
+			return candidate
+		}
+	}
+	if len(matches) > 0 {
+		return strings.TrimSpace(matches[0][1])
+	}
+
+	hostPattern := regexp.MustCompile(`(?m)^\s*hostname = \[([^\]]+)\]\s*$`)
+	if match := hostPattern.FindStringSubmatch(output); len(match) >= 2 {
+		return normalizeHostInput(match[1])
 	}
 	return ""
 }

--- a/cli/setup_discovery_test.go
+++ b/cli/setup_discovery_test.go
@@ -58,7 +58,7 @@ func TestDetectDefaultHAHostFallsBackToMDNSBeforeHomeassistantLocal(t *testing.T
 	}
 }
 
-func TestDetectDefaultHAHostFallsBackToHomeassistantLocal(t *testing.T) {
+func TestDetectDefaultHAHostLeavesDefaultBlankWhenNothingWasConfirmed(t *testing.T) {
 	originalResolve := resolveHAURLBaseWithinTimeoutForDiscovery
 	originalMDNS := discoverHAViaMDNSForDiscovery
 	originalARP := collectARPHostsForDiscovery
@@ -75,8 +75,8 @@ func TestDetectDefaultHAHostFallsBackToHomeassistantLocal(t *testing.T) {
 	collectARPHostsForDiscovery = func() []string { return nil }
 
 	got := detectDefaultHAHost(runtimeConfig{})
-	if got != "homeassistant.local" {
-		t.Fatalf("detectDefaultHAHost() = %q, want %q", got, "homeassistant.local")
+	if got != "" {
+		t.Fatalf("detectDefaultHAHost() = %q, want blank", got)
 	}
 }
 
@@ -179,11 +179,33 @@ func TestDetectDefaultHAHostChoiceStopsAfterOverallTimeout(t *testing.T) {
 	}
 
 	host, discovered := detectDefaultHAHostChoice(runtimeConfig{})
-	if host != "homeassistant.local" || discovered {
-		t.Fatalf("detectDefaultHAHostChoice() = (%q, %v), want (%q, false)", host, discovered, "homeassistant.local")
+	if host != "" || discovered {
+		t.Fatalf("detectDefaultHAHostChoice() = (%q, %v), want blank false result", host, discovered)
 	}
 	if calls != 1 {
 		t.Fatalf("calls = %d, want 1", calls)
+	}
+}
+
+func TestDetectDefaultHAHostChoiceFallsBackToSavedAddressWhenNoHostWasConfirmed(t *testing.T) {
+	originalResolve := resolveHAURLBaseWithinTimeoutForDiscovery
+	originalMDNS := discoverHAViaMDNSForDiscovery
+	originalARP := collectARPHostsForDiscovery
+	defer func() {
+		resolveHAURLBaseWithinTimeoutForDiscovery = originalResolve
+		discoverHAViaMDNSForDiscovery = originalMDNS
+		collectARPHostsForDiscovery = originalARP
+	}()
+
+	resolveHAURLBaseWithinTimeoutForDiscovery = func(string, time.Duration) (string, error) {
+		return "", assertDiscoveryFailure{}
+	}
+	discoverHAViaMDNSForDiscovery = func() string { return "" }
+	collectARPHostsForDiscovery = func() []string { return nil }
+
+	host, discovered := detectDefaultHAHostChoice(runtimeConfig{HAURL: "http://saved-ha.local:8123"})
+	if host != "saved-ha.local" || discovered {
+		t.Fatalf("detectDefaultHAHostChoice() = (%q, %v), want (%q, false)", host, discovered, "saved-ha.local")
 	}
 }
 
@@ -269,12 +291,15 @@ func TestDiscoverHAViaMDNSKeepsLookupOutputAfterTimeoutStyleCompletion(t *testin
 	originalBrowse := runMDNSBrowseForDiscovery
 	originalLookup := runMDNSLookupForDiscovery
 	originalAvailable := mdnsAvailableForDiscovery
+	originalPlatform := setupDiscoveryPlatformOS
 	defer func() {
 		runMDNSBrowseForDiscovery = originalBrowse
 		runMDNSLookupForDiscovery = originalLookup
 		mdnsAvailableForDiscovery = originalAvailable
+		setupDiscoveryPlatformOS = originalPlatform
 	}()
 
+	setupDiscoveryPlatformOS = "darwin"
 	mdnsAvailableForDiscovery = func() bool { return true }
 	runMDNSBrowseForDiscovery = func() (string, error) {
 		return `Browsing for _home-assistant._tcp.local
@@ -293,6 +318,54 @@ func TestDiscoverHAViaMDNSKeepsLookupOutputAfterTimeoutStyleCompletion(t *testin
 	got := discoverHAViaMDNS()
 	if got != "192.168.1.5" {
 		t.Fatalf("discoverHAViaMDNS() = %q, want %q", got, "192.168.1.5")
+	}
+}
+
+func TestParseAvahiBrowseHostReturnsInternalURLHost(t *testing.T) {
+	output := `+ enp0s31f6 IPv4 Home Assistant _home-assistant._tcp local
+= enp0s31f6 IPv4 Home Assistant _home-assistant._tcp local
+   hostname = [homeassistant.local]
+   address = [fe80::1234]
+   address = [192.168.1.55]
+   port = [8123]
+   txt = ["internal_url=http://192.168.1.55:8123" "base_url=http://192.168.1.55:8123"]
+`
+
+	got := parseAvahiBrowseHost(output)
+	if got != "192.168.1.55" {
+		t.Fatalf("parseAvahiBrowseHost() = %q, want %q", got, "192.168.1.55")
+	}
+}
+
+func TestDiscoverHAViaMDNSUsesAvahiBrowseOnLinux(t *testing.T) {
+	originalBrowse := runMDNSBrowseForDiscovery
+	originalLookup := runMDNSLookupForDiscovery
+	originalAvailable := mdnsAvailableForDiscovery
+	originalPlatform := setupDiscoveryPlatformOS
+	defer func() {
+		runMDNSBrowseForDiscovery = originalBrowse
+		runMDNSLookupForDiscovery = originalLookup
+		mdnsAvailableForDiscovery = originalAvailable
+		setupDiscoveryPlatformOS = originalPlatform
+	}()
+
+	setupDiscoveryPlatformOS = "linux"
+	mdnsAvailableForDiscovery = func() bool { return true }
+	runMDNSBrowseForDiscovery = func() (string, error) {
+		return `= enp0s31f6 IPv4 Home Assistant _home-assistant._tcp local
+   hostname = [homeassistant.local]
+   address = [192.168.1.56]
+   port = [8123]
+`, nil
+	}
+	runMDNSLookupForDiscovery = func(instance string) (string, error) {
+		t.Fatalf("runMDNSLookupForDiscovery called with %q; avahi-browse output should be self-contained", instance)
+		return "", nil
+	}
+
+	got := discoverHAViaMDNS()
+	if got != "192.168.1.56" {
+		t.Fatalf("discoverHAViaMDNS() = %q, want %q", got, "192.168.1.56")
 	}
 }
 

--- a/cli/setup_discovery_ui.go
+++ b/cli/setup_discovery_ui.go
@@ -23,7 +23,7 @@ func detectDefaultHAHostWithFeedback(out io.Writer, cfg runtimeConfig) (string, 
 	})
 	armSetupNextPromptSkipsStaleBlankInput()
 	if err != nil {
-		return "homeassistant.local", false
+		return preferredUnverifiedHAHost(cfg), false
 	}
 	renderSetupDiscoveryResult(out, found.host, found.discovered)
 	return found.host, found.discovered

--- a/cli/setup_discovery_ui_test.go
+++ b/cli/setup_discovery_ui_test.go
@@ -37,6 +37,30 @@ func TestDetectDefaultHAHostWithFeedbackReportsResultWithoutTTYSpinner(t *testin
 	}
 }
 
+func TestDetectDefaultHAHostWithFeedbackAsksForManualAddressWhenNothingWasConfirmed(t *testing.T) {
+	originalDetect := detectDefaultHAHostChoiceForSetup
+	defer func() {
+		detectDefaultHAHostChoiceForSetup = originalDetect
+	}()
+
+	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, bool) {
+		return "", false
+	}
+
+	output := &strings.Builder{}
+	host, discovered := detectDefaultHAHostWithFeedback(output, runtimeConfig{})
+
+	if host != "" {
+		t.Fatalf("host = %q, want blank", host)
+	}
+	if discovered {
+		t.Fatal("expected discovered=false")
+	}
+	if !strings.Contains(output.String(), "enter the Home Assistant address manually") {
+		t.Fatalf("missing manual entry guidance:\n%s", output.String())
+	}
+}
+
 func TestDetectDefaultHAHostWithFeedbackDoesNotDelayFastTTYDiscovery(t *testing.T) {
 	originalDetect := detectDefaultHAHostChoiceForSetup
 	originalTTY := writerSupportsTTYForSetup

--- a/cli/setup_interactive_test.go
+++ b/cli/setup_interactive_test.go
@@ -104,7 +104,8 @@ func TestInteractiveSetupFreshInstallShowsWizardAndInstallsGeminiSkills(t *testi
 		}
 	}
 	if !strings.Contains(output, "Found Home Assistant candidate:") &&
-		!strings.Contains(output, "No confirmed Home Assistant found automatically; defaulting to homeassistant.local") {
+		!strings.Contains(output, "No confirmed Home Assistant found automatically; enter the Home Assistant address manually") &&
+		!strings.Contains(output, "No confirmed Home Assistant found automatically; using your saved address as a starting point:") {
 		t.Fatalf("wizard output missing discovery result:\n%s", output)
 	}
 	discoveryIdx := strings.Index(output, "Discovering Home Assistant on your network...")

--- a/cli/setup_ui.go
+++ b/cli/setup_ui.go
@@ -171,8 +171,10 @@ func renderSetupDiscoveryResult(out io.Writer, host string, discovered bool) {
 	session := resolveSetupUISession(out)
 	if discovered {
 		fmt.Fprintf(out, "  %s Found Home Assistant candidate: %s\n", session.style("success", session.successMarker()), host)
+	} else if strings.TrimSpace(host) != "" {
+		fmt.Fprintf(out, "  %s No confirmed Home Assistant found automatically; using your saved address as a starting point: %s\n", session.style("warning", session.warningMarker()), host)
 	} else {
-		fmt.Fprintf(out, "  %s No confirmed Home Assistant found automatically; defaulting to homeassistant.local\n", session.style("warning", session.warningMarker()))
+		fmt.Fprintf(out, "  %s No confirmed Home Assistant found automatically; enter the Home Assistant address manually\n", session.style("warning", session.warningMarker()))
 	}
 	fmt.Fprintln(out)
 }

--- a/install.sh
+++ b/install.sh
@@ -132,7 +132,7 @@ has_interactive_tty() {
     return 0
   fi
 
-  if : </dev/tty 2>/dev/null; then
+  if : 2>/dev/null </dev/tty; then
     return 0
   fi
 

--- a/scripts/dev-sync.sh
+++ b/scripts/dev-sync.sh
@@ -13,6 +13,7 @@ REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 . "${REPO_ROOT}/scripts/onboarding/lib/install-local-skills-claude.sh"
 
 CLAUDE_PLUGIN_STATE_TOOL="$(claude_plugin_state_tool)"
+CURRENT_PLATFORM_ID="$(detect_platform_id)"
 
 synced=()
 file_clients_synced=0
@@ -87,6 +88,15 @@ sync_gemini() {
   fi
 
   echo "[dev:sync] Gemini: not installed — skipped"
+}
+
+sync_hermes() {
+  if [[ "${CURRENT_PLATFORM_ID}" == "windows" ]]; then
+    echo "[dev:sync] Hermes Agent: native Windows sync not supported — use the WSL2/Linux HA NOVA install instead"
+    return
+  fi
+
+  sync_file_client "Hermes Agent" "${HOME}/.hermes/skills/ha-nova" "hermes"
 }
 
 sync_claude() {
@@ -250,6 +260,7 @@ require_repo_invariants
 sync_file_client "Codex" "${HOME}/.agents/skills/ha-nova" "codex"
 sync_file_client "OpenCode" "${HOME}/.config/opencode/skills/ha-nova" "opencode"
 sync_gemini
+sync_hermes
 sync_claude
 if [[ "${file_clients_synced}" -eq 0 ]]; then
   sync_shared_tools

--- a/scripts/onboarding/lib/install-local-skills-gemini.sh
+++ b/scripts/onboarding/lib/install-local-skills-gemini.sh
@@ -1,19 +1,7 @@
 #!/usr/bin/env bash
 
 cleanup_gemini_unprefixed() {
-  local skills_dir="$1"
-
-  for skill_dir in "${SOURCE_SKILLS_DIR}"/*/SKILL.md; do
-    local src_name
-    src_name="$(basename "$(dirname "$skill_dir")")"
-    [[ "$src_name" == "ha-nova" ]] && continue
-    local bare_dir="${skills_dir}/${src_name}"
-    if [[ -d "$bare_dir" && -f "${bare_dir}/SKILL.md" ]] && \
-       grep -q 'ha-nova' "${bare_dir}/SKILL.md" 2>/dev/null; then
-      rm -rf "$bare_dir"
-      log "[gemini] Removed un-prefixed migration artifact: ${src_name}"
-    fi
-  done
+  :
 }
 
 cleanup_gemini_orphans() {

--- a/scripts/release/build-install-bundle.sh
+++ b/scripts/release/build-install-bundle.sh
@@ -115,7 +115,7 @@ build_unix_bundle() {
   prepare_bundle_root "${stage_dir}" "${os_name}" "${arch_name}" >/dev/null
 
   output="${OUTPUT_DIR}/ha-nova-installer-bundle-${os_name}-${arch_name}.tar.gz"
-  tar -czf "${output}" -C "${stage_dir}" ha-nova
+  COPYFILE_DISABLE=1 tar --format ustar -czf "${output}" -C "${stage_dir}" ha-nova
   rm -rf "${stage_dir}"
   log "Built ${output}"
 }

--- a/tests/onboarding/dev-sync-contract.test.ts
+++ b/tests/onboarding/dev-sync-contract.test.ts
@@ -24,6 +24,14 @@ describe("dev-sync contract", () => {
     expect(content).toContain('sync_file_client "OpenCode"');
   });
 
+  it("syncs Hermes only on POSIX-style installs", () => {
+    expect(content).toContain('CURRENT_PLATFORM_ID="$(detect_platform_id)"');
+    expect(content).toContain('sync_hermes()');
+    expect(content).toContain('sync_file_client "Hermes Agent" "${HOME}/.hermes/skills/ha-nova" "hermes"');
+    expect(content).toContain("native Windows sync not supported");
+    expect(content).toContain("WSL2/Linux HA NOVA install");
+  });
+
   it("generates the version-check wrapper directly instead of copying a tracked shell shim", () => {
     expect(content).toContain('write_repo_cli_wrapper "${config_dir}/version-check" "check-update" "--quiet"');
     expect(content).not.toContain('scripts/version-check.sh');

--- a/tests/onboarding/install-skills-per-client.test.ts
+++ b/tests/onboarding/install-skills-per-client.test.ts
@@ -146,6 +146,30 @@ describe("S-4: client-specific skill installation", () => {
     }
   });
 
+  it("does not delete user-owned bare Gemini skills during cleanup", { timeout: 120000 }, () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-skill-gemini-user-owned-"));
+    const claudeLogFile = join(home, "claude.log");
+    const binDir = createMockBinaries({ claudeLogFile });
+    const userSkill = join(home, ".gemini", "skills", "read");
+
+    mkdirSync(userSkill, { recursive: true });
+    writeFileSync(join(userSkill, "SKILL.md"), "name: read\nThis is my own ha-nova helper note.\n");
+
+    const result = spawnSync(
+      "bash",
+      ["scripts/onboarding/install-local-skills.sh", "gemini"],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        timeout: 60000,
+        env: mockEnv(home, binDir),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(join(userSkill, "SKILL.md"), "utf8")).toContain("This is my own");
+  });
+
   it("installs hermes skills with directory names aligned to their namespaced skill IDs", () => {
     const { home, result } = installSkills("hermes");
     expect(result.status).toBe(0);

--- a/tests/onboarding/installer-contract.test.ts
+++ b/tests/onboarding/installer-contract.test.ts
@@ -81,6 +81,7 @@ describe("install.sh contract", () => {
 
   it("starts ha-nova setup only when interactive and respects HA_NOVA_NO_SETUP", () => {
     expect(content).toContain("has_interactive_tty()");
+    expect(content).toContain('if : 2>/dev/null </dev/tty; then');
     expect(content).toContain("HA_NOVA_NO_SETUP");
     expect(content).toContain('run_setup "${BIN_LINK}"');
     expect(content).toContain("Next step: ha-nova setup");


### PR DESCRIPTION
## Summary
- add Linux Avahi discovery and stop falling back blindly to homeassistant.local when nothing was confirmed
- preserve user-owned bare Gemini skills during cleanup
- harden installer/dev bundle metadata and Hermes dev sync handling

## Verification
- npm run verify
- go test ./... (cli)
- npx vitest run tests/onboarding/install-skills-per-client.test.ts tests/onboarding/installer-contract.test.ts tests/onboarding/dev-sync-contract.test.ts
- git diff --check