### PR TITLE
fix: harden relay runtime failure modes

### DIFF
--- a/cli/bundle_apply.go
+++ b/cli/bundle_apply.go
@@ -22,6 +22,12 @@ func stageBundle(paths runtimePaths, version string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	keepStageDir := false
+	defer func() {
+		if !keepStageDir {
+			_ = os.RemoveAll(stageDir)
+		}
+	}()
 
 	archivePath := filepath.Join(stageDir, bundleAssetName())
 	checksumURL := strings.TrimSpace(os.Getenv("HA_NOVA_BUNDLE_SHA256_URL"))
@@ -74,7 +80,15 @@ func stageBundle(paths runtimePaths, version string) (string, error) {
 	if err := validateBundleRoot(stageRoot); err != nil {
 		return "", err
 	}
+	keepStageDir = true
 	return stageRoot, nil
+}
+
+func cleanupStagedBundle(stageRoot string) {
+	stageDir := filepath.Dir(stageRoot)
+	if strings.HasPrefix(filepath.Base(stageDir), "ha-nova-stage-") {
+		_ = os.RemoveAll(stageDir)
+	}
 }
 
 func extractArchive(archivePath, destDir string) error {

--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -28,7 +28,11 @@ func runDoctor(paths runtimePaths, _ []string) int {
 
 	cfg, cfgErr := loadConfig(paths)
 	token, tokenErr := readRelayAuthTokenForDoctor()
-	state := loadStateOrDefault(paths)
+	state, stateErr := loadStateOrDefaultChecked(paths)
+	if stateErr != nil {
+		printHumanErr("%s", stateErr)
+		return 1
+	}
 	status := 0
 
 	if cfgErr == nil {

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -26,7 +26,11 @@ func runSetup(paths runtimePaths, args []string) int {
 	}
 
 	cfg, _ := loadConfig(paths)
-	state := loadStateOrDefault(paths)
+	state, err := loadStateOrDefaultChecked(paths)
+	if err != nil {
+		printHumanErr("%s", err)
+		return 1
+	}
 
 	if !*nonInteractive {
 		return interactiveSetup(paths, cfg, state, target, *host, *haURL, *relayURL, *relayToken)
@@ -35,7 +39,7 @@ func runSetup(paths runtimePaths, args []string) int {
 	if target == "" {
 		target = "all"
 	}
-	selectedClients, skippedClients, err := resolveSetupClients(paths, target)
+	selectedClients, skippedClients, err := resolveSetupClientsWithState(paths, target, state)
 	if err != nil {
 		printHumanErr("%s", err)
 		return 1

--- a/cli/command_uninstall.go
+++ b/cli/command_uninstall.go
@@ -72,7 +72,11 @@ func runUninstall(paths runtimePaths, args []string) int {
 		return 1
 	}
 
-	state := loadStateOrDefault(paths)
+	state, err := loadStateOrDefaultChecked(paths)
+	if err != nil {
+		printHumanErr("%s", err)
+		return 1
+	}
 	source := detectInstallSource(paths, state)
 	mode := uninstallModeFromFlag(*purge)
 	recoveryMode := false

--- a/cli/command_update.go
+++ b/cli/command_update.go
@@ -25,7 +25,11 @@ func runUpdate(paths runtimePaths, args []string) int {
 		printHumanErr("%s", err)
 		return 1
 	}
-	state := loadStateOrDefault(paths)
+	state, err := loadStateOrDefaultChecked(paths)
+	if err != nil {
+		printHumanErr("%s", err)
+		return 1
+	}
 	source := detectInstallSource(paths, state)
 	if source == installSourceLegacyWindowsPackage {
 		printHumanErr("Legacy private/test Windows package installs are no longer supported for in-place update.")
@@ -79,6 +83,7 @@ func runUpdate(paths runtimePaths, args []string) int {
 		printHumanInfo("Update staged. Restart your shell/client after the updater finishes.")
 		return 0
 	}
+	defer cleanupStagedBundle(stageRoot)
 
 	rollbackInstall, commitInstall, err := applyStagedBundleWithRollback(paths, stageRoot)
 	if err != nil {
@@ -119,6 +124,7 @@ func runInternalReplace(paths runtimePaths, args []string) int {
 		printHumanErr("missing --stage-root")
 		return 1
 	}
+	defer cleanupStagedBundle(*stageRoot)
 	waitForParentReleaseForReplace(*parentPID)
 	rollbackInstall, commitInstall, err := applyStagedBundleWithRollbackForReplace(paths, *stageRoot)
 	if err != nil {

--- a/cli/relay.go
+++ b/cli/relay.go
@@ -23,13 +23,14 @@ var httpClient = &http.Client{
 }
 
 type relayRequestOptions struct {
-	InlineJSON string
-	JSONFile   string
-	JQFilter   string
-	JQFile     string
-	OutputFile string
-	Method     string
-	Path       string
+	InlineJSON   string
+	JSONFile     string
+	JQFilter     string
+	JQFile       string
+	OutputFile   string
+	Method       string
+	Path         string
+	StrictStatus bool
 }
 
 func runRelayCommand(paths runtimePaths, args []string) int {
@@ -72,6 +73,7 @@ func parseRelayFlags(command string, args []string) (relayRequestOptions, error)
 		fs.StringVar(&opts.InlineJSON, "body", "", "inline JSON body")
 		fs.StringVar(&opts.InlineJSON, "d", "", "inline JSON body")
 		fs.StringVar(&opts.JSONFile, "body-file", "", "path to JSON body file")
+		fs.BoolVar(&opts.StrictStatus, "strict-status", false, "exit nonzero for any upstream HTTP error status")
 	default:
 		return opts, fmt.Errorf("unsupported relay command: %s", command)
 	}
@@ -193,6 +195,10 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 		printErr("%s", err)
 		return 1
 	}
+	upstreamExitStatus := 0
+	if endpoint == "core" {
+		upstreamExitStatus = relayCoreUpstreamExitStatus(bodyBytes, opts.StrictStatus)
+	}
 
 	jqFilter, err := loadJQFilter(opts)
 	if err != nil {
@@ -225,6 +231,28 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 	}
 
 	if resp.StatusCode >= 400 {
+		return 1
+	}
+	if upstreamExitStatus != 0 {
+		return upstreamExitStatus
+	}
+	return 0
+}
+
+func relayCoreUpstreamExitStatus(body []byte, strict bool) int {
+	var envelope struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Status int `json:"status"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil || !envelope.OK {
+		return 0
+	}
+	if envelope.Data.Status >= 500 {
+		return 1
+	}
+	if strict && envelope.Data.Status >= 400 {
 		return 1
 	}
 	return 0

--- a/cli/relay_test.go
+++ b/cli/relay_test.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -87,4 +92,117 @@ func TestApplyJQFilterAcceptsWrappedRegexFilter(t *testing.T) {
 	if strings.Contains(res.output, "switch.kitchen") {
 		t.Fatalf("unexpected output: %q", res.output)
 	}
+}
+
+func TestRelayCoreReturnsNonzeroForUpstream5xx(t *testing.T) {
+	paths := setupRelayProxyTest(t, 503)
+
+	exitCode, _ := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "core", []string{"--method", "GET", "--path", "/api/states"})
+	})
+
+	if exitCode != 1 {
+		t.Fatalf("runRelayProxy() exit = %d, want 1", exitCode)
+	}
+}
+
+func TestRelayCoreAllowsUpstream404ByDefault(t *testing.T) {
+	paths := setupRelayProxyTest(t, 404)
+
+	exitCode, _ := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "core", []string{"--method", "GET", "--path", "/api/states/missing"})
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("runRelayProxy() exit = %d, want 0", exitCode)
+	}
+}
+
+func TestRelayCoreStrictStatusReturnsNonzeroForUpstream404(t *testing.T) {
+	paths := setupRelayProxyTest(t, 404)
+
+	exitCode, _ := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "core", []string{"--method", "GET", "--path", "/api/states/missing", "--strict-status"})
+	})
+
+	if exitCode != 1 {
+		t.Fatalf("runRelayProxy() exit = %d, want 1", exitCode)
+	}
+}
+
+func TestRunSetupFailsLoudlyForCorruptStateFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.StateFile), 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(paths.StateFile, []byte(`{not-json`), 0o600); err != nil {
+		t.Fatalf("write corrupt state: %v", err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runSetup(paths, []string{"--non-interactive", "--host", "127.0.0.1", "--relay-token", "test", "claude"})
+	})
+
+	if exitCode != 1 {
+		t.Fatalf("runSetup() exit = %d, want 1", exitCode)
+	}
+	for _, want := range []string{"state file is corrupt", paths.StateFile, "rerun setup"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestLoadStateOrDefaultCheckedTreatsMissingStateAsFirstRun(t *testing.T) {
+	paths := runtimePaths{StateFile: filepath.Join(t.TempDir(), "state.json")}
+
+	state, err := loadStateOrDefaultChecked(paths)
+	if err != nil {
+		t.Fatalf("loadStateOrDefaultChecked() error: %v", err)
+	}
+	if state.SchemaVersion != stateSchemaVersion {
+		t.Fatalf("SchemaVersion = %d, want %d", state.SchemaVersion, stateSchemaVersion)
+	}
+	if state.ClientInstallModes == nil {
+		t.Fatal("ClientInstallModes must be initialized")
+	}
+}
+
+func setupRelayProxyTest(t *testing.T, upstreamStatus int) runtimePaths {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".test-relay-token"))
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/core" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"ok":true,"data":{"status":%d,"body":{"message":"upstream status"}}}`, upstreamStatus)
+	}))
+	t.Cleanup(relayServer.Close)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := saveConfig(paths, runtimeConfig{
+		HAHost:       "127.0.0.1",
+		HAURL:        "http://127.0.0.1:8123",
+		RelayBaseURL: relayServer.URL,
+	}); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := writeRelayAuthToken("test-token"); err != nil {
+		t.Fatalf("writeRelayAuthToken() error: %v", err)
+	}
+	return paths
 }

--- a/cli/release.go
+++ b/cli/release.go
@@ -83,7 +83,14 @@ func fetchLatestRelease(paths runtimePaths, quiet bool, allowCache bool) (releas
 func buildUpdateCheckResult(paths runtimePaths) updateCheckResult {
 	current := localVersion(paths)
 	_, cacheStatus := inspectCachedRelease(paths)
-	state := loadStateOrDefault(paths)
+	state, err := loadStateOrDefaultChecked(paths)
+	if err != nil {
+		return updateCheckResult{
+			CurrentVersion: current,
+			Status:         "check_failed",
+			Message:        err.Error(),
+		}
+	}
 	channels := inspectInstallChannels(paths, state)
 	result := updateCheckResult{
 		CurrentVersion: current,

--- a/cli/setup_clients.go
+++ b/cli/setup_clients.go
@@ -59,7 +59,15 @@ func indexNumber(value int) string {
 }
 
 func resolveSetupClients(paths runtimePaths, target string) ([]string, []string, error) {
-	choices, err := buildSetupClientChoices(paths, loadStateOrDefault(paths))
+	state, err := loadStateOrDefaultChecked(paths)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resolveSetupClientsWithState(paths, target, state)
+}
+
+func resolveSetupClientsWithState(paths runtimePaths, target string, state installState) ([]string, []string, error) {
+	choices, err := buildSetupClientChoices(paths, state)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cli/state.go
+++ b/cli/state.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -26,8 +27,38 @@ func loadState(paths runtimePaths) (installState, error) {
 
 	var state installState
 	if err := json.Unmarshal(data, &state); err != nil {
+		return installState{}, fmt.Errorf("HA NOVA state file is corrupt: %s. Move or remove %s, then rerun setup if needed", err, paths.StateFile)
+	}
+	return normalizeState(state), nil
+}
+
+func loadStateOrDefault(paths runtimePaths) installState {
+	state, err := loadStateOrDefaultChecked(paths)
+	if err != nil {
+		return defaultInstallState()
+	}
+	return state
+}
+
+func loadStateOrDefaultChecked(paths runtimePaths) (installState, error) {
+	state, err := loadState(paths)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return defaultInstallState(), nil
+		}
 		return installState{}, err
 	}
+	return state, nil
+}
+
+func defaultInstallState() installState {
+	return installState{
+		SchemaVersion:      stateSchemaVersion,
+		ClientInstallModes: map[string]string{},
+	}
+}
+
+func normalizeState(state installState) installState {
 	if state.SchemaVersion == 0 {
 		state.SchemaVersion = stateSchemaVersion
 	}
@@ -36,17 +67,6 @@ func loadState(paths runtimePaths) (installState, error) {
 	}
 	state.InstallSource = normalizeInstallSource(state.InstallSource)
 	sort.Strings(state.InstalledClients)
-	return state, nil
-}
-
-func loadStateOrDefault(paths runtimePaths) installState {
-	state, err := loadState(paths)
-	if err != nil {
-		return installState{
-			SchemaVersion:      stateSchemaVersion,
-			ClientInstallModes: map[string]string{},
-		}
-	}
 	return state
 }
 

--- a/nova/src/http/errors.ts
+++ b/nova/src/http/errors.ts
@@ -17,6 +17,10 @@ export function invalidJson(): HttpError {
   return new HttpError(400, "INVALID_JSON", "Request body is not valid JSON");
 }
 
+export function payloadTooLarge(limitBytes: number): HttpError {
+  return new HttpError(413, "PAYLOAD_TOO_LARGE", `Request body exceeds ${limitBytes} bytes`);
+}
+
 export interface ErrorEnvelope {
   ok: false;
   error: {

--- a/nova/src/http/server.ts
+++ b/nova/src/http/server.ts
@@ -1,15 +1,20 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 
 import { authorizeRequest } from "../security/auth.js";
-import { invalidJson, toErrorResponse } from "./errors.js";
+import { invalidJson, payloadTooLarge, toErrorResponse } from "./errors.js";
 import type { Router } from "./router.js";
+
+export const DEFAULT_MAX_JSON_BODY_BYTES = 1_048_576;
 
 export interface HttpServerOptions {
   authToken: string;
   router: Router;
+  maxJsonBodyBytes?: number;
 }
 
 export function createHttpServer(options: HttpServerOptions): Server {
+  const maxJsonBodyBytes = options.maxJsonBodyBytes ?? DEFAULT_MAX_JSON_BODY_BYTES;
+
   return createServer(async (request, response) => {
     try {
       const authResult = authorizeRequest(request.headers.authorization, options.authToken);
@@ -26,7 +31,7 @@ export function createHttpServer(options: HttpServerOptions): Server {
 
       const method = request.method?.toUpperCase() ?? "GET";
       const path = toPathname(request.url);
-      const body = await parseJsonBody(request);
+      const body = await parseJsonBody(request, maxJsonBodyBytes);
       const data = await options.router.dispatch(method, path, {
         request,
         path,
@@ -52,13 +57,13 @@ function toPathname(urlValue: string | undefined): string {
   return new URL(urlValue, "http://localhost").pathname;
 }
 
-async function parseJsonBody(request: IncomingMessage): Promise<unknown> {
+async function parseJsonBody(request: IncomingMessage, maxBytes: number): Promise<unknown> {
   const method = request.method?.toUpperCase() ?? "GET";
   if (method === "GET" || method === "HEAD") {
     return null;
   }
 
-  const rawBody = await readBody(request);
+  const rawBody = await readBody(request, maxBytes);
   if (!rawBody) {
     return null;
   }
@@ -70,11 +75,17 @@ async function parseJsonBody(request: IncomingMessage): Promise<unknown> {
   }
 }
 
-async function readBody(request: IncomingMessage): Promise<string> {
+async function readBody(request: IncomingMessage, maxBytes: number): Promise<string> {
   const chunks: Buffer[] = [];
+  let totalBytes = 0;
 
   for await (const chunk of request) {
-    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    const buffer = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    totalBytes += buffer.byteLength;
+    if (totalBytes > maxBytes) {
+      throw payloadTooLarge(maxBytes);
+    }
+    chunks.push(buffer);
   }
 
   return Buffer.concat(chunks).toString("utf8");

--- a/tests/http/core-proxy.test.ts
+++ b/tests/http/core-proxy.test.ts
@@ -313,15 +313,92 @@ describe("core proxy endpoint", () => {
       }
     });
   });
+
+  it("returns 413 before routing when core body exceeds the configured limit", async () => {
+    const router = createRouter();
+    let routed = false;
+    router.register("POST", "/core", () => {
+      routed = true;
+      return { ok: true };
+    });
+
+    const { baseUrl } = await startServer(servers, router, 48);
+    const response = await fetch(`${baseUrl}/core`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        method: "GET",
+        path: "/api/states",
+        pad: "x".repeat(48)
+      })
+    });
+
+    expect(response.status).toBe(413);
+    expect(routed).toBe(false);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "PAYLOAD_TOO_LARGE",
+        message: "Request body exceeds 48 bytes"
+      }
+    });
+  });
+
+  it("accepts an exact-limit valid core body", async () => {
+    const router = createRouter();
+    router.register(
+      "POST",
+      "/core",
+      createCoreProxyHandler({
+        coreClient: {
+          request: async (input) => ({
+            status: 200,
+            body: {
+              method: input.method,
+              path: input.path
+            }
+          })
+        }
+      })
+    );
+
+    const body = jsonBodyWithPad('{"method":"GET","path":"/api/states","body":{"pad":"', '"}}', 96);
+    const { baseUrl } = await startServer(servers, router, Buffer.byteLength(body));
+    const response = await fetch(`${baseUrl}/core`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+        "content-type": "application/json"
+      },
+      body
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      data: {
+        status: 200,
+        body: {
+          method: "GET",
+          path: "/api/states"
+        }
+      }
+    });
+  });
 });
 
 async function startServer(
   servers: Array<ReturnType<typeof createHttpServer>>,
-  router: ReturnType<typeof createRouter>
+  router: ReturnType<typeof createRouter>,
+  maxJsonBodyBytes?: number
 ): Promise<{ baseUrl: string }> {
   const server = createHttpServer({
     authToken: TEST_AUTH_TOKEN,
-    router
+    router,
+    ...(maxJsonBodyBytes === undefined ? {} : { maxJsonBodyBytes })
   });
 
   servers.push(server);
@@ -341,4 +418,13 @@ async function startServer(
   return {
     baseUrl: `http://127.0.0.1:${address.port}`
   };
+}
+
+function jsonBodyWithPad(prefix: string, suffix: string, targetBytes: number): string {
+  const fixedBytes = Buffer.byteLength(prefix) + Buffer.byteLength(suffix);
+  const padBytes = targetBytes - fixedBytes;
+  if (padBytes < 0) {
+    throw new Error("targetBytes is smaller than fixed JSON body");
+  }
+  return `${prefix}${"x".repeat(padBytes)}${suffix}`;
 }

--- a/tests/http/ws-proxy.test.ts
+++ b/tests/http/ws-proxy.test.ts
@@ -158,15 +158,78 @@ describe("ws proxy endpoint", () => {
       }
     });
   });
+
+  it("returns 413 before routing when ws body exceeds the configured limit", async () => {
+    const router = createRouter();
+    let routed = false;
+    router.register("POST", "/ws", () => {
+      routed = true;
+      return { ok: true };
+    });
+
+    const { baseUrl } = await startServer(servers, router, 32);
+    const response = await fetch(`${baseUrl}/ws`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ type: "ping", pad: "x".repeat(32) })
+    });
+
+    expect(response.status).toBe(413);
+    expect(routed).toBe(false);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "PAYLOAD_TOO_LARGE",
+        message: "Request body exceeds 32 bytes"
+      }
+    });
+  });
+
+  it("accepts an exact-limit valid ws body", async () => {
+    const router = createRouter();
+    router.register(
+      "POST",
+      "/ws",
+      createWsProxyHandler({
+        wsClient: {
+          sendMessage: async (message) => ({ echoed: message.type })
+        }
+      })
+    );
+
+    const body = jsonBodyWithPad('{"type":"ping","pad":"', '"}', 64);
+    const { baseUrl } = await startServer(servers, router, Buffer.byteLength(body));
+    const response = await fetch(`${baseUrl}/ws`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+        "content-type": "application/json"
+      },
+      body
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      data: {
+        echoed: "ping"
+      }
+    });
+  });
 });
 
 async function startServer(
   servers: Array<ReturnType<typeof createHttpServer>>,
-  router: ReturnType<typeof createRouter>
+  router: ReturnType<typeof createRouter>,
+  maxJsonBodyBytes?: number
 ): Promise<{ baseUrl: string }> {
   const server = createHttpServer({
     authToken: TEST_AUTH_TOKEN,
-    router
+    router,
+    ...(maxJsonBodyBytes === undefined ? {} : { maxJsonBodyBytes })
   });
 
   servers.push(server);
@@ -186,4 +249,13 @@ async function startServer(
   return {
     baseUrl: `http://127.0.0.1:${address.port}`
   };
+}
+
+function jsonBodyWithPad(prefix: string, suffix: string, targetBytes: number): string {
+  const fixedBytes = Buffer.byteLength(prefix) + Buffer.byteLength(suffix);
+  const padBytes = targetBytes - fixedBytes;
+  if (padBytes < 0) {
+    throw new Error("targetBytes is smaller than fixed JSON body");
+  }
+  return `${prefix}${"x".repeat(padBytes)}${suffix}`;
 }


### PR DESCRIPTION
## Summary
- reject oversized JSON bodies before routing for /ws and /core
- keep /health response shape unchanged while preserving setup/doctor readiness behavior
- make relay core fail on upstream 5xx and add opt-in strict status handling for 4xx
- fail loudly on corrupt state files while keeping missing state as first-run
- clean staged update bundles after successful replacement paths

## Verification
- npm run verify
- go test ./... (cli)
- npx vitest run tests/http/core-proxy.test.ts tests/http/ws-proxy.test.ts tests/http/health.test.ts
- git diff --check