### PR TITLE
fix(installer): PowerShell-native install.ps1, drop WinGet legacy guard

### DIFF
--- a/cli/install_source.go
+++ b/cli/install_source.go
@@ -31,21 +31,28 @@ func detectInstallSource(paths runtimePaths, state installState) string {
 	if strings.TrimSpace(os.Getenv("HA_NOVA_DEV_ROOT")) != "" {
 		return installSourceDev
 	}
-	if legacyWindowsPackageSourcePresent(paths) {
+	if legacyWindowsPackageBinaryRunning() {
 		return installSourceLegacyWindowsPackage
 	}
 
+	// A current bundle install on disk takes precedence over on-disk WinGet
+	// legacy residue: install.ps1 no longer blocks on leftover private/test
+	// WinGet package paths, so a fresh bundle install over residue must
+	// classify as bundle — update/uninstall then work, and uninstall removes
+	// the residue via removeLegacyWindowsPackageResidue. Only a binary that
+	// itself runs from a WinGet-managed path still classifies as legacy.
 	sourceRoot := resolveSourceRoot(paths)
-	if sourceRoot != "" {
-		if bundleInstallPresentOnDisk(sourceRoot) {
-			if filepath.Clean(sourceRoot) != filepath.Clean(paths.InstallRoot) {
-				return installSourceDev
-			}
-			return installSourceBundle
-		}
+	if sourceRoot != "" && bundleInstallPresentOnDisk(sourceRoot) {
 		if filepath.Clean(sourceRoot) != filepath.Clean(paths.InstallRoot) {
 			return installSourceDev
 		}
+		return installSourceBundle
+	}
+	if legacyWindowsPackageSourcePresent(paths) {
+		return installSourceLegacyWindowsPackage
+	}
+	if sourceRoot != "" && filepath.Clean(sourceRoot) != filepath.Clean(paths.InstallRoot) {
+		return installSourceDev
 	}
 	if channelChecksUseWindowsPlatform() && normalizeInstallSource(state.InstallSource) == installSourceLegacyWindowsPackage && !bundleInstallPresentOnDisk(paths.InstallRoot) {
 		return installSourceLegacyWindowsPackage
@@ -100,11 +107,19 @@ func sourceRootCandidates(paths runtimePaths) []string {
 	return candidates
 }
 
+func legacyWindowsPackageBinaryRunning() bool {
+	if !channelChecksUseWindowsPlatform() {
+		return false
+	}
+	exePath, err := executablePathForInstallSource()
+	return err == nil && isLegacyWindowsPackageManagedPath(exePath)
+}
+
 func legacyWindowsPackageSourcePresent(paths runtimePaths) bool {
 	if !channelChecksUseWindowsPlatform() {
 		return false
 	}
-	if exePath, err := executablePathForInstallSource(); err == nil && isLegacyWindowsPackageManagedPath(exePath) {
+	if legacyWindowsPackageBinaryRunning() {
 		return true
 	}
 	if fileExists(legacyWindowsPackageLinkPath(paths)) {

--- a/cli/legacy_windows_source_test.go
+++ b/cli/legacy_windows_source_test.go
@@ -247,3 +247,83 @@ func TestRunUninstallGuidesLegacyWindowsPackageRemoval(t *testing.T) {
 		}
 	}
 }
+
+func TestDetectInstallSourcePrefersFreshBundleOverOnDiskWinGetResidue(t *testing.T) {
+	originalPlatform := channelChecksUseWindowsPlatform
+	originalExecutable := executablePathForInstallSource
+	defer func() {
+		channelChecksUseWindowsPlatform = originalPlatform
+		executablePathForInstallSource = originalExecutable
+	}()
+
+	channelChecksUseWindowsPlatform = func() bool { return true }
+
+	home := t.TempDir()
+	installRoot := filepath.Join(home, "AppData", "Local", "Programs", "ha-nova")
+	if err := os.MkdirAll(installRoot, 0o755); err != nil {
+		t.Fatalf("mkdir install root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(installRoot, publicBinaryName()), []byte("bundle"), 0o755); err != nil {
+		t.Fatalf("write bundle binary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(installRoot, "bundle.json"), []byte(`{"bundle_format_version":1}`), 0o644); err != nil {
+		t.Fatalf("write bundle metadata: %v", err)
+	}
+
+	// Leftover WinGet residue on disk, but the running binary is the fresh
+	// bundle install: update/uninstall must work, uninstall cleans the
+	// residue. install.ps1 no longer blocks this state.
+	linksDir := filepath.Join(home, "AppData", "Local", "Microsoft", "WinGet", "Links")
+	if err := os.MkdirAll(linksDir, 0o755); err != nil {
+		t.Fatalf("mkdir links dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(linksDir, publicBinaryName()), []byte("legacy"), 0o755); err != nil {
+		t.Fatalf("write legacy link: %v", err)
+	}
+
+	executablePathForInstallSource = func() (string, error) {
+		return filepath.Join(installRoot, publicBinaryName()), nil
+	}
+
+	paths := runtimePaths{
+		Home:        home,
+		InstallRoot: installRoot,
+	}
+
+	if got := detectInstallSource(paths, installState{}); got != installSourceBundle {
+		t.Fatalf("detectInstallSource() = %q, want %q", got, installSourceBundle)
+	}
+}
+
+func TestDetectInstallSourceKeepsLegacyForOnDiskResidueWithoutBundle(t *testing.T) {
+	originalPlatform := channelChecksUseWindowsPlatform
+	originalExecutable := executablePathForInstallSource
+	defer func() {
+		channelChecksUseWindowsPlatform = originalPlatform
+		executablePathForInstallSource = originalExecutable
+	}()
+
+	channelChecksUseWindowsPlatform = func() bool { return true }
+
+	home := t.TempDir()
+	linksDir := filepath.Join(home, "AppData", "Local", "Microsoft", "WinGet", "Links")
+	if err := os.MkdirAll(linksDir, 0o755); err != nil {
+		t.Fatalf("mkdir links dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(linksDir, publicBinaryName()), []byte("legacy"), 0o755); err != nil {
+		t.Fatalf("write legacy link: %v", err)
+	}
+
+	executablePathForInstallSource = func() (string, error) {
+		return filepath.Join(t.TempDir(), publicBinaryName()), nil
+	}
+
+	paths := runtimePaths{
+		Home:        home,
+		InstallRoot: filepath.Join(home, "AppData", "Local", "Programs", "ha-nova"),
+	}
+
+	if got := detectInstallSource(paths, installState{}); got != installSourceLegacyWindowsPackage {
+		t.Fatalf("detectInstallSource() = %q, want %q", got, installSourceLegacyWindowsPackage)
+	}
+}

--- a/install.ps1
+++ b/install.ps1
@@ -7,15 +7,12 @@ $ErrorActionPreference = "Stop"
 
 $RepoOwner = "markusleben"
 $RepoName = "ha-nova"
-$LegacyWindowsPackageId = "markusleben.ha-nova"
 $LatestReleaseUrl = "https://api.github.com/repos/markusleben/ha-nova/releases/latest"
 $ReleaseBaseUrl = "https://github.com/$RepoOwner/$RepoName/releases/download"
 $LocalAppDataDir = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { Join-Path $HOME "AppData\Local" }
 $AppDataDir = if ($env:APPDATA) { $env:APPDATA } else { Join-Path $HOME "AppData\Roaming" }
 $InstallDir = Join-Path $LocalAppDataDir "Programs\ha-nova"
 $PublicCommandDir = $InstallDir
-$LegacyWindowsPackageLink = Join-Path $LocalAppDataDir "Microsoft\WinGet\Links\ha-nova.exe"
-$LegacyWindowsPackagesDir = Join-Path $LocalAppDataDir "Microsoft\WinGet\Packages"
 $LegacyUninstallUrl = "https://raw.githubusercontent.com/markusleben/ha-nova/main/scripts/legacy-uninstall.ps1"
 $ConfigDir = Join-Path $AppDataDir "ha-nova"
 $UninstallStatusPath = Join-Path $LocalAppDataDir "ha-nova\uninstall-status.json"
@@ -200,53 +197,6 @@ Run the cleanup first:
   irm $LegacyUninstallUrl | iex
 
 Then run this installer again.
-"@
-}
-
-function Test-OldWindowsPackageBundleRoot {
-  param(
-    [string]$Candidate
-  )
-
-  if (-not $Candidate) {
-    return $false
-  }
-
-  $root = $Candidate.TrimEnd('\')
-  return (Test-Path -LiteralPath (Join-Path $root "ha-nova.exe")) -and (Test-Path -LiteralPath (Join-Path $root "bundle.json"))
-}
-
-function Test-OldWindowsPackageInstall {
-  if (Test-Path -LiteralPath $LegacyWindowsPackageLink) {
-    return $true
-  }
-
-  $packageRoots = @(Get-ChildItem -LiteralPath $LegacyWindowsPackagesDir -Directory -ErrorAction SilentlyContinue | Where-Object { $_.Name -like "$LegacyWindowsPackageId*" })
-  foreach ($packageRoot in $packageRoots) {
-    if (Test-OldWindowsPackageBundleRoot -Candidate (Join-Path $packageRoot.FullName "ha-nova")) {
-      return $true
-    }
-    if (Test-OldWindowsPackageBundleRoot -Candidate $packageRoot.FullName) {
-      return $true
-    }
-  }
-
-  return $false
-}
-
-function Stop-ForOldWindowsPackageInstall {
-  Fail @"
-An older private or test Windows package install of HA NOVA was detected.
-This installer will not create a second Windows install state.
-
-Remove the older HA NOVA app from Windows first:
-  Installed Apps / App Installer -> uninstall HA NOVA
-
-If Windows left stale package files behind, remove:
-  $LegacyWindowsPackageLink
-  $LegacyWindowsPackagesDir\$LegacyWindowsPackageId*
-
-Then rerun install.ps1.
 "@
 }
 
@@ -489,7 +439,7 @@ Then run this installer again.
 "@
 }
 
-function Invoke-WebRequestWithQuietProgress {
+function Invoke-DownloadFile {
   param(
     [Parameter(Mandatory = $true)][string]$Uri,
     [Parameter(Mandatory = $true)][string]$OutFile
@@ -522,8 +472,8 @@ function Install-Bundle {
   New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
 
   try {
-    Invoke-WebRequestWithQuietProgress -Uri $bundleUrl -OutFile $archivePath
-    Invoke-WebRequestWithQuietProgress -Uri (Get-BundleChecksumUrl -Version $Version) -OutFile $checksumPath
+    Invoke-DownloadFile -Uri $bundleUrl -OutFile $archivePath
+    Invoke-DownloadFile -Uri (Get-BundleChecksumUrl -Version $Version) -OutFile $checksumPath
     $expectedHash = (Get-Content -LiteralPath $checksumPath -Raw).Trim().Split()[0]
     $actualHash = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
     if (-not $expectedHash -or $actualHash -ne $expectedHash.ToLowerInvariant()) {
@@ -661,9 +611,6 @@ if (-not (Test-CurrentInstall) -and (Test-LegacyInstall)) {
 }
 if ($uninstallRecovery = Get-UninstallRecoveryState) {
   Stop-ForUninstallRecovery -Recovery $uninstallRecovery
-}
-if (Test-OldWindowsPackageInstall) {
-  Stop-ForOldWindowsPackageInstall
 }
 $bundleResult = Install-Bundle -Version $version
 Ensure-InstallDirOnPath | Out-Null

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -61,7 +61,7 @@ describe("release contract", () => {
   });
 
   it("keeps the Windows installer bundle-managed while preserving quiet download UX", () => {
-    expect(installer).toContain("Invoke-WebRequestWithQuietProgress");
+    expect(installer).toContain("Invoke-DownloadFile");
     expect(installer).toContain('$global:ProgressPreference = "SilentlyContinue"');
     expect(installer).not.toContain("Stop-ForWingetInstall");
     expect(installer).not.toContain("Get-Command winget");

--- a/tests/onboarding/windows-installer-contract.test.ts
+++ b/tests/onboarding/windows-installer-contract.test.ts
@@ -1,0 +1,126 @@
+import { constants, readFileSync, statSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+describe("install.ps1 contract", () => {
+  const content = readFileSync("install.ps1", "utf8");
+
+  it("exists as the native Windows bootstrap entrypoint", () => {
+    const stats = statSync("install.ps1");
+    expect((stats.mode & constants.S_IRUSR) !== 0).toBe(true);
+    expect(content).toContain("PowerShell");
+    expect(content).toContain("Set-StrictMode -Version Latest");
+  });
+
+  it("supports plain UI mode and linear fallback output", () => {
+    expect(content).toContain("HA_NOVA_PLAIN_UI");
+    expect(content).toContain("NO_COLOR");
+    expect(content).toContain("Test-PlainUi");
+    expect(content).toContain("ForegroundColor Yellow");
+    expect(content).toContain('Write-Output "  [!] $Message"');
+    expect(content).toContain("[Console]::Error.WriteLine");
+    expect(content).toContain(
+      "No interactive terminal detected; setup was not started automatically.",
+    );
+  });
+
+  it("uses GitHub Releases latest unless HA_NOVA_VERSION is pinned", () => {
+    expect(content).toContain(
+      "https://api.github.com/repos/markusleben/ha-nova/releases/latest",
+    );
+    expect(content).toContain("HA_NOVA_VERSION");
+    expect(content).toContain("tag_name");
+    expect(content).not.toContain(
+      "raw.githubusercontent.com/markusleben/ha-nova/main/version.json",
+    );
+  });
+
+  it("supports maintainer-only bundle URL overrides for private RC tests", () => {
+    expect(content).toContain("HA_NOVA_BUNDLE_URL");
+    expect(content).toContain("HA_NOVA_BUNDLE_SHA256_URL");
+    expect(content).toContain("Get-BundleUrl");
+    expect(content).toContain("Get-BundleChecksumUrl");
+    expect(content).toContain("Downloaded bundle version");
+  });
+
+  it("downloads the Windows bundle and validates bundle.json natively", () => {
+    expect(content).toContain("ha-nova-installer-bundle-windows-amd64.zip");
+    expect(content).toContain("Windows amd64 bundle only");
+    expect(content).toContain("x64 emulation");
+    expect(content).toContain("Expand-Archive");
+    expect(content).toContain("bundle.json");
+    expect(content).toContain(".sha256");
+    expect(content).toContain("Get-FileHash");
+    expect(content).toContain("ha-nova.exe");
+    expect(content).not.toContain("git clone");
+    expect(content).not.toContain("npm install");
+  });
+
+  it("keeps progress suppression local to bundle downloads and restores the previous preference", () => {
+    expect(content).toContain("function Invoke-DownloadFile");
+    expect(content).toContain("$previousProgressPreference = $global:ProgressPreference");
+    expect(content).toContain('$global:ProgressPreference = "SilentlyContinue"');
+    expect(content).toContain("finally");
+    expect(content).toContain(
+      "$global:ProgressPreference = $previousProgressPreference",
+    );
+    expect(content).not.toContain(
+      "$ProgressPreference = 'SilentlyContinue'",
+    );
+  });
+
+  it("stays PowerShell-native without winget or Git Bash assumptions", () => {
+    expect(content).not.toContain("Get-Command winget");
+    expect(content).not.toContain("Microsoft\\WinGet\\Links\\ha-nova.exe");
+    expect(content).not.toContain("Microsoft\\WinGet\\Packages");
+    expect(content).not.toContain("winget-managed HA NOVA install was detected");
+    expect(content).not.toContain("winget upgrade --id");
+    expect(content).not.toContain("winget uninstall --id");
+    expect(content).not.toContain("Git.Git");
+    expect(content).not.toContain("git-bash.exe");
+    expect(content).not.toContain("bash.exe");
+  });
+
+  it("blocks over an unfinished background uninstall instead of layering a new install", () => {
+    expect(content).toContain("uninstall-status.json");
+    expect(content).toContain(
+      "A background HA NOVA uninstall is still running on Windows.",
+    );
+    expect(content).toContain(
+      "A previous background HA NOVA uninstall did not finish cleanly.",
+    );
+    expect(content).toContain("ha-nova uninstall --yes");
+    expect(content).toContain("ha-nova uninstall --yes --purge");
+  });
+
+  it("detects legacy installs and prints the dedicated cleanup one-liner", () => {
+    expect(content).toContain("legacy-uninstall.ps1");
+    expect(content).toContain(
+      "raw.githubusercontent.com/markusleben/ha-nova/main/scripts/legacy-uninstall.ps1",
+    );
+    expect(content).toContain("onboarding.env");
+    expect(content).toContain("check-update.cmd");
+    expect(content).not.toContain('(Join-Path $LegacyConfigDir "relay")');
+    expect(content).not.toContain('(Join-Path $LegacyConfigDir "relay.exe")');
+    expect(content).not.toContain('(Join-Path $LegacyConfigDir "version-check")');
+  });
+
+  it("uses native Windows app locations and starts setup through the Go runtime", () => {
+    expect(content).toContain("LOCALAPPDATA");
+    expect(content).toContain("APPDATA");
+    expect(content).toContain("Programs\\ha-nova");
+    expect(content).toContain("$PublicCommandDir = $InstallDir");
+    expect(content).toContain("Ensure-InstallDirOnPath");
+    expect(content).toContain("HA_NOVA_NO_SETUP");
+    expect(content).toContain("Start-Setup");
+    expect(content).toContain("& $BinaryPath setup");
+    expect(content).not.toContain("ha-nova.cmd");
+  });
+
+  it("keeps bootstrap logic out of product state persistence", () => {
+    expect(content).not.toContain("Write-State");
+    expect(content).not.toContain("state.json");
+    expect(content).not.toContain("install_source");
+    expect(content).not.toContain("path_managed");
+  });
+});


### PR DESCRIPTION
## Summary
- Renames the download helper to `Invoke-DownloadFile`; `$ProgressPreference` suppression stays local to bundle downloads via try/finally.
- Removes the maintainer-only WinGet legacy package guard (`Microsoft\WinGet\Links/Packages` paths): WinGet distribution was removed in #138, only private/test maintainer installs ever matched, and `scripts/legacy-uninstall.ps1` still detects the portable link for current-install detection.
- Adds `tests/onboarding/windows-installer-contract.test.ts` pinning the PowerShell-native contract (no winget/Git-Bash assumptions, bundle-managed flow, uninstall-recovery gating) and updates the one release-contract assertion to the new helper name.

## Verification
- `npm test`: 64 files / 489 tests green standalone on this branch (478 base + 11 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)