### PR TITLE
docs: simplify Hermes release wording

### DIFF
--- a/.hermes/INSTALL.md
+++ b/.hermes/INSTALL.md
@@ -2,7 +2,7 @@
 
 This page only covers Hermes-specific deltas.
 
-> **Release status:** Hermes support is implemented for the next HA NOVA release train, but it is not part of the current stable release until the final release PR, tag, and artifacts publish it. Until then, `README.md` remains the stable public product truth.
+> **Release status:** Hermes is planned for the next HA NOVA release. It is not included in the current stable release yet. Until the final release is published, `README.md` remains the stable product page.
 
 For the stable installer, lifecycle commands, and general troubleshooting, use [README.md](../README.md) and the [latest GitHub release](https://github.com/markusleben/ha-nova/releases/latest).
 
@@ -21,15 +21,15 @@ Support status:
 
 Evidence status:
 - `Maintainer-validated` means the maintainer ran that exact path on a real machine recently.
-- `Community validation` is welcome and useful, but it is advisory only and does not replace maintainer release proof.
+- Community test reports are welcome and useful, but they are advisory only and do not replace maintainer release proof.
 - `Planned / not yet validated` means the path is part of the intended support model, but the current release cycle does not claim a fresh maintainer proof yet.
 
 ## Platform Routing
 
-Current support/evidence truth lives in [docs/reference/hermes-platform-validation.md](../docs/reference/hermes-platform-validation.md).
+Current support and test status lives in [docs/reference/hermes-platform-validation.md](../docs/reference/hermes-platform-validation.md).
 
-- macOS native Hermes follows the native macOS path.
-- Linux native Hermes is the current focus for inline secure-storage recovery; GNOME Keyring is the actively maintainer-validated path.
+- On macOS, use the native Hermes app/CLI path.
+- On Linux, GNOME Keyring is the path we actively test for inline secure-storage recovery.
 - Linux non-GNOME Secret Service backends stay supported only when secure local storage already works; inline recovery is not claimed there yet.
 - Windows native Hermes is not supported. Use WSL2 instead.
 - Windows + WSL2 Hermes must run entirely inside the same WSL shell where `hermes --help` already works.
@@ -58,7 +58,7 @@ Current support/evidence truth lives in [docs/reference/hermes-platform-validati
 - Connect or repair with `ha-nova setup hermes`.
 - `ha-nova setup hermes` also repairs older Hermes installs whose bare sub-skill directory names could make `skills_list` and `skill_view` disagree.
 - On Windows with WSL2, run update and repair commands from the same WSL shell where Hermes is installed.
-- Validate the current route and proof status in [docs/reference/hermes-platform-validation.md](../docs/reference/hermes-platform-validation.md).
+- Check the current route and test status in [docs/reference/hermes-platform-validation.md](../docs/reference/hermes-platform-validation.md).
 - Validate the install with `ha-nova doctor`.
 - Hermes does not surface HA NOVA update notices automatically yet. Use `ha-nova check-update` or `ha-nova doctor` when you want to check manually.
 
@@ -75,8 +75,8 @@ After setup, HA NOVA skills are available inside Hermes with the HA NOVA namespa
 
 ## Community Validation
 
-- If you validate Hermes on another macOS build, Linux distro, desktop session, or Secret Service backend, open the Hermes platform validation issue template and redact all tokens and secrets.
-- Community validation helps us expand the matrix faster, but maintainer-validated rows stay the release signoff source of truth.
+- If you test Hermes on another macOS build, Linux distro, desktop session, or Secret Service backend, open the Hermes platform validation issue template and redact all tokens and secrets.
+- Community reports help us expand platform coverage faster, but maintainer-run tests stay the release signoff source of truth.
 
 ## Related
 

--- a/docs/reference/hermes-platform-validation.md
+++ b/docs/reference/hermes-platform-validation.md
@@ -1,8 +1,8 @@
-# Hermes Platform Validation
+# Hermes Platform Test Status
 
-This is the active truth source for Hermes support evidence in HA NOVA.
+This page tracks which Hermes paths HA NOVA intends to support and which ones have been tested on real machines.
 
-> **Release status:** This matrix tracks the next release train. Hermes support is not part of the current stable release until the final release PR publishes matching README claims, release notes, tag, and artifacts.
+> **Release status:** This page tracks work for the next release. Hermes is not included in the current stable release yet; the final release PR must publish matching README copy, release notes, tag, and artifacts.
 
 Use it to answer two separate questions cleanly:
 
@@ -15,10 +15,10 @@ Use it to answer two separate questions cleanly:
 - `Supported with limitation`: the route is real, but one UX slice is intentionally narrower today.
 - `Not supported`: the route is outside the current HA NOVA support model.
 
-## Evidence Status
+## Test Status
 
 - `Maintainer-validated`: the maintainer ran this exact route on a real machine recently enough to cite it for release confidence.
-- `Community validation`: a user reported a real result for this route. Helpful signal; not release signoff on its own.
+- `Community report`: a user reported a real result for this route. Helpful signal; not release signoff on its own.
 - `Planned / not yet validated`: the route belongs to the support model, but does not yet have a fresh maintainer proof in this matrix.
 
 ## Current Matrix
@@ -40,7 +40,7 @@ Use it to answer two separate questions cleanly:
 
 ## Community Validation Rules
 
-- Community reports are advisory only. They help expand the matrix, but they do not replace maintainer-validated release proof.
+- Community reports are advisory only. They help expand platform coverage, but they do not replace maintainer-run release proof.
 - Never paste Home Assistant long-lived access tokens, relay auth tokens, keyring passwords, or unredacted shell history into an issue.
 - Prefer structured reports through the Hermes platform validation issue template so distro, session, and backend details stay comparable.
 

--- a/docs/work/2026-04-24-hermes-release-claim-gating.md
+++ b/docs/work/2026-04-24-hermes-release-claim-gating.md
@@ -8,7 +8,7 @@ Ship Hermes Agent support in the next HA NOVA release without letting the public
 
 ## Scope
 
-- Keep the Hermes implementation, registry entry, installer behavior, tests, `.hermes/INSTALL.md`, and validation matrix in the Hermes support PR.
+- Keep the Hermes implementation, registry entry, installer behavior, tests, `.hermes/INSTALL.md`, and platform test-status doc in the Hermes support PR.
 - Keep public `README.md` release-conservative until the final release PR.
 - Use a final release PR to flip the public README support claim after the release-bound proof matrix is complete.
 
@@ -16,7 +16,7 @@ Ship Hermes Agent support in the next HA NOVA release without letting the public
 
 - `README.md` is stable public product truth.
 - `.hermes/INSTALL.md` is the Hermes overlay for the unreleased next release while this work is still in-flight.
-- `docs/reference/hermes-platform-validation.md` is the proof matrix and must record the strongest current evidence without overstating unvalidated routes.
+- `docs/reference/hermes-platform-validation.md` records platform test status and must state the strongest current proof without overstating untested routes.
 - The final release PR must either:
   - restore the public Hermes claim in `README.md`, if release proof is complete, or
   - keep Hermes absent from the public support list, if proof is incomplete.

--- a/tests/onboarding/client-install-docs-contract.test.ts
+++ b/tests/onboarding/client-install-docs-contract.test.ts
@@ -101,7 +101,7 @@ describe("client install docs contract", () => {
     expect(opencodeInstall).toContain("still early and not fully tested yet");
 
     expect(hermesInstall).toContain("Hermes Agent");
-    expect(hermesInstall).toContain("not part of the current stable release");
+    expect(hermesInstall).toContain("not included in the current stable release yet");
     expect(hermesInstall).toContain("ha-nova setup hermes");
     expect(hermesInstall).toContain("ha-nova check-update");
     expect(hermesInstall).toContain("What Supported Means Here");
@@ -142,7 +142,7 @@ describe("client install docs contract", () => {
     expect(hermesReleaseGate).toContain("Status: active");
     expect(hermesReleaseGate).toContain("Keep public `README.md` release-conservative until the final release PR.");
     expect(hermesReleaseGate).toContain("restore the public Hermes claim in `README.md`, if release proof is complete");
-    expect(hermesInstall).toContain("not part of the current stable release until the final release PR");
+    expect(hermesInstall).toContain("not included in the current stable release yet");
     expect(readme).not.toContain("Hermes Agent");
   });
 });

--- a/tests/onboarding/project-docs-contract.test.ts
+++ b/tests/onboarding/project-docs-contract.test.ts
@@ -90,14 +90,14 @@ describe("project docs contract", () => {
     expect(governance).toContain("keep the root `docs/breadcrumbs.md` short and current only");
   });
 
-  it("tracks Hermes support evidence in a dedicated active reference doc", () => {
-    expect(hermesValidation).toContain("This is the active truth source for Hermes support evidence in HA NOVA.");
+  it("tracks Hermes platform support and test status in a dedicated active reference doc", () => {
+    expect(hermesValidation).toContain("This page tracks which Hermes paths HA NOVA intends to support and which ones have been tested on real machines.");
     expect(hermesValidation).toContain("## Support Status");
     expect(hermesValidation).toContain("Supported with limitation");
     expect(hermesValidation).toContain("Not supported");
-    expect(hermesValidation).toContain("## Evidence Status");
+    expect(hermesValidation).toContain("## Test Status");
     expect(hermesValidation).toContain("Maintainer-validated");
-    expect(hermesValidation).toContain("Community validation");
+    expect(hermesValidation).toContain("Community report");
     expect(hermesValidation).toContain("Planned / not yet validated");
     expect(hermesValidation).toContain("## Repair Check");
     expect(hermesValidation).toContain("configured but not attached");


### PR DESCRIPTION
## Summary
- remove awkward 'validation matrix' style wording from Hermes docs
- say plainly that Hermes is planned for the next release but not in the current stable release yet
- keep docs contracts aligned with the simpler wording

## Verification
- npm run verify:docs
- pre-push hook: typecheck, safe tests, build, docs fact-check
- git diff --check