### PR TITLE
feat: service credentials, token-file storage, and client attach hardening

### DIFF
--- a/.hermes/INSTALL.md
+++ b/.hermes/INSTALL.md
@@ -1,15 +1,16 @@
 # Hermes Agent Install Overlay
 
-This page only covers Hermes-specific deltas.
-
 > **Release status:** Hermes support is implemented for the next HA NOVA release train, but it is not part of the current stable release until the final release PR, tag, and artifacts publish it. Until then, `README.md` remains the stable public product truth.
+
+This page only covers Hermes-specific deltas.
 
 For the stable installer, lifecycle commands, and general troubleshooting, use [README.md](../README.md) and the [latest GitHub release](https://github.com/markusleben/ha-nova/releases/latest).
 
 ## Setup Choice
 
-- Use the normal HA NOVA installer flow.
-- In the setup wizard, choose `Hermes Agent`.
+- Desktop terminal path: run `ha-nova setup hermes`.
+- Service, headless, SSH, systemd user service, or gateway path: run `ha-nova setup --service hermes`.
+- If you run `ha-nova setup hermes` and HA NOVA detects that the desktop keyring is locked or unavailable, setup asks whether to switch to the service/gateway token file.
 - Install Hermes separately; HA NOVA handles the skills and onboarding, not the Hermes app itself.
 
 ## What Supported Means Here
@@ -45,17 +46,19 @@ Current support/evidence truth lives in [docs/reference/hermes-platform-validati
 
 ## Linux Notes
 
-- On Linux, HA NOVA expects a working Secret Service session for secure local token storage.
+- On Linux desktop sessions, HA NOVA uses the OS Secret Service / keyring for secure local token storage.
+- For Hermes sessions that run without an unlocked desktop keyring, use `ha-nova setup --service hermes`. This stores only the Relay Auth Token in `~/.config/ha-nova/relay-token` with strict local file permissions.
 - If HA NOVA asks for a local Linux keyring password, it stays on this machine. HA NOVA only uses it to unlock or create local secure storage. It is not your Relay token, not your Home Assistant token, and it is not sent to the Relay, Home Assistant, Hermes, or any AI provider.
 - If no Secret Service provider is running, setup fails early with an explicit prerequisite message instead of raw `org.freedesktop.secrets` D-Bus errors.
 - If Linux is using GNOME Keyring and the default collection is locked or uninitialized, `ha-nova setup hermes` can guide recovery inline.
 - If Linux uses another Secret Service backend, keep the backend working first; HA NOVA does not pretend inline GNOME-only recovery exists there.
-- If you run setup or repair over SSH, use the same logged-in desktop user session that owns the user D-Bus / Secret Service session.
+- If you run setup or repair over SSH and want desktop keyring storage, use the same logged-in desktop user session that owns the user D-Bus / Secret Service session. If that is not available, use the service path instead.
 
 ## Updates and Repair
 
 - Run `ha-nova doctor` first. If Hermes is configured but not attached, doctor points you to `ha-nova setup hermes`.
 - Connect or repair with `ha-nova setup hermes`.
+- Repair service or gateway credentials with `ha-nova setup --service hermes`.
 - `ha-nova setup hermes` also repairs older Hermes installs whose bare sub-skill directory names could make `skills_list` and `skill_view` disagree.
 - On Windows with WSL2, run update and repair commands from the same WSL shell where Hermes is installed.
 - Validate the current route and proof status in [docs/reference/hermes-platform-validation.md](../docs/reference/hermes-platform-validation.md).

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -9,6 +9,7 @@ For the stable installer, lifecycle commands, and general troubleshooting, use [
 - Use the normal HA NOVA installer flow.
 - In the setup wizard, choose `OpenCode`.
 - Install the OpenCode client separately; HA NOVA handles the skills and onboarding, not the OpenCode app itself.
+- OpenCode Desktop uses the same skill path as the terminal client: `~/.config/opencode/skills/ha-nova`.
 
 ## Windows Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,12 @@ Work style: Be radically precise. No fluff. Pure information only (drop grammar;
 - Avoid manual `git stash`; if Git auto-stashes during pull/rebase, that’s fine (hint, not hard guardrail).
 - If user types a command (“pull and push”), that’s consent for that command.
 - Big review: `git --no-pager diff --color=never`.
+- **Worktree simplicity:** keep local `main` clean; do not do feature work there.
+- **One topic, one branch:** avoid mixed runtime/docs/release/installer branches unless the behavior truly cannot be separated.
+- **Dirty legacy worktrees are read-only source material:** port changes explicitly into clean branches; do not PR or release directly from them.
+- **README is stable release truth:** do not add future feature claims to `README.md`; keep planned or unreleased claims in active `docs/work/*` notes until release.
+- **Local PR checkpoint:** before creating any PR, show the user `git status --short --branch`, `git diff --stat`, public-claim diffs such as `README.md`, targeted tests run, and remaining risks.
+- **KISS process rule:** prefer fewer rules and fewer files; add process docs/scripts only when they remove a recurring real problem.
 - **Review clearance is commit-specific:** any new relevant delta after the last bot-reviewed commit invalidates prior review clearance.
 - **Relevant delta means:** any code, tests, docs-that-change-behavior, scripts, workflow files, release metadata, installer/update flow, or release notes change that alters the commit to merge or tag.
 - **Push is not review:** a new push never inherits the previous clean review state.
@@ -70,10 +76,12 @@ Work style: Be radically precise. No fluff. Pure information only (drop grammar;
 - **Release/tag/publish gate:** never create/move a release tag, start RC/final publish, or call a commit release-ready unless the exact remote commit state intended for tag/release is represented by the latest fully reviewed PR state with no unreviewed deltas beyond it.
 - **Release-bound review hardening:** do local/self review before opening the PR. After the PR exists, use the fast path only: after each relevant fix, run targeted local verification, push immediately, and trigger `@codex` immediately. After PR creation, Codex bot + CI are the review path; do not add extra local review gates in between.
 - **Manifest-label rule:** if a PR changes `package.json`, `package-lock.json`, `nova/package.json`, or `nova/package-lock.json`, add `manifest-review:approved` immediately after `gh pr create` and before `@codex` / `gh pr checks --watch`.
+- **Manifest-label invalidation rule:** after any later relevant SHA on a manifest-changing PR (push, force-push, rebase, or cherry-pick rewrite), re-apply `manifest-review:approved` on that current PR state before expecting `manifest-review-gate` to pass.
 - **PR Merge / Release Commit Gate — MANDATORY CHECKLIST (do NOT skip any step):**
   The `codex-review-gate` workflow waits ~9 min for the Codex review bot. Bot signals: `eyes` reaction = review in progress, `👍` reaction = no findings, review comments = findings.
   - [ ] 1. `gh pr create ...`
   - [ ] 2. If the PR changes `package.json`, `package-lock.json`, `nova/package.json`, or `nova/package-lock.json`, add the maintainer label immediately: `gh pr edit <nr> --add-label manifest-review:approved`
+  - [ ] 2a. If any later relevant SHA lands on that PR, remove/re-add the label on the latest PR state before re-checking: `gh pr edit <nr> --remove-label manifest-review:approved || true && gh pr edit <nr> --add-label manifest-review:approved`
   - [ ] 3. For the initial PR SHA and for every later relevant SHA: run targeted local verification only, push immediately if needed, then immediately trigger Codex review/re-review: `gh pr comment <nr> --body "@codex"`.
   - [ ] 4. `gh pr checks <nr> --watch` — wait for ALL required checks; for release-bound/high-risk deltas also wait for `codex-review-gate`
   - [ ] 5. Check bot signal across all channels: `gh api repos/<o>/<r>/issues/<nr>/reactions` (👍 = clean), `gh api repos/<o>/<r>/pulls/<nr>/reviews` (PR-level review findings), `gh api repos/<o>/<r>/pulls/<nr>/comments` (inline findings), and issue/discussion comments on the PR.

--- a/cli/auto_repair.go
+++ b/cli/auto_repair.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// autoRepairOutcome describes what auto-repair did for a single client.
+type autoRepairOutcome struct {
+	ClientID    string
+	ClientLabel string
+	Repaired    bool
+	Skipped     bool
+	SkipReason  string
+	Err         error
+}
+
+// attemptClientAutoRepair tries to silently reinstall a client that has
+// drifted out of an attached state. It is idempotent: when nothing needs
+// repair, it returns Skipped=true with no error.
+//
+// Auto-repair is intentionally conservative:
+//   - Skip if the client is already attached (no work needed).
+//   - Skip if the client runtime is missing — the user must install the
+//     client first.
+//   - Skip Claude Code in dev/local marketplace mode — developers handle
+//     their own setup explicitly.
+//   - Skip Claude Code if the `claude` CLI is not on PATH — re-attach
+//     requires it; falling through would surface a confusing error.
+//   - Re-validate Claude state immediately before mutating: the caller's
+//     status may be stale or based on a torn read of Claude's state files
+//     (the session-start hook fires while Claude Code itself is writing
+//     them). Unreadable state never drives a destructive reinstall.
+//
+// Failure to repair is reported but does not abort caller workflows.
+func attemptClientAutoRepair(paths runtimePaths, client clientStatus) autoRepairOutcome {
+	outcome := autoRepairOutcome{ClientID: client.ID, ClientLabel: client.Label}
+
+	if client.Ready {
+		outcome.Skipped = true
+		outcome.SkipReason = "already ready"
+		return outcome
+	}
+	if !client.RuntimeDetected {
+		outcome.Skipped = true
+		outcome.SkipReason = "client runtime not detected"
+		return outcome
+	}
+	if client.Attached {
+		outcome.Skipped = true
+		outcome.SkipReason = "already attached"
+		return outcome
+	}
+
+	state := loadStateOrDefault(paths)
+	if normalizeInstallSource(detectInstallSource(paths, state)) == installSourceDev {
+		outcome.Skipped = true
+		outcome.SkipReason = "dev install mode"
+		return outcome
+	}
+
+	sourceRoot := resolveSourceRoot(paths)
+
+	if client.ID == "claude" {
+		if _, err := exec.LookPath("claude"); err != nil {
+			outcome.Skipped = true
+			outcome.SkipReason = "claude CLI not on PATH"
+			return outcome
+		}
+		snapshot := inspectClaudeInstallSnapshot(paths, state)
+		if snapshot.StateUnreadable {
+			outcome.Skipped = true
+			outcome.SkipReason = "claude plugin state unreadable; skipped destructive repair"
+			return outcome
+		}
+		if snapshot.Attached {
+			outcome.Skipped = true
+			outcome.SkipReason = "already attached"
+			return outcome
+		}
+	}
+
+	if _, err := installClient(paths, sourceRoot, client.ID); err != nil {
+		outcome.Err = fmt.Errorf("auto-repair %s: %w", client.ID, err)
+		return outcome
+	}
+
+	outcome.Repaired = true
+	return outcome
+}
+
+// runClientAutoRepair iterates over configured clients and attempts to
+// repair any whose attachment has drifted. Returns the per-client outcomes.
+//
+// Repairs are serialized across processes: the session-start hook fires one
+// background run per starting client session, and concurrent runs would race
+// on Claude's plugin state files.
+//
+// Callers (typically `ha-nova doctor --auto-repair`) decide how to render
+// the outcomes. The function itself prints nothing.
+func runClientAutoRepair(paths runtimePaths, statuses []clientStatus) []autoRepairOutcome {
+	release, acquired := acquireAutoRepairLock(paths)
+	if !acquired {
+		outcomes := make([]autoRepairOutcome, 0, len(statuses))
+		for _, status := range statuses {
+			outcomes = append(outcomes, autoRepairOutcome{
+				ClientID:    status.ID,
+				ClientLabel: status.Label,
+				Skipped:     true,
+				SkipReason:  "another auto-repair run is in progress",
+			})
+		}
+		return outcomes
+	}
+	defer release()
+
+	outcomes := make([]autoRepairOutcome, 0, len(statuses))
+	for _, status := range statuses {
+		outcomes = append(outcomes, attemptClientAutoRepair(paths, status))
+	}
+	return outcomes
+}

--- a/cli/auto_repair_lock.go
+++ b/cli/auto_repair_lock.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// A lock left behind by a crashed run must not block repair forever; anything
+// older than this is treated as stale and stolen.
+const autoRepairLockStaleAfter = 10 * time.Minute
+
+// acquireAutoRepairLock serializes auto-repair runs across processes (two
+// Claude Code sessions starting at once both fire the session-start hook).
+// Returns a release func and whether the lock was acquired.
+//
+// Lock infrastructure problems fail open: a missing config dir or an
+// unexpected filesystem error must not permanently disable repair, so those
+// cases report acquired with a no-op release. Only a fresh lock held by
+// another run reports not acquired.
+func acquireAutoRepairLock(paths runtimePaths) (func(), bool) {
+	dir := strings.TrimSpace(paths.ConfigDir)
+	if dir == "" {
+		return func() {}, true
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return func() {}, true
+	}
+	lockPath := filepath.Join(dir, "auto-repair.lock")
+	for attempt := 0; attempt < 2; attempt++ {
+		file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			file.Close()
+			return func() { os.Remove(lockPath) }, true
+		}
+		if !os.IsExist(err) {
+			return func() {}, true
+		}
+		info, statErr := os.Stat(lockPath)
+		if statErr != nil {
+			if isNotExist(statErr) {
+				continue
+			}
+			return func() {}, true
+		}
+		if time.Since(info.ModTime()) < autoRepairLockStaleAfter {
+			return func() {}, false
+		}
+		os.Remove(lockPath)
+	}
+	return func() {}, false
+}

--- a/cli/auto_repair_test.go
+++ b/cli/auto_repair_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAttemptClientAutoRepair_SkipsWhenReady(t *testing.T) {
+	client := clientStatus{
+		ID:              "claude",
+		Label:           "Claude Code",
+		SupportedOnOS:   true,
+		RuntimeDetected: true,
+		Attached:        true,
+		Ready:           true,
+	}
+	got := attemptClientAutoRepair(runtimePaths{}, client)
+	if got.Repaired {
+		t.Fatalf("expected no repair, got Repaired=true")
+	}
+	if !got.Skipped {
+		t.Fatalf("expected Skipped=true, got Skipped=false")
+	}
+	if got.Err != nil {
+		t.Fatalf("expected no error, got %v", got.Err)
+	}
+	if !strings.Contains(got.SkipReason, "ready") {
+		t.Fatalf("expected SkipReason to mention 'ready', got %q", got.SkipReason)
+	}
+}
+
+func TestAttemptClientAutoRepair_SkipsWhenRuntimeMissing(t *testing.T) {
+	client := clientStatus{
+		ID:              "claude",
+		Label:           "Claude Code",
+		RuntimeDetected: false,
+	}
+	got := attemptClientAutoRepair(runtimePaths{}, client)
+	if got.Repaired {
+		t.Fatalf("expected no repair, got Repaired=true")
+	}
+	if !got.Skipped {
+		t.Fatalf("expected Skipped=true")
+	}
+	if !strings.Contains(got.SkipReason, "runtime") {
+		t.Fatalf("expected SkipReason to mention 'runtime', got %q", got.SkipReason)
+	}
+}
+
+func TestAttemptClientAutoRepair_SkipsWhenAlreadyAttached(t *testing.T) {
+	client := clientStatus{
+		ID:              "claude",
+		Label:           "Claude Code",
+		RuntimeDetected: true,
+		Attached:        true,
+	}
+	got := attemptClientAutoRepair(runtimePaths{}, client)
+	if got.Repaired {
+		t.Fatalf("expected no repair, got Repaired=true")
+	}
+	if !got.Skipped {
+		t.Fatalf("expected Skipped=true")
+	}
+	if !strings.Contains(got.SkipReason, "attached") {
+		t.Fatalf("expected SkipReason to mention 'attached', got %q", got.SkipReason)
+	}
+}
+
+func TestAttemptClientAutoRepair_SkipsClaudeWhenStateUnreadable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logPath := filepath.Join(t.TempDir(), "claude.log")
+	t.Setenv("PATH", installClaudeMarketplaceMock(t, logPath, "")+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	pluginsDir := filepath.Join(home, ".claude", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	// Simulate a torn write by Claude Code: file exists but is invalid JSON.
+	if err := os.WriteFile(filepath.Join(pluginsDir, "installed_plugins.json"), []byte(`{"plugins": {"ha-nova@ha-`), 0o644); err != nil {
+		t.Fatalf("write torn installed plugins: %v", err)
+	}
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	got := attemptClientAutoRepair(paths, clientStatus{ID: "claude", Label: "Claude Code", RuntimeDetected: true})
+	if !got.Skipped {
+		t.Fatalf("expected Skipped=true, got %+v", got)
+	}
+	if !strings.Contains(got.SkipReason, "unreadable") {
+		t.Fatalf("expected SkipReason to mention 'unreadable', got %q", got.SkipReason)
+	}
+	if got.Err != nil {
+		t.Fatalf("expected no error, got %v", got.Err)
+	}
+	if data, err := os.ReadFile(logPath); err == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("expected no claude CLI invocation for unreadable state, got:\n%s", string(data))
+	}
+}
+
+func TestAttemptClientAutoRepair_SkipsClaudeWhenSnapshotHealthyAtRepairTime(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logPath := filepath.Join(t.TempDir(), "claude.log")
+	t.Setenv("PATH", installClaudeMarketplaceMock(t, logPath, "")+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeInstalledClaudePluginFixture(t, home)
+	if err := os.WriteFile(
+		filepath.Join(home, ".claude", "plugins", "known_marketplaces.json"),
+		[]byte(`{"ha-nova":{"source":"`+strings.ReplaceAll(filepath.Join(home, "marketplace"), `\`, `\\`)+`"}}`),
+		0o644,
+	); err != nil {
+		t.Fatalf("write known marketplaces: %v", err)
+	}
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	// The caller's status claims detached (e.g. computed from a stale read),
+	// but the live snapshot at repair time is healthy.
+	got := attemptClientAutoRepair(paths, clientStatus{ID: "claude", Label: "Claude Code", RuntimeDetected: true})
+	if !got.Skipped {
+		t.Fatalf("expected Skipped=true, got %+v", got)
+	}
+	if !strings.Contains(got.SkipReason, "attached") {
+		t.Fatalf("expected SkipReason to mention 'attached', got %q", got.SkipReason)
+	}
+	if data, err := os.ReadFile(logPath); err == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("expected no claude CLI invocation for healthy state, got:\n%s", string(data))
+	}
+}
+
+func TestRunClientAutoRepair_SkipsWhenLockHeld(t *testing.T) {
+	configDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(configDir, "auto-repair.lock"), nil, 0o600); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+
+	got := runClientAutoRepair(runtimePaths{ConfigDir: configDir}, []clientStatus{
+		{ID: "claude", Label: "Claude Code", Ready: true, RuntimeDetected: true, Attached: true},
+	})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 outcome, got %d", len(got))
+	}
+	if !got[0].Skipped || !strings.Contains(got[0].SkipReason, "in progress") {
+		t.Fatalf("expected lock skip outcome, got %+v", got[0])
+	}
+	if _, err := os.Stat(filepath.Join(configDir, "auto-repair.lock")); err != nil {
+		t.Fatalf("expected foreign lock to stay in place, got %v", err)
+	}
+}
+
+func TestRunClientAutoRepair_StealsStaleLockAndReleases(t *testing.T) {
+	configDir := t.TempDir()
+	lockPath := filepath.Join(configDir, "auto-repair.lock")
+	if err := os.WriteFile(lockPath, nil, 0o600); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+	stale := time.Now().Add(-autoRepairLockStaleAfter - time.Minute)
+	if err := os.Chtimes(lockPath, stale, stale); err != nil {
+		t.Fatalf("age lock: %v", err)
+	}
+
+	got := runClientAutoRepair(runtimePaths{ConfigDir: configDir}, []clientStatus{
+		{ID: "claude", Label: "Claude Code", Ready: true, RuntimeDetected: true, Attached: true},
+	})
+	if len(got) != 1 || !got[0].Skipped || !strings.Contains(got[0].SkipReason, "ready") {
+		t.Fatalf("expected stale lock to be stolen and run to proceed, got %+v", got)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("expected lock to be released after run, got %v", err)
+	}
+}
+
+func TestRunClientAutoRepair_HandlesEmptyList(t *testing.T) {
+	got := runClientAutoRepair(runtimePaths{}, nil)
+	if len(got) != 0 {
+		t.Fatalf("expected empty outcomes, got %d", len(got))
+	}
+}
+
+func TestRunClientAutoRepair_PreservesOrder(t *testing.T) {
+	clients := []clientStatus{
+		{ID: "codex", Label: "Codex CLI", Ready: true, RuntimeDetected: true, Attached: true},
+		{ID: "gemini", Label: "Gemini CLI", Ready: true, RuntimeDetected: true, Attached: true},
+	}
+	got := runClientAutoRepair(runtimePaths{}, clients)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 outcomes, got %d", len(got))
+	}
+	if got[0].ClientID != "codex" || got[1].ClientID != "gemini" {
+		t.Fatalf("expected order codex,gemini; got %s,%s", got[0].ClientID, got[1].ClientID)
+	}
+	for _, oc := range got {
+		if oc.Repaired || oc.Err != nil {
+			t.Fatalf("expected idempotent skip for ready client %s, got %+v", oc.ClientID, oc)
+		}
+	}
+}

--- a/cli/bundle_apply.go
+++ b/cli/bundle_apply.go
@@ -233,6 +233,9 @@ func validateBundleRoot(stageRoot string) error {
 	if _, err := os.Stat(registryPath); err != nil {
 		return fmt.Errorf("client registry missing from staged update")
 	}
+	if err := validateClientRegistryFile(registryPath); err != nil {
+		return err
+	}
 	meta, err := loadBundleMetadataFile(metaPath)
 	if err != nil {
 		return err

--- a/cli/claude_snapshot.go
+++ b/cli/claude_snapshot.go
@@ -15,6 +15,11 @@ type claudeInstallSnapshot struct {
 	UsableInstallPath bool
 	Attached          bool
 	MismatchReason    string
+	// StateUnreadable marks snapshots taken while a Claude state file existed
+	// but could not be read or parsed — e.g. a torn write while Claude Code
+	// itself updates installed_plugins.json. Such snapshots must never drive
+	// destructive repair.
+	StateUnreadable bool
 }
 
 func claudeMarketplaceBaseRoot(paths runtimePaths) string {
@@ -67,11 +72,17 @@ func inspectClaudeInstallSnapshot(paths runtimePaths, state installState) claude
 		snapshot.ExpectedSource = expectedSource
 	}
 	currentSource, hasCurrentSource, err := readClaudeMarketplaceSource(paths.Home)
-	if err == nil && hasCurrentSource {
+	if err != nil {
+		snapshot.StateUnreadable = true
+	} else if hasCurrentSource {
 		snapshot.MarketplaceSource = currentSource
 		snapshot.MarketplaceFound = true
 	}
-	snapshot.PluginFound, snapshot.UsableInstallPath = readClaudePluginInstallSnapshot(paths.Home)
+	var pluginStateUnreadable bool
+	snapshot.PluginFound, snapshot.UsableInstallPath, pluginStateUnreadable = readClaudePluginInstallState(paths.Home)
+	if pluginStateUnreadable {
+		snapshot.StateUnreadable = true
+	}
 
 	switch {
 	case !snapshot.MarketplaceFound:
@@ -89,28 +100,36 @@ func inspectClaudeInstallSnapshot(paths runtimePaths, state installState) claude
 }
 
 func readClaudePluginInstallSnapshot(home string) (bool, bool) {
+	found, usable, _ := readClaudePluginInstallState(home)
+	return found, usable
+}
+
+func readClaudePluginInstallState(home string) (found, usable, stateUnreadable bool) {
 	if strings.TrimSpace(home) == "" {
-		return false, false
+		return false, false, false
 	}
 	data, err := os.ReadFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))
 	if err != nil {
-		return false, false
+		if isNotExist(err) {
+			return false, false, false
+		}
+		return false, false, true
 	}
 	var raw map[string]any
 	if err := unmarshalClaudeJSON(data, &raw); err != nil {
-		return false, false
+		return false, false, true
 	}
-	return claudePluginInstallSnapshotFromValue(raw["plugins"])
+	found, usable = claudePluginInstallSnapshotFromValue(raw["plugins"])
+	return found, usable, false
 }
 
 func claudePluginInstallSnapshotFromValue(value any) (bool, bool) {
 	switch typed := value.(type) {
 	case []any:
-		recordFound := false
+		recordFound := len(typed) > 0
 		usableInstallPath := false
 		for _, entry := range typed {
-			found, usable := claudePluginInstallSnapshotFromValue(entry)
-			recordFound = recordFound || found
+			_, usable := claudePluginInstallSnapshotFromValue(entry)
 			usableInstallPath = usableInstallPath || usable
 		}
 		return recordFound, usableInstallPath

--- a/cli/claude_snapshot.go
+++ b/cli/claude_snapshot.go
@@ -126,10 +126,11 @@ func readClaudePluginInstallState(home string) (found, usable, stateUnreadable b
 func claudePluginInstallSnapshotFromValue(value any) (bool, bool) {
 	switch typed := value.(type) {
 	case []any:
-		recordFound := len(typed) > 0
+		recordFound := false
 		usableInstallPath := false
 		for _, entry := range typed {
-			_, usable := claudePluginInstallSnapshotFromValue(entry)
+			found, usable := claudePluginInstallSnapshotFromValue(entry)
+			recordFound = recordFound || found
 			usableInstallPath = usableInstallPath || usable
 		}
 		return recordFound, usableInstallPath

--- a/cli/claude_snapshot_test.go
+++ b/cli/claude_snapshot_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func TestClaudePluginInstallSnapshotFromValueIgnoresForeignArrayEntries(t *testing.T) {
+	value := []any{
+		map[string]any{
+			"name":        "some-other-plugin@other-marketplace",
+			"installPath": t.TempDir(),
+		},
+	}
+
+	found, usable := claudePluginInstallSnapshotFromValue(value)
+	if found || usable {
+		t.Fatalf("expected foreign array entries to be ignored, got found=%v usable=%v", found, usable)
+	}
+}
+
+func TestClaudePluginInstallSnapshotFromValueFindsHaNovaArrayEntry(t *testing.T) {
+	installPath := t.TempDir()
+	value := []any{
+		map[string]any{
+			"name":        "some-other-plugin@other-marketplace",
+			"installPath": installPath,
+		},
+		map[string]any{
+			"ha-nova@ha-nova": []any{
+				map[string]any{"installPath": installPath},
+			},
+		},
+	}
+
+	found, usable := claudePluginInstallSnapshotFromValue(value)
+	if !found || !usable {
+		t.Fatalf("expected ha-nova array entry to be detected, got found=%v usable=%v", found, usable)
+	}
+}

--- a/cli/client_availability_test.go
+++ b/cli/client_availability_test.go
@@ -3,9 +3,30 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func TestClientRuntimeDetectedFindsUserLocalBin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("user-local executable fallback is Unix-style")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	binDir := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir user local bin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "hermes"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write hermes executable: %v", err)
+	}
+
+	if !clientRuntimeDetected("hermes") {
+		t.Fatal("expected runtime detection to find ~/.local/bin/hermes when PATH omits it")
+	}
+}
 
 func TestBuildSetupClientChoicesDisablesMissingRuntime(t *testing.T) {
 	withClientRuntimeAvailability(t, map[string]bool{})

--- a/cli/client_claude.go
+++ b/cli/client_claude.go
@@ -201,7 +201,7 @@ func removeClaudeMarketplaceRecord(home string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return true, os.WriteFile(path, updated, 0o644)
+	return true, writeFileAtomic(path, updated, 0o644)
 }
 
 func removeClaudePluginRecord(home string) error {
@@ -228,7 +228,7 @@ func removeClaudePluginRecord(home string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, updated, 0o644)
+	return writeFileAtomic(path, updated, 0o644)
 }
 
 func unmarshalClaudeJSON(data []byte, target any) error {

--- a/cli/client_gemini.go
+++ b/cli/client_gemini.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 )
 
-var sameSkillRefPattern = regexp.MustCompile("`skills/([^`/]+)/([^`]+)`")
 var sharedSkillRefPattern = regexp.MustCompile("`skills/([^`]+)`")
 var docsRefPattern = regexp.MustCompile("`docs/reference/([^`]+)`")
 
@@ -147,9 +146,6 @@ func rewriteFlatMarkdown(skillName, content, sourceDir, sourceRoot string, subSk
 		return fmt.Sprintf("`%s`", filepath.Join(sourceRoot, "docs", "reference", parts[1]))
 	})
 	content = sharedSkillRefPattern.ReplaceAllStringFunc(content, func(match string) string {
-		if sameSkillRefPattern.MatchString(match) {
-			return match
-		}
 		parts := sharedSkillRefPattern.FindStringSubmatch(match)
 		return fmt.Sprintf("`%s`", filepath.Join(sourceRoot, "skills", parts[1]))
 	})

--- a/cli/client_hermes.go
+++ b/cli/client_hermes.go
@@ -139,9 +139,6 @@ func rewriteHermesMarkdown(skillName, content, sourceDir, sourceRoot string, sub
 		return fmt.Sprintf("`%s`", filepath.Join(sourceRoot, "docs", "reference", parts[1]))
 	})
 	content = sharedSkillRefPattern.ReplaceAllStringFunc(content, func(match string) string {
-		if sameSkillRefPattern.MatchString(match) {
-			return match
-		}
 		parts := sharedSkillRefPattern.FindStringSubmatch(match)
 		return fmt.Sprintf("`%s`", filepath.Join(sourceRoot, "skills", parts[1]))
 	})

--- a/cli/client_registry.go
+++ b/cli/client_registry.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,14 +9,32 @@ import (
 )
 
 type clientRegistryEntry struct {
-	ID          string   `json:"id"`
-	Label       string   `json:"label"`
-	AdapterKind string   `json:"adapter_kind"`
-	SupportedOS []string `json:"supported_os"`
+	ID          string                      `json:"id"`
+	Label       string                      `json:"label"`
+	AdapterKind string                      `json:"adapter_kind"`
+	SupportedOS []string                    `json:"supported_os"`
+	Setup       clientRegistrySetup         `json:"setup,omitempty"`
+	PerOS       map[string]clientRegistryOS `json:"per_os,omitempty"`
+}
+
+type clientRegistrySetup struct {
+	ServiceCredentials *clientRegistryServiceCredentials `json:"service_credentials,omitempty"`
+}
+
+type clientRegistryServiceCredentials struct {
+	RecommendedWhen []string `json:"recommended_when"`
+	Label           string   `json:"label"`
+	Help            string   `json:"help"`
+	Disabled        bool     `json:"disabled,omitempty"`
+}
+
+type clientRegistryOS struct {
+	Setup *clientRegistrySetup `json:"setup,omitempty"`
 }
 
 type clientRegistryFile struct {
-	Clients []clientRegistryEntry `json:"clients"`
+	RegistryFormatVersion int                   `json:"registry_format_version,omitempty"`
+	Clients               []clientRegistryEntry `json:"clients"`
 }
 
 func loadClientRegistry(paths runtimePaths) ([]clientRegistryEntry, error) {
@@ -28,19 +47,63 @@ func loadClientRegistry(paths runtimePaths) ([]clientRegistryEntry, error) {
 		return nil, err
 	}
 
+	return parseClientRegistry(data)
+}
+
+func parseClientRegistry(data []byte) ([]clientRegistryEntry, error) {
 	var file clientRegistryFile
-	if err := json.Unmarshal(data, &file); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&file); err != nil {
 		return nil, fmt.Errorf("invalid client registry: %w", err)
+	}
+	if file.RegistryFormatVersion != 0 && file.RegistryFormatVersion != 1 {
+		return nil, fmt.Errorf("invalid client registry: unsupported registry_format_version %d", file.RegistryFormatVersion)
 	}
 	if len(file.Clients) == 0 {
 		return nil, fmt.Errorf("invalid client registry: no clients configured")
 	}
+	seen := map[string]bool{}
 	for _, client := range file.Clients {
 		if client.ID == "" || client.Label == "" || client.AdapterKind == "" || len(client.SupportedOS) == 0 {
 			return nil, fmt.Errorf("invalid client registry entry: %+v", client)
 		}
+		if !isKnownClientRegistryAdapter(client.AdapterKind) {
+			return nil, fmt.Errorf("invalid client registry: unknown adapter %q for %s", client.AdapterKind, client.ID)
+		}
+		if seen[client.ID] {
+			return nil, fmt.Errorf("invalid client registry: duplicate client id %q", client.ID)
+		}
+		seen[client.ID] = true
+		for _, osName := range client.SupportedOS {
+			if !isKnownClientRegistryOS(osName) {
+				return nil, fmt.Errorf("invalid client registry: unknown OS %q for %s", osName, client.ID)
+			}
+		}
+		if err := validateClientRegistrySetup(client.ID, client.Setup); err != nil {
+			return nil, err
+		}
+		for osName, override := range client.PerOS {
+			if !isKnownClientRegistryOS(osName) {
+				return nil, fmt.Errorf("invalid client registry: unknown per_os key %q for %s", osName, client.ID)
+			}
+			if override.Setup != nil {
+				if err := validateClientRegistrySetup(client.ID, *override.Setup); err != nil {
+					return nil, err
+				}
+			}
+		}
 	}
 	return file.Clients, nil
+}
+
+func validateClientRegistryFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	_, err = parseClientRegistry(data)
+	return err
 }
 
 func locateClientRegistry(paths runtimePaths) (string, error) {
@@ -76,4 +139,79 @@ func clientSupportedOnCurrentOS(client clientRegistryEntry) bool {
 		}
 	}
 	return false
+}
+
+func isKnownClientRegistryOS(value string) bool {
+	switch value {
+	case "macos", "linux", "windows":
+		return true
+	default:
+		return false
+	}
+}
+
+func isKnownClientRegistryAdapter(value string) bool {
+	switch value {
+	case "skill_tree", "skill_flat", "plugin_marketplace":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateClientRegistrySetup(clientID string, setup clientRegistrySetup) error {
+	if setup.ServiceCredentials == nil {
+		return nil
+	}
+	serviceCredentials := setup.ServiceCredentials
+	if serviceCredentials.Disabled {
+		return nil
+	}
+	if serviceCredentials.Label == "" {
+		return fmt.Errorf("invalid client registry: setup.service_credentials.label missing for %s", clientID)
+	}
+	if serviceCredentials.Help == "" {
+		return fmt.Errorf("invalid client registry: setup.service_credentials.help missing for %s", clientID)
+	}
+	if len(serviceCredentials.RecommendedWhen) == 0 {
+		return fmt.Errorf("invalid client registry: setup.service_credentials.recommended_when missing for %s", clientID)
+	}
+	for _, value := range serviceCredentials.RecommendedWhen {
+		switch value {
+		case "headless", "locked_keyring", "systemd_user_service":
+		default:
+			return fmt.Errorf("invalid client registry: unknown service credential recommendation %q for %s", value, clientID)
+		}
+	}
+	return nil
+}
+
+func clientSetupForCurrentOS(client clientRegistryEntry) clientRegistrySetup {
+	setup := client.Setup
+	if override, ok := client.PerOS[bundlePlatformOS()]; ok && override.Setup != nil {
+		setup = *override.Setup
+	}
+	return setup
+}
+
+func clientSupportsServiceCredentials(client clientRegistryEntry) bool {
+	serviceCredentials := clientSetupForCurrentOS(client).ServiceCredentials
+	return serviceCredentials != nil && !serviceCredentials.Disabled
+}
+
+func selectedClientsSupportServiceCredentials(paths runtimePaths, selectedClients []string) (clientRegistryEntry, bool, error) {
+	clients, err := loadClientRegistry(paths)
+	if err != nil {
+		return clientRegistryEntry{}, false, err
+	}
+	selected := map[string]bool{}
+	for _, client := range selectedClients {
+		selected[client] = true
+	}
+	for _, client := range clients {
+		if selected[client.ID] && clientSupportsServiceCredentials(client) {
+			return client, true, nil
+		}
+	}
+	return clientRegistryEntry{}, false, nil
 }

--- a/cli/client_registry_test.go
+++ b/cli/client_registry_test.go
@@ -34,6 +34,148 @@ func TestLoadClientRegistryRejectsInvalidEntry(t *testing.T) {
 	}
 }
 
+func TestLoadClientRegistryRejectsUnknownSetupCapability(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HA_NOVA_DEV_ROOT", root)
+
+	writeTestRegistry(t, root, `{"clients":[{"id":"hermes","label":"Hermes Agent","adapter_kind":"skill_tree","supported_os":["linux"],"setup":{"magic":true}}]}`)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	if _, err := loadClientRegistry(paths); err == nil {
+		t.Fatal("expected unknown setup capability to fail")
+	}
+}
+
+func TestLoadClientRegistryRejectsUnknownAdapter(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HA_NOVA_DEV_ROOT", root)
+
+	writeTestRegistry(t, root, `{"clients":[{"id":"future","label":"Future Client","adapter_kind":"mystery","supported_os":["linux"]}]}`)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	if _, err := loadClientRegistry(paths); err == nil {
+		t.Fatal("expected unknown adapter to fail")
+	}
+}
+
+func TestLoadClientRegistryValidatesServiceCredentials(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "missing label",
+			body: `{"clients":[{"id":"hermes","label":"Hermes Agent","adapter_kind":"skill_tree","supported_os":["linux"],"setup":{"service_credentials":{"recommended_when":["headless"],"help":"Use for service sessions."}}}]}`,
+		},
+		{
+			name: "invalid recommendation",
+			body: `{"clients":[{"id":"hermes","label":"Hermes Agent","adapter_kind":"skill_tree","supported_os":["linux"],"setup":{"service_credentials":{"recommended_when":["maybe"],"label":"Service mode","help":"Use for service sessions."}}}]}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			t.Setenv("HA_NOVA_DEV_ROOT", root)
+			writeTestRegistry(t, root, tc.body)
+
+			paths, err := detectPaths()
+			if err != nil {
+				t.Fatalf("detectPaths() error: %v", err)
+			}
+
+			if _, err := loadClientRegistry(paths); err == nil {
+				t.Fatal("expected invalid service credentials to fail")
+			}
+		})
+	}
+}
+
+func TestClientServiceCredentialsHonorPerOSDisable(t *testing.T) {
+	client := clientRegistryEntry{
+		ID:          "future",
+		Label:       "Future Client",
+		AdapterKind: "skill_tree",
+		SupportedOS: []string{"macos", "linux", "windows"},
+		Setup: clientRegistrySetup{
+			ServiceCredentials: &clientRegistryServiceCredentials{
+				RecommendedWhen: []string{"headless"},
+				Label:           "Service mode",
+				Help:            "Use for service sessions.",
+			},
+		},
+		PerOS: map[string]clientRegistryOS{
+			bundlePlatformOS(): {
+				Setup: &clientRegistrySetup{
+					ServiceCredentials: &clientRegistryServiceCredentials{Disabled: true},
+				},
+			},
+		},
+	}
+	if clientSupportsServiceCredentials(client) {
+		t.Fatal("expected current OS override to disable service credentials")
+	}
+}
+
+func TestSelectedClientsServiceCredentialHintUsesRegistryMetadata(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HA_NOVA_DEV_ROOT", root)
+
+	writeTestRegistry(t, root, `{"clients":[
+		{"id":"future","label":"Future Client","adapter_kind":"skill_tree","supported_os":["macos","linux","windows"],"setup":{"service_credentials":{"recommended_when":["headless"],"label":"Service mode","help":"Use for service sessions."}}},
+		{"id":"plain","label":"Plain Client","adapter_kind":"skill_tree","supported_os":["macos","linux","windows"]}
+	]}`)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	serviceCredentials, label, ok, err := selectedClientsServiceCredentialHint(paths, []string{"future"})
+	if err != nil {
+		t.Fatalf("selectedClientsServiceCredentialHint() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("expected registry-declared service credentials")
+	}
+	if label != "Future Client" || serviceCredentials.Label != "Service mode" {
+		t.Fatalf("unexpected service credentials: label=%q credentials=%+v", label, serviceCredentials)
+	}
+
+	if _, _, ok, err := selectedClientsServiceCredentialHint(paths, []string{"plain"}); err != nil || ok {
+		t.Fatalf("expected plain client not to advertise service credentials: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestRequireSelectedClientServiceCredentialsUsesRegistryMetadata(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HA_NOVA_DEV_ROOT", root)
+
+	writeTestRegistry(t, root, `{"clients":[
+		{"id":"future","label":"Future Client","adapter_kind":"skill_tree","supported_os":["macos","linux","windows"],"setup":{"service_credentials":{"recommended_when":["headless"],"label":"Service mode","help":"Use for service sessions."}}},
+		{"id":"plain","label":"Plain Client","adapter_kind":"skill_tree","supported_os":["macos","linux","windows"]}
+	]}`)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	if err := requireSelectedClientServiceCredentials(paths, []string{"future"}); err != nil {
+		t.Fatalf("expected fake registry client to support service credentials: %v", err)
+	}
+	if err := requireSelectedClientServiceCredentials(paths, []string{"plain"}); err == nil {
+		t.Fatal("expected fake registry client without capability to fail service credentials")
+	}
+}
+
 func TestClientSupportedOnCurrentOSHonorsRegistryOSList(t *testing.T) {
 	client := clientRegistryEntry{
 		ID:          "future",

--- a/cli/client_status.go
+++ b/cli/client_status.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 type clientStatus struct {
@@ -52,7 +53,25 @@ func clientRuntimeDetected(client string) bool {
 		return false
 	}
 	_, err := exec.LookPath(command)
-	return err == nil
+	if err == nil {
+		return true
+	}
+	return executableInUserLocalBin(command)
+}
+
+func executableInUserLocalBin(command string) bool {
+	if strings.ContainsRune(command, os.PathSeparator) {
+		return false
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(home, ".local", "bin", command))
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
 }
 
 func clientRuntimeCommand(client string) string {
@@ -107,7 +126,7 @@ func configuredClientStatuses(paths runtimePaths, state installState) ([]clientS
 
 func clientStatusReason(client string, status clientStatus) string {
 	if !status.SupportedOnOS {
-		return fmt.Sprintf("not supported on %s", bundlePlatformOS())
+		return clientUnsupportedOSReason(client, bundlePlatformOS())
 	}
 	if status.RuntimeDetected {
 		return ""
@@ -129,6 +148,13 @@ func clientStatusReason(client string, status clientStatus) string {
 	default:
 		return "install this client first"
 	}
+}
+
+func clientUnsupportedOSReason(client, osName string) string {
+	if client == "hermes" && osName == "windows" {
+		return "not supported on native Windows; run HA NOVA setup inside WSL2 instead"
+	}
+	return fmt.Sprintf("not supported on %s", osName)
 }
 
 func fileExists(path string) bool {

--- a/cli/clients_test.go
+++ b/cli/clients_test.go
@@ -699,6 +699,64 @@ func TestRemoveInstalledClientsRemovesBrokenClaudeRecordWhenPluginInstallPathIsG
 	}
 }
 
+func TestRemoveInstalledClientsRemovesHermesSkillTree(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	hermesRoot := filepath.Join(home, ".hermes", "skills", "ha-nova")
+	if err := os.MkdirAll(filepath.Join(hermesRoot, "ha-nova"), 0o755); err != nil {
+		t.Fatalf("mkdir Hermes context skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hermesRoot, "ha-nova", "SKILL.md"), []byte("name: ha-nova"), 0o644); err != nil {
+		t.Fatalf("write Hermes context skill: %v", err)
+	}
+
+	if err := removeInstalledClients(paths, installState{InstalledClients: []string{"hermes"}}); err != nil {
+		t.Fatalf("removeInstalledClients() error: %v", err)
+	}
+	if _, err := os.Stat(hermesRoot); !os.IsNotExist(err) {
+		t.Fatalf("expected Hermes skill tree to be removed, got err=%v", err)
+	}
+}
+
+func TestRemoveInstalledClientsRemovesHermesSkillTreeWhenStateMissesHermes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	hermesRoot := filepath.Join(home, ".hermes", "skills", "ha-nova")
+	if err := os.MkdirAll(filepath.Join(hermesRoot, "ha-nova"), 0o755); err != nil {
+		t.Fatalf("mkdir Hermes context skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hermesRoot, "ha-nova", "SKILL.md"), []byte("name: ha-nova"), 0o644); err != nil {
+		t.Fatalf("write Hermes context skill: %v", err)
+	}
+	for _, skillDir := range hermesLegacyRequiredSkillDirs[1:] {
+		if err := os.MkdirAll(filepath.Join(hermesRoot, skillDir), 0o755); err != nil {
+			t.Fatalf("mkdir legacy Hermes skill %s: %v", skillDir, err)
+		}
+		if err := os.WriteFile(filepath.Join(hermesRoot, skillDir, "SKILL.md"), []byte("name: "+skillDir), 0o644); err != nil {
+			t.Fatalf("write legacy Hermes skill %s: %v", skillDir, err)
+		}
+	}
+
+	if err := removeInstalledClients(paths, installState{InstalledClients: []string{"codex"}}); err != nil {
+		t.Fatalf("removeInstalledClients() error: %v", err)
+	}
+	if _, err := os.Stat(hermesRoot); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy Hermes skill tree to be removed, got err=%v", err)
+	}
+}
+
 func installClaudeMock(t *testing.T, home, logPath string) string {
 	t.Helper()
 
@@ -897,4 +955,15 @@ func writeClaudeMarketplaceRegistrationFixture(t *testing.T, home, source string
 
 func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+func TestClientUnsupportedOSReasonRoutesHermesOnWindowsToWSL2(t *testing.T) {
+	got := clientUnsupportedOSReason("hermes", "windows")
+	if !strings.Contains(got, "WSL2") {
+		t.Fatalf("expected WSL2 routing hint for hermes on windows, got %q", got)
+	}
+
+	if got := clientUnsupportedOSReason("opencode", "windows"); got != "not supported on windows" {
+		t.Fatalf("expected generic unsupported message for opencode, got %q", got)
+	}
 }

--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -12,7 +12,22 @@ import (
 
 var readRelayAuthTokenForDoctor = readRelayAuthToken
 
-func runDoctor(paths runtimePaths, _ []string) int {
+func runDoctor(paths runtimePaths, args []string) int {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	autoRepair := fs.Bool("auto-repair", false, "silently reattach drifted clients before reporting")
+	quiet := fs.Bool("quiet", false, "suppress info lines; only print warnings, errors, and repair actions")
+	if err := fs.Parse(args); err != nil {
+		printHumanErr("%s", err)
+		return 1
+	}
+	doctorInfo := func(format string, parts ...any) {
+		if *quiet {
+			return
+		}
+		printHumanInfo(format, parts...)
+	}
+
 	if recovery := inspectWindowsUninstallStatus(paths); recovery.Kind != windowsUninstallStatusKindNone {
 		switch recovery.Kind {
 		case windowsUninstallStatusKindRunning:
@@ -36,16 +51,19 @@ func runDoctor(paths runtimePaths, _ []string) int {
 	status := 0
 
 	if cfgErr == nil {
-		printHumanInfo("Config present: %s", paths.ConfigFile)
+		doctorInfo("Config present: %s", paths.ConfigFile)
 	} else {
 		printHumanErr("%s", cfgErr)
 		return 1
 	}
 
 	if tokenErr == nil && token != "" {
-		printHumanInfo("Relay auth token present in secure storage")
+		doctorInfo("Relay auth token present in %s", relayAuthTokenStorageLabel())
 	} else {
 		printHumanErr("%s", relayAuthTokenProblemMessage(tokenErr))
+		if hint := doctorServiceCredentialRecoveryHint(paths, state, tokenErr); hint != "" {
+			printHumanWarn("%s", hint)
+		}
 		if hint := setupSecureStorageRecoveryHint(tokenErr); hint != "" {
 			printHumanWarn("%s", hint)
 		}
@@ -56,7 +74,7 @@ func runDoctor(paths runtimePaths, _ []string) int {
 		printHumanErr("Home Assistant unreachable: %s", err)
 		status = 1
 	} else {
-		printHumanInfo("Home Assistant reachable: %s", cfg.HAURL)
+		doctorInfo("Home Assistant reachable: %s", cfg.HAURL)
 	}
 	haReachable := status == 0
 
@@ -65,7 +83,7 @@ func runDoctor(paths runtimePaths, _ []string) int {
 		printHumanErr("Relay health failed: %s", readiness.HealthErr)
 		status = 1
 	} else {
-		printHumanInfo("Relay health reachable: %s/health", cfg.RelayBaseURL)
+		doctorInfo("Relay health reachable: %s/health", cfg.RelayBaseURL)
 		if notice := checkRelayVersion(paths, readiness.HealthBody); !notice.empty() {
 			printHumanNotice(notice)
 			status = 1
@@ -74,9 +92,9 @@ func runDoctor(paths runtimePaths, _ []string) int {
 			switch {
 			case readiness.WSReady:
 				if readiness.UsedWSPing {
-					printHumanInfo("Relay /ws ping succeeded")
+					doctorInfo("Relay /ws ping succeeded")
 				}
-				printHumanInfo("Connected to Home Assistant")
+				doctorInfo("Connected to Home Assistant")
 			case readiness.LLATIssue:
 				printHumanErr("Relay reports degraded upstream WS capability")
 				printHumanErr(`The Home Assistant Access Token field ("ha_llat") in NOVA Relay is missing or invalid`)
@@ -98,11 +116,33 @@ func runDoctor(paths runtimePaths, _ []string) int {
 		printHumanErr("%s", err)
 		status = 1
 	} else if len(clientStatuses) > 0 {
+		if *autoRepair {
+			needsRepair := false
+			for _, c := range clientStatuses {
+				if c.RuntimeDetected && !c.Attached && !c.Ready {
+					needsRepair = true
+					break
+				}
+			}
+			if needsRepair {
+				for _, outcome := range runClientAutoRepair(paths, clientStatuses) {
+					switch {
+					case outcome.Repaired:
+						printHumanInfo("Auto-repaired %s attachment", outcome.ClientLabel)
+					case outcome.Err != nil:
+						printHumanWarn("Auto-repair %s failed: %s", outcome.ClientLabel, outcome.Err)
+					}
+				}
+				if refreshed, refreshErr := configuredClientStatuses(paths, state); refreshErr == nil {
+					clientStatuses = refreshed
+				}
+			}
+		}
 		installSource := detectInstallSource(paths, state)
 		for _, client := range clientStatuses {
 			switch {
 			case client.Ready:
-				printHumanInfo("%s ready now", client.Label)
+				doctorInfo("%s ready now", client.Label)
 			case !client.RuntimeDetected:
 				printHumanWarn("%s configured, but client runtime not detected now", client.Label)
 				printHumanWarn("%s", doctorClientRepairHint(client, installSource))
@@ -122,7 +162,7 @@ func runDoctor(paths runtimePaths, _ []string) int {
 		printHumanNotice(notice)
 	}
 	if status == 0 {
-		printHumanInfo("Doctor checks passed")
+		doctorInfo("Doctor checks passed")
 	}
 	return status
 }

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -60,16 +60,18 @@ func runSetup(paths runtimePaths, args []string) int {
 		}
 	}
 
+	if *serviceMode {
+		if err := requireSelectedClientServiceCredentials(paths, selectedClients); err != nil {
+			printHumanErr("%s", err)
+			return 1
+		}
+	}
 	cfg, err = applySetupFlagOverrides(cfg, *host, *haURL, *relayURL)
 	if err != nil {
 		printHumanErr("%s", err)
 		return 1
 	}
 	if *serviceMode {
-		if err := requireSelectedClientServiceCredentials(paths, selectedClients); err != nil {
-			printHumanErr("%s", err)
-			return 1
-		}
 		cfg = enableServiceRelayTokenFile(paths, cfg)
 		restoreTokenFileOverride := withRelayAuthTokenFileOverride(cfg.RelayTokenFile)
 		defer restoreTokenFileOverride()

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -71,10 +71,16 @@ func runSetup(paths runtimePaths, args []string) int {
 		printHumanErr("%s", err)
 		return 1
 	}
+	formerServiceTokenFile := ""
+	formerServiceToken := ""
 	if *serviceMode {
 		cfg = enableServiceRelayTokenFile(paths, cfg)
 		restoreTokenFileOverride := withRelayAuthTokenFileOverride(cfg.RelayTokenFile)
 		defer restoreTokenFileOverride()
+	} else {
+		var liftTokenFileSuppression func()
+		cfg, formerServiceTokenFile, formerServiceToken, liftTokenFileSuppression = disableServiceRelayTokenFile(paths, cfg)
+		defer liftTokenFileSuppression()
 	}
 	if cfg.HAHost == "" && cfg.HAURL != "" {
 		cfg.HAHost = strings.TrimPrefix(strings.TrimPrefix(cfg.HAURL, "http://"), "https://")
@@ -103,6 +109,10 @@ func runSetup(paths runtimePaths, args []string) int {
 		}
 		if existing, err := readRelayAuthToken(); err == nil {
 			token = existing
+		} else if isMissingRelayAuthTokenError(err) && formerServiceToken != "" {
+			// Returning from service to desktop mode: migrate the token from
+			// the former service token file into the OS keyring.
+			token = formerServiceToken
 		} else if !isMissingRelayAuthTokenError(err) {
 			printHumanErr("%s", relayAuthTokenProblemMessage(err))
 			if hint := setupSecureStorageRecoveryHint(err); hint != "" {
@@ -211,6 +221,7 @@ func runSetup(paths runtimePaths, args []string) int {
 		return 1
 	}
 
+	cleanupFormerServiceTokenFile(formerServiceTokenFile)
 	return runDoctor(paths, nil)
 }
 

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -221,7 +221,7 @@ func runSetup(paths runtimePaths, args []string) int {
 		return 1
 	}
 
-	cleanupFormerServiceTokenFile(formerServiceTokenFile)
+	finalizeServiceTokenFileMigration(formerServiceTokenFile, token)
 	return runDoctor(paths, nil)
 }
 

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -72,14 +72,20 @@ func runSetup(paths runtimePaths, args []string) int {
 		return 1
 	}
 	formerServiceTokenFile := ""
-	formerServiceToken := ""
+	migrationToken := ""
 	if *serviceMode {
+		// Read any already-stored token BEFORE the file override redirects
+		// token reads, so `--service` without --relay-token migrates an
+		// existing desktop-keyring token into the service token file.
+		if existing, err := readRelayAuthToken(); err == nil {
+			migrationToken = strings.TrimSpace(existing)
+		}
 		cfg = enableServiceRelayTokenFile(paths, cfg)
 		restoreTokenFileOverride := withRelayAuthTokenFileOverride(cfg.RelayTokenFile)
 		defer restoreTokenFileOverride()
 	} else {
 		var liftTokenFileSuppression func()
-		cfg, formerServiceTokenFile, formerServiceToken, liftTokenFileSuppression = disableServiceRelayTokenFile(paths, cfg)
+		cfg, formerServiceTokenFile, migrationToken, liftTokenFileSuppression = disableServiceRelayTokenFile(paths, cfg)
 		defer liftTokenFileSuppression()
 	}
 	if cfg.HAHost == "" && cfg.HAURL != "" {
@@ -109,10 +115,10 @@ func runSetup(paths runtimePaths, args []string) int {
 		}
 		if existing, err := readRelayAuthToken(); err == nil {
 			token = existing
-		} else if isMissingRelayAuthTokenError(err) && formerServiceToken != "" {
-			// Returning from service to desktop mode: migrate the token from
-			// the former service token file into the OS keyring.
-			token = formerServiceToken
+		} else if isMissingRelayAuthTokenError(err) && migrationToken != "" {
+			// Mode switch in either direction: migrate the token that was
+			// stored in the previous backend (keyring or service file).
+			token = migrationToken
 		} else if !isMissingRelayAuthTokenError(err) {
 			printHumanErr("%s", relayAuthTokenProblemMessage(err))
 			if hint := setupSecureStorageRecoveryHint(err); hint != "" {

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -26,7 +26,15 @@ func runSetup(paths runtimePaths, args []string) int {
 		target = remaining[0]
 	}
 
-	cfg, _ := loadConfig(paths)
+	cfg, cfgErr := loadConfig(paths)
+	if cfgErr != nil {
+		// Preserve credential routing from an incomplete config: the token
+		// file setting decides where token reads/writes go, so the repair
+		// path must see it even when relay_base_url is missing.
+		if raw, rawErr := loadJSONConfig(paths.ConfigFile); rawErr == nil {
+			cfg.RelayTokenFile = raw.RelayTokenFile
+		}
+	}
 	state, err := loadStateOrDefaultChecked(paths)
 	if err != nil {
 		printHumanErr("%s", err)

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -15,6 +15,7 @@ func runSetup(paths runtimePaths, args []string) int {
 	relayURL := fs.String("relay-url", "", "Relay base URL")
 	relayToken := fs.String("relay-token", "", "Relay auth token")
 	nonInteractive := fs.Bool("non-interactive", false, "Disable prompts")
+	serviceMode := fs.Bool("service", false, "Use a service-safe relay token file instead of desktop secure storage")
 	if err := fs.Parse(normalizeSetupArgs(args)); err != nil {
 		printHumanErr("%s", err)
 		return 1
@@ -33,11 +34,15 @@ func runSetup(paths runtimePaths, args []string) int {
 	}
 
 	if !*nonInteractive {
-		return interactiveSetup(paths, cfg, state, target, *host, *haURL, *relayURL, *relayToken)
+		return interactiveSetup(paths, cfg, state, target, *host, *haURL, *relayURL, *relayToken, *serviceMode)
 	}
 
 	if target == "" {
 		target = "all"
+	}
+	if *serviceMode && target == "all" {
+		printHumanErr("service credentials require a specific client; use: ha-nova setup --service <client>")
+		return 1
 	}
 	selectedClients, skippedClients, err := resolveSetupClientsWithState(paths, target, state)
 	if err != nil {
@@ -60,17 +65,18 @@ func runSetup(paths runtimePaths, args []string) int {
 		printHumanErr("%s", err)
 		return 1
 	}
-	if cfg.HAHost == "" && cfg.HAURL != "" {
-		cfg.HAHost = strings.TrimPrefix(strings.TrimPrefix(cfg.HAURL, "http://"), "https://")
-		cfg.HAHost = strings.TrimSuffix(cfg.HAHost, ":8123")
-	}
-	if cfg.HAHost == "" && !*nonInteractive {
-		answer, err := promptLine("Home Assistant host", cfg.HAHost)
-		if err != nil {
+	if *serviceMode {
+		if err := requireSelectedClientServiceCredentials(paths, selectedClients); err != nil {
 			printHumanErr("%s", err)
 			return 1
 		}
-		cfg.HAHost = strings.TrimSpace(answer)
+		cfg = enableServiceRelayTokenFile(paths, cfg)
+		restoreTokenFileOverride := withRelayAuthTokenFileOverride(cfg.RelayTokenFile)
+		defer restoreTokenFileOverride()
+	}
+	if cfg.HAHost == "" && cfg.HAURL != "" {
+		cfg.HAHost = strings.TrimPrefix(strings.TrimPrefix(cfg.HAURL, "http://"), "https://")
+		cfg.HAHost = strings.TrimSuffix(cfg.HAHost, ":8123")
 	}
 	if cfg.HAHost == "" {
 		printHumanErr("missing Home Assistant host; use --host or run interactively")
@@ -177,14 +183,6 @@ func runSetup(paths runtimePaths, args []string) int {
 	}
 
 	printHumanInfo("Saved HA NOVA configuration")
-	if !*nonInteractive {
-		if err := copyToClipboardForSetup(token); err == nil {
-			printHumanInfo("Copied relay token to clipboard")
-		}
-		if err := openBrowserForSetup(cfg.HAURL + "/hassio/addon/2368fcfa_ha_nova_relay/config"); err != nil {
-			printHumanWarn("Browser launch skipped; open this URL manually if needed: %s/hassio/addon/2368fcfa_ha_nova_relay/config", cfg.HAURL)
-		}
-	}
 
 	_, issue, ok := verifySetupConnectionOnce(os.Stdout, cfg, token)
 	if !ok {
@@ -242,15 +240,31 @@ func restoreRelayAuthToken(previousToken string, hadPreviousToken, tokenChanged 
 }
 
 func normalizeSetupArgs(args []string) []string {
-	if len(args) < 2 {
-		return args
-	}
-	if strings.HasPrefix(args[0], "-") || !isSetupTarget(args[0]) {
-		return args
-	}
-	for _, arg := range args[1:] {
+	targetIndex := -1
+	skipNext := false
+	for index, arg := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
 		if strings.HasPrefix(arg, "-") {
-			return append(append([]string{}, args[1:]...), args[0])
+			if setupFlagRequiresValue(arg) {
+				skipNext = true
+			}
+			continue
+		}
+		if !strings.HasPrefix(arg, "-") {
+			targetIndex = index
+		}
+	}
+	if targetIndex < 0 || targetIndex == len(args)-1 {
+		return args
+	}
+	for _, arg := range args[targetIndex+1:] {
+		if strings.HasPrefix(arg, "-") {
+			normalized := append([]string{}, args[:targetIndex]...)
+			normalized = append(normalized, args[targetIndex+1:]...)
+			return append(normalized, args[targetIndex])
 		}
 	}
 	return args
@@ -259,6 +273,19 @@ func normalizeSetupArgs(args []string) []string {
 func isSetupTarget(value string) bool {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "all", "claude", "codex", "opencode", "gemini", "hermes":
+		return true
+	default:
+		return false
+	}
+}
+
+func setupFlagRequiresValue(arg string) bool {
+	name := strings.TrimLeft(arg, "-")
+	if strings.Contains(name, "=") {
+		return false
+	}
+	switch name {
+	case "host", "ha-url", "relay-url", "relay-token":
 		return true
 	default:
 		return false

--- a/cli/command_uninstall.go
+++ b/cli/command_uninstall.go
@@ -250,6 +250,12 @@ func finalizeLocalUninstall(paths runtimePaths, state installState, report *unin
 }
 
 func finalizeLocalUninstallWithProgress(paths runtimePaths, state installState, report *uninstallReport, mode uninstallMode, beforeStep func(string) error) error {
+	relayTokenFile := ""
+	if mode == uninstallModePurge {
+		if cfg, err := loadConfig(paths); err == nil {
+			relayTokenFile = strings.TrimSpace(cfg.RelayTokenFile)
+		}
+	}
 	if beforeStep != nil {
 		if err := beforeStep("client_integrations"); err != nil {
 			return fmt.Errorf("failed before client_integrations: %w", err)
@@ -295,8 +301,27 @@ func finalizeLocalUninstallWithProgress(paths runtimePaths, state installState, 
 				return fmt.Errorf("failed before token_cleanup: %w", err)
 			}
 		}
-		if err := applyUninstallTokenPolicy(report); err != nil {
-			return fmt.Errorf("failed to remove relay auth token: %w", err)
+		tokenFileHandled := false
+		if relayTokenFile != "" {
+			var err error
+			tokenFileHandled, err = applyUninstallServiceTokenFilePolicy(paths, relayTokenFile, report)
+			if err != nil {
+				return fmt.Errorf("failed to remove relay auth token: %w", err)
+			}
+		}
+		if tokenFileHandled {
+			applyUninstallKeyringTokenBestEffort(report)
+		}
+		if !tokenFileHandled {
+			restoreTokenFileOverride := func() {}
+			if relayTokenFile != "" {
+				restoreTokenFileOverride = withRelayAuthTokenFileOverride(relayTokenFile)
+			}
+			if err := applyUninstallTokenPolicy(report); err != nil {
+				restoreTokenFileOverride()
+				return fmt.Errorf("failed to remove relay auth token: %w", err)
+			}
+			restoreTokenFileOverride()
 		}
 		if err := removeDirIfEmptyWithReport(paths.ConfigDir, report); err != nil {
 			return fmt.Errorf("failed to remove managed config directory: %w", err)

--- a/cli/command_uninstall.go
+++ b/cli/command_uninstall.go
@@ -310,7 +310,9 @@ func finalizeLocalUninstallWithProgress(paths runtimePaths, state installState, 
 			}
 		}
 		if tokenFileHandled {
+			restoreSuppression := withRelayAuthTokenFileSuppressed()
 			applyUninstallKeyringTokenBestEffort(report)
+			restoreSuppression()
 		}
 		if !tokenFileHandled {
 			restoreTokenFileOverride := func() {}

--- a/cli/command_uninstall.go
+++ b/cli/command_uninstall.go
@@ -252,7 +252,10 @@ func finalizeLocalUninstall(paths runtimePaths, state installState, report *unin
 func finalizeLocalUninstallWithProgress(paths runtimePaths, state installState, report *uninstallReport, mode uninstallMode, beforeStep func(string) error) error {
 	relayTokenFile := ""
 	if mode == uninstallModePurge {
-		if cfg, err := loadConfig(paths); err == nil {
+		// Read the raw config: token-file cleanup must not depend on setup
+		// completeness (loadConfig fails when relay_base_url is missing,
+		// which would silently skip service token file removal on purge).
+		if cfg, err := loadJSONConfig(paths.ConfigFile); err == nil {
 			relayTokenFile = strings.TrimSpace(cfg.RelayTokenFile)
 		}
 	}

--- a/cli/command_uninstall.go
+++ b/cli/command_uninstall.go
@@ -318,15 +318,20 @@ func finalizeLocalUninstallWithProgress(paths runtimePaths, state installState, 
 			restoreSuppression()
 		}
 		if !tokenFileHandled {
-			restoreTokenFileOverride := func() {}
+			restoreSuppression := func() {}
 			if relayTokenFile != "" {
-				restoreTokenFileOverride = withRelayAuthTokenFileOverride(relayTokenFile)
+				// The configured token file lies outside the managed config
+				// directory; the boundary check above deliberately left it
+				// alone. Never delete user-managed files — clean only the OS
+				// keyring copy.
+				restoreSuppression = withRelayAuthTokenFileSuppressed()
+				report.addNote(fmt.Sprintf("Kept the relay token file outside the HA NOVA config directory: %s", relayTokenFile))
 			}
 			if err := applyUninstallTokenPolicy(report); err != nil {
-				restoreTokenFileOverride()
+				restoreSuppression()
 				return fmt.Errorf("failed to remove relay auth token: %w", err)
 			}
-			restoreTokenFileOverride()
+			restoreSuppression()
 		}
 		if err := removeDirIfEmptyWithReport(paths.ConfigDir, report); err != nil {
 			return fmt.Errorf("failed to remove managed config directory: %w", err)

--- a/cli/config.go
+++ b/cli/config.go
@@ -7,10 +7,11 @@ import (
 )
 
 type runtimeConfig struct {
-	SchemaVersion int    `json:"schema_version"`
-	HAHost        string `json:"ha_host"`
-	HAURL         string `json:"ha_url"`
-	RelayBaseURL  string `json:"relay_base_url"`
+	SchemaVersion  int    `json:"schema_version"`
+	HAHost         string `json:"ha_host"`
+	HAURL          string `json:"ha_url"`
+	RelayBaseURL   string `json:"relay_base_url"`
+	RelayTokenFile string `json:"relay_token_file,omitempty"`
 }
 
 type config = runtimeConfig

--- a/cli/doctor_test.go
+++ b/cli/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -349,4 +350,188 @@ func captureCommandOutput(t *testing.T, fn func() int) (int, string) {
 	_ = stderrWriter.Close()
 
 	return exitCode, (<-stdoutDone) + (<-stderrDone)
+}
+
+func TestRunDoctorShowsInteractiveRecoveryHintForRecoverableLinuxSecureStorage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(haServer.Close)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := saveConfig(paths, runtimeConfig{
+		HAHost:       normalizeHostInput(haServer.URL),
+		HAURL:        haServer.URL,
+		RelayBaseURL: "http://relay.test:8791",
+	}); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+
+	originalRead := readRelayAuthTokenForDoctor
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	defer func() {
+		readRelayAuthTokenForDoctor = originalRead
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+	}()
+	readRelayAuthTokenForDoctor = func() (string, error) {
+		return "", desktopKeyringLockedError("default Secret Service collection is locked")
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return true, nil
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runDoctor(paths, nil)
+	})
+	if exitCode == 0 {
+		t.Fatalf("expected doctor to fail when secure storage needs recovery:\n%s", output)
+	}
+	if !strings.Contains(output, "Recovery: run `ha-nova setup` interactively to unlock local secure storage on this Linux machine.") {
+		t.Fatalf("expected interactive recovery hint:\n%s", output)
+	}
+}
+
+func TestRunDoctorReportsConfiguredServiceTokenFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(haServer.Close)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	cfg := runtimeConfig{
+		HAHost:         normalizeHostInput(haServer.URL),
+		HAURL:          haServer.URL,
+		RelayBaseURL:   "http://relay.test:8791",
+		RelayTokenFile: defaultRelayAuthTokenFile(paths),
+	}
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := writeRelayAuthTokenFile(cfg.RelayTokenFile, "test-relay-token"); err != nil {
+		t.Fatalf("writeRelayAuthTokenFile() error = %v", err)
+	}
+
+	originalHealth := fetchRelayHealthForReadiness
+	originalWSPing := probeRelayWSPingForReadiness
+	defer func() {
+		fetchRelayHealthForReadiness = originalHealth
+		probeRelayWSPingForReadiness = originalWSPing
+	}()
+	fetchRelayHealthForReadiness = func(relayBaseURL, token string) ([]byte, error) {
+		return []byte(`{"status":"ok","data":{"ha_ws_connected":true},"version":"0.1.12"}`), nil
+	}
+	probeRelayWSPingForReadiness = func(relayBaseURL, token string) (relayWSPingResponse, error) {
+		return relayWSPingResponse{StatusCode: http.StatusOK, Body: []byte(`{"type":"pong"}`)}, nil
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runDoctor(paths, nil)
+	})
+	if exitCode != 0 {
+		t.Fatalf("runDoctor() exit = %d, want 0\n%s", exitCode, output)
+	}
+	if !strings.Contains(output, "Relay auth token present in service token file") {
+		t.Fatalf("expected service-token-file wording:\n%s", output)
+	}
+}
+
+func TestRunDoctorShowsRepairHintForDetachedConfiguredHermes(t *testing.T) {
+	withClientRuntimeAvailability(t, map[string]bool{"hermes": true})
+
+	paths, _ := doctorTestSetup(t)
+	originalHealth := fetchRelayHealthForReadiness
+	originalWSPing := probeRelayWSPingForReadiness
+	defer func() {
+		fetchRelayHealthForReadiness = originalHealth
+		probeRelayWSPingForReadiness = originalWSPing
+	}()
+	fetchRelayHealthForReadiness = func(relayBaseURL, token string) ([]byte, error) {
+		return []byte(`{"status":"ok","data":{"ha_ws_connected":true},"version":"0.1.12"}`), nil
+	}
+	probeRelayWSPingForReadiness = func(relayBaseURL, token string) (relayWSPingResponse, error) {
+		return relayWSPingResponse{StatusCode: http.StatusOK, Body: []byte(`{"type":"pong"}`)}, nil
+	}
+
+	state := loadStateOrDefault(paths)
+	state.InstalledClients = []string{"hermes"}
+	if err := saveState(paths, state); err != nil {
+		t.Fatalf("saveState() error: %v", err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runDoctor(paths, nil)
+	})
+	if exitCode == 0 {
+		t.Fatalf("expected doctor to degrade for detached Hermes:\n%s", output)
+	}
+	if !strings.Contains(output, "Hermes Agent configured, but HA NOVA is not attached") {
+		t.Fatalf("expected detached Hermes warning:\n%s", output)
+	}
+	if !strings.Contains(output, "Repair: run `ha-nova setup hermes`.") {
+		t.Fatalf("expected concrete Hermes repair hint:\n%s", output)
+	}
+}
+
+func TestRunDoctorShowsRepairHintForLegacyHermesBundleWithoutState(t *testing.T) {
+	withClientRuntimeAvailability(t, map[string]bool{"hermes": true})
+
+	paths, _ := doctorTestSetup(t)
+	originalHealth := fetchRelayHealthForReadiness
+	originalWSPing := probeRelayWSPingForReadiness
+	defer func() {
+		fetchRelayHealthForReadiness = originalHealth
+		probeRelayWSPingForReadiness = originalWSPing
+	}()
+	fetchRelayHealthForReadiness = func(relayBaseURL, token string) ([]byte, error) {
+		return []byte(`{"status":"ok","data":{"ha_ws_connected":true},"version":"0.1.12"}`), nil
+	}
+	probeRelayWSPingForReadiness = func(relayBaseURL, token string) (relayWSPingResponse, error) {
+		return relayWSPingResponse{StatusCode: http.StatusOK, Body: []byte(`{"type":"pong"}`)}, nil
+	}
+
+	hermesRoot := filepath.Join(paths.Home, ".hermes", "skills", "ha-nova")
+	if err := os.MkdirAll(filepath.Join(hermesRoot, "ha-nova"), 0o755); err != nil {
+		t.Fatalf("mkdir Hermes context skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hermesRoot, "ha-nova", "SKILL.md"), []byte("name: ha-nova"), 0o644); err != nil {
+		t.Fatalf("write Hermes context skill: %v", err)
+	}
+	for _, skillDir := range hermesLegacyRequiredSkillDirs[1:] {
+		if err := os.MkdirAll(filepath.Join(hermesRoot, skillDir), 0o755); err != nil {
+			t.Fatalf("mkdir legacy Hermes skill %s: %v", skillDir, err)
+		}
+		if err := os.WriteFile(filepath.Join(hermesRoot, skillDir, "SKILL.md"), []byte("name: "+skillDir), 0o644); err != nil {
+			t.Fatalf("write legacy Hermes skill %s: %v", skillDir, err)
+		}
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runDoctor(paths, nil)
+	})
+	if exitCode == 0 {
+		t.Fatalf("expected doctor to degrade for legacy Hermes bundle:\n%s", output)
+	}
+	if !strings.Contains(output, "Hermes Agent configured, but HA NOVA is not attached") {
+		t.Fatalf("expected legacy Hermes warning:\n%s", output)
+	}
+	if !strings.Contains(output, "Repair: run `ha-nova setup hermes`.") {
+		t.Fatalf("expected legacy Hermes repair hint:\n%s", output)
+	}
 }

--- a/cli/gemini_install_test.go
+++ b/cli/gemini_install_test.go
@@ -77,3 +77,40 @@ func TestInstallGeminiClientUsesNamespacedFlatSkillNames(t *testing.T) {
 		t.Fatalf("expected Gemini context skill to rewrite dispatch refs, got %q", string(contextSkill))
 	}
 }
+
+// Matches the bash installer (scripts/onboarding/install-local-skills.sh):
+// same-skill companion refs become bare filenames, every other `skills/...`
+// or `docs/reference/...` ref becomes an absolute path into the source root
+// so the installed flat skill can still reach cross-skill files like agent
+// templates and the jq filter.
+func TestRewriteFlatMarkdownAbsolutizesCrossSkillRefs(t *testing.T) {
+	sourceRoot := t.TempDir()
+	sourceDir := filepath.Join(sourceRoot, "skills", "write")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "patterns.md"), []byte("companion"), 0o644); err != nil {
+		t.Fatalf("write companion: %v", err)
+	}
+
+	content := "Same-skill: `skills/write/patterns.md`. Cross-skill: `skills/review/SKILL.md`.\n" +
+		"Agent template: `skills/ha-nova/agents/apply-agent.md`. Filter: `skills/ha-nova/config-body-filter.jq`.\n" +
+		"Docs: `docs/reference/ha-template-reference.md`.\n"
+
+	got := rewriteFlatMarkdown("write", content, sourceDir, sourceRoot, []string{"write", "review"})
+
+	for _, want := range []string{
+		"`patterns.md`",
+		"`" + filepath.Join(sourceRoot, "skills", "review", "SKILL.md") + "`",
+		"`" + filepath.Join(sourceRoot, "skills", "ha-nova", "agents", "apply-agent.md") + "`",
+		"`" + filepath.Join(sourceRoot, "skills", "ha-nova", "config-body-filter.jq") + "`",
+		"`" + filepath.Join(sourceRoot, "docs", "reference", "ha-template-reference.md") + "`",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected rewritten content to contain %q, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "`skills/") {
+		t.Fatalf("expected no relative skills/ refs to remain, got:\n%s", got)
+	}
+}

--- a/cli/hermes_install_test.go
+++ b/cli/hermes_install_test.go
@@ -112,3 +112,37 @@ func TestInstallHermesClientFailsWhenContextSkillIsMissing(t *testing.T) {
 		t.Fatalf("expected missing Hermes context skill error, got %v", err)
 	}
 }
+
+// Mirror of TestRewriteFlatMarkdownAbsolutizesCrossSkillRefs for the Hermes
+// rewriter: the Go and bash installers must produce the same ref shapes.
+func TestRewriteHermesMarkdownAbsolutizesCrossSkillRefs(t *testing.T) {
+	sourceRoot := t.TempDir()
+	sourceDir := filepath.Join(sourceRoot, "skills", "write")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "patterns.md"), []byte("companion"), 0o644); err != nil {
+		t.Fatalf("write companion: %v", err)
+	}
+
+	content := "Same-skill: `skills/write/patterns.md`. Cross-skill: `skills/review/SKILL.md`.\n" +
+		"Agent template: `skills/ha-nova/agents/apply-agent.md`. Filter: `skills/ha-nova/config-body-filter.jq`.\n" +
+		"Docs: `docs/reference/ha-template-reference.md`.\n"
+
+	got := rewriteHermesMarkdown("write", content, sourceDir, sourceRoot, []string{"write", "review"})
+
+	for _, want := range []string{
+		"`patterns.md`",
+		"`" + filepath.Join(sourceRoot, "skills", "review", "SKILL.md") + "`",
+		"`" + filepath.Join(sourceRoot, "skills", "ha-nova", "agents", "apply-agent.md") + "`",
+		"`" + filepath.Join(sourceRoot, "skills", "ha-nova", "config-body-filter.jq") + "`",
+		"`" + filepath.Join(sourceRoot, "docs", "reference", "ha-template-reference.md") + "`",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected rewritten content to contain %q, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "`skills/") {
+		t.Fatalf("expected no relative skills/ refs to remain, got:\n%s", got)
+	}
+}

--- a/cli/keyring_darwin.go
+++ b/cli/keyring_darwin.go
@@ -19,6 +19,9 @@ func readRelayAuthToken() (string, error) {
 		}
 		return token, nil
 	}
+	if token, overridden, err := readRelayAuthTokenFileOverride(); overridden {
+		return token, err
+	}
 	u, err := user.Current()
 	if err != nil {
 		return "", fmt.Errorf("cannot determine current user: %w", err)
@@ -50,6 +53,9 @@ func writeRelayAuthToken(token string) error {
 		}
 		return nil
 	}
+	if overridden, err := writeRelayAuthTokenFileOverride(token); overridden {
+		return err
+	}
 	u, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("cannot determine current user: %w", err)
@@ -75,6 +81,9 @@ func deleteRelayAuthToken() error {
 			return fmt.Errorf("cannot delete relay auth token: %w", err)
 		}
 		return nil
+	}
+	if overridden, err := deleteRelayAuthTokenFileOverride(); overridden {
+		return err
 	}
 	u, err := user.Current()
 	if err != nil {

--- a/cli/keyring_linux.go
+++ b/cli/keyring_linux.go
@@ -27,6 +27,12 @@ func readRelayAuthToken() (string, error) {
 	if token, overridden, err := readRelayAuthTokenFileOverride(); overridden {
 		return token, err
 	}
+	// Fail fast with the local credential-store class instead of letting
+	// go-keyring hang in a Secret Service unlock prompt (issue #200). The
+	// recovery probe uses the low-level wrappers directly and stays exempt.
+	if err := relayAuthTokenLinuxReadPreflight(); err != nil {
+		return "", relayAuthTokenReadError(relayAuthTokenServiceName(), err)
+	}
 	return readSecretWithService(relayAuthTokenServiceName())
 }
 
@@ -53,6 +59,9 @@ func deleteRelayAuthToken() error {
 	if overridden, err := deleteRelayAuthTokenFileOverride(); overridden {
 		return err
 	}
+	if err := relayAuthTokenLinuxReadPreflight(); err != nil {
+		return err
+	}
 	return deleteSecretWithService(relayAuthTokenServiceName())
 }
 
@@ -65,9 +74,6 @@ func currentKeyringUsername() (string, error) {
 }
 
 func readSecretWithService(service string) (string, error) {
-	if err := relayAuthTokenLinuxReadPreflight(); err != nil {
-		return "", relayAuthTokenReadError(service, err)
-	}
 	username, err := currentKeyringUsername()
 	if err != nil {
 		return "", err
@@ -92,9 +98,6 @@ func writeSecretWithService(service, token string) error {
 }
 
 func deleteSecretWithService(service string) error {
-	if err := relayAuthTokenLinuxReadPreflight(); err != nil {
-		return err
-	}
 	username, err := currentKeyringUsername()
 	if err != nil {
 		return err

--- a/cli/keyring_linux.go
+++ b/cli/keyring_linux.go
@@ -12,6 +12,7 @@ import (
 var keyringGetWithService = keyring.Get
 var keyringSetWithService = keyring.Set
 var keyringDeleteWithService = keyring.Delete
+var inspectLinuxSecureStorageStateForKeyring = inspectLinuxSecureStorageState
 
 func readRelayAuthToken() (string, error) {
 	if token, overridden, err := readRelayAuthTokenOverride(); overridden {
@@ -23,6 +24,9 @@ func readRelayAuthToken() (string, error) {
 		}
 		return token, nil
 	}
+	if token, overridden, err := readRelayAuthTokenFileOverride(); overridden {
+		return token, err
+	}
 	return readSecretWithService(relayAuthTokenServiceName())
 }
 
@@ -33,6 +37,9 @@ func writeRelayAuthToken(token string) error {
 		}
 		return nil
 	}
+	if overridden, err := writeRelayAuthTokenFileOverride(token); overridden {
+		return err
+	}
 	return writeSecretWithService(relayAuthTokenServiceName(), token)
 }
 
@@ -42,6 +49,9 @@ func deleteRelayAuthToken() error {
 			return fmt.Errorf("cannot delete relay auth token: %w", err)
 		}
 		return nil
+	}
+	if overridden, err := deleteRelayAuthTokenFileOverride(); overridden {
+		return err
 	}
 	return deleteSecretWithService(relayAuthTokenServiceName())
 }
@@ -55,6 +65,9 @@ func currentKeyringUsername() (string, error) {
 }
 
 func readSecretWithService(service string) (string, error) {
+	if err := relayAuthTokenLinuxReadPreflight(); err != nil {
+		return "", relayAuthTokenReadError(service, err)
+	}
 	username, err := currentKeyringUsername()
 	if err != nil {
 		return "", err
@@ -79,6 +92,9 @@ func writeSecretWithService(service, token string) error {
 }
 
 func deleteSecretWithService(service string) error {
+	if err := relayAuthTokenLinuxReadPreflight(); err != nil {
+		return err
+	}
 	username, err := currentKeyringUsername()
 	if err != nil {
 		return err
@@ -87,4 +103,19 @@ func deleteSecretWithService(service string) error {
 		return normalizeLinuxKeyringError(err)
 	}
 	return nil
+}
+
+func relayAuthTokenLinuxReadPreflight() error {
+	state, err := inspectLinuxSecureStorageStateForKeyring()
+	if err != nil {
+		return err
+	}
+	switch state.kind {
+	case linuxSecureStorageStateNeedsInit:
+		return desktopKeyringInitializationRequiredError("no default Secret Service collection configured")
+	case linuxSecureStorageStateLocked:
+		return desktopKeyringLockedError("default Secret Service collection is locked")
+	default:
+		return nil
+	}
 }

--- a/cli/keyring_linux_test.go
+++ b/cli/keyring_linux_test.go
@@ -9,7 +9,8 @@ import (
 	"github.com/zalando/go-keyring"
 )
 
-func TestReadSecretWithServiceStopsBeforeKeyringWhenLinuxStorageLocked(t *testing.T) {
+func TestReadRelayAuthTokenStopsBeforeKeyringWhenLinuxStorageLocked(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	originalInspect := inspectLinuxSecureStorageStateForKeyring
 	originalGet := keyringGetWithService
 	defer func() {
@@ -21,17 +22,19 @@ func TestReadSecretWithServiceStopsBeforeKeyringWhenLinuxStorageLocked(t *testin
 		return linuxSecureStorageState{kind: linuxSecureStorageStateLocked}, nil
 	}
 	keyringGetWithService = func(service, username string) (string, error) {
-		t.Fatal("readSecretWithService called go-keyring even though the default collection is locked")
+		t.Fatal("readRelayAuthToken called go-keyring even though the default collection is locked")
 		return "", keyring.ErrNotFound
 	}
 
-	_, err := readSecretWithService("ha-nova.test")
+	_, err := readRelayAuthToken()
 	if !isDesktopKeyringLockedError(err) {
 		t.Fatalf("expected locked keyring classification, got %v", err)
 	}
 }
 
-func TestReadSecretWithServiceUsesKeyringWhenLinuxStorageWritable(t *testing.T) {
+// The secure-storage recovery probe stubs the keyring vars and must reach
+// them directly: the low-level wrapper stays preflight-free by contract.
+func TestReadSecretWithServiceBypassesPreflight(t *testing.T) {
 	originalInspect := inspectLinuxSecureStorageStateForKeyring
 	originalGet := keyringGetWithService
 	defer func() {
@@ -40,7 +43,8 @@ func TestReadSecretWithServiceUsesKeyringWhenLinuxStorageWritable(t *testing.T) 
 	}()
 
 	inspectLinuxSecureStorageStateForKeyring = func() (linuxSecureStorageState, error) {
-		return linuxSecureStorageState{kind: linuxSecureStorageStateWritable}, nil
+		t.Fatal("readSecretWithService must not run the preflight; the recovery probe depends on direct keyring access")
+		return linuxSecureStorageState{}, nil
 	}
 	keyringGetWithService = func(service, username string) (string, error) {
 		return "relay-token", nil
@@ -55,7 +59,8 @@ func TestReadSecretWithServiceUsesKeyringWhenLinuxStorageWritable(t *testing.T) 
 	}
 }
 
-func TestReadSecretWithServiceClassifiesLinuxStorageInspectionErrors(t *testing.T) {
+func TestReadRelayAuthTokenClassifiesLinuxStorageInspectionErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	originalInspect := inspectLinuxSecureStorageStateForKeyring
 	originalGet := keyringGetWithService
 	defer func() {
@@ -67,11 +72,11 @@ func TestReadSecretWithServiceClassifiesLinuxStorageInspectionErrors(t *testing.
 		return linuxSecureStorageState{}, desktopKeyringUnavailableError("Secret Service preflight timed out")
 	}
 	keyringGetWithService = func(service, username string) (string, error) {
-		t.Fatal("readSecretWithService called go-keyring after preflight failure")
+		t.Fatal("readRelayAuthToken called go-keyring after preflight failure")
 		return "", errors.New("unreachable")
 	}
 
-	_, err := readSecretWithService("ha-nova.test")
+	_, err := readRelayAuthToken()
 	if !isDesktopKeyringUnavailableError(err) {
 		t.Fatalf("expected unavailable keyring classification, got %v", err)
 	}

--- a/cli/keyring_linux_test.go
+++ b/cli/keyring_linux_test.go
@@ -1,0 +1,78 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+func TestReadSecretWithServiceStopsBeforeKeyringWhenLinuxStorageLocked(t *testing.T) {
+	originalInspect := inspectLinuxSecureStorageStateForKeyring
+	originalGet := keyringGetWithService
+	defer func() {
+		inspectLinuxSecureStorageStateForKeyring = originalInspect
+		keyringGetWithService = originalGet
+	}()
+
+	inspectLinuxSecureStorageStateForKeyring = func() (linuxSecureStorageState, error) {
+		return linuxSecureStorageState{kind: linuxSecureStorageStateLocked}, nil
+	}
+	keyringGetWithService = func(service, username string) (string, error) {
+		t.Fatal("readSecretWithService called go-keyring even though the default collection is locked")
+		return "", keyring.ErrNotFound
+	}
+
+	_, err := readSecretWithService("ha-nova.test")
+	if !isDesktopKeyringLockedError(err) {
+		t.Fatalf("expected locked keyring classification, got %v", err)
+	}
+}
+
+func TestReadSecretWithServiceUsesKeyringWhenLinuxStorageWritable(t *testing.T) {
+	originalInspect := inspectLinuxSecureStorageStateForKeyring
+	originalGet := keyringGetWithService
+	defer func() {
+		inspectLinuxSecureStorageStateForKeyring = originalInspect
+		keyringGetWithService = originalGet
+	}()
+
+	inspectLinuxSecureStorageStateForKeyring = func() (linuxSecureStorageState, error) {
+		return linuxSecureStorageState{kind: linuxSecureStorageStateWritable}, nil
+	}
+	keyringGetWithService = func(service, username string) (string, error) {
+		return "relay-token", nil
+	}
+
+	token, err := readSecretWithService("ha-nova.test")
+	if err != nil {
+		t.Fatalf("readSecretWithService() error = %v", err)
+	}
+	if token != "relay-token" {
+		t.Fatalf("token = %q, want relay-token", token)
+	}
+}
+
+func TestReadSecretWithServiceClassifiesLinuxStorageInspectionErrors(t *testing.T) {
+	originalInspect := inspectLinuxSecureStorageStateForKeyring
+	originalGet := keyringGetWithService
+	defer func() {
+		inspectLinuxSecureStorageStateForKeyring = originalInspect
+		keyringGetWithService = originalGet
+	}()
+
+	inspectLinuxSecureStorageStateForKeyring = func() (linuxSecureStorageState, error) {
+		return linuxSecureStorageState{}, desktopKeyringUnavailableError("Secret Service preflight timed out")
+	}
+	keyringGetWithService = func(service, username string) (string, error) {
+		t.Fatal("readSecretWithService called go-keyring after preflight failure")
+		return "", errors.New("unreachable")
+	}
+
+	_, err := readSecretWithService("ha-nova.test")
+	if !isDesktopKeyringUnavailableError(err) {
+		t.Fatalf("expected unavailable keyring classification, got %v", err)
+	}
+}

--- a/cli/keyring_preflight.go
+++ b/cli/keyring_preflight.go
@@ -7,5 +7,8 @@ func relayAuthTokenSetupPreflight() error {
 	if relayAuthTokenTestFile() != "" {
 		return nil
 	}
+	if relayAuthTokenFileEnabled() {
+		return nil
+	}
 	return relayAuthTokenPlatformSetupPreflight()
 }

--- a/cli/keyring_service.go
+++ b/cli/keyring_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -15,6 +16,11 @@ var errDesktopKeyringUnavailable = errors.New("desktop keyring unavailable")
 var errDesktopKeyringSetupRequired = errors.New("desktop keyring setup required")
 var errDesktopKeyringLocked = errors.New("desktop keyring locked")
 var errDesktopKeyringInitializationRequired = errors.New("desktop keyring initialization required")
+var errRelayAuthTokenFileInvalid = errors.New("relay token file invalid")
+var errRelayTokenStorageConfigUnreadable = errors.New("relay token storage config unreadable")
+
+var relayAuthTokenFilePathOverride string
+var relayAuthTokenFilePlatformOS = runtime.GOOS
 
 func relayAuthTokenServiceName() string {
 	if override := strings.TrimSpace(os.Getenv("HA_NOVA_KEYRING_SERVICE")); override != "" {
@@ -46,6 +52,174 @@ func readRelayAuthTokenOverride() (string, bool, error) {
 		return "", true, err
 	}
 	return strings.TrimSpace(string(data)), true, nil
+}
+
+func relayAuthTokenFileServiceName(path string) string {
+	return "service token file " + path
+}
+
+func defaultRelayAuthTokenFile(paths runtimePaths) string {
+	return filepath.Join(paths.ConfigDir, "relay-token")
+}
+
+func relayAuthTokenFilePathFromConfig() (string, bool, error) {
+	if relayAuthTokenFilePathOverride != "" {
+		return relayAuthTokenFilePathOverride, true, nil
+	}
+	paths, err := detectPaths()
+	if err != nil {
+		return "", false, err
+	}
+	// Read the raw config instead of loadConfig: token storage must not
+	// depend on relay_base_url being set, and an unreadable config must
+	// fail loud instead of silently falling back to the OS keyring — on
+	// headless Linux that fallback can hang in Secret Service unlock
+	// prompts even though a token file is configured (issue #200).
+	cfg, err := loadJSONConfig(paths.ConfigFile)
+	if err != nil {
+		if isNotExist(err) {
+			return "", false, nil
+		}
+		return "", true, fmt.Errorf("%w: %v (fix or remove the config file, or rerun: ha-nova setup)", errRelayTokenStorageConfigUnreadable, err)
+	}
+	path := strings.TrimSpace(cfg.RelayTokenFile)
+	if path == "" {
+		return "", false, nil
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(paths.ConfigDir, path)
+	}
+	return filepath.Clean(path), true, nil
+}
+
+func readRelayAuthTokenFile(path string) (string, error) {
+	if err := validateRelayAuthTokenFile(path); err != nil {
+		if isNotExist(err) {
+			return "", missingRelayAuthTokenError(relayAuthTokenFileServiceName(path))
+		}
+		return "", relayAuthTokenReadError(relayAuthTokenFileServiceName(path), err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", relayAuthTokenReadError(relayAuthTokenFileServiceName(path), err)
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return "", relayAuthTokenReadError(relayAuthTokenFileServiceName(path), fmt.Errorf("%w: empty file", errRelayAuthTokenFileInvalid))
+	}
+	return token, nil
+}
+
+func writeRelayAuthTokenFile(path, token string) error {
+	if relayAuthTokenFilePlatformOS == "windows" {
+		return fmt.Errorf("cannot write relay auth token: %w: service token files are not supported on native Windows", errRelayAuthTokenFileInvalid)
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return fmt.Errorf("cannot write relay auth token: %w: empty token", errRelayAuthTokenFileInvalid)
+	}
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return fmt.Errorf("cannot write relay auth token: %w", err)
+	}
+	if err := hardenRelayAuthTokenFileParent(parent); err != nil {
+		return fmt.Errorf("cannot write relay auth token: %w", err)
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("cannot write relay auth token: %w: symlink not allowed", errRelayAuthTokenFileInvalid)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("cannot write relay auth token: %w: not a regular file", errRelayAuthTokenFileInvalid)
+		}
+		if err := validateRelayAuthTokenFile(path); err != nil {
+			return fmt.Errorf("cannot write relay auth token: %w", err)
+		}
+	} else if !isNotExist(err) {
+		return fmt.Errorf("cannot write relay auth token: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
+		return fmt.Errorf("cannot write relay auth token: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("cannot write relay auth token: %w", err)
+	}
+	return nil
+}
+
+func deleteRelayAuthTokenFile(path string) error {
+	if err := os.Remove(path); err != nil && !isNotExist(err) {
+		return fmt.Errorf("cannot delete relay auth token: %w", err)
+	}
+	return nil
+}
+
+func validateRelayAuthTokenFile(path string) error {
+	if relayAuthTokenFilePlatformOS == "windows" {
+		return fmt.Errorf("%w: service token files are not supported on native Windows", errRelayAuthTokenFileInvalid)
+	}
+	parent := filepath.Dir(path)
+	if err := validateRelayAuthTokenFileParent(parent); err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: symlink not allowed", errRelayAuthTokenFileInvalid)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: not a regular file", errRelayAuthTokenFileInvalid)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("%w: permissions must be 0600 or stricter", errRelayAuthTokenFileInvalid)
+	}
+	if err := validateRelayAuthTokenFileOwner(info); err != nil {
+		return err
+	}
+	return nil
+}
+
+func hardenRelayAuthTokenFileParent(parent string) error {
+	info, err := os.Stat(parent)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%w: parent is not a directory", errRelayAuthTokenFileInvalid)
+	}
+	if err := validateRelayAuthTokenFileOwner(info); err != nil {
+		return err
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		if err := os.Chmod(parent, 0o700); err != nil {
+			return err
+		}
+	}
+	return validateRelayAuthTokenFileParent(parent)
+}
+
+func validateRelayAuthTokenFileParent(parent string) error {
+	info, err := os.Stat(parent)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%w: parent is not a directory", errRelayAuthTokenFileInvalid)
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return fmt.Errorf("%w: parent directory must not be group/world writable", errRelayAuthTokenFileInvalid)
+	}
+	if err := validateRelayAuthTokenFileOwner(info); err != nil {
+		return err
+	}
+	return nil
+}
+
+func relayAuthTokenFileEnabled() bool {
+	_, ok, err := relayAuthTokenFilePathFromConfig()
+	return ok && err == nil
 }
 
 func missingRelayAuthTokenError(service string) error {
@@ -109,6 +283,9 @@ func relayAuthTokenProblemMessage(err error) string {
 	}
 	if isDesktopKeyringSetupRequiredError(err) {
 		return "secure storage is present but not ready on this Linux machine; rerun `ha-nova setup` interactively to finish local secure storage setup"
+	}
+	if errors.Is(err, errRelayAuthTokenFileInvalid) {
+		return fmt.Sprintf("service token file is not usable: %s", err)
 	}
 	return fmt.Sprintf("relay auth token unavailable: %s", err)
 }
@@ -287,6 +464,46 @@ func writeRelayAuthTokenOverride(token string) (bool, error) {
 		return true, err
 	}
 	return true, os.WriteFile(path, []byte(token), 0o600)
+}
+
+func readRelayAuthTokenFileOverride() (string, bool, error) {
+	path, ok, err := relayAuthTokenFilePathFromConfig()
+	if err != nil || !ok {
+		return "", ok, err
+	}
+	token, err := readRelayAuthTokenFile(path)
+	return token, true, err
+}
+
+func writeRelayAuthTokenFileOverride(token string) (bool, error) {
+	path, ok, err := relayAuthTokenFilePathFromConfig()
+	if errors.Is(err, errRelayTokenStorageConfigUnreadable) {
+		// Setup rewrites the config anyway; an unreadable config must not
+		// block the repair path, only reads fail loud.
+		return false, nil
+	}
+	if err != nil || !ok {
+		return ok, err
+	}
+	return true, writeRelayAuthTokenFile(path, token)
+}
+
+func deleteRelayAuthTokenFileOverride() (bool, error) {
+	path, ok, err := relayAuthTokenFilePathFromConfig()
+	if errors.Is(err, errRelayTokenStorageConfigUnreadable) {
+		return false, nil
+	}
+	if err != nil || !ok {
+		return ok, err
+	}
+	return true, deleteRelayAuthTokenFile(path)
+}
+
+func relayAuthTokenStorageLabel() string {
+	if path, ok, err := relayAuthTokenFilePathFromConfig(); err == nil && ok {
+		return relayAuthTokenFileServiceName(path)
+	}
+	return "secure storage"
 }
 
 func deleteRelayAuthTokenOverride() (bool, error) {

--- a/cli/keyring_service.go
+++ b/cli/keyring_service.go
@@ -74,9 +74,6 @@ func defaultRelayAuthTokenFile(paths runtimePaths) string {
 }
 
 func relayAuthTokenFilePathFromConfig() (string, bool, error) {
-	if relayAuthTokenFileSuppressed {
-		return "", false, nil
-	}
 	if relayAuthTokenFilePathOverride != "" {
 		path := relayAuthTokenFilePathOverride
 		if !filepath.IsAbs(path) {
@@ -87,6 +84,9 @@ func relayAuthTokenFilePathFromConfig() (string, bool, error) {
 			path = filepath.Join(paths.ConfigDir, path)
 		}
 		return filepath.Clean(path), true, nil
+	}
+	if relayAuthTokenFileSuppressed {
+		return "", false, nil
 	}
 	paths, err := detectPaths()
 	if err != nil {

--- a/cli/keyring_service.go
+++ b/cli/keyring_service.go
@@ -78,7 +78,15 @@ func relayAuthTokenFilePathFromConfig() (string, bool, error) {
 		return "", false, nil
 	}
 	if relayAuthTokenFilePathOverride != "" {
-		return relayAuthTokenFilePathOverride, true, nil
+		path := relayAuthTokenFilePathOverride
+		if !filepath.IsAbs(path) {
+			paths, err := detectPaths()
+			if err != nil {
+				return "", false, err
+			}
+			path = filepath.Join(paths.ConfigDir, path)
+		}
+		return filepath.Clean(path), true, nil
 	}
 	paths, err := detectPaths()
 	if err != nil {

--- a/cli/keyring_service.go
+++ b/cli/keyring_service.go
@@ -20,7 +20,18 @@ var errRelayAuthTokenFileInvalid = errors.New("relay token file invalid")
 var errRelayTokenStorageConfigUnreadable = errors.New("relay token storage config unreadable")
 
 var relayAuthTokenFilePathOverride string
+var relayAuthTokenFileSuppressed bool
 var relayAuthTokenFilePlatformOS = runtime.GOOS
+
+// withRelayAuthTokenFileSuppressed routes token reads/deletes to the OS
+// credential store even when the config references a token file. Purge uses
+// it after the token file was already removed so a leftover desktop-mode
+// keyring entry still gets cleaned up.
+func withRelayAuthTokenFileSuppressed() func() {
+	previous := relayAuthTokenFileSuppressed
+	relayAuthTokenFileSuppressed = true
+	return func() { relayAuthTokenFileSuppressed = previous }
+}
 
 func relayAuthTokenServiceName() string {
 	if override := strings.TrimSpace(os.Getenv("HA_NOVA_KEYRING_SERVICE")); override != "" {
@@ -63,6 +74,9 @@ func defaultRelayAuthTokenFile(paths runtimePaths) string {
 }
 
 func relayAuthTokenFilePathFromConfig() (string, bool, error) {
+	if relayAuthTokenFileSuppressed {
+		return "", false, nil
+	}
 	if relayAuthTokenFilePathOverride != "" {
 		return relayAuthTokenFilePathOverride, true, nil
 	}

--- a/cli/keyring_service_test.go
+++ b/cli/keyring_service_test.go
@@ -367,3 +367,28 @@ func TestRelayTokenStorageHonorsTokenFileWithoutRelayBaseURL(t *testing.T) {
 		t.Fatalf("unexpected token %q", token)
 	}
 }
+
+func TestRelayAuthTokenFileSuppressionRoutesToKeyring(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := os.MkdirAll(paths.ConfigDir, 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`{"relay_token_file":"relay-token"}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if _, ok, err := relayAuthTokenFilePathFromConfig(); !ok || err != nil {
+		t.Fatalf("expected token file to be configured, got ok=%v err=%v", ok, err)
+	}
+
+	restore := withRelayAuthTokenFileSuppressed()
+	defer restore()
+	if path, ok, err := relayAuthTokenFilePathFromConfig(); ok || err != nil || path != "" {
+		t.Fatalf("expected suppression to report no token file, got path=%q ok=%v err=%v", path, ok, err)
+	}
+}

--- a/cli/keyring_service_test.go
+++ b/cli/keyring_service_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -43,7 +45,325 @@ func TestRelayAuthTokenProblemMessageDifferentiatesMissingAndUnavailable(t *test
 	if got := relayAuthTokenProblemMessage(missingRelayAuthTokenError("ha-nova.relay-auth-token")); got != "relay auth token missing; run: ha-nova setup" {
 		t.Fatalf("missing-token message = %q", got)
 	}
+	if got := relayAuthTokenProblemMessage(errors.New("dbus: couldn't determine address of session bus")); got != "secure storage unavailable in this Linux session; run HA NOVA from a terminal inside the Linux desktop session on this machine, and then run: ha-nova setup" {
+		t.Fatalf("secret-service-session-unavailable message = %q", got)
+	}
+	if got := relayAuthTokenProblemMessage(errors.New("exec: \"dbus-launch\": executable file not found in $PATH")); got != "secure storage unavailable in this Linux session; run HA NOVA from a terminal inside the Linux desktop session on this machine, and then run: ha-nova setup" {
+		t.Fatalf("secret-service-dbus-launch-missing message = %q", got)
+	}
+	if got := relayAuthTokenProblemMessage(errors.New("The name org.freedesktop.secrets was not provided by any .service files")); got != "secure storage unavailable on this Linux machine; start a Secret Service provider (for example GNOME Keyring or KWallet Secrets) and then run: ha-nova setup" {
+		t.Fatalf("secret-service-unavailable message = %q", got)
+	}
+	if got := relayAuthTokenProblemMessage(errors.New("Secret Service preflight timed out")); got != "secure storage unavailable on this Linux machine; start a Secret Service provider (for example GNOME Keyring or KWallet Secrets) and then run: ha-nova setup" {
+		t.Fatalf("secret-service-timeout message = %q", got)
+	}
+	if got := relayAuthTokenProblemMessage(errors.New("org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.secrets was not provided by any .service files")); got != "secure storage unavailable on this Linux machine; start a Secret Service provider (for example GNOME Keyring or KWallet Secrets) and then run: ha-nova setup" {
+		t.Fatalf("secret-service-serviceunknown message = %q", got)
+	}
+	lockedWant := "secure storage is present but locked on this Linux machine; unlock the default keyring and then run: ha-nova setup"
+	if got := relayAuthTokenProblemMessage(desktopKeyringLockedError("default Secret Service collection is locked")); got != lockedWant {
+		t.Fatalf("secret-service-locked message = %q", got)
+	}
+	initWant := "secure storage is present but not initialized on this Linux machine; initialize the default keyring and then run: ha-nova setup"
+	if got := relayAuthTokenProblemMessage(errors.New("Object does not exist at path \"/org/freedesktop/secrets/collection/login\"")); got != initWant {
+		t.Fatalf("secret-service-login-missing message = %q", got)
+	}
+	if got := relayAuthTokenProblemMessage(errors.New("no such secret collection")); got != initWant {
+		t.Fatalf("secret-service-no-collection message = %q", got)
+	}
+	if got := relayAuthTokenProblemMessage(errors.New("no default Secret Service collection configured")); got != initWant {
+		t.Fatalf("secret-service-no-default message = %q", got)
+	}
 	if got := relayAuthTokenProblemMessage(errors.New("keychain locked")); got != "relay auth token unavailable: keychain locked" {
 		t.Fatalf("unavailable-token message = %q", got)
+	}
+}
+
+func TestRelayAuthTokenSetupPreflightSkipsPlatformCheckForInsecureTestOverride(t *testing.T) {
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(t.TempDir(), ".test-relay-auth-token"))
+
+	originalPlatformPreflight := relayAuthTokenPlatformSetupPreflight
+	defer func() {
+		relayAuthTokenPlatformSetupPreflight = originalPlatformPreflight
+	}()
+	relayAuthTokenPlatformSetupPreflight = func() error {
+		t.Fatal("did not expect platform keyring preflight when insecure test override is enabled")
+		return nil
+	}
+
+	if err := relayAuthTokenSetupPreflight(); err != nil {
+		t.Fatalf("relayAuthTokenSetupPreflight() error = %v", err)
+	}
+}
+
+func TestRelayAuthTokenSetupSaveErrorExplainsDesktopKeyringUnavailable(t *testing.T) {
+	err := relayAuthTokenSetupSaveError(errors.New("The name org.freedesktop.secrets was not provided by any .service files"))
+	want := "cannot save relay token: secure storage unavailable on this Linux machine. Start a Secret Service provider (for example GNOME Keyring or KWallet Secrets) and rerun `ha-nova setup`"
+	if err == nil || err.Error() != want {
+		t.Fatalf("relayAuthTokenSetupSaveError() = %v, want %q", err, want)
+	}
+}
+
+func TestRelayAuthTokenSetupSaveErrorExplainsLinuxSessionBusMissing(t *testing.T) {
+	err := relayAuthTokenSetupSaveError(errors.New("dbus: couldn't determine address of session bus"))
+	want := "cannot save relay token: secure storage unavailable in this Linux session. Run HA NOVA from a terminal inside the Linux desktop session on this machine, and rerun `ha-nova setup`"
+	if err == nil || err.Error() != want {
+		t.Fatalf("relayAuthTokenSetupSaveError() = %v, want %q", err, want)
+	}
+}
+
+func TestRelayAuthTokenSetupSaveErrorExplainsLinuxKeyringInitialization(t *testing.T) {
+	err := relayAuthTokenSetupSaveError(errors.New("no default Secret Service collection configured"))
+	want := "cannot save relay token: secure storage is present but not initialized on this Linux machine. Initialize the default keyring and rerun `ha-nova setup`"
+	if err == nil || err.Error() != want {
+		t.Fatalf("relayAuthTokenSetupSaveError() = %v, want %q", err, want)
+	}
+}
+
+func TestRelayAuthTokenSetupSaveErrorExplainsLinuxKeyringLocked(t *testing.T) {
+	err := relayAuthTokenSetupSaveError(desktopKeyringLockedError("default Secret Service collection is locked"))
+	want := "cannot save relay token: secure storage is present but locked on this Linux machine. Unlock the default keyring and rerun `ha-nova setup`"
+	if err == nil || err.Error() != want {
+		t.Fatalf("relayAuthTokenSetupSaveError() = %v, want %q", err, want)
+	}
+}
+
+func TestRelayAuthTokenFileRoundTrip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	path := filepath.Join(t.TempDir(), "ha-nova", "relay-token")
+
+	if err := writeRelayAuthTokenFile(path, "secret-token"); err != nil {
+		t.Fatalf("writeRelayAuthTokenFile() error = %v", err)
+	}
+	token, err := readRelayAuthTokenFile(path)
+	if err != nil {
+		t.Fatalf("readRelayAuthTokenFile() error = %v", err)
+	}
+	if token != "secret-token" {
+		t.Fatalf("token = %q, want secret-token", token)
+	}
+}
+
+func TestRelayAuthTokenUsesConfiguredServiceFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	cfg := runtimeConfig{
+		HAHost:         "192.168.1.5",
+		HAURL:          "http://192.168.1.5:8123",
+		RelayBaseURL:   "http://192.168.1.5:8791",
+		RelayTokenFile: defaultRelayAuthTokenFile(paths),
+	}
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatalf("saveConfig() error = %v", err)
+	}
+
+	if err := writeRelayAuthToken("service-token"); err != nil {
+		t.Fatalf("writeRelayAuthToken() error = %v", err)
+	}
+	token, err := readRelayAuthToken()
+	if err != nil {
+		t.Fatalf("readRelayAuthToken() error = %v", err)
+	}
+	if token != "service-token" {
+		t.Fatalf("token = %q, want service-token", token)
+	}
+	if _, err := os.Stat(cfg.RelayTokenFile); err != nil {
+		t.Fatalf("expected service token file: %v", err)
+	}
+}
+
+func TestRelayAuthTokenFileRejectsUnsafePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "relay-token")
+	if err := os.WriteFile(path, []byte("secret-token"), 0o644); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	_, err := readRelayAuthTokenFile(path)
+	if err == nil || !strings.Contains(err.Error(), "permissions must be 0600 or stricter") {
+		t.Fatalf("expected permission error, got %v", err)
+	}
+	if err := writeRelayAuthTokenFile(path, "new-secret-token"); err == nil || !strings.Contains(err.Error(), "permissions must be 0600 or stricter") {
+		t.Fatalf("expected write to reject unsafe existing file, got %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read token file: %v", err)
+	}
+	if strings.Contains(string(data), "new-secret-token") {
+		t.Fatalf("write leaked token into unsafe existing file")
+	}
+}
+
+func TestRelayAuthTokenFileWriteHardensUnsafeOwnedParentPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	dir := filepath.Join(t.TempDir(), "ha-nova")
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		t.Fatalf("mkdir token dir: %v", err)
+	}
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatalf("chmod token dir: %v", err)
+	}
+
+	path := filepath.Join(dir, "relay-token")
+	if err := writeRelayAuthTokenFile(path, "secret-token"); err != nil {
+		t.Fatalf("writeRelayAuthTokenFile() error = %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat token dir: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("expected parent directory to be hardened, mode=%o", info.Mode().Perm())
+	}
+	token, err := readRelayAuthTokenFile(path)
+	if err != nil {
+		t.Fatalf("readRelayAuthTokenFile() error = %v", err)
+	}
+	if token != "secret-token" {
+		t.Fatalf("token = %q, want secret-token", token)
+	}
+}
+
+func TestRelayAuthTokenFileRejectsNativeWindowsBeforeWrite(t *testing.T) {
+	originalPlatform := relayAuthTokenFilePlatformOS
+	defer func() {
+		relayAuthTokenFilePlatformOS = originalPlatform
+	}()
+	relayAuthTokenFilePlatformOS = "windows"
+
+	path := filepath.Join(t.TempDir(), "relay-token")
+	err := writeRelayAuthTokenFile(path, "secret-token")
+	if err == nil || !strings.Contains(err.Error(), "service token files are not supported on native Windows") {
+		t.Fatalf("expected native Windows rejection, got %v", err)
+	}
+	if _, err := os.Stat(path); !isNotExist(err) {
+		t.Fatalf("expected token file not to be written on native Windows, err=%v", err)
+	}
+}
+
+func TestRelayAuthTokenFileRejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target-token")
+	link := filepath.Join(dir, "relay-token")
+	if err := os.WriteFile(target, []byte("secret-token"), 0o600); err != nil {
+		t.Fatalf("write target token: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	_, err := readRelayAuthTokenFile(link)
+	if err == nil || !strings.Contains(err.Error(), "symlink not allowed") {
+		t.Fatalf("expected symlink error, got %v", err)
+	}
+}
+
+func TestRelayAuthTokenFileRejectsEmptyTokenWithoutLeakingSecret(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	path := filepath.Join(t.TempDir(), "relay-token")
+	if err := os.WriteFile(path, []byte("\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	_, err := readRelayAuthTokenFile(path)
+	if err == nil || !strings.Contains(err.Error(), "empty file") {
+		t.Fatalf("expected empty-token error, got %v", err)
+	}
+	if strings.Contains(relayAuthTokenProblemMessage(err), "secret-token") {
+		t.Fatalf("problem message leaked token: %s", relayAuthTokenProblemMessage(err))
+	}
+}
+
+func TestRelayTokenStorageReadsFailLoudWhenConfigUnreadable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := os.MkdirAll(paths.ConfigDir, 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write corrupt config: %v", err)
+	}
+
+	// Reads must fail loud instead of silently falling back to the OS
+	// keyring (issue #200: that fallback can hang on headless Linux).
+	_, overridden, err := readRelayAuthTokenFileOverride()
+	if !overridden {
+		t.Fatalf("expected unreadable config to be handled by the token-file path, got overridden=false")
+	}
+	if !errors.Is(err, errRelayTokenStorageConfigUnreadable) {
+		t.Fatalf("expected config-unreadable error, got %v", err)
+	}
+
+	// Writes and deletes fall back to the platform keystore so that
+	// `ha-nova setup` can still repair an unreadable config.
+	if handled, err := writeRelayAuthTokenFileOverride("token"); handled || err != nil {
+		t.Fatalf("expected write to skip the token-file path, got handled=%v err=%v", handled, err)
+	}
+	if handled, err := deleteRelayAuthTokenFileOverride(); handled || err != nil {
+		t.Fatalf("expected delete to skip the token-file path, got handled=%v err=%v", handled, err)
+	}
+
+	// A missing config keeps the normal keyring fallback for reads.
+	if err := os.Remove(paths.ConfigFile); err != nil {
+		t.Fatalf("remove config: %v", err)
+	}
+	if _, overridden, err := readRelayAuthTokenFileOverride(); overridden || err != nil {
+		t.Fatalf("expected missing config to fall back to keyring, got overridden=%v err=%v", overridden, err)
+	}
+}
+
+func TestRelayTokenStorageHonorsTokenFileWithoutRelayBaseURL(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := os.MkdirAll(paths.ConfigDir, 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	tokenPath := filepath.Join(paths.ConfigDir, "relay-token")
+	if err := writeRelayAuthTokenFile(tokenPath, "configured-token"); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`{"relay_token_file":"relay-token"}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	token, overridden, err := readRelayAuthTokenFileOverride()
+	if !overridden || err != nil {
+		t.Fatalf("expected token file to be honored, got overridden=%v err=%v", overridden, err)
+	}
+	if token != "configured-token" {
+		t.Fatalf("unexpected token %q", token)
 	}
 }

--- a/cli/keyring_token_file_unix.go
+++ b/cli/keyring_token_file_unix.go
@@ -1,0 +1,30 @@
+//go:build darwin || linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+func validateRelayAuthTokenFileOwner(info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("%w: cannot inspect owner", errRelayAuthTokenFileInvalid)
+	}
+	current, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("%w: cannot determine current user", errRelayAuthTokenFileInvalid)
+	}
+	uid, err := strconv.ParseUint(current.Uid, 10, 32)
+	if err != nil {
+		return fmt.Errorf("%w: cannot parse current user", errRelayAuthTokenFileInvalid)
+	}
+	if stat.Uid != uint32(uid) {
+		return fmt.Errorf("%w: file must be owned by the current user", errRelayAuthTokenFileInvalid)
+	}
+	return nil
+}

--- a/cli/keyring_token_file_windows.go
+++ b/cli/keyring_token_file_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func validateRelayAuthTokenFileOwner(_ os.FileInfo) error {
+	return nil
+}

--- a/cli/keyring_windows.go
+++ b/cli/keyring_windows.go
@@ -22,6 +22,9 @@ func readRelayAuthToken() (string, error) {
 		}
 		return token, nil
 	}
+	if token, overridden, err := readRelayAuthTokenFileOverride(); overridden {
+		return token, err
+	}
 	u, err := user.Current()
 	if err != nil {
 		return "", fmt.Errorf("cannot determine current user: %w", err)
@@ -60,6 +63,9 @@ func writeRelayAuthToken(token string) error {
 		}
 		return nil
 	}
+	if overridden, err := writeRelayAuthTokenFileOverride(token); overridden {
+		return err
+	}
 	u, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("cannot determine current user: %w", err)
@@ -76,6 +82,9 @@ func deleteRelayAuthToken() error {
 			return fmt.Errorf("cannot delete relay auth token: %w", err)
 		}
 		return nil
+	}
+	if overridden, err := deleteRelayAuthTokenFileOverride(); overridden {
+		return err
 	}
 	u, err := user.Current()
 	if err != nil {

--- a/cli/main.go
+++ b/cli/main.go
@@ -64,6 +64,7 @@ func printUsage() {
 	fmt.Fprintln(os.Stdout, "")
 	fmt.Fprintln(os.Stdout, "Usage:")
 	fmt.Fprintln(os.Stdout, "  ha-nova setup [client]")
+	fmt.Fprintln(os.Stdout, "  ha-nova setup --service [client]")
 	fmt.Fprintln(os.Stdout, "  ha-nova doctor")
 	fmt.Fprintln(os.Stdout, "  ha-nova check-update [--quiet] [--json]")
 	fmt.Fprintln(os.Stdout, "  ha-nova update [--version <tag>]")

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -300,3 +300,21 @@ func TestNormalizeSetupArgsMovesTargetAfterFlags(t *testing.T) {
 		t.Fatalf("normalizeSetupArgs() = %v, want %v", got, want)
 	}
 }
+
+func TestNormalizeSetupArgsMovesFutureRegistryTargetAfterFlags(t *testing.T) {
+	got := normalizeSetupArgs([]string{
+		"future-client",
+		"--service",
+		"--host", "127.0.0.1",
+	})
+
+	want := []string{
+		"--service",
+		"--host", "127.0.0.1",
+		"future-client",
+	}
+
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("normalizeSetupArgs() = %v, want %v", got, want)
+	}
+}

--- a/cli/release_test.go
+++ b/cli/release_test.go
@@ -308,7 +308,6 @@ func TestRunCheckUpdateJSONOffersStableReturnFromRC(t *testing.T) {
 	}
 }
 
-
 func TestRunCheckUpdateTextModeUsesSingleFetch(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cli/setup_discovery.go
+++ b/cli/setup_discovery.go
@@ -17,8 +17,8 @@ var collectARPHostsForDiscovery = collectARPHosts
 var runMDNSBrowseForDiscovery = runMDNSBrowse
 var runMDNSLookupForDiscovery = runMDNSLookup
 var mdnsAvailableForDiscovery = defaultMDNSDiscoveryAvailable
-var setupDiscoveryOverallTimeout = 20 * time.Second
 var setupDiscoveryPlatformOS = runtime.GOOS
+var setupDiscoveryOverallTimeout = 20 * time.Second
 
 func detectDefaultHAHost(cfg runtimeConfig) string {
 	host, _ := detectDefaultHAHostChoice(cfg)
@@ -40,15 +40,6 @@ func detectDefaultHAHostChoice(cfg runtimeConfig) (string, bool) {
 		}
 	}
 	return preferredUnverifiedHAHost(cfg), false
-}
-
-func preferredUnverifiedHAHost(cfg runtimeConfig) string {
-	for _, candidate := range []string{cfg.HAHost, cfg.HAURL, cfg.RelayBaseURL} {
-		if host := normalizeHostInput(candidate); host != "" {
-			return host
-		}
-	}
-	return ""
 }
 
 func collectCandidateHosts(cfg runtimeConfig) []string {
@@ -78,6 +69,15 @@ func collectCandidateHosts(cfg runtimeConfig) []string {
 	}
 
 	return candidates
+}
+
+func preferredUnverifiedHAHost(cfg runtimeConfig) string {
+	for _, candidate := range []string{cfg.HAHost, cfg.HAURL, cfg.RelayBaseURL} {
+		if host := normalizeHostInput(candidate); host != "" {
+			return host
+		}
+	}
+	return ""
 }
 
 func discoverHAViaMDNS() string {

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -648,7 +648,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				printHumanErr("cannot save state: %s", err)
 				return 1
 			}
-			cleanupFormerServiceTokenFile(formerServiceTokenFile)
+			finalizeServiceTokenFileMigration(formerServiceTokenFile, token)
 			renderSetupCompleteBanner(os.Stdout, selectedClients)
 			return 0
 		}

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -220,15 +220,16 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 		printHumanErr("%s", relayAuthTokenSetupSaveError(tokenStoragePreflightErr))
 		return 1
 	}
-	if !hadSavedTokenBeforeSetup && formerServiceToken != "" {
-		// Returning from service to desktop mode: offer the token from the
-		// former service token file so the user does not have to re-paste it.
-		savedTokenBeforeSetup = formerServiceToken
-		hadSavedTokenBeforeSetup = true
-	}
-
 	if existingToken == "" {
 		existingToken = savedTokenBeforeSetup
+	}
+	if existingToken == "" && !hadSavedTokenBeforeSetup && formerServiceToken != "" {
+		// Returning from service to desktop mode: prefill the token from the
+		// former service token file so the user does not have to re-paste it,
+		// but deliberately do NOT mark it as a previously stored token —
+		// persistence must treat it as new and write it into the OS keyring
+		// before the saved config stops referencing the token file.
+		existingToken = formerServiceToken
 	}
 
 	overrideApplied := strings.TrimSpace(hostFlag) != "" || strings.TrimSpace(haURLFlag) != "" || strings.TrimSpace(relayURLFlag) != ""

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -91,7 +91,7 @@ func maskSecretHint(value string) string {
 	return "***" + value[len(value)-4:]
 }
 
-func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState, target string, hostFlag, haURLFlag, relayURLFlag, relayTokenFlag string) int {
+func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState, target string, hostFlag, haURLFlag, relayURLFlag, relayTokenFlag string, serviceMode bool) int {
 	const (
 		setupStageClient = iota
 		setupStageSecureStorageRecovery
@@ -153,7 +153,49 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 		}
 	}
 
+	restoreTokenFileOverride := func() {}
+	defer func() {
+		restoreTokenFileOverride()
+	}()
+	if serviceMode {
+		if target == "all" {
+			printHumanErr("service credentials require a specific client; use: ha-nova setup --service <client>")
+			return 1
+		}
+		if err := requireSelectedClientServiceCredentials(paths, selectedClients); err != nil {
+			printHumanErr("%s", err)
+			return 1
+		}
+		cfg = enableServiceRelayTokenFile(paths, cfg)
+		restoreTokenFileOverride = withRelayAuthTokenFileOverride(cfg.RelayTokenFile)
+	}
+
 	tokenStoragePreflightErr = relayAuthTokenSetupPreflightForSetup()
+	if !serviceMode {
+		serviceCredentials, serviceClientID, hasServiceCredentials, serviceErr := selectedClientsServiceCredentialHint(paths, selectedClients)
+		if serviceErr != nil {
+			printHumanErr("%s", serviceErr)
+			return 1
+		}
+		if hasServiceCredentials && shouldOfferServiceCredentials(tokenStoragePreflightErr) {
+			useServiceCredentials, err := promptSetupServiceCredentialsInteractive(reader, os.Stdout, serviceCredentials, serviceClientID)
+			if err == errSetupExit {
+				printHumanInfo("Setup cancelled")
+				return 0
+			}
+			if err != nil {
+				printHumanErr("%s", err)
+				return 1
+			}
+			if useServiceCredentials {
+				serviceMode = true
+				restoreTokenFileOverride()
+				cfg = enableServiceRelayTokenFile(paths, cfg)
+				restoreTokenFileOverride = withRelayAuthTokenFileOverride(cfg.RelayTokenFile)
+				tokenStoragePreflightErr = relayAuthTokenSetupPreflightForSetup()
+			}
+		}
+	}
 	if tokenStoragePreflightErr == nil {
 		if savedToken, err := readRelayAuthTokenForSetup(); err == nil && strings.TrimSpace(savedToken) != "" {
 			savedTokenBeforeSetup = strings.TrimSpace(savedToken)

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -173,6 +173,12 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			printHumanErr("%s", err)
 			return 1
 		}
+		// Read any already-stored token BEFORE the file override redirects
+		// token reads, so an existing desktop-keyring token can be offered
+		// for migration into the service token file.
+		if existing, err := readRelayAuthToken(); err == nil {
+			formerServiceToken = strings.TrimSpace(existing)
+		}
 		cfg = enableServiceRelayTokenFile(paths, cfg)
 		restoreTokenFileOverride = withRelayAuthTokenFileOverride(cfg.RelayTokenFile)
 	}

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -178,7 +178,10 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 	}
 
 	tokenStoragePreflightErr = relayAuthTokenSetupPreflightForSetup()
-	if !serviceMode {
+	// Service credentials stay a client-scoped deployment decision: only
+	// offer the mid-flow switch for a specific target, mirroring the
+	// explicit `--service all` rejection above.
+	if !serviceMode && target != "all" {
 		serviceCredentials, serviceClientID, hasServiceCredentials, serviceErr := selectedClientsServiceCredentialHint(paths, selectedClients)
 		if serviceErr != nil {
 			printHumanErr("%s", serviceErr)

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -157,6 +157,13 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 	defer func() {
 		restoreTokenFileOverride()
 	}()
+	formerServiceTokenFile := ""
+	formerServiceToken := ""
+	if !serviceMode {
+		var liftTokenFileSuppression func()
+		cfg, formerServiceTokenFile, formerServiceToken, liftTokenFileSuppression = disableServiceRelayTokenFile(paths, cfg)
+		defer liftTokenFileSuppression()
+	}
 	if serviceMode {
 		if target == "all" {
 			printHumanErr("service credentials require a specific client; use: ha-nova setup --service <client>")
@@ -189,6 +196,8 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			}
 			if useServiceCredentials {
 				serviceMode = true
+				formerServiceTokenFile = ""
+				formerServiceToken = ""
 				restoreTokenFileOverride()
 				cfg = enableServiceRelayTokenFile(paths, cfg)
 				restoreTokenFileOverride = withRelayAuthTokenFileOverride(cfg.RelayTokenFile)
@@ -210,6 +219,12 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 		printRelayTokenStorageSetupWarning(tokenStoragePreflightErr)
 		printHumanErr("%s", relayAuthTokenSetupSaveError(tokenStoragePreflightErr))
 		return 1
+	}
+	if !hadSavedTokenBeforeSetup && formerServiceToken != "" {
+		// Returning from service to desktop mode: offer the token from the
+		// former service token file so the user does not have to re-paste it.
+		savedTokenBeforeSetup = formerServiceToken
+		hadSavedTokenBeforeSetup = true
 	}
 
 	if existingToken == "" {
@@ -633,6 +648,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				printHumanErr("cannot save state: %s", err)
 				return 1
 			}
+			cleanupFormerServiceTokenFile(formerServiceTokenFile)
 			renderSetupCompleteBanner(os.Stdout, selectedClients)
 			return 0
 		}

--- a/cli/setup_interactive_test.go
+++ b/cli/setup_interactive_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -71,7 +72,7 @@ func TestInteractiveSetupFreshInstallShowsWizardAndInstallsGeminiSkills(t *testi
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -83,6 +84,7 @@ func TestInteractiveSetupFreshInstallShowsWizardAndInstallsGeminiSkills(t *testi
 		"Which AI client do you use?",
 		"1) Claude Code",
 		"4) Gemini CLI",
+		"5) Hermes Agent",
 		"Discovering Home Assistant on your network...",
 		"I'll open your browser to add the HA NOVA repository.",
 		"Once the repository is added:",
@@ -160,6 +162,161 @@ func TestInteractiveSetupFreshInstallShowsWizardAndInstallsGeminiSkills(t *testi
 	}
 }
 
+func TestInteractiveSetupFreshInstallCanTargetHermes(t *testing.T) {
+	withClientRuntimeAvailability(t, map[string]bool{"hermes": true})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	defer relayServer.Close()
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	input := joinSetupInputs(
+		[]string{"5", haServer.URL},
+		setupWizardRelayInstallPrompts(),
+		setupWizardGenerateRelayTokenPrompts(),
+		setupWizardLLATPrompts(),
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	for _, want := range []string{
+		"5) Hermes Agent",
+		"Setting up HA NOVA for Hermes Agent...",
+		"Installed for: Hermes Agent",
+		"Setup complete!",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("wizard output missing %q:\n%s", want, output)
+		}
+	}
+
+	for _, skillDir := range hermesRequiredSkillDirs {
+		skillPath := filepath.Join(home, ".hermes", "skills", "ha-nova", skillDir, "SKILL.md")
+		if _, err := os.Stat(skillPath); err != nil {
+			t.Fatalf("expected Hermes skill %s to exist at %s: %v", skillDir, skillPath, err)
+		}
+	}
+}
+
+func TestInteractiveSetupOffersServiceCredentialsForHermesWhenKeyringLocked(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	withClientRuntimeAvailability(t, map[string]bool{"hermes": true})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	defer relayServer.Close()
+
+	originalPreflight := relayAuthTokenSetupPreflightForSetup
+	defer func() {
+		relayAuthTokenSetupPreflightForSetup = originalPreflight
+	}()
+	relayAuthTokenSetupPreflightForSetup = func() error {
+		if relayAuthTokenFilePathOverride != "" {
+			return nil
+		}
+		return desktopKeyringLockedError("default keyring is locked")
+	}
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	input := joinSetupInputs(
+		[]string{"5", "y", haServer.URL},
+		setupWizardRelayInstallPrompts(),
+		setupWizardGenerateRelayTokenPrompts(),
+		setupWizardLLATPrompts(),
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	for _, want := range []string{
+		"Service / gateway mode is available for Hermes Agent.",
+		"Choose yes for SSH, systemd, headless, or gateway sessions. Choose no for a normal desktop terminal with an unlocked keyring.",
+		"Use service/gateway token file instead of desktop keyring?",
+		"Setting up HA NOVA for Hermes Agent...",
+		"Setup complete!",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("wizard output missing %q:\n%s", want, output)
+		}
+	}
+
+	saved, err := loadRuntimeConfig(paths)
+	if err != nil {
+		t.Fatalf("loadRuntimeConfig() error: %v", err)
+	}
+	if saved.RelayTokenFile != defaultRelayAuthTokenFile(paths) {
+		t.Fatalf("RelayTokenFile = %q, want %q", saved.RelayTokenFile, defaultRelayAuthTokenFile(paths))
+	}
+	token, err := readRelayAuthTokenFile(saved.RelayTokenFile)
+	if err != nil {
+		t.Fatalf("readRelayAuthTokenFile() error: %v", err)
+	}
+	if strings.TrimSpace(token) == "" {
+		t.Fatal("expected service token file to contain the generated relay token")
+	}
+}
+
 func TestInteractiveSetupFreshInstallCanPasteExistingRelayToken(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -199,7 +356,7 @@ func TestInteractiveSetupFreshInstallCanPasteExistingRelayToken(t *testing.T) {
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -260,7 +417,7 @@ func TestInteractiveSetupFreshInstallPastedTokenSkipsLLATWalkthroughWhenVerifySu
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -290,6 +447,194 @@ func TestInteractiveSetupFreshInstallPastedTokenSkipsLLATWalkthroughWhenVerifySu
 	}
 	if strings.Contains(output, "automations\n\n\n  Existing relay token found:") {
 		t.Fatalf("expected single-gap spacing before reuse-token note:\n%s", output)
+	}
+}
+
+func TestInteractiveSetupFailsEarlyWhenLinuxKeyringPreflightFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	defer relayServer.Close()
+
+	originalPreflight := relayAuthTokenSetupPreflightForSetup
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	defer func() {
+		relayAuthTokenSetupPreflightForSetup = originalPreflight
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+	}()
+	relayAuthTokenSetupPreflightForSetup = func() error {
+		return desktopKeyringSetupRequiredError("no default Secret Service collection configured")
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return false, nil
+	}
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	input := joinSetupInputs(
+		[]string{"4", haServer.URL},
+		setupWizardRelayInstallPrompts(),
+		setupWizardGenerateRelayTokenPrompts(),
+		setupWizardLLATPrompts(),
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
+		return exitCode
+	})
+	if exitCode != 1 {
+		t.Fatalf("interactiveSetup() exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	if !strings.Contains(output, "secure storage is present but not initialized on this Linux machine") {
+		t.Fatalf("expected keyring guidance in output:\n%s", output)
+	}
+	if strings.Contains(output, "Step 1 of 5") {
+		t.Fatalf("expected setup to stop before relay install walkthrough:\n%s", output)
+	}
+	if _, err := os.Stat(paths.ConfigFile); !isNotExist(err) {
+		t.Fatalf("expected config not to be written after preflight failure, err=%v", err)
+	}
+	if _, err := os.Stat(paths.StateFile); !isNotExist(err) {
+		t.Fatalf("expected state not to be written after preflight failure, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token")); !isNotExist(err) {
+		t.Fatalf("expected token file not to be written after preflight failure, err=%v", err)
+	}
+}
+
+func TestInteractiveSetupRecoversSecureStorageBeforeHostStep(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	defer relayServer.Close()
+
+	originalPreflight := relayAuthTokenSetupPreflightForSetup
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	originalReadSecret := readSetupSecretInputForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		relayAuthTokenSetupPreflightForSetup = originalPreflight
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+		readSetupSecretInputForSetup = originalReadSecret
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	preflightCalls := 0
+	relayAuthTokenSetupPreflightForSetup = func() error {
+		preflightCalls++
+		if preflightCalls == 1 {
+			return desktopKeyringSetupRequiredError("no default Secret Service collection configured")
+		}
+		return nil
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return true, nil
+	}
+	recoveryCalls := 0
+	runPlatformSecureStorageRecoveryForSetup = func(action platformSecureStorageRecoveryAction, secret []byte) error {
+		recoveryCalls++
+		if action != platformSecureStorageRecoveryInitialize {
+			t.Fatalf("unexpected recovery action %q", action)
+		}
+		if string(secret) != "linux-local-keyring" {
+			t.Fatalf("unexpected recovery secret %q", string(secret))
+		}
+		return nil
+	}
+	readSetupSecretInputForSetup = func(fd int) ([]byte, error) {
+		if fd <= 0 {
+			t.Fatalf("expected terminal fd, got %d", fd)
+		}
+		return []byte("linux-local-keyring"), nil
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	input := joinSetupInputs(
+		[]string{"4", "", haServer.URL},
+		setupWizardRelayInstallPrompts(),
+		setupWizardGenerateRelayTokenPrompts(),
+		setupWizardLLATPrompts(),
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	if !strings.Contains(output, "Local secure storage needs setup") {
+		t.Fatalf("expected dedicated secure storage recovery page:\n%s", output)
+	}
+	if !strings.Contains(output, "not the Relay token or the Home Assistant token") {
+		t.Fatalf("expected explicit local-password guidance:\n%s", output)
+	}
+	if !strings.Contains(output, "HA NOVA, NOVA Relay, and Home Assistant never receive it.") {
+		t.Fatalf("expected explicit local-only keyring guidance:\n%s", output)
+	}
+	if !strings.Contains(output, "Set up local secure storage now") {
+		t.Fatalf("expected recovery action prompt:\n%s", output)
+	}
+	if !strings.Contains(output, "Home Assistant address (IP, hostname, or URL)") {
+		t.Fatalf("expected setup to continue to host prompt after recovery:\n%s", output)
+	}
+	if recoveryCalls != 1 {
+		t.Fatalf("expected one recovery attempt, got %d", recoveryCalls)
 	}
 }
 
@@ -326,7 +671,7 @@ func TestInteractiveSetupWithHostAndRelayTokenFlagsSkipsLLATWalkthrough(t *testi
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "claude", normalizeHostInput(haServer.URL), haServer.URL, relayServer.URL, "relay-token-from-flag")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "claude", normalizeHostInput(haServer.URL), haServer.URL, relayServer.URL, "relay-token-from-flag", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -380,7 +725,7 @@ func TestInteractiveSetupBackFromVerifyDoesNotPersistConfig(t *testing.T) {
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -439,7 +784,7 @@ func TestInteractiveSetupBackFromRelayInstallLetsUserChangeHost(t *testing.T) {
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -546,7 +891,7 @@ func TestInteractiveSetupRelayTokenFlagCanBackToHostAfterVerifyFailure(t *testin
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "gemini", "", "", failingRelay.URL, "relay-token-flagged")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "gemini", "", "", failingRelay.URL, "relay-token-flagged", false)
 		return exitCode
 	})
 	if exitCode != 1 {
@@ -603,7 +948,7 @@ func TestInteractiveSetupExitAtTokenChoiceCancelsCleanly(t *testing.T) {
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -655,7 +1000,7 @@ func TestInteractiveSetupInitialClientPageAllowsRepeatedBack(t *testing.T) {
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -664,6 +1009,9 @@ func TestInteractiveSetupInitialClientPageAllowsRepeatedBack(t *testing.T) {
 }
 
 func TestInteractiveSetupAlreadyDoneUsesResumeBanner(t *testing.T) {
+	withClientRuntimeAvailability(t, map[string]bool{"claude": true})
+	withClientAttachmentPresence(t, map[string]bool{"claude": true})
+
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("HA_NOVA_NO_BROWSER", "1")
@@ -708,7 +1056,7 @@ func TestInteractiveSetupAlreadyDoneUsesResumeBanner(t *testing.T) {
 	writeClaudeMarketplaceRegistrationFixture(t, home, filepath.Join(paths.ConfigDir, "claude-marketplace"))
 
 	stdout, stderr := captureInteractiveSetupIO(t, "", func() int {
-		return interactiveSetup(paths, cfg, state, "claude", "", "", "", "")
+		return interactiveSetup(paths, cfg, state, "claude", "", "", "", "", false)
 	})
 
 	output := stdout + stderr
@@ -760,7 +1108,7 @@ func TestInteractiveSetupPartialResumeSkipsTokenChoiceAndVerifiesFirstWhenWSIsPe
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "claude", "", "", "", "")
+		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "claude", "", "", "", "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -826,7 +1174,7 @@ func TestInteractiveSetupPartialResumeTTYShowsContinuePromptBeforeClearing(t *te
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, "\n"+"n\n", func() int {
-		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "claude", "", "", "", "")
+		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "claude", "", "", "", "", false)
 		return exitCode
 	})
 	if exitCode != 1 {
@@ -872,7 +1220,7 @@ func TestInteractiveSetupRelayTokenFlagPersistsBeforeVerify(t *testing.T) {
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, joinSetupInputs(setupWizardLLATPrompts(), []string{"n"}), func() int {
-		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "claude", "", "", "", "flag-token-from-cli")
+		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "claude", "", "", "", "flag-token-from-cli", false)
 		return exitCode
 	})
 	if exitCode != 1 {
@@ -949,7 +1297,7 @@ func TestInteractiveSetupCompletedResumeRejectsBrokenHostOverride(t *testing.T) 
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, "", func() int {
-		exitCode = interactiveSetup(paths, cfg, state, "claude", "bad-host.local", "", "", "")
+		exitCode = interactiveSetup(paths, cfg, state, "claude", "bad-host.local", "", "", "", false)
 		return exitCode
 	})
 	if exitCode != 1 {
@@ -1016,7 +1364,7 @@ func TestInteractiveSetupWSDegradedEndsIncomplete(t *testing.T) {
 		[]string{"3", "3", "3"},
 	)
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "claude", "", "", "", "")
+		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "claude", "", "", "", "", false)
 		return exitCode
 	})
 
@@ -1099,7 +1447,7 @@ func TestInteractiveSetupWSDegradedMentionsLLATCause(t *testing.T) {
 		[]string{"n"},
 	)
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "claude", "", "", "", "")
+		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "claude", "", "", "", "", false)
 		return exitCode
 	})
 	if exitCode != 1 {
@@ -1183,7 +1531,7 @@ func TestInteractiveSetupWSDegradedUsesWSPingSuccessAsReady(t *testing.T) {
 
 	input := joinSetupInputs(setupWizardLLATPrompts(), nil)
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		return interactiveSetup(paths, cfg, state, "claude", "", "", "", "")
+		return interactiveSetup(paths, cfg, state, "claude", "", "", "", "", false)
 	})
 	output := stdout + stderr
 	if !strings.Contains(output, "Connected to Home Assistant") {
@@ -1276,7 +1624,7 @@ func TestInteractiveSetupCompletedResumePersistsExplicitEndpointOverrides(t *tes
 		t.Fatalf("saveState() error: %v", err)
 	}
 
-	exitCode := interactiveSetup(paths, cfg, state, "claude", "192.168.1.123", haServer.URL, relayServer.URL, "")
+	exitCode := interactiveSetup(paths, cfg, state, "claude", "192.168.1.123", haServer.URL, relayServer.URL, "", false)
 	if exitCode != 0 {
 		t.Fatalf("interactiveSetup() exit = %d, want 0", exitCode)
 	}
@@ -1357,7 +1705,7 @@ func TestInteractiveSetupCompletedResumeUsesOverrideHealthInsteadOfOldHealthySta
 		[]string{"n"},
 	)
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, cfg, state, "claude", "192.168.1.123", haServer.URL, degradedRelay.URL, "")
+		exitCode = interactiveSetup(paths, cfg, state, "claude", "192.168.1.123", haServer.URL, degradedRelay.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 1 {
@@ -1446,7 +1794,7 @@ func TestInteractiveSetupContinueAnywayPersistsExplicitURL(t *testing.T) {
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", "", "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", "", "", false)
 		return exitCode
 	})
 	if exitCode != 1 {
@@ -1583,6 +1931,9 @@ func TestPromptValidHAHostIgnoresMultipleStaleBlanksAfterDiscoveryProgress(t *te
 }
 
 func TestInteractiveSetupCompletedResumePersistsHostOnlyOverride(t *testing.T) {
+	withClientRuntimeAvailability(t, map[string]bool{"claude": true})
+	withClientAttachmentPresence(t, map[string]bool{"claude": true})
+
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("HA_NOVA_NO_BROWSER", "1")
@@ -1659,7 +2010,7 @@ func TestInteractiveSetupCompletedResumePersistsHostOnlyOverride(t *testing.T) {
 	writeClaudeMarketplaceRegistrationFixture(t, home, filepath.Join(paths.ConfigDir, "claude-marketplace"))
 
 	stdout, stderr := captureInteractiveSetupIO(t, "", func() int {
-		return interactiveSetup(paths, cfg, state, "claude", "192.168.1.123", "", "", "")
+		return interactiveSetup(paths, cfg, state, "claude", "192.168.1.123", "", "", "", false)
 	})
 	output := stdout + stderr
 	if !strings.Contains(output, "Everything is already set up!") {

--- a/cli/setup_noninteractive_test.go
+++ b/cli/setup_noninteractive_test.go
@@ -239,7 +239,7 @@ func TestRunSetupNonInteractiveServiceModeRequiresRegistryCapability(t *testing.
 	exitCode, output := captureCommandOutput(t, func() int {
 		return runSetup(paths, []string{
 			"--service",
-			"--host", "192.168.1.5",
+			"--host", "203.0.113.1",
 			"--relay-token", "test-relay-token",
 			"--non-interactive",
 			"gemini",
@@ -270,7 +270,7 @@ func TestRunSetupNonInteractiveServiceModeRequiresSpecificClient(t *testing.T) {
 	exitCode, output := captureCommandOutput(t, func() int {
 		return runSetup(paths, []string{
 			"--service",
-			"--host", "192.168.1.5",
+			"--host", "203.0.113.1",
 			"--relay-token", "test-relay-token",
 			"--non-interactive",
 			"all",

--- a/cli/setup_noninteractive_test.go
+++ b/cli/setup_noninteractive_test.go
@@ -496,3 +496,93 @@ func TestRunSetupNonInteractiveDesktopModeMigratesAwayFromServiceTokenFile(t *te
 		t.Fatalf("migrated token = %q, want service-token", strings.TrimSpace(string(migrated)))
 	}
 }
+
+func TestRunSetupNonInteractiveDesktopModeMigratesFromIncompleteServiceConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	withClientRuntimeAvailability(t, map[string]bool{"hermes": true})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+	keyringFile := filepath.Join(home, ".test-relay-auth-token")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", keyringFile)
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	originalHealth := fetchRelayHealthForSetup
+	originalWSPing := probeRelayWSPingForSetup
+	originalReadinessHealth := fetchRelayHealthForReadiness
+	originalReadinessWSPing := probeRelayWSPingForReadiness
+	defer func() {
+		fetchRelayHealthForSetup = originalHealth
+		probeRelayWSPingForSetup = originalWSPing
+		fetchRelayHealthForReadiness = originalReadinessHealth
+		probeRelayWSPingForReadiness = originalReadinessWSPing
+	}()
+	fetchRelayHealthForSetup = func(relayBaseURL, token string) ([]byte, error) {
+		return []byte(`{"status":"ok","data":{"ha_ws_connected":true}}`), nil
+	}
+	probeRelayWSPingForSetup = func(relayBaseURL, token string) (relayWSPingResponse, error) {
+		return relayWSPingResponse{StatusCode: http.StatusOK, Body: []byte(`{"ok":true,"data":null}`)}, nil
+	}
+	fetchRelayHealthForReadiness = func(relayBaseURL, token string) ([]byte, error) {
+		return []byte(`{"status":"ok","data":{"ha_ws_connected":true}}`), nil
+	}
+	probeRelayWSPingForReadiness = func(relayBaseURL, token string) (relayWSPingResponse, error) {
+		return relayWSPingResponse{StatusCode: http.StatusOK, Body: []byte(`{"ok":true,"data":null}`)}, nil
+	}
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	// Incomplete former service-mode config: relay_base_url missing, so
+	// loadConfig fails — credential routing must still be honored.
+	if err := os.MkdirAll(paths.ConfigDir, 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	tokenFilePath := defaultRelayAuthTokenFile(paths)
+	if err := writeRelayAuthTokenFile(tokenFilePath, "service-token"); err != nil {
+		t.Fatalf("write service token file: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`{"relay_token_file":"relay-token"}`), 0o600); err != nil {
+		t.Fatalf("write incomplete config: %v", err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runSetup(paths, []string{
+			"--host", normalizeHostInput(haServer.URL),
+			"--ha-url", haServer.URL,
+			"--relay-url", "http://relay.test:8791",
+			"--non-interactive",
+			"hermes",
+		})
+	})
+	if exitCode != 0 {
+		t.Fatalf("expected desktop setup to succeed:\n%s", output)
+	}
+	cfg, err := loadConfig(paths)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	if cfg.RelayTokenFile != "" {
+		t.Fatalf("RelayTokenFile = %q, want empty (desktop mode)", cfg.RelayTokenFile)
+	}
+	if _, err := os.Stat(tokenFilePath); !isNotExist(err) {
+		t.Fatalf("expected former service token file to be removed, err=%v", err)
+	}
+	migrated, err := os.ReadFile(keyringFile)
+	if err != nil {
+		t.Fatalf("read keyring file: %v", err)
+	}
+	if strings.TrimSpace(string(migrated)) != "service-token" {
+		t.Fatalf("migrated token = %q, want service-token", strings.TrimSpace(string(migrated)))
+	}
+}

--- a/cli/setup_noninteractive_test.go
+++ b/cli/setup_noninteractive_test.go
@@ -405,3 +405,94 @@ func TestRunSetupNonInteractiveFailsOnLinuxKeyringPreflightBeforeWrite(t *testin
 		t.Fatalf("expected token file not to be written after preflight failure, err=%v", err)
 	}
 }
+
+func TestRunSetupNonInteractiveDesktopModeMigratesAwayFromServiceTokenFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	withClientRuntimeAvailability(t, map[string]bool{"hermes": true})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+	keyringFile := filepath.Join(home, ".test-relay-auth-token")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", keyringFile)
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	originalHealth := fetchRelayHealthForSetup
+	originalWSPing := probeRelayWSPingForSetup
+	originalReadinessHealth := fetchRelayHealthForReadiness
+	originalReadinessWSPing := probeRelayWSPingForReadiness
+	defer func() {
+		fetchRelayHealthForSetup = originalHealth
+		probeRelayWSPingForSetup = originalWSPing
+		fetchRelayHealthForReadiness = originalReadinessHealth
+		probeRelayWSPingForReadiness = originalReadinessWSPing
+	}()
+	fetchRelayHealthForSetup = func(relayBaseURL, token string) ([]byte, error) {
+		return []byte(`{"status":"ok","data":{"ha_ws_connected":true}}`), nil
+	}
+	probeRelayWSPingForSetup = func(relayBaseURL, token string) (relayWSPingResponse, error) {
+		return relayWSPingResponse{StatusCode: http.StatusOK, Body: []byte(`{"ok":true,"data":null}`)}, nil
+	}
+	fetchRelayHealthForReadiness = func(relayBaseURL, token string) ([]byte, error) {
+		return []byte(`{"status":"ok","data":{"ha_ws_connected":true}}`), nil
+	}
+	probeRelayWSPingForReadiness = func(relayBaseURL, token string) (relayWSPingResponse, error) {
+		return relayWSPingResponse{StatusCode: http.StatusOK, Body: []byte(`{"ok":true,"data":null}`)}, nil
+	}
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	// Previous service-mode install: config references the token file.
+	if err := os.MkdirAll(paths.ConfigDir, 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	tokenFilePath := defaultRelayAuthTokenFile(paths)
+	if err := writeRelayAuthTokenFile(tokenFilePath, "service-token"); err != nil {
+		t.Fatalf("write service token file: %v", err)
+	}
+	if err := saveConfig(paths, runtimeConfig{HAHost: "ha.test", HAURL: "http://ha.test:8123", RelayBaseURL: "http://relay.test:8791", RelayTokenFile: "relay-token"}); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+
+	// Documented desktop path: setup without --service and without a token
+	// flag must migrate the credential back to the OS keyring.
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runSetup(paths, []string{
+			"--host", normalizeHostInput(haServer.URL),
+			"--ha-url", haServer.URL,
+			"--relay-url", "http://relay.test:8791",
+			"--non-interactive",
+			"hermes",
+		})
+	})
+	if exitCode != 0 {
+		t.Fatalf("expected desktop setup to succeed:\n%s", output)
+	}
+	cfg, err := loadConfig(paths)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	if cfg.RelayTokenFile != "" {
+		t.Fatalf("RelayTokenFile = %q, want empty (desktop mode)", cfg.RelayTokenFile)
+	}
+	if _, err := os.Stat(tokenFilePath); !isNotExist(err) {
+		t.Fatalf("expected former service token file to be removed, err=%v", err)
+	}
+	migrated, err := os.ReadFile(keyringFile)
+	if err != nil {
+		t.Fatalf("read keyring file: %v", err)
+	}
+	if strings.TrimSpace(string(migrated)) != "service-token" {
+		t.Fatalf("migrated token = %q, want service-token", strings.TrimSpace(string(migrated)))
+	}
+}

--- a/cli/setup_noninteractive_test.go
+++ b/cli/setup_noninteractive_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -151,6 +152,141 @@ func TestRunSetupNonInteractiveSkipsClipboardAndBrowserSideEffects(t *testing.T)
 	}
 }
 
+func TestRunSetupNonInteractiveServiceModeWritesRelayTokenFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	withClientRuntimeAvailability(t, map[string]bool{"hermes": true})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	originalHealth := fetchRelayHealthForSetup
+	originalWSPing := probeRelayWSPingForSetup
+	originalReadinessHealth := fetchRelayHealthForReadiness
+	originalReadinessWSPing := probeRelayWSPingForReadiness
+	defer func() {
+		fetchRelayHealthForSetup = originalHealth
+		probeRelayWSPingForSetup = originalWSPing
+		fetchRelayHealthForReadiness = originalReadinessHealth
+		probeRelayWSPingForReadiness = originalReadinessWSPing
+	}()
+	fetchRelayHealthForSetup = func(relayBaseURL, token string) ([]byte, error) {
+		return []byte(`{"status":"ok","data":{"ha_ws_connected":true}}`), nil
+	}
+	probeRelayWSPingForSetup = func(relayBaseURL, token string) (relayWSPingResponse, error) {
+		return relayWSPingResponse{StatusCode: http.StatusOK, Body: []byte(`{"ok":true,"data":null}`)}, nil
+	}
+	fetchRelayHealthForReadiness = func(relayBaseURL, token string) ([]byte, error) {
+		return []byte(`{"status":"ok","data":{"ha_ws_connected":true}}`), nil
+	}
+	probeRelayWSPingForReadiness = func(relayBaseURL, token string) (relayWSPingResponse, error) {
+		return relayWSPingResponse{StatusCode: http.StatusOK, Body: []byte(`{"ok":true,"data":null}`)}, nil
+	}
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runSetup(paths, []string{
+			"--service",
+			"--host", normalizeHostInput(haServer.URL),
+			"--ha-url", haServer.URL,
+			"--relay-url", "http://relay.test:8791",
+			"--relay-token", "test-relay-token",
+			"--non-interactive",
+			"hermes",
+		})
+	})
+	if exitCode != 0 {
+		t.Fatalf("expected service setup to succeed:\n%s", output)
+	}
+	cfg, err := loadConfig(paths)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	if cfg.RelayTokenFile != defaultRelayAuthTokenFile(paths) {
+		t.Fatalf("RelayTokenFile = %q, want %q", cfg.RelayTokenFile, defaultRelayAuthTokenFile(paths))
+	}
+	token, err := readRelayAuthTokenFile(cfg.RelayTokenFile)
+	if err != nil {
+		t.Fatalf("readRelayAuthTokenFile() error = %v", err)
+	}
+	if token != "test-relay-token" {
+		t.Fatalf("token = %q, want test-relay-token", token)
+	}
+}
+
+func TestRunSetupNonInteractiveServiceModeRequiresRegistryCapability(t *testing.T) {
+	withClientRuntimeAvailability(t, map[string]bool{"gemini": true})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runSetup(paths, []string{
+			"--service",
+			"--host", "192.168.1.5",
+			"--relay-token", "test-relay-token",
+			"--non-interactive",
+			"gemini",
+		})
+	})
+	if exitCode == 0 {
+		t.Fatalf("expected service setup to fail for client without registry capability:\n%s", output)
+	}
+	if !strings.Contains(output, "Gemini CLI does not support service credentials") {
+		t.Fatalf("expected registry capability error:\n%s", output)
+	}
+	if _, err := os.Stat(defaultRelayAuthTokenFile(paths)); !isNotExist(err) {
+		t.Fatalf("expected service token file not to be written, err=%v", err)
+	}
+}
+
+func TestRunSetupNonInteractiveServiceModeRequiresSpecificClient(t *testing.T) {
+	withClientRuntimeAvailability(t, map[string]bool{"hermes": true})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runSetup(paths, []string{
+			"--service",
+			"--host", "192.168.1.5",
+			"--relay-token", "test-relay-token",
+			"--non-interactive",
+			"all",
+		})
+	})
+	if exitCode == 0 {
+		t.Fatalf("expected service setup to fail for all target:\n%s", output)
+	}
+	if !strings.Contains(output, "service credentials require a specific client; use: ha-nova setup --service <client>") {
+		t.Fatalf("expected explicit service target error:\n%s", output)
+	}
+	if _, err := os.Stat(defaultRelayAuthTokenFile(paths)); !isNotExist(err) {
+		t.Fatalf("expected service token file not to be written, err=%v", err)
+	}
+}
+
 func TestRunSetupNonInteractiveRollsBackWhenInitialStateSaveFails(t *testing.T) {
 	withClientRuntimeAvailability(t, map[string]bool{"claude": true})
 	home := t.TempDir()
@@ -206,5 +342,66 @@ func TestRunSetupNonInteractiveRollsBackWhenInitialStateSaveFails(t *testing.T) 
 	}
 	if _, err := os.Stat(filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token")); !isNotExist(err) {
 		t.Fatalf("expected token rollback on state save failure, err=%v", err)
+	}
+}
+
+func TestRunSetupNonInteractiveFailsOnLinuxKeyringPreflightBeforeWrite(t *testing.T) {
+	withClientRuntimeAvailability(t, map[string]bool{"claude": true})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	originalPreflight := relayAuthTokenSetupPreflightForSetup
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	defer func() {
+		relayAuthTokenSetupPreflightForSetup = originalPreflight
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+	}()
+	relayAuthTokenSetupPreflightForSetup = func() error {
+		return desktopKeyringSetupRequiredError("no default Secret Service collection configured")
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return true, nil
+	}
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runSetup(paths, []string{
+			"claude",
+			"--host", normalizeHostInput(haServer.URL),
+			"--ha-url", haServer.URL,
+			"--relay-url", "http://relay.test:8791",
+			"--relay-token", "test-relay-token",
+			"--non-interactive",
+		})
+	})
+	if exitCode != 1 {
+		t.Fatalf("expected non-interactive setup to fail on keyring preflight:\n%s", output)
+	}
+	if !strings.Contains(output, "cannot save relay token: secure storage is present but not initialized on this Linux machine") {
+		t.Fatalf("expected actionable keyring preflight error:\n%s", output)
+	}
+	if !strings.Contains(output, "Recovery: run `ha-nova setup` interactively to set up local secure storage on this Linux machine.") {
+		t.Fatalf("expected interactive recovery hint:\n%s", output)
+	}
+	if _, err := os.Stat(paths.ConfigFile); !isNotExist(err) {
+		t.Fatalf("expected config not to be written after preflight failure, err=%v", err)
+	}
+	if _, err := os.Stat(paths.StateFile); !isNotExist(err) {
+		t.Fatalf("expected state not to be written after preflight failure, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token")); !isNotExist(err) {
+		t.Fatalf("expected token file not to be written after preflight failure, err=%v", err)
 	}
 }

--- a/cli/setup_persistence_test.go
+++ b/cli/setup_persistence_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -158,5 +161,319 @@ func TestPersistInteractiveSetupStateRestoresSnapshotWhenConfigSaveFails(t *test
 	}
 	if restoredToken != "previous-token" {
 		t.Fatalf("token not restored after config-save rollback: got %q", restoredToken)
+	}
+}
+
+func TestPersistInteractiveSetupStateReturnsActionableLinuxKeyringError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	originalWrite := writeRelayAuthTokenForSetupPersistence
+	defer func() {
+		writeRelayAuthTokenForSetupPersistence = originalWrite
+	}()
+	writeRelayAuthTokenForSetupPersistence = func(string) error {
+		return errors.New("The name org.freedesktop.secrets was not provided by any .service files")
+	}
+
+	nextCfg := runtimeConfig{
+		HAHost:       "192.168.1.5",
+		HAURL:        "http://192.168.1.5:8123",
+		RelayBaseURL: "http://192.168.1.5:8791",
+	}
+	nextState := installState{
+		SchemaVersion:      stateSchemaVersion,
+		InstalledClients:   []string{"hermes"},
+		ClientInstallModes: map[string]string{},
+	}
+
+	err = persistInteractiveSetupState(paths, nextCfg, &nextState, "", false, "new-token")
+	want := "cannot save relay token: secure storage unavailable on this Linux machine. Start a Secret Service provider (for example GNOME Keyring or KWallet Secrets) and rerun `ha-nova setup`"
+	if err == nil || err.Error() != want {
+		t.Fatalf("persistInteractiveSetupState() error = %v, want %q", err, want)
+	}
+}
+
+func TestPersistInteractiveSetupStateReturnsActionableLinuxSessionBusError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	originalWrite := writeRelayAuthTokenForSetupPersistence
+	defer func() {
+		writeRelayAuthTokenForSetupPersistence = originalWrite
+	}()
+	writeRelayAuthTokenForSetupPersistence = func(string) error {
+		return errors.New("dbus: couldn't determine address of session bus")
+	}
+
+	nextCfg := runtimeConfig{
+		HAHost:       "192.168.1.5",
+		HAURL:        "http://192.168.1.5:8123",
+		RelayBaseURL: "http://192.168.1.5:8791",
+	}
+	nextState := installState{
+		SchemaVersion:      stateSchemaVersion,
+		InstalledClients:   []string{"hermes"},
+		ClientInstallModes: map[string]string{},
+	}
+
+	err = persistInteractiveSetupState(paths, nextCfg, &nextState, "", false, "new-token")
+	want := "cannot save relay token: secure storage unavailable in this Linux session. Run HA NOVA from a terminal inside the Linux desktop session on this machine, and rerun `ha-nova setup`"
+	if err == nil || err.Error() != want {
+		t.Fatalf("persistInteractiveSetupState() error = %v, want %q", err, want)
+	}
+}
+
+func TestPersistInteractiveSetupStateReturnsActionableLinuxKeyringInitializationError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	originalWrite := writeRelayAuthTokenForSetupPersistence
+	defer func() {
+		writeRelayAuthTokenForSetupPersistence = originalWrite
+	}()
+	writeRelayAuthTokenForSetupPersistence = func(string) error {
+		return desktopKeyringLockedError("default Secret Service collection is locked")
+	}
+
+	nextCfg := runtimeConfig{
+		HAHost:       "192.168.1.5",
+		HAURL:        "http://192.168.1.5:8123",
+		RelayBaseURL: "http://192.168.1.5:8791",
+	}
+	nextState := installState{
+		SchemaVersion:      stateSchemaVersion,
+		InstalledClients:   []string{"hermes"},
+		ClientInstallModes: map[string]string{},
+	}
+
+	err = persistInteractiveSetupState(paths, nextCfg, &nextState, "", false, "new-token")
+	want := "cannot save relay token: secure storage is present but locked on this Linux machine. Unlock the default keyring and rerun `ha-nova setup`"
+	if err == nil || err.Error() != want {
+		t.Fatalf("persistInteractiveSetupState() error = %v, want %q", err, want)
+	}
+}
+
+func TestPersistInteractiveSetupStateWithRecoveryRetriesOnce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	originalWrite := writeRelayAuthTokenForSetupPersistence
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	originalReadSecret := readSetupSecretInputForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		writeRelayAuthTokenForSetupPersistence = originalWrite
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+		readSetupSecretInputForSetup = originalReadSecret
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	writeCalls := 0
+	writeRelayAuthTokenForSetupPersistence = func(token string) error {
+		writeCalls++
+		if writeCalls == 1 {
+			return desktopKeyringLockedError("default Secret Service collection is locked")
+		}
+		return originalWrite(token)
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return true, nil
+	}
+	recoveryCalls := 0
+	runPlatformSecureStorageRecoveryForSetup = func(action platformSecureStorageRecoveryAction, secret []byte) error {
+		recoveryCalls++
+		if action != platformSecureStorageRecoveryUnlock {
+			t.Fatalf("unexpected recovery action %q", action)
+		}
+		if string(secret) != "linux-local-keyring" {
+			t.Fatalf("unexpected recovery secret %q", string(secret))
+		}
+		return nil
+	}
+	readSetupSecretInputForSetup = func(int) ([]byte, error) {
+		return []byte("linux-local-keyring"), nil
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	cfg := runtimeConfig{
+		HAHost:       "192.168.1.5",
+		HAURL:        "http://192.168.1.5:8123",
+		RelayBaseURL: "http://192.168.1.5:8791",
+	}
+	state := installState{
+		SchemaVersion:      stateSchemaVersion,
+		InstalledClients:   []string{"hermes"},
+		ClientInstallModes: map[string]string{},
+	}
+	recovery := setupSecureStorageRecoveryState{}
+
+	if err := persistInteractiveSetupStateWithRecovery(bufio.NewReader(strings.NewReader("\n")), io.Discard, paths, cfg, &state, "", false, "new-token", &recovery); err != nil {
+		t.Fatalf("persistInteractiveSetupStateWithRecovery() error = %v", err)
+	}
+	if recoveryCalls != 1 {
+		t.Fatalf("expected one recovery call, got %d", recoveryCalls)
+	}
+	if writeCalls != 2 {
+		t.Fatalf("expected one retry after recovery, got %d write calls", writeCalls)
+	}
+}
+
+func TestPersistInteractiveSetupStateWithRecoveryDoesNotRepromptAfterAttempt(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	originalWrite := writeRelayAuthTokenForSetupPersistence
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	defer func() {
+		writeRelayAuthTokenForSetupPersistence = originalWrite
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+	}()
+
+	writeRelayAuthTokenForSetupPersistence = func(string) error {
+		return desktopKeyringLockedError("default Secret Service collection is locked")
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return true, nil
+	}
+	runPlatformSecureStorageRecoveryForSetup = func(action platformSecureStorageRecoveryAction, _ []byte) error {
+		if action != platformSecureStorageRecoveryUnlock {
+			t.Fatalf("unexpected recovery action %q", action)
+		}
+		t.Fatal("did not expect recovery once the run already attempted it")
+		return nil
+	}
+
+	cfg := runtimeConfig{
+		HAHost:       "192.168.1.5",
+		HAURL:        "http://192.168.1.5:8123",
+		RelayBaseURL: "http://192.168.1.5:8791",
+	}
+	state := installState{
+		SchemaVersion:      stateSchemaVersion,
+		InstalledClients:   []string{"hermes"},
+		ClientInstallModes: map[string]string{},
+	}
+	recovery := setupSecureStorageRecoveryState{saveRetryAttempted: true}
+
+	err = persistInteractiveSetupStateWithRecovery(bufio.NewReader(strings.NewReader("\n")), io.Discard, paths, cfg, &state, "", false, "new-token", &recovery)
+	if err == nil {
+		t.Fatal("expected setup persistence to fail without a second recovery prompt")
+	}
+}
+
+func TestPersistInteractiveSetupStateWithRecoveryRetriesInitializationOnce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	originalWrite := writeRelayAuthTokenForSetupPersistence
+	originalSupport := detectPlatformSecureStorageRecoverySupportForSetup
+	originalRunRecovery := runPlatformSecureStorageRecoveryForSetup
+	originalReadSecret := readSetupSecretInputForSetup
+	originalTTY := writerSupportsTTYForSetup
+	originalInputTTY := uiInputSupportsTTY
+	defer func() {
+		writeRelayAuthTokenForSetupPersistence = originalWrite
+		detectPlatformSecureStorageRecoverySupportForSetup = originalSupport
+		runPlatformSecureStorageRecoveryForSetup = originalRunRecovery
+		readSetupSecretInputForSetup = originalReadSecret
+		writerSupportsTTYForSetup = originalTTY
+		uiInputSupportsTTY = originalInputTTY
+	}()
+
+	writeCalls := 0
+	writeRelayAuthTokenForSetupPersistence = func(token string) error {
+		writeCalls++
+		if writeCalls == 1 {
+			return desktopKeyringInitializationRequiredError("no default Secret Service collection configured")
+		}
+		return originalWrite(token)
+	}
+	detectPlatformSecureStorageRecoverySupportForSetup = func() (bool, error) {
+		return true, nil
+	}
+	recoveryCalls := 0
+	runPlatformSecureStorageRecoveryForSetup = func(action platformSecureStorageRecoveryAction, secret []byte) error {
+		recoveryCalls++
+		if action != platformSecureStorageRecoveryInitialize {
+			t.Fatalf("unexpected recovery action %q", action)
+		}
+		if string(secret) != "linux-local-keyring" {
+			t.Fatalf("unexpected recovery secret %q", string(secret))
+		}
+		return nil
+	}
+	reads := 0
+	readSetupSecretInputForSetup = func(int) ([]byte, error) {
+		reads++
+		return []byte("linux-local-keyring"), nil
+	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	uiInputSupportsTTY = func() bool { return true }
+
+	cfg := runtimeConfig{
+		HAHost:       "192.168.1.5",
+		HAURL:        "http://192.168.1.5:8123",
+		RelayBaseURL: "http://192.168.1.5:8791",
+	}
+	state := installState{
+		SchemaVersion:      stateSchemaVersion,
+		InstalledClients:   []string{"hermes"},
+		ClientInstallModes: map[string]string{},
+	}
+	recovery := setupSecureStorageRecoveryState{}
+
+	if err := persistInteractiveSetupStateWithRecovery(bufio.NewReader(strings.NewReader("\n")), io.Discard, paths, cfg, &state, "", false, "new-token", &recovery); err != nil {
+		t.Fatalf("persistInteractiveSetupStateWithRecovery() error = %v", err)
+	}
+	if recoveryCalls != 1 {
+		t.Fatalf("expected one initialization recovery call, got %d", recoveryCalls)
+	}
+	if writeCalls != 2 {
+		t.Fatalf("expected one failed save plus one retry, got %d writes", writeCalls)
+	}
+	if reads != 2 {
+		t.Fatalf("expected create-password prompt plus confirmation, got %d reads", reads)
 	}
 }

--- a/cli/setup_secure_storage_recovery_test.go
+++ b/cli/setup_secure_storage_recovery_test.go
@@ -338,7 +338,7 @@ func TestInteractiveSetupRecoveryBackDoesNotBypassGate(t *testing.T) {
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -436,7 +436,7 @@ func TestInteractiveSetupRecoversWhenSavedTokenReadNeedsRecovery(t *testing.T) {
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -532,7 +532,7 @@ func TestInteractiveSetupReusesSavedTokenAfterReadRecovery(t *testing.T) {
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -586,7 +586,7 @@ func TestInteractiveSetupDeclinedReadRecoveryMentionsSavedTokenAccess(t *testing
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, joinSetupInputs([]string{"4", "n"}), func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", "http://relay.test:8791", "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", "http://relay.test:8791", "", false)
 		return exitCode
 	})
 	if exitCode != 1 {
@@ -684,7 +684,7 @@ func TestInteractiveSetupRetriesSaveTimeRecoveryInline(t *testing.T) {
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -788,7 +788,7 @@ func TestInteractiveSetupRetriesSaveTimeInitializationRecoveryInline(t *testing.
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "")
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", relayServer.URL, "", false)
 		return exitCode
 	})
 	if exitCode != 0 {

--- a/cli/setup_service_credentials.go
+++ b/cli/setup_service_credentials.go
@@ -46,6 +46,24 @@ func disableServiceRelayTokenFile(paths runtimePaths, cfg runtimeConfig) (runtim
 	return cfg, path, formerToken, withRelayAuthTokenFileSuppressed()
 }
 
+// finalizeServiceTokenFileMigration force-writes the active token into the
+// OS keyring before removing the former service token file, so the
+// migration can never delete the only stored copy of the credential —
+// regardless of whether the persistence layer considered the token
+// unchanged (it compares values, not destination stores).
+func finalizeServiceTokenFileMigration(path, token string) {
+	if path == "" {
+		return
+	}
+	if strings.TrimSpace(token) != "" {
+		if err := writeRelayAuthToken(token); err != nil {
+			printHumanWarn("Keeping the former service token file %s: could not store the token in OS secure storage: %s", path, err)
+			return
+		}
+	}
+	cleanupFormerServiceTokenFile(path)
+}
+
 // cleanupFormerServiceTokenFile removes the now-orphaned service token file
 // after a successful desktop-mode setup so no secret copy stays behind.
 func cleanupFormerServiceTokenFile(path string) {
@@ -88,6 +106,7 @@ func requireSelectedClientServiceCredentials(paths runtimePaths, selectedClients
 func shouldOfferServiceCredentials(tokenStorageErr error) bool {
 	if tokenStorageErr != nil {
 		return isDesktopKeyringSessionUnavailableError(tokenStorageErr) ||
+			isDesktopKeyringUnavailableError(tokenStorageErr) ||
 			isDesktopKeyringLockedError(tokenStorageErr) ||
 			isDesktopKeyringInitializationRequiredError(tokenStorageErr) ||
 			isDesktopKeyringSetupRequiredError(tokenStorageErr)

--- a/cli/setup_service_credentials.go
+++ b/cli/setup_service_credentials.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 )
 
 func enableServiceRelayTokenFile(paths runtimePaths, cfg runtimeConfig) runtimeConfig {
@@ -19,6 +21,42 @@ func withRelayAuthTokenFileOverride(path string) func() {
 	return func() {
 		relayAuthTokenFilePathOverride = previous
 	}
+}
+
+// disableServiceRelayTokenFile returns token storage to the OS keyring when
+// setup runs without --service: the documented desktop path must not keep
+// using a previously configured service token file. It clears the config
+// field, suppresses token-file routing for the rest of the run, and returns
+// the absolute former file path plus its token (best effort) so setup can
+// migrate the credential and remove the file after success.
+func disableServiceRelayTokenFile(paths runtimePaths, cfg runtimeConfig) (runtimeConfig, string, string, func()) {
+	path := strings.TrimSpace(cfg.RelayTokenFile)
+	if path == "" {
+		return cfg, "", "", func() {}
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(paths.ConfigDir, path)
+	}
+	path = filepath.Clean(path)
+	formerToken := ""
+	if token, err := readRelayAuthTokenFile(path); err == nil {
+		formerToken = token
+	}
+	cfg.RelayTokenFile = ""
+	return cfg, path, formerToken, withRelayAuthTokenFileSuppressed()
+}
+
+// cleanupFormerServiceTokenFile removes the now-orphaned service token file
+// after a successful desktop-mode setup so no secret copy stays behind.
+func cleanupFormerServiceTokenFile(path string) {
+	if path == "" {
+		return
+	}
+	if err := deleteRelayAuthTokenFile(path); err != nil {
+		printHumanWarn("Could not remove the former service token file %s: %s", path, err)
+		return
+	}
+	printHumanInfo("Token storage returned to OS secure storage; removed the former service token file.")
 }
 
 func selectedClientsServiceCredentialHint(paths runtimePaths, selectedClients []string) (clientRegistryServiceCredentials, string, bool, error) {

--- a/cli/setup_service_credentials.go
+++ b/cli/setup_service_credentials.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+)
+
+func enableServiceRelayTokenFile(paths runtimePaths, cfg runtimeConfig) runtimeConfig {
+	if cfg.RelayTokenFile == "" {
+		cfg.RelayTokenFile = defaultRelayAuthTokenFile(paths)
+	}
+	return cfg
+}
+
+func withRelayAuthTokenFileOverride(path string) func() {
+	previous := relayAuthTokenFilePathOverride
+	relayAuthTokenFilePathOverride = path
+	return func() {
+		relayAuthTokenFilePathOverride = previous
+	}
+}
+
+func selectedClientsServiceCredentialHint(paths runtimePaths, selectedClients []string) (clientRegistryServiceCredentials, string, bool, error) {
+	client, ok, err := selectedClientsSupportServiceCredentials(paths, selectedClients)
+	if err != nil || !ok {
+		return clientRegistryServiceCredentials{}, "", ok, err
+	}
+	serviceCredentials := clientSetupForCurrentOS(client).ServiceCredentials
+	if serviceCredentials == nil {
+		return clientRegistryServiceCredentials{}, "", false, nil
+	}
+	return *serviceCredentials, client.Label, true, nil
+}
+
+func requireSelectedClientServiceCredentials(paths runtimePaths, selectedClients []string) error {
+	_, _, ok, err := selectedClientsServiceCredentialHint(paths, selectedClients)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+	if len(selectedClients) == 1 {
+		return fmt.Errorf("%s does not support service credentials", setupClientLabel(selectedClients[0]))
+	}
+	return fmt.Errorf("none of the selected clients support service credentials")
+}
+
+func shouldOfferServiceCredentials(tokenStorageErr error) bool {
+	if tokenStorageErr != nil {
+		return isDesktopKeyringSessionUnavailableError(tokenStorageErr) ||
+			isDesktopKeyringLockedError(tokenStorageErr) ||
+			isDesktopKeyringInitializationRequiredError(tokenStorageErr) ||
+			isDesktopKeyringSetupRequiredError(tokenStorageErr)
+	}
+	return false
+}
+
+func promptSetupServiceCredentialsInteractive(reader *bufio.Reader, out io.Writer, serviceCredentials clientRegistryServiceCredentials, clientLabel string) (bool, error) {
+	label := serviceCredentials.Label
+	if label == "" {
+		label = "Service / gateway mode"
+	}
+	renderSetupParagraph(out,
+		fmt.Sprintf("%s is available for %s.", label, clientLabel),
+		serviceCredentials.Help,
+	)
+	renderSetupParagraphTight(out, "Choose yes for SSH, systemd, headless, or gateway sessions. Choose no for a normal desktop terminal with an unlocked keyring.")
+	return promptYesNoFromReader(reader, out, "Use service/gateway token file instead of desktop keyring?", false)
+}
+
+func doctorServiceCredentialRecoveryHint(paths runtimePaths, state installState, err error) string {
+	if !shouldOfferServiceCredentials(err) {
+		return ""
+	}
+	clients, loadErr := loadClientRegistry(paths)
+	if loadErr != nil {
+		return ""
+	}
+	for _, client := range clients {
+		if !clientSupportsServiceCredentials(client) {
+			continue
+		}
+		status := evaluateClientStatus(paths, state, client)
+		if status.Configured || status.Attached {
+			return fmt.Sprintf("Recovery: run `ha-nova setup --service %s` if %s runs without an unlocked desktop keyring.", client.ID, client.Label)
+		}
+	}
+	return ""
+}

--- a/cli/setup_service_credentials.go
+++ b/cli/setup_service_credentials.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -43,7 +44,16 @@ func disableServiceRelayTokenFile(paths runtimePaths, cfg runtimeConfig) (runtim
 		formerToken = token
 	}
 	cfg.RelayTokenFile = ""
-	return cfg, path, formerToken, withRelayAuthTokenFileSuppressed()
+	cleanupPath := path
+	configDir := filepath.Clean(paths.ConfigDir)
+	if rel, err := filepath.Rel(configDir, path); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		// User-managed token file outside the managed config directory:
+		// migrate the credential, but never delete the file — the same
+		// boundary purge applies for external paths.
+		cleanupPath = ""
+		printHumanInfo("Keeping the external relay token file in place: %s", path)
+	}
+	return cfg, cleanupPath, formerToken, withRelayAuthTokenFileSuppressed()
 }
 
 // finalizeServiceTokenFileMigration force-writes the active token into the

--- a/cli/setup_service_credentials_test.go
+++ b/cli/setup_service_credentials_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestShouldOfferServiceCredentialsCoversBlockedKeyringClasses(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"session unavailable", desktopKeyringSessionUnavailableError("no session bus"), true},
+		{"provider unavailable", desktopKeyringUnavailableError("no Secret Service provider"), true},
+		{"locked", desktopKeyringLockedError("default collection locked"), true},
+		{"init required", desktopKeyringInitializationRequiredError("no default collection"), true},
+		{"nil error", nil, false},
+	}
+	for _, tc := range cases {
+		if got := shouldOfferServiceCredentials(tc.err); got != tc.want {
+			t.Fatalf("%s: shouldOfferServiceCredentials() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestFinalizeServiceTokenFileMigrationWritesKeyringBeforeDeleting(t *testing.T) {
+	if relayAuthTokenFilePlatformOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	keyringFile := filepath.Join(home, ".test-relay-auth-token")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", keyringFile)
+
+	tokenDir := filepath.Join(home, ".config", "ha-nova")
+	if err := os.MkdirAll(tokenDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	tokenPath := filepath.Join(tokenDir, "relay-token")
+	if err := writeRelayAuthTokenFile(tokenPath, "migrated-token"); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	finalizeServiceTokenFileMigration(tokenPath, "migrated-token")
+
+	stored, err := os.ReadFile(keyringFile)
+	if err != nil {
+		t.Fatalf("expected token to be written to the keyring before deletion: %v", err)
+	}
+	if strings.TrimSpace(string(stored)) != "migrated-token" {
+		t.Fatalf("stored token = %q, want migrated-token", strings.TrimSpace(string(stored)))
+	}
+	if _, err := os.Stat(tokenPath); !isNotExist(err) {
+		t.Fatalf("expected former service token file to be removed, err=%v", err)
+	}
+}

--- a/cli/setup_service_credentials_test.go
+++ b/cli/setup_service_credentials_test.go
@@ -58,3 +58,40 @@ func TestFinalizeServiceTokenFileMigrationWritesKeyringBeforeDeleting(t *testing
 		t.Fatalf("expected former service token file to be removed, err=%v", err)
 	}
 }
+
+func TestDisableServiceRelayTokenFileKeepsExternalPaths(t *testing.T) {
+	if relayAuthTokenFilePlatformOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	externalDir := filepath.Join(home, "secrets")
+	if err := os.MkdirAll(externalDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	externalToken := filepath.Join(externalDir, "relay-token")
+	if err := writeRelayAuthTokenFile(externalToken, "external-token"); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	cfg, cleanupPath, formerToken, restore := disableServiceRelayTokenFile(paths, runtimeConfig{RelayTokenFile: externalToken})
+	defer restore()
+	if cfg.RelayTokenFile != "" {
+		t.Fatalf("expected RelayTokenFile to be cleared, got %q", cfg.RelayTokenFile)
+	}
+	if cleanupPath != "" {
+		t.Fatalf("expected no cleanup path for external token files, got %q", cleanupPath)
+	}
+	if formerToken != "external-token" {
+		t.Fatalf("formerToken = %q, want external-token", formerToken)
+	}
+
+	finalizeServiceTokenFileMigration(cleanupPath, "external-token")
+	if _, err := os.Stat(externalToken); err != nil {
+		t.Fatalf("expected external token file to survive migration, err=%v", err)
+	}
+}

--- a/cli/setup_state_test.go
+++ b/cli/setup_state_test.go
@@ -369,3 +369,46 @@ func TestClientAppearsInstalledForClaudeIgnoresForeignPluginArrayEntries(t *test
 		t.Fatal("expected foreign Claude plugin array entries to count as not installed")
 	}
 }
+
+func TestClientAppearsInstalledForHermesRequiresCompleteBundle(t *testing.T) {
+	withClientRuntimeAvailability(t, map[string]bool{"hermes": true})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, ".hermes", "skills", "ha-nova", "ha-nova"), 0o755); err != nil {
+		t.Fatalf("mkdir Hermes context skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".hermes", "skills", "ha-nova", "ha-nova", "SKILL.md"), []byte("name: ha-nova"), 0o644); err != nil {
+		t.Fatalf("write Hermes context skill: %v", err)
+	}
+
+	entry, ok, err := findRegistryClient(paths, "hermes")
+	if err != nil {
+		t.Fatalf("findRegistryClient() error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected hermes registry entry")
+	}
+	if evaluateClientStatus(paths, installState{}, entry).Ready {
+		t.Fatal("expected incomplete Hermes bundle to count as not installed")
+	}
+
+	for _, skillDir := range hermesRequiredSkillDirs[1:] {
+		if err := os.MkdirAll(filepath.Join(home, ".hermes", "skills", "ha-nova", skillDir), 0o755); err != nil {
+			t.Fatalf("mkdir Hermes skill %s: %v", skillDir, err)
+		}
+		if err := os.WriteFile(filepath.Join(home, ".hermes", "skills", "ha-nova", skillDir, "SKILL.md"), []byte("name: "+skillDir), 0o644); err != nil {
+			t.Fatalf("write Hermes skill %s: %v", skillDir, err)
+		}
+	}
+
+	if !evaluateClientStatus(paths, installState{}, entry).Ready {
+		t.Fatal("expected complete Hermes bundle to count as installed")
+	}
+}

--- a/cli/uninstall_feedback.go
+++ b/cli/uninstall_feedback.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -95,4 +96,62 @@ func applyUninstallTokenPolicy(report *uninstallReport) error {
 		report.addRemoved("relay auth token")
 	}
 	return nil
+}
+
+// applyUninstallKeyringTokenBestEffort removes a leftover relay token from
+// the OS credential store after the service token file was already handled.
+// An earlier desktop-mode setup may have stored a token there before the
+// user switched to service mode. Service machines often run headless with a
+// locked or absent keyring, so failures only add a note instead of aborting
+// the purge.
+func applyUninstallKeyringTokenBestEffort(report *uninstallReport) {
+	if !shouldDeleteRelayAuthTokenOnUninstall() {
+		return
+	}
+	token, err := readRelayAuthTokenForUninstall()
+	if err != nil {
+		if !isMissingRelayAuthTokenError(err) {
+			report.addNote("Could not check the OS credential store for a leftover relay token. If an earlier desktop-mode setup stored one, remove the 'ha-nova' entry manually.")
+		}
+		return
+	}
+	if strings.TrimSpace(token) == "" {
+		return
+	}
+	if err := deleteRelayAuthTokenForUninstall(); err != nil {
+		report.addNote("Could not remove the leftover relay token from the OS credential store. Remove the 'ha-nova' entry manually.")
+		return
+	}
+	report.addRemoved("relay auth token (OS credential store)")
+}
+
+func applyUninstallServiceTokenFilePolicy(paths runtimePaths, path string, report *uninstallReport) (bool, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false, nil
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(paths.ConfigDir, path)
+	}
+	path = filepath.Clean(path)
+	configDir := filepath.Clean(paths.ConfigDir)
+	rel, err := filepath.Rel(configDir, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return false, nil
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		if isNotExist(err) {
+			return true, nil
+		}
+		return true, err
+	}
+	if info.IsDir() {
+		return true, nil
+	}
+	if err := os.Remove(path); err != nil && !isNotExist(err) {
+		return true, err
+	}
+	report.addRemoved("relay auth token")
+	return true, nil
 }

--- a/cli/uninstall_test.go
+++ b/cli/uninstall_test.go
@@ -723,3 +723,42 @@ func TestApplyUninstallKeyringTokenBestEffortToleratesLockedKeyring(t *testing.T
 		t.Fatalf("expected a manual-cleanup note, got %+v", report.notes)
 	}
 }
+
+func TestPurgeFindsServiceTokenFileWhenConfigIsIncomplete(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := os.MkdirAll(paths.ConfigDir, 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	// Incomplete service-mode config: relay_base_url missing, token file set.
+	if err := os.WriteFile(paths.ConfigFile, []byte(`{"relay_token_file":"relay-token"}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	tokenPath := defaultRelayAuthTokenFile(paths)
+	if err := writeRelayAuthTokenFile(tokenPath, "service-token"); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	originalRead := readRelayAuthTokenForUninstall
+	originalDelete := deleteRelayAuthTokenForUninstall
+	defer func() {
+		readRelayAuthTokenForUninstall = originalRead
+		deleteRelayAuthTokenForUninstall = originalDelete
+	}()
+	readRelayAuthTokenForUninstall = func() (string, error) {
+		return "", missingRelayAuthTokenError("test keyring")
+	}
+	deleteRelayAuthTokenForUninstall = func() error { return nil }
+
+	report := &uninstallReport{}
+	if err := finalizeLocalUninstall(paths, installState{}, report, uninstallModePurge); err != nil {
+		t.Fatalf("finalizeLocalUninstall() error: %v", err)
+	}
+	if _, err := os.Stat(tokenPath); !isNotExist(err) {
+		t.Fatalf("expected service token file to be purged despite incomplete config, err=%v", err)
+	}
+}

--- a/cli/uninstall_test.go
+++ b/cli/uninstall_test.go
@@ -72,6 +72,123 @@ func TestRunUninstallReportsConcreteRemovalsAndTokenPolicy(t *testing.T) {
 	}
 }
 
+func TestRunUninstallStandardKeepsServiceTokenFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	cfg := runtimeConfig{
+		HAHost:         "192.168.1.5",
+		HAURL:          "http://192.168.1.5:8123",
+		RelayBaseURL:   "http://192.168.1.5:8791",
+		RelayTokenFile: defaultRelayAuthTokenFile(paths),
+	}
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := writeRelayAuthTokenFile(cfg.RelayTokenFile, "service-token"); err != nil {
+		t.Fatalf("writeRelayAuthTokenFile() error: %v", err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runUninstall(paths, []string{"--yes"})
+	})
+	if exitCode != 0 {
+		t.Fatalf("runUninstall() exit = %d\n%s", exitCode, output)
+	}
+	if _, err := os.Stat(cfg.RelayTokenFile); err != nil {
+		t.Fatalf("expected standard uninstall to keep service token file: %v", err)
+	}
+	if _, err := os.Stat(paths.ConfigFile); err != nil {
+		t.Fatalf("expected standard uninstall to keep config file: %v", err)
+	}
+}
+
+func TestRunUninstallPurgeRemovesServiceTokenFileAfterConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	cfg := runtimeConfig{
+		HAHost:         "192.168.1.5",
+		HAURL:          "http://192.168.1.5:8123",
+		RelayBaseURL:   "http://192.168.1.5:8791",
+		RelayTokenFile: defaultRelayAuthTokenFile(paths),
+	}
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := writeRelayAuthTokenFile(cfg.RelayTokenFile, "service-token"); err != nil {
+		t.Fatalf("writeRelayAuthTokenFile() error: %v", err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runUninstall(paths, []string{"--yes", "--purge"})
+	})
+	if exitCode != 0 {
+		t.Fatalf("runUninstall() exit = %d\n%s", exitCode, output)
+	}
+	if _, err := os.Stat(cfg.RelayTokenFile); !isNotExist(err) {
+		t.Fatalf("expected purge to remove service token file, err=%v", err)
+	}
+	if _, err := os.Stat(paths.ConfigFile); !isNotExist(err) {
+		t.Fatalf("expected purge to remove config file, err=%v", err)
+	}
+}
+
+func TestRunUninstallPurgeRemovesUnsafeServiceTokenFileAfterConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	cfg := runtimeConfig{
+		HAHost:         "192.168.1.5",
+		HAURL:          "http://192.168.1.5:8123",
+		RelayBaseURL:   "http://192.168.1.5:8791",
+		RelayTokenFile: defaultRelayAuthTokenFile(paths),
+	}
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := writeRelayAuthTokenFile(cfg.RelayTokenFile, "service-token"); err != nil {
+		t.Fatalf("writeRelayAuthTokenFile() error: %v", err)
+	}
+	if err := os.Chmod(cfg.RelayTokenFile, 0o644); err != nil {
+		t.Fatalf("chmod service token file: %v", err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runUninstall(paths, []string{"--yes", "--purge"})
+	})
+	if exitCode != 0 {
+		t.Fatalf("runUninstall() exit = %d\n%s", exitCode, output)
+	}
+	if _, err := os.Stat(cfg.RelayTokenFile); !isNotExist(err) {
+		t.Fatalf("expected purge to remove unsafe service token file, err=%v", err)
+	}
+	if _, err := os.Stat(paths.ConfigFile); !isNotExist(err) {
+		t.Fatalf("expected purge to remove config file, err=%v", err)
+	}
+}
+
 func TestRunUninstallShowsPreflightAndRelayStillRunningNote(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -551,5 +668,58 @@ func TestRunUninstallStandardRemoveKeepsConfigAndTokenForReinstall(t *testing.T)
 	}
 	if !strings.Contains(output, "Kept Home Assistant connection config and stored relay token") {
 		t.Fatalf("expected standard uninstall retention note:\n%s", output)
+	}
+}
+
+func TestApplyUninstallKeyringTokenBestEffortRemovesLeftoverDesktopToken(t *testing.T) {
+	originalRead := readRelayAuthTokenForUninstall
+	originalDelete := deleteRelayAuthTokenForUninstall
+	defer func() {
+		readRelayAuthTokenForUninstall = originalRead
+		deleteRelayAuthTokenForUninstall = originalDelete
+	}()
+
+	deleted := false
+	readRelayAuthTokenForUninstall = func() (string, error) {
+		return "stale-desktop-token", nil
+	}
+	deleteRelayAuthTokenForUninstall = func() error {
+		deleted = true
+		return nil
+	}
+
+	report := &uninstallReport{}
+	applyUninstallKeyringTokenBestEffort(report)
+	if !deleted {
+		t.Fatalf("expected leftover keyring token to be deleted")
+	}
+	if len(report.removed) != 1 || !strings.Contains(report.removed[0], "credential store") {
+		t.Fatalf("expected credential store removal to be reported, got %+v", report.removed)
+	}
+}
+
+func TestApplyUninstallKeyringTokenBestEffortToleratesLockedKeyring(t *testing.T) {
+	originalRead := readRelayAuthTokenForUninstall
+	originalDelete := deleteRelayAuthTokenForUninstall
+	defer func() {
+		readRelayAuthTokenForUninstall = originalRead
+		deleteRelayAuthTokenForUninstall = originalDelete
+	}()
+
+	readRelayAuthTokenForUninstall = func() (string, error) {
+		return "", desktopKeyringLockedError("default secret service collection is locked")
+	}
+	deleteRelayAuthTokenForUninstall = func() error {
+		t.Fatalf("delete must not run when the keyring read failed")
+		return nil
+	}
+
+	report := &uninstallReport{}
+	applyUninstallKeyringTokenBestEffort(report)
+	if len(report.removed) != 0 {
+		t.Fatalf("did not expect removals, got %+v", report.removed)
+	}
+	if len(report.notes) != 1 || !strings.Contains(report.notes[0], "credential store") {
+		t.Fatalf("expected a manual-cleanup note, got %+v", report.notes)
 	}
 }

--- a/cli/uninstall_test.go
+++ b/cli/uninstall_test.go
@@ -762,3 +762,66 @@ func TestPurgeFindsServiceTokenFileWhenConfigIsIncomplete(t *testing.T) {
 		t.Fatalf("expected service token file to be purged despite incomplete config, err=%v", err)
 	}
 }
+
+func TestPurgeKeepsExternalTokenFileAndCleansKeyringOnly(t *testing.T) {
+	if relayAuthTokenFilePlatformOS == "windows" {
+		t.Skip("service token files are not supported on native Windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := os.MkdirAll(paths.ConfigDir, 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	// User-managed token file OUTSIDE the managed config directory.
+	externalDir := filepath.Join(home, "secrets")
+	if err := os.MkdirAll(externalDir, 0o700); err != nil {
+		t.Fatalf("mkdir external dir: %v", err)
+	}
+	externalToken := filepath.Join(externalDir, "relay-token")
+	if err := os.WriteFile(externalToken, []byte("external-token\n"), 0o600); err != nil {
+		t.Fatalf("write external token: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`{"relay_token_file":"`+externalToken+`"}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	originalRead := readRelayAuthTokenForUninstall
+	originalDelete := deleteRelayAuthTokenForUninstall
+	defer func() {
+		readRelayAuthTokenForUninstall = originalRead
+		deleteRelayAuthTokenForUninstall = originalDelete
+	}()
+	keyringDeleted := false
+	readRelayAuthTokenForUninstall = func() (string, error) {
+		return "keyring-token", nil
+	}
+	deleteRelayAuthTokenForUninstall = func() error {
+		keyringDeleted = true
+		return nil
+	}
+
+	report := &uninstallReport{}
+	if err := finalizeLocalUninstall(paths, installState{}, report, uninstallModePurge); err != nil {
+		t.Fatalf("finalizeLocalUninstall() error: %v", err)
+	}
+	if _, err := os.Stat(externalToken); err != nil {
+		t.Fatalf("expected external token file to be left untouched, err=%v", err)
+	}
+	if !keyringDeleted {
+		t.Fatalf("expected the OS keyring copy to be cleaned")
+	}
+	foundNote := false
+	for _, note := range report.notes {
+		if strings.Contains(note, "outside the HA NOVA config directory") {
+			foundNote = true
+		}
+	}
+	if !foundNote {
+		t.Fatalf("expected a kept-external-file note, got %+v", report.notes)
+	}
+}

--- a/cli/update_security_test.go
+++ b/cli/update_security_test.go
@@ -96,6 +96,26 @@ func TestValidateBundleRootRejectsMissingClientRegistry(t *testing.T) {
 	}
 }
 
+func TestValidateBundleRootRejectsInvalidClientRegistry(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "bundle.json"), []byte(fmt.Sprintf(`{"bundle_format_version":1,"os":"%s","arch":"%s","binary_name":"%s"}`, bundlePlatformOS(), bundlePlatformArch(), publicBinaryName())), 0o644); err != nil {
+		t.Fatalf("write bundle.json: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "clients"), 0o755); err != nil {
+		t.Fatalf("mkdir clients: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "clients", "registry.json"), []byte(`{"clients":[{"id":"hermes","label":"Hermes Agent","adapter_kind":"skill_tree","supported_os":["linux"],"setup":{"service_credentials":{"recommended_when":["maybe"],"label":"Service mode","help":"Use for service sessions."}}}]}`), 0o644); err != nil {
+		t.Fatalf("write registry.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, publicBinaryName()), []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+
+	if err := validateBundleRoot(root); err == nil {
+		t.Fatal("expected invalid client registry to fail validation")
+	}
+}
+
 func TestVerifyFileChecksumAcceptsMatchingSHA256(t *testing.T) {
 	dir := t.TempDir()
 	archivePath := filepath.Join(dir, "ha-nova-installer-bundle-linux-amd64.tar.gz")

--- a/cli/update_sync_test.go
+++ b/cli/update_sync_test.go
@@ -163,6 +163,21 @@ func TestPostUpdateSyncRefreshesAllDetectedClients(t *testing.T) {
 		t.Fatalf("write Gemini review skill: %v", err)
 	}
 
+	if err := os.MkdirAll(filepath.Join(home, ".hermes", "skills", "ha-nova", "ha-nova"), 0o755); err != nil {
+		t.Fatalf("mkdir Hermes context skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".hermes", "skills", "ha-nova", "ha-nova", "SKILL.md"), []byte("name: ha-nova"), 0o644); err != nil {
+		t.Fatalf("write Hermes context skill: %v", err)
+	}
+	for _, skillDir := range hermesLegacyRequiredSkillDirs[1:] {
+		if err := os.MkdirAll(filepath.Join(home, ".hermes", "skills", "ha-nova", skillDir), 0o755); err != nil {
+			t.Fatalf("mkdir Hermes skill %s: %v", skillDir, err)
+		}
+		if err := os.WriteFile(filepath.Join(home, ".hermes", "skills", "ha-nova", skillDir, "SKILL.md"), []byte("name: "+skillDir), 0o644); err != nil {
+			t.Fatalf("write Hermes skill %s: %v", skillDir, err)
+		}
+	}
+
 	logPath := filepath.Join(home, "claude.log")
 	t.Setenv("PATH", installClaudeMock(t, home, logPath)+string(os.PathListSeparator)+os.Getenv("PATH"))
 
@@ -189,7 +204,7 @@ func TestPostUpdateSyncRefreshesAllDetectedClients(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadState() error: %v", err)
 	}
-	for _, client := range []string{"claude", "codex", "opencode", "gemini"} {
+	for _, client := range []string{"claude", "codex", "opencode", "gemini", "hermes"} {
 		if !containsClient(state.InstalledClients, client) {
 			t.Fatalf("expected saved state to include %s, got %+v", client, state.InstalledClients)
 		}
@@ -197,6 +212,19 @@ func TestPostUpdateSyncRefreshesAllDetectedClients(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(home, ".gemini", "skills", "ha-nova-review", "SKILL.md")); err != nil {
 		t.Fatalf("expected Gemini skill refresh output: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".hermes", "skills", "ha-nova", "ha-nova-read", "SKILL.md")); err != nil {
+		t.Fatalf("expected Hermes skill refresh output: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".hermes", "skills", "ha-nova", "read")); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy Hermes read directory to be migrated away, got err=%v", err)
+	}
+	readData, err := os.ReadFile(filepath.Join(home, ".hermes", "skills", "ha-nova", "ha-nova-read", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read migrated Hermes read skill: %v", err)
+	}
+	if !strings.Contains(string(readData), "name: ha-nova-read") {
+		t.Fatalf("expected migrated Hermes read skill to use canonical namespaced frontmatter, got %q", string(readData))
 	}
 
 	codexInfo, err := os.Lstat(filepath.Join(home, ".agents", "skills", "ha-nova"))
@@ -321,6 +349,61 @@ func TestRunUpdateAlreadyCurrentRetriesInstalledClientSync(t *testing.T) {
 
 	if !claudePluginInstalled(home) {
 		t.Fatal("expected Claude plugin to be installed after retry")
+	}
+}
+
+func TestRunUpdateAlreadyCurrentMigratesLegacyHermesBundle(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error: %v", err)
+	}
+	t.Setenv("HA_NOVA_DEV_ROOT", filepath.Clean(filepath.Join(cwd, "..")))
+
+	originalRuntimeDetected := clientRuntimeDetectedForStatus
+	clientRuntimeDetectedForStatus = func(string) bool { return true }
+	t.Cleanup(func() {
+		clientRuntimeDetectedForStatus = originalRuntimeDetected
+	})
+
+	if err := os.MkdirAll(filepath.Dir(paths.VersionFile), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(paths.VersionFile, []byte(`{"skill_version":"0.2.2","min_relay_version":"0.1.0"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, ".hermes", "skills", "ha-nova", "ha-nova"), 0o755); err != nil {
+		t.Fatalf("mkdir Hermes context skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".hermes", "skills", "ha-nova", "ha-nova", "SKILL.md"), []byte("name: ha-nova\n"), 0o644); err != nil {
+		t.Fatalf("write Hermes context skill: %v", err)
+	}
+	for _, skillDir := range hermesLegacyRequiredSkillDirs[1:] {
+		if err := os.MkdirAll(filepath.Join(home, ".hermes", "skills", "ha-nova", skillDir), 0o755); err != nil {
+			t.Fatalf("mkdir legacy Hermes skill %s: %v", skillDir, err)
+		}
+		if err := os.WriteFile(filepath.Join(home, ".hermes", "skills", "ha-nova", skillDir, "SKILL.md"), []byte("name: "+skillDir+"\n"), 0o644); err != nil {
+			t.Fatalf("write legacy Hermes skill %s: %v", skillDir, err)
+		}
+	}
+
+	if exitCode := runUpdate(paths, []string{"--version", "0.2.2"}); exitCode != 0 {
+		t.Fatalf("runUpdate() exit = %d, want 0", exitCode)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, ".hermes", "skills", "ha-nova", "ha-nova-review", "SKILL.md")); err != nil {
+		t.Fatalf("expected migrated Hermes review skill: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".hermes", "skills", "ha-nova", "review")); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy Hermes review directory to be removed, got err=%v", err)
 	}
 }
 

--- a/cli/write_atomic.go
+++ b/cli/write_atomic.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomic replaces path via temp-file + rename so concurrent readers
+// (e.g. Claude Code reading its own plugin state) never observe a truncated
+// file. The temp file lives in the target directory so the rename stays on
+// one filesystem.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}

--- a/cli/write_atomic_test.go
+++ b/cli/write_atomic_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileAtomicReplacesContentAndLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	if err := writeFileAtomic(path, []byte("new"), 0o644); err != nil {
+		t.Fatalf("writeFileAtomic() error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(data) != "new" {
+		t.Fatalf("expected replaced content, got %q", string(data))
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected only the target file in dir, got %d entries", len(entries))
+	}
+}

--- a/clients/registry.json
+++ b/clients/registry.json
@@ -1,4 +1,5 @@
 {
+  "registry_format_version": 1,
   "clients": [
     {
       "id": "claude",
@@ -28,7 +29,14 @@
       "id": "hermes",
       "label": "Hermes Agent",
       "adapter_kind": "skill_tree",
-      "supported_os": ["macos", "linux"]
+      "supported_os": ["macos", "linux"],
+      "setup": {
+        "service_credentials": {
+          "recommended_when": ["headless", "locked_keyring", "systemd_user_service"],
+          "label": "Service / gateway mode",
+          "help": "Use this when Hermes runs from SSH, systemd, headless, or gateway sessions without an unlocked desktop keyring. Keep desktop keyring mode for a normal desktop terminal."
+        }
+      }
     }
   ]
 }

--- a/docs/archive/plans/2026-04-21-hermes-skill-view-mismatch-spec.md
+++ b/docs/archive/plans/2026-04-21-hermes-skill-view-mismatch-spec.md
@@ -1,0 +1,45 @@
+## Hermes `skill_view` Mismatch Spec
+
+Date: 2026-04-21
+Status: implemented
+
+### Problem
+
+Hermes shows HA NOVA sub-skills in `skills_list(category="ha-nova")`, but `skill_view("<listed-name>")` fails for names such as `ha-nova-history` and `ha-nova-review`.
+
+### Root Cause
+
+Before the fix, HA NOVA installed Hermes sub-skills under bare directory names like:
+
+- `~/.hermes/skills/ha-nova/history/SKILL.md`
+- `~/.hermes/skills/ha-nova/review/SKILL.md`
+
+but rewrites the frontmatter names to:
+
+- `name: ha-nova-history`
+- `name: ha-nova-review`
+
+This creates two competing identifiers for the same installed Hermes skill:
+
+- directory name: `history`
+- frontmatter name: `ha-nova-history`
+
+Hermes discovery and view lookup did not consistently tolerate that mismatch.
+
+### Goal
+
+Make Hermes install and status logic use one canonical installed identifier per sub-skill so list and view agree.
+
+### Implementation
+
+1. Hermes sub-skills now install into directories whose names match their rewritten frontmatter names.
+2. The context skill stays stable as `ha-nova`.
+3. Hermes-facing markdown keeps the `ha-nova-*` dispatch references.
+4. Go installer, shell installer, tests, and docs now match the canonical Hermes layout.
+
+### Exit Criteria
+
+- Hermes sub-skills install under `~/.hermes/skills/ha-nova/ha-nova-*/`.
+- Installed Hermes sub-skill directories match their `name:` frontmatter.
+- `ha-nova setup hermes` and `install-local-skills.sh hermes` follow the same layout.
+- Targeted Go and Vitest coverage passes for the Hermes install contract.

--- a/docs/reference/client-integration.md
+++ b/docs/reference/client-integration.md
@@ -1,0 +1,60 @@
+# Client Integration
+
+HA NOVA clients are registered in `clients/registry.json`.
+
+For a simple client, add the registry entry, add the client install overlay, and cover the behavior with setup/status/uninstall tests. Do not add a new Go `switch` unless the client needs a real adapter with behavior that the registry cannot express.
+
+## Minimal Client
+
+```json
+{
+  "id": "future",
+  "label": "Future Client",
+  "adapter_kind": "skill_tree",
+  "supported_os": ["macos", "linux"]
+}
+```
+
+## Service Credentials
+
+Some clients can run from a service, gateway, SSH, or headless session where the desktop keyring is not unlocked. Those clients can opt in to a setup prompt:
+
+```json
+{
+  "id": "hermes",
+  "label": "Hermes Agent",
+  "adapter_kind": "skill_tree",
+  "supported_os": ["macos", "linux"],
+  "setup": {
+    "service_credentials": {
+      "recommended_when": ["headless", "locked_keyring", "systemd_user_service"],
+      "label": "Service / gateway mode",
+      "help": "Use this when the client runs without an unlocked desktop keyring."
+    }
+  }
+}
+```
+
+This enables `ha-nova setup --service <client>` and lets interactive setup offer a service token file when the selected client declares the capability. The setup flow must stay generic: do not hardcode a Hermes-only branch for this prompt.
+
+The service token file stores only the Relay Auth Token. It does not store the Home Assistant Long-Lived Access Token.
+
+## OS Overrides
+
+Use `per_os` when a setup capability differs by platform:
+
+```json
+{
+  "per_os": {
+    "windows": {
+      "setup": {
+        "service_credentials": {
+          "disabled": true
+        }
+      }
+    }
+  }
+}
+```
+
+Keep registry metadata declarative. Do not add cleanup globs, shell hooks, or dynamic scripts to client entries.

--- a/docs/reference/documentation-governance.md
+++ b/docs/reference/documentation-governance.md
@@ -24,6 +24,8 @@ Use these files as the current sources of truth:
   - HA transport/routing truth
 - `docs/reference/skill-architecture.md`
   - skill topology and contributor index
+- `docs/reference/client-integration.md`
+  - client registry and setup capability truth
 - `.claude/INSTALL.md`, `.codex/INSTALL.md`, `.gemini/INSTALL.md`, `.opencode/INSTALL.md`, `.hermes/INSTALL.md`
   - client-specific install overlays; derived active docs that cover client deltas only and must point back to `README.md` for the shared install contract
 - `nova/DOCS.md`

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -177,21 +177,24 @@ macOS self-managed lifecycle:
 Linux real-machine onboarding:
 Helper:
 - use `scripts/smoke/linux-headless-setup-check.sh` as the executable assistant for the SSH/headless Linux lane; pass the host and install command via env, never hardcode host-specific details in the repo
-- by default the helper runs `HA_NOVA_NO_BROWSER=1 ha-nova setup`; for Hermes-specific proof, set `HA_NOVA_LIVE_SETUP_CMD='HA_NOVA_NO_BROWSER=1 ha-nova setup hermes'`
+- by default the helper runs `HA_NOVA_NO_BROWSER=1 ha-nova setup`; for Hermes desktop-keyring proof, set `HA_NOVA_LIVE_SETUP_CMD='HA_NOVA_NO_BROWSER=1 ha-nova setup hermes'`; for Hermes service/gateway proof, set `HA_NOVA_LIVE_SETUP_CMD='HA_NOVA_NO_BROWSER=1 ha-nova setup --service hermes'`
 - `HA_NOVA_LIVE_SKIP_INSTALL=1` is for repair/debug passes only; it does not satisfy the full release-bound fresh-install proof for this lane
 1. use a real Linux host with a desktop user session; when validating the SSH/headless recovery path, use an SSH shell inside that same logged-in user session
 2. fresh stable install via the public `install.sh` flow
-3. if secure storage is unavailable because no Secret Service provider is running, confirm setup fails with the explicit provider prerequisite message instead of raw `org.freedesktop.secrets` D-Bus text
-4. if secure storage is present but the default collection is still locked or uninitialized and the active Secret Service owner is GNOME Keyring, confirm interactive `ha-nova setup` offers the built-in local secure-storage recovery step before host/token work
-5. if the same locked/uninitialized state exists on a non-GNOME Secret Service backend, confirm setup stays fail-loud with the explicit prerequisite guidance and does not pretend inline recovery is available
-6. confirm the locked-flow copy asks for the existing local Linux keyring password, while the uninitialized-flow copy asks the user to create and confirm a new local Linux keyring password
-7. confirm a wrong local keyring password keeps the user on the locked recovery step with a clear local secure-storage error, and confirm a correct password unlocks the keyring and resumes setup
-8. confirm the fresh-init recovery path can create the default GNOME Keyring collection over SSH and then resumes setup without sending the user to a desktop GUI
-9. finish setup, then run `ha-nova doctor`
-10. if the lane includes Hermes or a pre-fix Hermes bundle, confirm `ha-nova doctor` reports a repairable Hermes mismatch instead of silently hiding it
-11. run `ha-nova setup hermes` and confirm the Hermes route repairs cleanly
-12. re-run `ha-nova doctor` and confirm it reports `Hermes Agent ready now`
-13. confirm the relay token is saved and can be reused by a second `ha-nova setup` / `ha-nova doctor` invocation without repeating recovery
+3. confirm Home Assistant auto-discovery prefers a real reachable result over an unverified `.local` guess when Avahi/mDNS evidence exists
+4. if secure storage is unavailable because no Secret Service provider is running, confirm setup fails with the explicit provider prerequisite message instead of raw `org.freedesktop.secrets` D-Bus text
+5. if secure storage is present but the default collection is still locked or uninitialized and the active Secret Service owner is GNOME Keyring, confirm interactive `ha-nova setup` offers the built-in local secure-storage recovery step before host/token work
+6. if the same locked/uninitialized state exists on a non-GNOME Secret Service backend, confirm setup stays fail-loud with the explicit prerequisite guidance and does not pretend inline recovery is available
+7. confirm the locked-flow copy asks for the existing local Linux keyring password, while the uninitialized-flow copy asks the user to create and confirm a new local Linux keyring password
+8. confirm a wrong local keyring password keeps the user on the locked recovery step with a clear local secure-storage error, and confirm a correct password unlocks the keyring and resumes setup
+9. confirm the fresh-init recovery path can create the default GNOME Keyring collection headlessly over SSH and then resumes setup without sending the user to a desktop GUI
+10. finish setup, then run `ha-nova doctor`
+11. if the lane includes Hermes or a pre-fix Hermes bundle, confirm `ha-nova doctor` reports a repairable Hermes mismatch instead of silently hiding it
+12. run `ha-nova setup hermes` and confirm the Hermes route repairs cleanly
+13. re-run `ha-nova doctor` and confirm it reports `Hermes Agent ready now`
+14. confirm the relay token is saved and can be reused by a second `ha-nova setup` / `ha-nova doctor` invocation without repeating recovery
+15. for the Hermes service/gateway lane, run `ha-nova setup --service hermes`, then `ha-nova doctor`, then one authenticated relay call from a fresh SSH/service-like shell without an unlocked desktop keyring
+16. for the Hermes service/gateway lane, run `ha-nova uninstall --yes --purge` and confirm the service token file is removed
 
 Windows self-managed:
 1. on fresh-profile runs, preinstall at least one supported client and verify it already runs on that exact machine/session

--- a/docs/work/2026-03-27-breadcrumbs.md
+++ b/docs/work/2026-03-27-breadcrumbs.md
@@ -18,6 +18,50 @@ Historical breadcrumb log:
 - Update the stable release-note template to publish tag-pinned installer commands plus matching `HA_NOVA_VERSION`
 - Tighten onboarding contract tests so stable public surfaces fail if they advertise `main/install.sh` or `main/install.ps1`
 
+## 2026-04-08: Release-Note Comparison
+
+### Completed
+- Reworked the release-note comparison plan after a six-agent gap review
+- Locked the compare algorithm to published GitHub releases plus exact SHAs instead of draft releases or release-branch names
+- Classified the current `v0.3.2..ea8a708` delta by user-facing behavior slices instead of by the squash commit headline
+- Prepared a release-note comparison artifact with an analysis matrix, exclusion audit, and a provisional draft
+
+### Next
+- Re-run the same comparison against the exact publish SHA once the next RC or stable release commit exists
+- Fill the install block placeholder with the real release tag only during release-cut work
+
+## 2026-04-09: README Positioning Refresh
+
+### Completed
+- Decided to separate the “why use HA NOVA” story from the lower-level implementation explanation
+- Reframed the Relay as the product foundation for trust, local control, and future growth
+- Reframed markdown skills as product leverage and community extensibility, not just a technical curiosity
+- Prepared a dedicated next-release notes draft from the current `v0.3.2..ea8a708` comparison
+- Ran a second README pass using multiple writing-focused subagents for positioning, accessibility, community pull, and MCP differentiation
+- Moved user value and differentiation ahead of Quick Start, compressed install into a clearer later section, and made the MCP contrast more decisive without sounding hostile
+- Simplified the README wording again so it uses easier English without sounding childish or vague
+- Added the missing Relay story: not just the trust boundary today, but also the small base where future HA-specific helpers can live without turning HA NOVA into a big MCP server
+
+### Next
+- Re-check the README after the next visible feature train so the promise stays aligned with shipped capability
+
+## 2026-04-17: Project Familiarization
+
+### Completed
+- Rebuilt the current project model with six parallel sub-analyses across docs, relay, CLI, skills, verification, and release/packaging.
+- Confirmed the core architecture is still: Go CLI + TypeScript relay + markdown skill system, with the relay intentionally dumb and the skills intentionally smart.
+- Confirmed the active relay surface is still Phase 1a only: `GET /health`, `POST /ws`, `POST /core`.
+- Confirmed the skill system remains the main product surface: one context skill plus eleven sub-skills, with `write` as the only explicitly agentized mutation flow.
+- Confirmed the strongest operational complexity sits in the CLI, especially Claude packaging/marketplace sync, install-source detection, and update-time client repair.
+- Confirmed the verification model is contract-heavy and host-safe by default, with stronger real-world proof available through opt-in smoke/live harnesses rather than default CI.
+- Ran focused Vitest verification successfully:
+  - `npm run test:safe -- tests/bootstrap/runtime-start.test.ts tests/skills/ha-nova-contract.test.ts tests/onboarding/install-skills-per-client.test.ts`
+- Ran `cd cli && go test ./...` and observed current workspace failures in Claude resume/setup tests caused by missing Claude release-snapshot payload expectations in the current worktree state.
+
+### Next
+- Use this familiarization model as the baseline for future work instead of re-discovering architecture per task.
+- Treat current CLI test failures as branch-state context until a task explicitly targets Claude packaging/setup repair.
+
 ## 2026-03-27: Review Synthesis + R-18 Follow-Up
 
 ### Completed
@@ -213,3 +257,401 @@ Historical breadcrumb log:
   - `npx vitest run tests/onboarding/bump-version.test.ts tests/onboarding/release-contract.test.ts`
   - `cd cli && go test ./... -run 'TestInstallClaudePlugin|TestPostUpdateSync|TestClientAppearsInstalledForClaude|TestRunDoctor'`
   - `git diff --check`
+## 2026-04-18: Linux Secure Storage Recovery
+
+### Completed
+- Reproduced the real Linux SSH setup failure on `markus@192.168.1.8` and proved the root cause was not a plain unlock failure but a missing Secret Service `default` collection alias on a fresh GNOME Keyring state
+- Proved live over SSH that GNOME Keyring's internal DBus methods can create the default collection headlessly (`CreateWithMasterPassword` + `SetAlias("default", ...)`) and can also unlock an existing locked collection (`UnlockWithMasterPassword`)
+- Reworked the Linux CLI path to distinguish locked-vs-uninitialized secure storage, tightened GNOME owner trust checks, and moved recovery from shell exec to DBus
+- Reworked setup UX copy so fresh-init asks the user to create a new local Linux keyring password, while locked recovery asks for the existing one
+- Tightened Linux preflight to require a real write/read/delete probe instead of trusting alias state alone
+- Added and updated Go coverage for the new Linux recovery actions, state classification, and setup/persistence UX
+
+### Next
+- Keep the Linux secure-storage slice in review until the remaining cleanup/test findings are closed
+
+## 2026-04-09: README Positioning Tightening
+
+### Completed
+- Tightened the README opening so the Relay case lands once up top instead of repeating the same trust/growth message across multiple sections
+- Kept the Relay explanation focused on three strong points: server-side trust, hard local work, and room for future HA-specific helpers
+- Simplified the split explanation and reduced repeated “plain markdown skills” / “small Relay” language in later sections
+- Recorded the new README defaults in the work spec and choices log
+- Removed direct opening repetition where two back-to-back sentences both started with `HA NOVA`
+- Replaced several remaining vague or awkward README lines with simpler, more direct wording across the opening, benefits, MCP comparison, and contribution close
+
+### Next
+- Re-read the full README once more for any remaining repetition outside the opening sections if more polishing is needed
+
+## 2026-04-12: Claude Agent Port
+
+### Completed
+- Found the local Claude source agent at `/Users/markus/.claude/agents/doc-review-orchestrator.md`
+- Read its companion memory file at `/Users/markus/.claude/agent-memory/doc-review-orchestrator/MEMORY.md`
+- Ported the reusable review method into a local Codex skill at `/Users/markus/.agents/skills/doc-review-orchestrator/SKILL.md`
+- Captured the port scope and defaults in a work spec
+
+### Next
+- Start a fresh Codex session when convenient so the new local skill can be discovered in the standard skill list
+
+## 2026-04-12: Release Note Refresh
+
+### Completed
+- Refreshed the release-note comparison from `v0.3.2..ea8a708` to `v0.3.2..b5e94aa`
+- Classified the three post-feature commits as docs-only follow-up work
+- Confirmed they do not create new public release-note bullets
+- Kept the next-release draft unchanged because the user-facing product delta is still the promoted skills plus Gemini auto-discovery
+
+### Next
+- Replace `<RELEASE_TAG>` in the draft once the actual release tag is chosen
+
+## 2026-04-13: Dependabot Release Preflight
+
+### Completed
+- Audited all open Dependabot PRs with `gh`
+- Confirmed current open set is `#166`, `#165`, `#164`, `#163`, `#156`
+- Verified root production deps still fail `npm audit --omit=dev` on critical `axios` advisories
+- Verified `nova/` production deps also fail `npm audit --omit=dev` on the same critical `axios` advisories
+- Classified the two `axios` bumps as release-lane candidates and the workflow/dev-dependency bumps as separate-later maintenance
+
+### Next
+- Either merge reviewed `axios` fixes through the normal PR path or carry equivalent fixes in a reviewed release-prep PR before calling the next tag release-ready
+
+## 2026-04-13: Combined Axios Release-Prep PR
+
+### Completed
+- Confirmed `#165` and `#164` could not pass CI independently because each PR left the other critical production `axios` audit finding in place
+- Built a combined branch from `origin/main`: `build/release-prep-axios-1-15-0`
+- Committed the bundled root + `nova` `axios` bumps at `ff2248e`
+- Verified locally with `npm audit --omit=dev --json` in root and `nova/`, `npm run verify:security`, and `npm run test:safe:core`
+- Opened PR `#167` with the combined fix, added `manifest-review:approved`, and triggered `@codex`
+- Confirmed Codex bot already returned a `+1` reaction on `#167`
+- Merged `#167` via squash as remote commit `1132ce7` after all required checks were green and the current PR SHA had a clean Codex result
+- Closed superseded Dependabot PRs `#165` and `#164`
+
+### Next
+- Continue release prep from `origin/main` at `1132ce7`
+- Re-evaluate which remaining open Dependabot PRs are intentionally deferred (`#166`, `#163`, `#156`)
+
+## 2026-04-13: Post-Axios Release Refresh
+
+### Completed
+- Refreshed the release compare target from the older provisional `b5e94aa` snapshot to `origin/main` at `1132ce7`
+- Reclassified the merged `axios` fix as a selective `Bug Fixes` candidate for the next release notes
+- Updated the release-note comparison artifact and the next-release draft to include the `axios` security fix
+- Rechecked the remaining open Dependabot PRs and kept `#166`, `#163`, and `#156` in the deferred lane
+
+### Next
+- Continue release prep from `1132ce7`
+- Keep the remaining open Dependabot PRs out of the release lane unless a new live release-path problem appears
+
+## 2026-04-13: Release Prep 0.4.0
+
+### Completed
+- Chose `0.4.0` as the next stable version
+- Verified `v0.4.0` is newer than the latest published stable release
+- Created a clean release-prep branch from `origin/main`: `build/release-prep-0-4-0`
+- Bumped release metadata to `0.4.0` in `version.json`, `package.json`, `package-lock.json`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`
+- Verified locally with `npm run verify:release-metadata`, `npm run verify:release-contracts`, targeted bump/release Vitest suites, and the full pre-push hook
+- Opened PR `#168`, added `manifest-review:approved`, and triggered `@codex`
+- Confirmed `#168` received a clean Codex `+1` and green CI on SHA `07d503c`
+- Merged `#168` via squash as remote commit `d1de3f1`
+- Tagged the reviewed remote merge commit as `v0.4.0`
+- Let `release.yml` publish the release successfully
+- Replaced the generated GitHub release text with the final user-facing body from `docs/work/2026-04-13-v0.4.0-release-body.md`
+
+### Next
+- If needed, do a short post-release sanity pass on the published installers and update path
+
+## 2026-04-13: Post-Release Sanity
+
+### Completed
+- Confirmed GitHub release `v0.4.0` is published with the intended final user-facing release notes
+- Confirmed release workflow `24336286371` finished successfully
+- Confirmed the release job plus all three post-publish smoke installer jobs (`ubuntu`, `macOS`, `Windows`) completed successfully
+- Confirmed the public raw installer scripts at tag `v0.4.0` resolve the latest release path by default and support explicit `HA_NOVA_VERSION` pinning
+- Confirmed the tagged `version.json` reports `0.4.0`
+- Confirmed the release assets and selected bundle checksum sidecars are present on GitHub
+- Confirmed `checksums.txt` covers the raw CLI binaries while the installer bundles ship separate `.sha256` sidecars
+
+### Next
+- Remaining optional work is follow-up housekeeping only; no immediate release issue was found
+
+## 2026-04-13: Claude Availability Troubleshooting
+
+### Completed
+- Confirmed the local Mac still has HA NOVA `0.3.2` installed
+- Confirmed the local installed HA NOVA skill tree does not include the new promoted skills from `v0.4.0`
+- Confirmed HA NOVA's own local state still says Claude is installed in plugin mode
+- Confirmed Claude itself does not currently list the `ha-nova` marketplace or the `ha-nova@ha-nova` plugin in `~/.claude/plugins/*` or `claude plugin list`
+- Confirmed the staged local Claude marketplace files still exist under `~/.config/ha-nova/claude-marketplace`
+- Determined the immediate issue is plugin-state drift: Claude is not loading the old HA NOVA install, so it cannot show the expected in-product update notice
+
+### Next
+- Explain the drift clearly to the user
+- If wanted, repair the local Claude registration and update the install to `v0.4.0`
+
+## 2026-04-13: Claude Drift Fix
+
+### Completed
+- Ran six review lanes across install/setup, doctor/status, update sync, uninstall/reset, regression coverage, and user-impact surface
+- Confirmed the strongest repo-controlled weakness was overly loose Claude success verification after install
+- Confirmed Claude plugin detection incorrectly treated blank `installPath` values as installed
+- Tightened the Go Claude install path so success now requires both marketplace registration and plugin presence after sync
+- Tightened Claude plugin detection so blank `installPath` no longer counts as installed
+- Added targeted regressions for marketplace disappearance after install and blank `installPath`
+- Verified with targeted Go tests covering doctor hints, update sync, retry behavior, stale-state handling, and the new Claude regressions
+
+### Next
+- If needed, repair the local Mac Claude registration with `ha-nova setup claude` and then update to `v0.4.0`
+
+## 2026-04-13: Claude Drift KISS Refinement
+
+### Completed
+- Ran a second six-lane refinement pass focused on minimality, detach semantics, likely trigger ranking, and regression scope
+- Kept `update` non-pruning after review convergence; no hidden state-clearing behavior was added
+- Hardened the Claude fallback `update -> install` branch so verifier failures now flow through rollback
+- Tightened Claude attachment truth again so unparseable plugin registry data no longer counts as installed
+- Added regressions for unparseable Claude registry data and fallback-install marketplace disappearance
+- Re-ran targeted Claude doctor/install/update regression tests successfully
+
+### Next
+- If this still detaches in the wild after the stricter verifier, the next step should be evidence capture around the real trigger, not a bigger architecture layer
+
+## 2026-04-13: Claude Real-Machine Repro
+
+### Completed
+- Snapshotted live local state before mutation under `/tmp/ha-nova-claude-snapshot-LIU4bi`
+- Built a local test binary from merged `origin/main` instead of trusting the installed `0.3.2` binary
+- Reproduced a controlled detached-Claude state by removing only the `ha-nova@ha-nova` plugin record from `~/.claude/plugins/installed_plugins.json`
+- Confirmed the stricter attach fix behaves correctly on the real Mac:
+  - `doctor` warned that Claude was configured but not attached
+  - `setup claude` repaired the state cleanly
+- Reproduced a second drift case by removing only the `ha-nova` marketplace entry from `~/.claude/plugins/known_marketplaces.json`
+- Confirmed a new real-machine gap: `doctor` stayed green in the marketplace-missing case even though `setup claude` still had to repair Claude
+
+### Next
+- Patch `doctor`/status to require both the Claude plugin and the Claude marketplace record for a healthy attach state
+
+## 2026-04-13: Claude Doctor Marketplace Fix
+
+### Completed
+- Created a clean clone from `origin/main` after detecting the first test worktree was polluted by unrelated local deltas
+- Patched Claude client status so `doctor` now treats Claude as attached only when both the plugin and marketplace record exist
+- Added a regression test for the missing-marketplace drift case
+- Verified targeted Go regressions on the clean clone
+- Re-ran the marketplace-missing real-machine test with the clean-clone binary:
+  - `doctor` now correctly warns on marketplace-only drift
+  - `setup claude` repairs the state
+  - final `doctor` returns to healthy
+- Opened PR `#170` (`fix: detect missing Claude marketplace in doctor`) and triggered `@codex`
+
+### Next
+- Wait for PR `#170` CI + Codex on the exact pushed SHA, then merge if clean
+
+## 2026-04-14: Claude Drift Evidence Capture
+
+### Completed
+- Merged PR `#170` first so the doctor/attach truth fix stayed isolated from follow-up forensics work
+- Created a separate follow-up branch in the clean clone for Claude drift evidence capture
+- Ran six focused review lanes across evidence quality, JSON/file-format risk, watcher KISS, test gaps, debugging value, and docs/scope
+- Built a compact `snapshot-home` / `write-watch-event` extension into `scripts/dev/claude-plugin-state.mjs`
+- Added a new local watcher wrapper at `scripts/dev/watch-claude-state.sh`
+- Hardened the watcher/helper after review:
+  - BOM-prefixed JSON parses cleanly
+  - invalid Claude JSON records parseability instead of killing the watcher
+  - foreign plugins / foreign marketplaces no longer false-positive as HA NOVA
+  - `attached` now requires a usable HA NOVA install path plus marketplace source
+  - watcher output includes a small per-event `changes` diff block
+  - launchd-safe command lookup now falls back to Homebrew paths for `node` / `fswatch`
+- Added targeted helper regressions for:
+  - full attached snapshot
+  - watch-event output
+  - foreign plugin false-positive prevention
+  - blank install path
+  - BOM on installed plugins
+  - BOM on known marketplaces
+  - invalid known marketplaces JSON
+- Verified on the clean clone:
+  - `npx vitest run tests/onboarding/claude-plugin-state-helper.test.ts`
+  - `go test -run 'TestDoctor|Test.*Claude.*' -count=1` in `cli/`
+  - `git diff --check`
+- Confirmed the live watcher runs on the Mac as a `launchd` submitted job:
+  - label `com.markusleben.ha-nova.claude-audit`
+  - stdout `/tmp/ha-nova-claude-audit.log`
+  - stderr `/tmp/ha-nova-claude-audit.err`
+  - audit output `~/Library/Caches/ha-nova/claude-drift-audit/{events.jsonl,latest.json}`
+- Confirmed the current live Claude state at watcher startup is attached again on the Mac:
+  - `known_marketplaces.json` includes `ha-nova`
+  - `settings.json` enables `ha-nova@ha-nova`
+  - `installed_plugins.json` contains `ha-nova@ha-nova` with install path `.../0.3.2`
+
+### Next
+- Commit and open the small follow-up PR for the evidence-capture tooling
+- Leave the watcher running until the next real detach or drift event appears
+- When detach happens again, inspect `events.jsonl` to identify the first changed Claude registry file and the exact field-level diff
+
+## 2026-04-14: Manifest Label Timing Miss
+
+### Completed
+- Opened PR `#171` for the Claude drift evidence-capture tooling
+- Caught a repeated `manifest-review-gate` failure after a force-push rebased the PR onto real `github/main`
+- Confirmed the root cause was label timing, not missing label presence:
+  - `manifest-review:approved` was present in GitHub UI
+  - the workflow invalidated the earlier label event because a newer relevant SHA landed afterward
+- Re-applied the manifest label on the current PR state
+- Wrote the explicit relabel rule into `AGENTS.md` and `docs/work/2026-03-27-choices.md`
+
+### Next
+- Keep treating manifest-changing PRs as `label on create` plus `relabel after any later relevant SHA`
+
+## 2026-04-14: Claude Detach Root Cause + GitHub Marketplace Fix
+
+### Completed
+- Reproduced the detached real-machine state again on the Mac and confirmed Claude no longer had `ha-nova` in:
+  - `~/.claude/plugins/known_marketplaces.json`
+  - `~/.claude/plugins/installed_plugins.json`
+  - `~/.claude/settings.json`
+- Pulled the live drift-audit evidence and confirmed the important order:
+  - `known_marketplaces.json` lost `ha-nova` first
+  - then `installed_plugins.json` / `settings.json` followed
+  - Claude wrote `.orphaned_at` in the HA NOVA plugin cache
+- Confirmed the old attached state right before detach was using the staged local marketplace path:
+  - `/Users/markus/.config/ha-nova/claude-marketplace`
+- Chose the KISS product fix:
+  - bundle installs now use the GitHub Claude marketplace source by default
+  - local staged marketplace stays dev-only / explicit override only
+- Tightened Claude attachment truth further:
+  - Claude attachment now requires both plugin record and marketplace record
+  - blank `installPath` no longer counts as installed
+  - post-sync verification now fails if the plugin exists but the marketplace registration is gone
+  - failed GitHub-source installs now roll the marketplace back instead of leaving a half-attached state behind
+- Updated tests for the new production/default behavior and added regression coverage for:
+  - bundle install defaulting to GitHub source
+  - stale local marketplace migration to GitHub source
+  - blank `installPath`
+  - missing marketplace record
+- Updated Claude reference docs to reflect the new production/default model
+- Used the new code path on the real Mac with `go run . internal-sync-clients` from `cli/` and repaired Claude successfully:
+  - `ha-nova@ha-nova` restored
+  - version now `0.4.1`
+  - marketplace source now `https://github.com/markusleben/ha-nova.git`
+  - `ha-nova doctor` returned healthy
+  - 15-second follow-up check stayed attached
+
+### Verification
+- `cd cli && go test -run 'TestInstallClaudePlugin|TestRemoveInstalledClients|TestRunDoctor|TestPostUpdateSync|TestClientAppearsInstalled' -count=1`
+- `npx vitest run tests/onboarding/client-install-docs-contract.test.ts`
+- `git diff --check`
+- Real-machine Claude checks:
+  - `claude plugin list`
+  - `claude plugin marketplace list`
+  - watcher audit under `~/Library/Caches/ha-nova/claude-drift-audit/`
+
+### Next
+- Open a focused PR for the GitHub-marketplace production fix
+- Keep the drift watcher running to see whether the GitHub-backed source stays stable longer-term on the real Mac
+
+## 2026-04-14
+
+### Claude release-snapshot implementation
+- Revisited the Claude production-source decision after confirming the user still needs an exact shipped-release attach, not just a more stable attach.
+- Confirmed in code that bundle and repair paths still used:
+  - floating/legacy GitHub migration logic in Go tests
+  - the flat local root `~/.config/ha-nova/claude-marketplace` for local staging
+- Implemented a new production default for bundle installs:
+  - exact versioned local release snapshots under `~/.config/ha-nova/claude-marketplace/releases/vX.Y.Z`
+- Kept the flat local root for repo/dev and explicit override only.
+- Tightened Claude attachment truth further:
+  - expected marketplace source must match
+  - plugin record must exist
+  - `installPath` must be usable
+- Changed bundle behavior so missing/incomplete Claude payload is now a hard failure instead of a GitHub fallback.
+- Updated helper parsing so dev/shell rollback can still read structured GitHub and git+ref marketplace entries.
+- Added/updated regressions for:
+  - bundle default -> versioned local snapshot
+  - legacy GitHub migration -> versioned local snapshot
+  - configured Claude repair when marketplace record is missing
+  - old flat local root no longer counting as healthy
+  - bundle payload missing -> loud failure
+- Updated Claude docs/spec notes to reflect:
+  - bundle installs use versioned local release snapshots
+  - flat root stays dev-only
+
+### Verification
+- `npx vitest run tests/onboarding/install-skills-per-client.test.ts tests/onboarding/dev-sync-behavior.test.ts tests/onboarding/desktop-validation-contract.test.ts`
+- `cd cli && go test ./... -run 'TestInstallClaudePluginUsesVersionedLocalMarketplaceByDefaultForInstalledBundle|TestInstallClaudePluginMigrates|TestInstallClaudePluginFailsWithout|TestPostUpdateSyncRefreshesDetectedInstalledClientsWithoutState|TestClientAppearsInstalledForClaude'`
+- `cd cli && go test ./... -run 'TestInstallClaudePluginUpdatesExistingPlugin|TestRunDoctor|TestPostUpdateSyncRefreshesAllDetectedClients'`
+
+### Real-machine proof
+- Ran an isolated temp-`HOME` Claude smoke on macOS using the current repo code plus the installed bundle payload.
+- Confirmed fresh `setup claude --non-interactive` attached Claude to:
+  - `/tmp/.../.config/ha-nova/claude-marketplace/releases/v0.4.1`
+- Confirmed on-disk proof in temp `HOME`:
+  - `known_marketplaces.json` pointed to the versioned local directory
+  - `installed_plugins.json` resolved to cache path `.../ha-nova/0.4.1`
+- Deliberately removed the `ha-nova` marketplace entry in temp `HOME`; `go run . doctor` failed correctly and same-version `go run . update --version 0.4.1` repaired it back to the same versioned local directory.
+- Backed up the real profile before mutation under:
+  - `~/Library/Caches/ha-nova/manual-claude-test-20260414-191656`
+- Confirmed real-profile pre-state:
+  - `doctor` reported `Claude Code is not attached correctly`
+  - `claude plugin list` had no `ha-nova`
+  - `claude plugin marketplace list` had no `ha-nova`
+- Repaired the real profile with:
+  - `cd cli && go run . setup claude --non-interactive`
+- Confirmed real-profile post-repair:
+  - `doctor` passed
+  - `claude plugin list` showed `ha-nova@ha-nova Version: 0.4.1`
+  - `claude plugin marketplace list` showed `Source: Directory (/Users/markus/.config/ha-nova/claude-marketplace/releases/v0.4.1)`
+- Deliberately removed the real `ha-nova` marketplace entry again; `doctor` failed correctly.
+- Repaired the real profile with same-version update:
+  - `cd cli && go run . update --version 0.4.1`
+- Confirmed final real-profile source returned to:
+  - `/Users/markus/.config/ha-nova/claude-marketplace/releases/v0.4.1`
+- Opened focused PR `#173` for the Claude release-snapshot fix.
+- Fixed two real Codex findings on the PR:
+  - foreign plugin arrays could falsely count as HA NOVA attached
+  - one architecture doc line still described the old GitHub-backed production path
+- Current PR head:
+  - `a1fadf56db8b74f74f23d6abfa9bfa540f6910de`
+- Current GitHub state:
+  - all CI checks green
+  - both old Codex review threads resolved
+  - latest explicit `@codex review` comments only have `eyes`, no fresh final bot result yet for `a1fadf5`
+- Remaining blocker is external:
+  - `mergeStateStatus: BLOCKED`
+  - `reviewDecision: REVIEW_REQUIRED`
+  - by repo rule, the high-risk PR is not "done" until a real current Codex result exists for the latest SHA
+- Received fresh current Codex result for the latest PR head via issue comment:
+  - `https://github.com/markusleben/ha-nova/pull/173#issuecomment-4250794033`
+  - message: `Codex Review: Didn't find any major issues.`
+- Confirmed the clean Codex result arrived after the final explicit review request for head `a1fadf56db8b74f74f23d6abfa9bfa540f6910de`.
+- Merged PR `#173` with squash + admin fallback after:
+  - all CI checks green
+  - real current Codex result present
+  - no new findings
+  - all review threads resolved
+- Final merge result:
+  - PR state: `MERGED`
+  - merge commit: `6b187d5cd3b9731f8d853f3757ae0b0389bc8e94`
+  - merged at: `2026-04-15T09:25:47Z`
+
+## 2026-04-18
+
+- Added the setup-only Linux secure-storage recovery stage and kept it intentionally GNOME-only by checking the active Secret Service owner before offering the built-in DBus recovery path.
+- Split recovery attempt tracking into initial-gate vs save-time retry so backing out of the first recovery page no longer bypasses the gate and a later persistence failure can still offer one retry.
+- Tightened recovery retry semantics so fatal backend/session failures stop immediately, while password rejection stays retryable with explicit local-password wording.
+- Added regressions for recovery back-navigation, saved-token read recovery, fatal-vs-retryable loop behavior, Linux owner detection/method support, Linux DBus recovery classification, and the release-contract Linux lane.
+- Re-ran `cd cli && go test -count=1 -timeout 180s ./...` plus `npx vitest run tests/onboarding/release-contract.test.ts` after the fixes.
+
+## 2026-04-21
+
+- Reproduced the Hermes skill-loading mismatch from user evidence at the contract level: `skills_list(category="ha-nova")` exposed HA NOVA namespaced sub-skills, but our Hermes installer still wrote them into bare directories like `history/` and `review/`.
+- Traced the mismatch to both Hermes installers:
+  - Go installer: `cli/client_hermes.go`
+  - shell installer: `scripts/onboarding/install-local-skills.sh`
+- Recorded the fix direction in `docs/archive/plans/2026-04-21-hermes-skill-view-mismatch-spec.md`: Hermes sub-skill directory names must equal their rewritten `name:` values.
+2026-06-10 (train port)
+- Ported the local main worktree's uncommitted train (service credentials + token file storage, Claude snapshot/auto-repair hardening, atomic state writes, Gemini/Hermes rewriter absolutization, purge keyring cleanup, issue #200 fail-loud token storage) onto origin/main as a clean branch via three-way delta application.
+- Deliberately dropped during the port: the local-only April 11 README conversion rewrite (superseded by origin's README evolution and the active Hermes release-claim gating), stale 0.4.0 version/manifest fields, and local variants of files where origin/main had newer reviewed versions (setup discovery tests, preflight session-bus dedup, claude-plugin-state.mjs, recovery test variants).
+- Preserved origin's Hermes release-claim gating: README stays release-conservative; the .hermes/INSTALL.md release-status note is kept; the public Hermes claim flip stays reserved for the final release PR.

--- a/docs/work/2026-03-27-choices.md
+++ b/docs/work/2026-03-27-choices.md
@@ -11,6 +11,38 @@
 - **Release-note generation rule:** publish stable install commands with tag-pinned raw installer URLs plus matching `HA_NOVA_VERSION`.
 - **Reason:** bootstrap script and installed payload should come from the same release tag.
 
+## 2026-04-08: Release-Note Comparison Defaults
+
+- **Comparison source of truth:** use published GitHub release metadata plus exact tag/target SHAs; never use drafts or historical release branches as baseline truth.
+- **Reason:** this repo's release contract is SHA-specific, and duplicate draft releases already exist for the same tag.
+- **Provisional preview target:** use `origin/main` only when no exact release SHA/tag has been chosen yet.
+- **Reason:** release-note previews still need a stable fallback, but final notes must be regenerated from the exact publish commit.
+- **Classification unit:** split mixed PRs into user-facing behavior slices; never classify an entire mixed commit/PR with one label.
+- **Reason:** the current post-`v0.3.2` delta mixes promoted skills, client packaging, docs, tests, and workflow hardening in one merged PR.
+- **Promotion rule:** a new dedicated supported workflow or top-level skill counts as `New Features`, even if the raw capability previously existed behind `fallback`.
+- **Reason:** users experience that as a new supported product surface, not as an internal refactor.
+- **Internal-only default:** treat `.github/workflows/**`, `tests/**`, `scripts/e2e/**`, `docs/work/**`, and `docs/reference/**` as non-note material unless they change shipped user behavior directly.
+- **Reason:** they are useful evidence, but not user-facing release bullets by themselves.
+
+## 2026-04-09: README Positioning Refresh
+
+- **README opening priority:** lead with user value, trust, and product promise before architecture details.
+- **Reason:** the GitHub README needs to sell why HA NOVA is worth trying, not just explain how it is built.
+- **Relay framing:** describe the Relay as the trust and scaling foundation for the product, not as a technical compromise.
+- **Reason:** server-side token isolation and local host access are core product strengths, not implementation trivia.
+- **Skills framing:** describe markdown skills as leverage for speed, transparency, and community contribution.
+- **Reason:** the project grows because capabilities can ship and improve quickly without burying logic in server code.
+- **Comparison posture:** keep the MCP comparison factual, but do not let it dominate the README narrative.
+- **Reason:** readers should first understand why HA NOVA is useful, then how it differs technically.
+- **README structure rule:** hero -> user value -> concrete examples -> differentiation -> architecture -> install details.
+- **Reason:** GitHub readers should understand the payoff before they hit caveats, platform notes, or internals.
+- **Differentiation rule:** describe HA NOVA as a Home Assistant workflow system, not just another integration.
+- **Reason:** the product win is guided, explicit, extensible HA workflows, not generic tool connectivity.
+- **README language rule:** use simple English a fifth grader could follow, but keep the tone adult and direct.
+- **Reason:** easier language makes the product easier to trust, easier to try, and easier to share.
+- **Relay positioning rule:** explain the Relay as both the trust boundary today and the small place where future HA-specific helpers can live later.
+- **Reason:** otherwise the Relay sounds like credential plumbing only and its product value gets lost.
+
 ## 2026-03-27: Review Synthesis + R-18 Follow-Up
 
 - **`R-18` write policy:** keep `R-18` advisory-only in pre-write preview; warn clearly, but do not block the write and do not add a second confirmation tier.
@@ -46,6 +78,23 @@
 - **Reason:** the `winget` publication lane adds external release latency without meaningfully reducing the real user setup work in Home Assistant.
 - **Windows lifecycle model:** treat Windows as bundle-managed/self-managed only; remove all `winget` source detection, mixed-channel behavior, and `winget`-specific update/uninstall logic.
 - **Reason:** one Windows install path is simpler to explain, test, support, and recover.
+
+## 2026-04-17
+
+- **Project development baseline:** treat HA NOVA as three tightly coupled but intentionally separated systems: Go CLI, TypeScript relay, and markdown skill tree.
+- **Reason:** future work is faster and safer when changes are placed in the correct layer instead of leaking logic across boundaries.
+
+- **Relay change default:** keep the relay transport-only unless a capability is impossible to express safely in skills.
+- **Reason:** the current design depends on the relay staying dumb and stable while skills evolve quickly.
+
+- **CLI risk default:** assume Claude packaging/setup/update paths are the highest-friction operational area before assuming a relay or skill bug.
+- **Reason:** current code and tests show Claude marketplace snapshot handling is the densest coupling point in the system.
+
+- **Verification default:** start with host-safe contract/regression checks, then escalate to smoke/live harnesses only when a change touches real HA behavior, installers, or client attachment.
+- **Reason:** the repo is optimized around cheap local confidence first and more expensive real-environment proof second.
+
+- **Architecture reading order default:** for future tasks, orient via `README.md` -> `PROJECT.md` -> `docs/reference/*.md` -> relevant skill or runtime entrypoint, not file-by-file repo scanning.
+- **Reason:** the repo already encodes its architecture in docs, and the code follows those boundaries closely enough that this path is higher-signal.
 - **Public PowerShell command:** keep `install.ps1` as the single supported Windows path, but publish stable commands from the release tag/release page instead of `main`.
 - **Reason:** keep the Windows path simple without turning `main` into a floating stable-install contract.
 - **Progress suppression rule:** move `$ProgressPreference = 'SilentlyContinue'` inside `install.ps1`, scoped only around the large `Invoke-WebRequest` downloads, and restore the previous value afterward.
@@ -148,6 +197,17 @@ Superseded in structure by the 2026-03-12 catalog split below. Keep the threshol
 - **R-10 stays independent**: H-09 does not auto-emit queue-saturation findings; R-10 is only reported when its own criteria match.
 
 ## 2026-03-12: Review Catalog Split
+
+## 2026-04-18: Linux Secure Storage Recovery
+
+- **Linux secure-storage state model:** split `unavailable`, `session unavailable`, `locked default collection`, and `missing default collection` instead of flattening everything into generic `setup required`.
+- **Reason:** SSH/headless Linux onboarding needs different UX and different recovery behavior for a locked keyring versus a truly uninitialized GNOME Keyring.
+- **GNOME recovery transport:** use GNOME Keyring's DBus internal password methods on one live session-bus connection; do not shell out to `gnome-keyring-daemon --unlock`.
+- **Reason:** the DBus path supports both unlock and fresh collection creation, avoids misleading "unlock" semantics for first-run setup, and removes the password handoff to an arbitrary executable path.
+- **Recovery scope:** keep inline recovery GNOME-only and fail loud on other Secret Service backends.
+- **Reason:** user convenience wins when we can prove the path end-to-end, but we should not pretend unsupported backends can recover inline when they cannot.
+- **Preflight proof rule:** Linux setup preflight must prove writable secure storage with a real write/read/delete probe after alias/state inspection.
+- **Reason:** `ReadAlias("default")` alone is not enough; the shipped UX must reflect whether HA NOVA can actually persist the relay token.
 
 - **Stable facade stays at `skills/review/SKILL.md`**: existing docs, agents, and clients keep one durable review entrypoint.
 - **Full rule catalog moves to `skills/review/checks.md`**: workflow and rule catalog are separated, but the rules remain pure Markdown.
@@ -1511,6 +1571,80 @@ Superseded in structure by the 2026-03-12 catalog split below. Keep the threshol
 
 ## 2026-04-14
 
+## 2026-04-09
+
+- **README language rule:** public-facing README copy should use simple adult English, with short sentences and common words.
+- **Reason:** the target reader should understand the value fast without product jargon or architecture-heavy wording.
+
+- **README repetition rule:** explain the core Relay/Skills idea once clearly, then only repeat it later if the new section adds meaningfully new information.
+- **Reason:** repeating the same architecture claim in multiple sections makes the README feel bloated and weaker instead of clearer.
+
+## 2026-04-12
+
+- **Claude-agent porting rule:** port local Claude agents into Codex as skills that preserve the useful workflow, not as literal agent clones.
+- **Reason:** Codex and Claude do not share the same native agent runtime, so the durable path is to capture the method in a reusable Codex skill.
+
+- **Doc-review port default:** keep `doc-review-orchestrator` general-purpose, evidence-first, and five-pass, while allowing parallel/subagent review only when the user explicitly asks for subagents.
+- **Reason:** this preserves the value of the original review method without conflicting with Codex session rules around delegation.
+
+- **Release-note refresh rule:** docs-only follow-up commits after a feature compare freeze stay omitted from public release notes unless they change shipped behavior or require user action.
+- **Reason:** release notes should stay about user-visible product changes, not documentation cleanup that landed afterward.
+
+## 2026-04-13
+
+- **Dependabot release-preflight rule:** treat open security bumps for shipped production dependencies as `blocker now`, but keep workflow bumps and toolchain-risk dev dependency bumps out of the release lane unless they fix the live release path.
+- **Reason:** release preflight should pull in real user/security fixes, not widen risk with workflow churn or optional toolchain updates right before tagging.
+
+- **Release-note security fix rule:** an important merged fix for shipped production dependencies may earn a selective `Bug Fixes` bullet even when the rest of the release is mostly feature-led.
+- **Reason:** critical shipped security fixes are user-relevant release material and should not disappear just because the headline of the release is still new features.
+
+- **Next stable version default:** use `0.4.0` for the next stable release after `v0.3.2`.
+- **Reason:** the delta adds three new first-class skills, a supported-client install/sync behavior improvement, and one important shipped security fix; this is clearly larger than a patch release.
+
+- **Claude availability diagnosis rule:** if HA NOVA is "missing" in Claude, verify both HA NOVA state and Claude's own plugin registry before assuming a simple version lag.
+- **Reason:** a stale local version can coexist with Claude plugin-state drift; in that case the old install cannot surface its own update notice because Claude is not loading the plugin at all.
+
+- **Claude success-verification rule:** a successful Claude sync must verify both the plugin record and the marketplace registration after the install/update command finishes.
+- **Reason:** checking only one side can persist a half-broken Claude attach and make later drift look like a valid install.
+
+- **Claude install-path rule:** blank `installPath` values in Claude plugin state count as broken, not installed.
+- **Reason:** an empty path is not a usable attachment and should not let HA NOVA treat Claude as healthy.
+
+- **Claude update-semantics rule:** `ha-nova update` stays repair-oriented and must not silently infer user intent by pruning Claude from persisted state on absence alone.
+- **Reason:** missing Claude records can mean damage, transient loss, or partial drift; auto-pruning in update is riskier than explicit detach handling.
+
+- **Claude KISS rule:** fix this bug by tightening the existing install verifier, not by introducing a new Claude state model, background sync, or telemetry subsystem.
+- **Reason:** the truth already exists on disk; adding another layer would create more drift surfaces, not fewer.
+
+- **Claude attachment truth rule:** `doctor` must use the same Claude attachment truth as repair reality: plugin present alone is not enough; the `ha-nova` marketplace record must also exist.
+- **Reason:** on the real Mac, a missing `known_marketplaces.json` entry left `doctor` falsely green even though `setup claude` still had real repair work to do.
+
+- **Real-machine Claude test rule:** prove Claude drift fixes with controlled, reversible registry edits on the real machine before calling the bug closed.
+- **Reason:** this bug lives at the boundary between HA NOVA and Claude state files; pure unit tests are necessary, but not sufficient.
+
+## 2026-04-14
+
+- **Claude drift evidence-capture rule:** keep detach forensics in a tiny local watcher under `scripts/dev`, not in product runtime.
+- **Reason:** the goal is to learn which Claude registry file drifts first; adding a product daemon would add new moving parts instead of evidence.
+
+- **Claude watcher robustness rule:** audit snapshots must survive BOM-prefixed or temporarily invalid Claude JSON files and record parseability as data instead of crashing.
+- **Reason:** detach evidence is most valuable exactly when Claude rewrites files into transient or malformed states.
+
+- **Claude watcher noise rule:** watch only the Claude registry files that matter and normalize plugin-directory events back to `installed_plugins.json` or `known_marketplaces.json`.
+- **Reason:** cache churn inside `.claude/plugins` would otherwise bury the real detach signal.
+
+- **Claude watcher launchd rule:** prefer `launchctl` over ad-hoc `nohup` for a real long-running Mac watcher.
+- **Reason:** launchd gives a persistent user job with predictable logs and avoids tool-session child cleanup.
+
+- **Manifest relabel rule:** on manifest-changing PRs, a later force-push/rebase/new SHA invalidates the old maintainer label timing for `manifest-review-gate`; remove/re-add the label on the latest PR state.
+- **Reason:** the gate compares the label event timestamp to later invalidating PR events, so an old label can stay present in GitHub UI and still no longer satisfy policy.
+
+- **Claude marketplace default rule:** normal bundle installs should use the GitHub-backed Claude marketplace source, not the staged local marketplace directory.
+- **Reason:** real-machine drift evidence showed Claude removing the local `ha-nova` marketplace entry first, then orphaning the plugin cache and clearing the plugin record/settings; official GitHub-backed marketplaces on the same machine stayed intact.
+
+- **Claude local marketplace scope rule:** keep `~/.config/ha-nova/claude-marketplace` for repo-local development or explicit override only.
+- **Reason:** the staged local marketplace is still useful for dev validation, but it is too fragile to remain the default production path.
+
 - **Claude production release-snapshot rule:** normal bundle installs must attach Claude to a versioned local release snapshot under `~/.config/ha-nova/claude-marketplace/releases/vX.Y.Z`, not to GitHub and not to the flat local root.
 - **Reason:** GitHub-backed marketplace sources still risk release drift, while the old flat local root was too reusable and fragile; the versioned local snapshot is the smallest model that keeps Claude on the exact shipped release.
 
@@ -1527,3 +1661,18 @@ Superseded in structure by the 2026-03-12 catalog split below. Keep the threshol
 
 - **Release-worthiness rule for `v0.4.2`:** ship the Claude release-snapshot fix as a patch release immediately instead of batching it.
 - **Reason:** the bug affects the live Claude attach model in the published product, and the fix is already merged, reviewed, and proven on a real macOS profile.
+## 2026-04-18
+
+- **Linux secure-storage recovery scope rule:** built-in inline recovery is GNOME-only and only when the active `org.freedesktop.secrets` owner is GNOME Keyring.
+- **Reason:** the recovery path depends on the running owner executable and must not pretend to work on arbitrary Secret Service backends.
+
+- **Linux secure-storage recovery proof rule:** post-unlock success is only real after a write/read/delete probe through the same Go keyring path used for token persistence.
+- **Reason:** alias/default-collection checks can look healthy while real token writes still fail.
+
+- **Linux release-lane rule:** any release-bound Linux setup or secure-storage change must keep the real-machine Linux onboarding lane in `docs/releasing.md`.
+- **Reason:** macOS and Windows proofs do not exercise Linux discovery, Secret Service classification, or GNOME recovery behavior.
+
+## 2026-04-21
+
+- **Hermes canonical-name rule:** Hermes-installed HA NOVA sub-skill directory names must match the rewritten `name:` frontmatter exactly, for example `~/.hermes/skills/ha-nova/ha-nova-review/SKILL.md` with `name: ha-nova-review`.
+- **Reason:** Hermes `skills_list` and `skill_view` do not reliably agree when the installed directory name and the frontmatter skill name diverge.

--- a/docs/work/2026-04-01-project-familiarization-spec.md
+++ b/docs/work/2026-04-01-project-familiarization-spec.md
@@ -1,0 +1,38 @@
+Status: active
+Date: 2026-04-01
+Owner: Codex
+
+# Project Familiarization Spec
+
+## Goal
+
+Build a precise working model of HA NOVA across:
+- product/docs contract
+- relay implementation
+- Go CLI / installer lifecycle
+- skill architecture
+- tests, CI, and release gates
+
+## Scope
+
+In scope:
+- read active SSOT docs
+- inspect core source entrypoints and representative modules
+- inspect representative skills
+- inspect verification/release workflows
+- run core verification where practical
+
+Out of scope:
+- behavior changes
+- refactors
+- release actions
+- GitHub remote operations
+
+## Deliverable
+
+A concise internal summary of:
+- system boundaries
+- runtime flows
+- safety model
+- verification posture
+- likely hotspots for future work

--- a/docs/work/2026-04-08-release-note-comparison-spec.md
+++ b/docs/work/2026-04-08-release-note-comparison-spec.md
@@ -1,0 +1,39 @@
+# Release Note Comparison Spec
+
+Date: 2026-04-08
+Status: completed
+
+## Goal
+
+Produce a decision-complete release-note comparison artifact for the next HA NOVA release train.
+
+## Scope
+
+- Resolve the baseline from the latest published stable GitHub release, not from drafts or historical release branches.
+- Resolve the target from the exact compare SHA; use `origin/main` only as a provisional preview target when no release SHA exists yet.
+- Build a full delta classification table before drafting any public note text.
+- Keep the output user-facing and short.
+
+## Current Target
+
+- Baseline release: `v0.3.2`
+- Baseline shape: published stable release
+- Provisional compare target: `main` at `b5e94aa`
+- Compare window: `v0.3.2..b5e94aa`
+- Current unpublished delta size: 4 commits total, but only 1 product-feature commit (`#162`) plus 3 docs-only follow-up commits
+
+## Rules Applied
+
+- Compare by exact SHA, not by branch name alone.
+- Treat promoted named supported workflows as `New Features`, even when the raw capability previously lived behind `fallback`.
+- Classify by changed user contract, not by directory.
+- Group by user-facing behavior slice, not by commit headline.
+- Exclude workflow/test/spec/harness churn unless it changes shipped user behavior directly.
+- Do not derive or propose the next release version in this pass.
+
+## Deliverables
+
+- Analysis matrix with explicit include/omit decisions for every user-facing delta slice.
+- Exclusion audit for internal-only churn.
+- Recommended release-note draft in the current short stable-release style.
+- Install block kept as a tag placeholder template until a real release tag exists.

--- a/docs/work/2026-04-08-release-note-comparison.md
+++ b/docs/work/2026-04-08-release-note-comparison.md
@@ -1,0 +1,124 @@
+# Release Note Comparison
+
+Date: 2026-04-13
+Mode: provisional stable preview
+
+## Compare Context
+
+- Baseline release: `v0.3.2`
+- Baseline published at: `2026-04-03T11:57:50Z`
+- Baseline commit: `89f9af2`
+- Target ref: `main`
+- Target commit: `1132ce7`
+- Compare window: `v0.3.2..1132ce7`
+- HEAD freeze at classification start: `1132ce7`
+- HEAD freeze at finalization: `1132ce7`
+- Target selection note: no published RC, no newer non-`main` release target, and no separate release branch with a different tree
+
+## Delta Classification Matrix
+
+| Candidate | Classification | Primary files | Include | Section | Rationale |
+|---|---|---|---|---|---|
+| Dedicated `dashboard` skill for storage dashboards, Lovelace resources, and targeted card changes | New Feature | `skills/dashboard/SKILL.md`, `README.md`, `skills/ha-nova/SKILL.md`, `skills/fallback/SKILL.md` | yes | `New Features` | This is a new named supported workflow with safer dashboard handling than the old generic fallback path. |
+| Dedicated `organize` skill for areas, floors, labels, categories, and richer entity/device metadata | New Feature | `skills/organize/SKILL.md`, `README.md`, `skills/ha-nova/SKILL.md`, `skills/fallback/SKILL.md` | yes | `New Features` | This exposes organization and registry metadata work as a first-class supported workflow. |
+| Dedicated `history` skill for bounded history, logbook timelines, and long-term statistics | New Feature | `skills/history/SKILL.md`, `README.md`, `skills/ha-nova/SKILL.md`, `skills/fallback/SKILL.md` | yes | `New Features` | This gives history and trend questions a dedicated read-only supported workflow instead of generic fallback handling. |
+| Gemini auto-discovers shipped subskills and syncs the newly promoted skills without hardcoded wiring | Install & Update Behavior | `cli/client_gemini.go`, `scripts/onboarding/lib/install-local-skills-common.sh` | yes | `New Features` | Supported-client behavior changes for Gemini users because the new skills now ship through install and sync automatically. |
+| Bundled `axios` bump to `1.15.0` in root and `nova` closes critical shipped production audit findings | Bug Fix | `package.json`, `package-lock.json`, `nova/package.json`, `nova/package-lock.json` | yes | `Bug Fixes` | This removes critical security issues from both shipped production manifests and was important enough to merge into the release lane before tagging. |
+| Routing ownership moves dashboard / organize / history out of generic `fallback` | release-note bullet folded into primary features | `skills/ha-nova/SKILL.md`, `skills/fallback/SKILL.md` | no | folded | This is user-visible, but it is better expressed inside the three promoted skill bullets than as a separate bullet. |
+| Stable install guidance in `nova/DOCS.md` points readers to the latest release instead of `main` | intentional omission: user-facing but too small | `nova/DOCS.md` | no | omit | Helpful docs support change, but too small and docs-only to deserve its own public release-note bullet. |
+| Conversion-focused README rewrite with stronger product positioning and roadmap teaser | intentional omission: user-facing but too small | `README.md`, `CONTRIBUTING.md` | no | omit | This improves presentation and docs quality, but it does not add or change shipped product behavior enough to deserve a release-note bullet. |
+| Cross-doc fixes for promoted skills, anchor targets, backup wording, and OpenCode URL | intentional omission: user-facing but too small | `README.md`, `PROJECT.md`, `nova/DOCS.md` | no | omit | Important doc accuracy cleanup, but still docs-only with no new user action or shipped feature delta. |
+| Client-install docs contract update after README rewrite | internal-only omission | `tests/onboarding/client-install-docs-contract.test.ts` | no | omit | This protects docs correctness, but it is validation only. |
+| Promoted live harness, contract tests, and proofing expansion | internal-only omission | `tests/**`, `scripts/e2e/**`, `package.json` | no | omit | Validation confidence only; no direct shipped behavior change by itself. |
+| Dependabot prepare workflow hardening | internal-only omission | `.github/workflows/dependabot-safe-lane-prepare.yml`, `tests/onboarding/dependabot-automation-contract.test.ts` | no | omit | Release-process hardening, not end-user product behavior. |
+| Reference docs and work specs for the promoted skills | internal-only omission | `docs/reference/**`, `docs/work/**` | no | omit | Supporting evidence and maintainer context only. |
+
+## Exclusion Audit
+
+Explicitly excluded from public release-note drafting unless they change shipped user behavior directly:
+
+- `.github/workflows/dependabot-safe-lane-prepare.yml`
+- `tests/**`
+- `scripts/e2e/**`
+- `docs/work/**`
+- `docs/reference/**`
+- `package.json` additions that only add maintainer/test scripts
+- `README.md`, `CONTRIBUTING.md`, `PROJECT.md`, and `nova/DOCS.md` changes that are messaging, anchor, URL, or docs-accuracy follow-up only
+
+Final exclusion statement:
+
+- No remaining internal-only deltas are represented as standalone public release-note bullets.
+- Post-`ea8a708` docs-only follow-up commits stay omitted, but the later merged `axios` security fix does add one selective `Bug Fixes` bullet.
+
+## Evidence Notes
+
+- Primary change source: PR `#162` (`feat: promote dashboard organize and history skills`)
+- Supporting verification in PR `#162`:
+  - targeted Vitest contract suite
+  - `cd cli && go test ./...`
+  - promoted smoke suite
+  - promoted full suite
+- Public-bullet evidence comes from shipped surfaces only:
+  - `skills/dashboard/SKILL.md`
+  - `skills/organize/SKILL.md`
+  - `skills/history/SKILL.md`
+  - `skills/ha-nova/SKILL.md`
+  - `skills/fallback/SKILL.md`
+  - `README.md`
+  - `cli/client_gemini.go`
+  - `scripts/onboarding/lib/install-local-skills-common.sh`
+
+## Post-Feature Refresh Check
+
+Commits added after the original `ea8a708` comparison:
+
+- `0f635f7` on 2026-04-11: README and CONTRIBUTING rewrite plus docs-contract update
+- `38b380b` on 2026-04-11: cross-doc fixes in `PROJECT.md` and `nova/DOCS.md`
+- `b5e94aa` on 2026-04-11: README URL, anchor, and narrowed backup wording fix
+- `1132ce7` on 2026-04-13: bundled root + `nova` `axios` bump to `1.15.0`
+
+Refresh conclusion:
+
+- The three April 11 commits improve docs quality and accuracy, but they do not introduce new shipped product behavior.
+- The April 13 `axios` merge is different: it closes critical production dependency findings in the shipped app and Relay package.
+- The release-note draft now gains one selective `Bug Fixes` bullet for that security update.
+
+## Recommended Release-Note Draft
+
+````md
+## New Features
+
+- Dashboard work now has a dedicated HA NOVA skill for safe storage dashboard edits, Lovelace resources, and targeted card changes.
+- Organization tasks now have a dedicated skill for areas, floors, labels, categories, and richer entity and device metadata.
+- History questions now have a dedicated read-only skill for bounded history, logbook timelines, and long-term statistics.
+- Gemini now picks up newly shipped HA NOVA sub-skills automatically during install and sync, so the promoted skills arrive there without manual wiring.
+
+## Bug Fixes
+
+- Updated `axios` to `1.15.0` in both the main app and the Relay package to close critical production dependency findings.
+
+## Install
+
+**macOS / Linux**
+```sh
+curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/<RELEASE_TAG>/install.sh | HA_NOVA_VERSION=<RELEASE_TAG> bash
+```
+
+**Windows (PowerShell)**
+```powershell
+$env:HA_NOVA_VERSION = '<RELEASE_TAG>'
+irm https://raw.githubusercontent.com/markusleben/ha-nova/<RELEASE_TAG>/install.ps1 | iex
+```
+
+## Already Installed?
+
+Run `ha-nova check-update` or `ha-nova update`.
+````
+
+## Finalization Gate
+
+Before turning this provisional draft into the final release body:
+
+1. Re-resolve the exact publish SHA or release tag.
+2. Re-run the same comparison if the target SHA changed after `1132ce7`.
+3. Replace `<RELEASE_TAG>` only when the actual release tag exists.

--- a/docs/work/2026-04-09-next-release-notes-draft.md
+++ b/docs/work/2026-04-09-next-release-notes-draft.md
@@ -1,0 +1,27 @@
+## New Features
+
+- Hermes Agent is now a first-class HA NOVA client path. HA NOVA now installs the bundled Hermes skill set directly, supports native macOS/Linux plus WSL2 on Windows, and can repair older Hermes installs with the simple `ha-nova doctor` -> `ha-nova setup hermes` flow.
+- Linux setup can now recover a locked or fresh GNOME Keyring inline during `ha-nova setup`, including SSH into the same logged-in desktop session.
+- HA NOVA now ships dedicated `dashboard`, `organize`, and `history` skills, making those workflows easier to discover and safer to use.
+- Gemini now picks up newly shipped HA NOVA sub-skills automatically during install and sync.
+
+## Bug Fixes
+
+- Updated `axios` to `1.15.0` in both the main app and the Relay package to close critical production dependency findings.
+
+## Install
+
+**macOS / Linux**
+```sh
+curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/<RELEASE_TAG>/install.sh | HA_NOVA_VERSION=<RELEASE_TAG> bash
+```
+
+**Windows (PowerShell)**
+```powershell
+$env:HA_NOVA_VERSION = '<RELEASE_TAG>'
+irm https://raw.githubusercontent.com/markusleben/ha-nova/<RELEASE_TAG>/install.ps1 | iex
+```
+
+## Already Installed?
+
+Run `ha-nova check-update` or `ha-nova update`.

--- a/docs/work/2026-04-09-readme-positioning-refresh-spec.md
+++ b/docs/work/2026-04-09-readme-positioning-refresh-spec.md
@@ -1,0 +1,30 @@
+# README Positioning Refresh Spec
+
+Date: 2026-04-09
+Status: completed
+
+## Goal
+
+Rewrite the public GitHub README so it explains why HA NOVA matters, why the Relay + Skills architecture is a strong foundation, and why early adopters should care.
+
+## Scope
+
+- Keep the README technically true.
+- Move product value and user outcomes ahead of implementation detail.
+- Explain the Relay as a strength, not as background plumbing.
+- Make the project feel worth trying and worth contributing to.
+- Keep install guidance clear and stable-release aligned.
+- Remove repeated architecture claims unless the repeat adds new information.
+
+## Messaging Defaults
+
+- Lead with what users get: safer Home Assistant automation and control through AI.
+- Present the Relay as a trust and expansion foundation: token stays on the server, host access stays local, skills can grow quickly without server churn.
+- Present Skills as leverage: fast iteration, transparent behavior, easy community contributions.
+- Keep early-access honesty, but frame it as a chance to help shape the product.
+- Keep the README in simple adult English and avoid saying the same Relay/Skills point in multiple sections.
+
+## Deliverables
+
+- A public-facing README rewrite with stronger opening, benefit-first framing, and clearer “why now / why this architecture / why join” positioning.
+- A separate next-release notes draft based on the current `v0.3.2..ea8a708` delta.

--- a/docs/work/2026-04-12-doc-review-orchestrator-port-spec.md
+++ b/docs/work/2026-04-12-doc-review-orchestrator-port-spec.md
@@ -1,0 +1,36 @@
+# Doc Review Orchestrator Port Spec
+
+Date: 2026-04-12
+Status: completed
+
+## Goal
+
+Make the local Claude agent `doc-review-orchestrator` usable from Codex by porting its review workflow into a local Codex skill.
+
+## Source
+
+- Claude agent: `/Users/markus/.claude/agents/doc-review-orchestrator.md`
+- Claude memory: `/Users/markus/.claude/agent-memory/doc-review-orchestrator/MEMORY.md`
+
+## Scope
+
+- Create a local Codex skill under `~/.agents/skills/doc-review-orchestrator/`.
+- Preserve the core review method:
+  - accuracy
+  - consistency
+  - completeness
+  - clarity
+  - structure
+- Adapt the workflow to Codex rules and tools instead of Claude-specific agent behavior.
+
+## Porting Defaults
+
+- Port as a skill, not as a Claude-style agent clone.
+- Keep the skill general-purpose instead of copying project-specific memory into it.
+- Preserve the five-pass review architecture.
+- Allow parallel/subagent passes only when the user explicitly asks for subagents and the current tool context supports that.
+- Keep the skill evidence-first and review-only by default; no rewrites unless the user asks.
+
+## Deliverable
+
+- `~/.agents/skills/doc-review-orchestrator/SKILL.md`

--- a/docs/work/2026-04-12-release-note-refresh-spec.md
+++ b/docs/work/2026-04-12-release-note-refresh-spec.md
@@ -1,0 +1,31 @@
+# Release Note Refresh Spec
+
+Date: 2026-04-12
+Status: completed
+
+## Goal
+
+Refresh the existing release-note comparison from the old provisional target `ea8a708` to the current `main` SHA and confirm whether any newer commits change the public release-note bullets.
+
+## Scope
+
+- Re-check the compare window from `v0.3.2` to current `main`.
+- Classify newer post-`ea8a708` commits.
+- Confirm whether the public release-note draft changes.
+- Keep the release-note body short and user-facing.
+
+## Current Compare Target
+
+- Baseline release: `v0.3.2`
+- Current target branch: `main`
+- Current target SHA at refresh: `b5e94aa`
+- Compare window: `v0.3.2..b5e94aa`
+
+## Default Applied
+
+- Docs-only and docs-contract-only follow-up commits do not become public release-note bullets unless they change shipped user behavior in a way users must act on.
+
+## Deliverables
+
+- Refreshed comparison artifact with the new SHA and updated omission matrix.
+- Refreshed release-note draft if needed.

--- a/docs/work/2026-04-13-claude-availability-troubleshooting-spec.md
+++ b/docs/work/2026-04-13-claude-availability-troubleshooting-spec.md
@@ -1,0 +1,41 @@
+# 2026-04-13 Claude Availability Troubleshooting Spec
+
+- Goal: find why HA NOVA is not available in Claude on this macOS machine.
+- Method: inspect local HA NOVA install, Claude integration files, plugin/skill paths, and CLI availability.
+- Scope: diagnosis first; no changes unless a clear fix is identified.
+
+## Findings
+
+- The local HA NOVA runtime is still `0.3.2`.
+- HA NOVA's own state says Claude is installed in `plugin` mode.
+- Claude itself does not currently list the `ha-nova` marketplace or the `ha-nova@ha-nova` plugin.
+- This means the old HA NOVA install cannot surface its own update notice inside Claude, because Claude is not loading it at all.
+- The current issue is not only "old version installed" but also local Claude plugin-state drift between HA NOVA state and Claude state.
+
+## Root Cause Summary
+
+- HA NOVA treated Claude plugin install success too loosely.
+- The Go installer verified marketplace registration before plugin install, but not again after plugin install.
+- Claude plugin record detection also accepted blank `installPath` values as "installed".
+- That combination made it easier for stale or partially broken Claude state to look valid enough for persistence.
+
+## Fix Applied
+
+- Claude install success now requires both:
+  - the `ha-nova` marketplace still present after sync
+  - the `ha-nova@ha-nova` plugin still present after sync
+- Blank Claude `installPath` values no longer count as installed.
+- Added regressions for:
+  - marketplace disappearing after plugin install
+  - blank `installPath`
+
+## Refinement Pass
+
+- Six focused review lanes converged on a KISS-safe direction:
+  - keep `update` repair-oriented; do not silently prune Claude from HA NOVA state
+  - avoid a new Claude state model or background telemetry system
+  - tighten the existing install truth instead of adding a new subsystem
+- Additional hardening applied:
+  - fallback `update -> install` now uses the same rollback-safe verifier path
+  - unparseable Claude plugin registry no longer counts as installed
+  - added regression for fallback install when marketplace disappears

--- a/docs/work/2026-04-13-claude-real-machine-test-spec.md
+++ b/docs/work/2026-04-13-claude-real-machine-test-spec.md
@@ -1,0 +1,47 @@
+# Claude Real-Machine Test Spec
+
+Date: 2026-04-13
+
+## Goal
+
+Verify the merged Claude attach-verification fix on the real macOS machine without depending on a new public release first.
+
+## Scope
+
+- Build a clean CLI binary from merged `origin/main`.
+- Keep the user's current Claude + HA NOVA state recoverable.
+- Exercise the real local Claude attach / doctor / repair path.
+- Confirm whether the stricter verifier catches detached or half-attached Claude state on this machine.
+
+## Safety
+
+- Snapshot relevant user state before any mutation:
+  - `~/.claude/plugins/`
+  - `~/.claude/settings.json`
+  - `~/.claude/settings.local.json`
+  - `~/.config/ha-nova/`
+- Build from a clean worktree, not from the dirty repo checkout.
+- Do not remove user data unless the test explicitly needs it.
+
+## Plan
+
+1. Capture current local state and installed versions.
+2. Create a clean worktree at merged `origin/main`.
+3. Build a standalone test binary from that exact SHA.
+4. Run non-mutating checks first:
+   - `doctor`
+   - `version`
+   - `claude plugin list`
+   - `claude plugin marketplace list`
+5. Run the smallest repair path that exercises the fix:
+   - `setup claude`
+6. Re-check doctor/plugin/marketplace/version state.
+7. Record result and next release implication.
+
+## Success
+
+- The test binary runs against the real user home.
+- Claude attach state is either:
+  - confirmed healthy, or
+  - detected as detached/half-attached and repaired cleanly.
+- We end with a clear answer whether the fix changes real-machine behavior.

--- a/docs/work/2026-04-13-dependabot-release-preflight-spec.md
+++ b/docs/work/2026-04-13-dependabot-release-preflight-spec.md
@@ -1,0 +1,5 @@
+# 2026-04-13 Dependabot Release Preflight Spec
+
+- Goal: classify open Dependabot PRs into blocker now vs separate later for release prep.
+- Method: inspect open PRs via gh and verify production dependency risk with npm audit / project scripts.
+- Scope: only release relevance, not full PR review.

--- a/docs/work/2026-04-13-post-axios-release-refresh-spec.md
+++ b/docs/work/2026-04-13-post-axios-release-refresh-spec.md
@@ -1,0 +1,5 @@
+# 2026-04-13 Post-Axios Release Refresh Spec
+
+- Goal: refresh release prep after merge commit 1132ce7 and decide whether the merged axios fix belongs in the next release notes.
+- Method: read remote git state, compare v0.3.2..origin/main, review remaining open Dependabot PRs, then update release-prep docs.
+- Scope: release relevance only; no new product/code changes.

--- a/docs/work/2026-04-13-post-release-sanity-spec.md
+++ b/docs/work/2026-04-13-post-release-sanity-spec.md
@@ -1,0 +1,5 @@
+# 2026-04-13 Post-Release Sanity Spec
+
+- Goal: run a lightweight post-release sanity pass for v0.4.0.
+- Scope: published GitHub release state, public installer/update paths, and release assets only.
+- Non-goal: full reinstall on this workstation.

--- a/docs/work/2026-04-13-release-prep-spec.md
+++ b/docs/work/2026-04-13-release-prep-spec.md
@@ -1,0 +1,5 @@
+# 2026-04-13 Release Prep Spec
+
+- Goal: prepare the next release from origin/main after merge commit 1132ce7.
+- Default: bump to 0.4.0 because the release adds three first-class skills plus a supported-client behavior improvement, with one selective security bug fix.
+- Scope: version metadata, release draft inputs, and release-prep PR artifacts only.

--- a/docs/work/2026-04-13-review-lane-3-update-flow-spec.md
+++ b/docs/work/2026-04-13-review-lane-3-update-flow-spec.md
@@ -1,0 +1,29 @@
+# 2026-04-13 Review Lane 3 Update Flow Spec
+
+## Goal
+
+Inspect installed-client update/setup repair behavior with focus on Claude marketplace sync and persisted install state.
+
+## Questions
+
+- Which files own installed-client sync during `ha-nova update` and `ha-nova setup`?
+- Does HA NOVA automatically repair a stale Claude detach state?
+- Can Claude remain marked installed in HA NOVA state after the Claude plugin or marketplace is removed externally?
+- If so, is that intentional retry state or a real bug for end-user update/setup behavior?
+
+## Scope
+
+- `cli/command_update.go`
+- `cli/command_setup.go`
+- `cli/setup_interactive.go`
+- `cli/state.go`
+- `cli/client_status.go`
+- `cli/client_detection.go`
+- `cli/client_install.go`
+- `cli/client_claude.go`
+- `cli/claude_marketplace.go`
+- relevant tests/docs for Claude stale-state and marketplace sync
+
+## Deliverable
+
+Review findings with likely root cause, current repair behavior, and fix options with file references.

--- a/docs/work/2026-04-13-v0.4.0-release-body.md
+++ b/docs/work/2026-04-13-v0.4.0-release-body.md
@@ -1,0 +1,27 @@
+## New Features
+
+- Dashboard work now has a dedicated HA NOVA skill for safe storage dashboard edits, Lovelace resources, and targeted card changes.
+- Organization tasks now have a dedicated skill for areas, floors, labels, categories, and richer entity and device metadata.
+- History questions now have a dedicated read-only skill for bounded history, logbook timelines, and long-term statistics.
+- Gemini now picks up newly shipped HA NOVA sub-skills automatically during install and sync, so the promoted skills arrive there without manual wiring.
+
+## Bug Fixes
+
+- Updated `axios` to `1.15.0` in both the main app and the Relay package to close critical production dependency findings.
+
+## Install
+
+**macOS / Linux**
+```sh
+curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/v0.4.0/install.sh | HA_NOVA_VERSION=v0.4.0 bash
+```
+
+**Windows (PowerShell)**
+```powershell
+$env:HA_NOVA_VERSION = 'v0.4.0'
+irm https://raw.githubusercontent.com/markusleben/ha-nova/v0.4.0/install.ps1 | iex
+```
+
+## Already Installed?
+
+Run `ha-nova check-update` or `ha-nova update`.

--- a/docs/work/2026-04-14-claude-detach-root-cause-fix-spec.md
+++ b/docs/work/2026-04-14-claude-detach-root-cause-fix-spec.md
@@ -1,0 +1,49 @@
+# Claude Detach Root Cause + Fix Spec
+
+Date: 2026-04-14
+
+## Problem
+
+On the real Mac, HA NOVA keeps getting detached from Claude again after a successful attach.
+
+Observed live sequence from the drift audit:
+
+1. `known_marketplaces.json` loses the `ha-nova` marketplace entry first.
+2. `installed_plugins.json` then loses `ha-nova@ha-nova`.
+3. `settings.json` loses the enabled plugin state.
+4. Claude writes `.orphaned_at` inside the cached HA NOVA plugin tree.
+
+This is no longer just a false-positive HA NOVA status bug. Claude is actually orphaning the HA NOVA plugin state.
+
+## Working Hypothesis
+
+The unstable piece is the local staged Claude marketplace source at:
+
+- `~/.config/ha-nova/claude-marketplace`
+
+Current bundle installs still prefer that local directory source for Claude. The real Mac evidence shows Claude first removing that marketplace source and then orphaning the plugin cache. Official Claude marketplaces on this machine use GitHub sources, not local directory sources.
+
+## Goal
+
+Make Claude installs stable for all users without adding a new background runtime or a second state model.
+
+## KISS Fix Plan
+
+1. Stop preferring the staged local Claude marketplace for normal bundle installs.
+2. Keep local marketplace mode only for dev or explicit override.
+3. Pin production Claude installs to the installed HA NOVA release tag, not a floating repo source.
+4. Migrate existing bundle installs from the staged local source to the pinned GitHub marketplace source on the next repair/sync.
+5. Keep the stricter attach verification:
+   - plugin record must exist
+   - marketplace record must exist
+   - install path must be usable
+6. Add regression coverage for:
+   - bundle install uses pinned GitHub source
+   - legacy local staged source migrates to pinned GitHub source
+   - pinned GitHub refs stay distinct and preserved when intentionally requested
+
+## Out of Scope
+
+- No new daemon
+- No product telemetry service
+- No speculative auto-repair loop outside existing setup/update/sync paths

--- a/docs/work/2026-04-14-claude-drift-evidence-capture-spec.md
+++ b/docs/work/2026-04-14-claude-drift-evidence-capture-spec.md
@@ -1,0 +1,41 @@
+# Claude Drift Evidence Capture Spec
+
+Date: 2026-04-14
+
+## Goal
+
+Capture durable evidence when Claude detaches HA NOVA again, without adding a new daemon system inside the product.
+
+## Scope
+
+- Reuse the existing Claude state helper.
+- Add a compact machine-readable snapshot of the relevant Claude registry files.
+- Add a small local watcher script for macOS using `fswatch`.
+- Start the watcher on the current Mac after implementation.
+
+## Files To Track
+
+- `~/.claude/plugins/installed_plugins.json`
+- `~/.claude/plugins/known_marketplaces.json`
+- `~/.claude/settings.json`
+- `~/.claude/settings.local.json`
+
+## Output
+
+- append-only `events.jsonl`
+- rolling `latest.json`
+- enough metadata to answer:
+  - which file changed first
+  - what the Claude attach state looked like before/after
+  - whether plugin / marketplace / settings drifted together or separately
+
+## Non-Goals
+
+- no long-running product daemon
+- no OS-wide audit subsystem
+- no guessing which external process changed the file
+
+## Success
+
+- We can start one command locally and keep collecting Claude drift evidence.
+- The watcher output stays simple JSON so later analysis is easy.

--- a/docs/work/2026-04-17-hermes-hardening-spec.md
+++ b/docs/work/2026-04-17-hermes-hardening-spec.md
@@ -1,0 +1,33 @@
+# Hermes Hardening Spec
+
+Date: 2026-04-17
+
+## Goal
+
+Close the concrete Hermes review findings without widening scope:
+
+- prevent native Windows `dev-sync` failures for Hermes
+- detect incomplete Hermes bundles as detached/incomplete
+- fail loud when Hermes source payload is incomplete during install
+- clarify the WSL2-only Hermes-on-Windows workflow in shared docs
+- add regression coverage for Hermes install, doctor, uninstall, and onboarding contracts
+
+## Non-Goals
+
+- no new Hermes provider capabilities beyond the already-added client support
+- no relay changes
+- no redesign of non-Hermes client health checks
+
+## Planned Changes
+
+1. Add a Hermes bundle completeness helper and use it for status/detection.
+2. Make Hermes install fail when the shipped source context skill is missing.
+3. Teach `dev-sync` to skip Hermes on native Windows with an explicit WSL2 note.
+4. Extend macOS RC validation and Windows cleanup helpers for Hermes-specific paths.
+5. Tighten README / Hermes overlay / shared update guide wording for WSL2.
+6. Add regression tests for:
+   - incomplete Hermes bundle not counting as ready
+   - Hermes doctor repair hint
+   - Hermes uninstall cleanup
+   - Hermes missing source payload failure
+   - Hermes onboarding/install shell coverage, including native Windows rejection

--- a/docs/work/2026-04-17-hermes-live-ssh-validation-spec.md
+++ b/docs/work/2026-04-17-hermes-live-ssh-validation-spec.md
@@ -1,0 +1,23 @@
+## Hermes Live SSH Validation
+
+Date: 2026-04-17
+
+### Scope
+
+Validate the real Hermes Linux install path on a live remote host without adding any host-specific SSH details to the repository.
+
+### Plan
+
+1. Copy the current worktree to a temporary remote directory.
+2. Run the Hermes local-skill installer from that temporary checkout inside a login shell, so the remote Hermes binary is discoverable in `PATH`.
+3. Verify the installed Hermes bundle shape and namespaced sub-skill output under `~/.hermes/skills/ha-nova`, with sub-skill directory names matching their `name:` values.
+4. Verify the repo `dev-sync` path refreshes Hermes correctly on Linux.
+5. Remove the temporary remote checkout after validation.
+
+### Exit Criteria
+
+- `bash scripts/onboarding/install-local-skills.sh hermes` succeeds on a real remote Hermes host.
+- The installed Hermes bundle contains the expected HA NOVA root skill and required sub-skills.
+- Hermes sub-skills keep namespaced frontmatter such as `ha-nova-review`.
+- `bash scripts/dev-sync.sh` refreshes Hermes successfully on that host.
+- No SSH host/path details are committed to the repo.

--- a/docs/work/2026-04-17-linux-keyring-preflight-spec.md
+++ b/docs/work/2026-04-17-linux-keyring-preflight-spec.md
@@ -1,0 +1,29 @@
+# Linux keyring setup preflight
+
+Date: 2026-04-17
+
+## Goal
+
+Detect Linux relay-token storage prerequisites during `ha-nova setup` before the first keyring write attempt.
+
+## Constraints
+
+- Keep KISS.
+- No insecure token fallback.
+- No prompt-heavy or hanging D-Bus unlock flow during preflight.
+- Preserve existing fail-loud behavior for unexpected keyring errors.
+
+## Plan
+
+1. Add a Linux-only keyring preflight that:
+   - checks session-bus availability,
+   - calls Secret Service `ReadAlias("default")`,
+   - classifies missing provider vs missing default collection,
+   - avoids unlock/write operations.
+2. Hook preflight into interactive setup as an early warning when no saved token exists yet.
+3. Hook preflight into non-interactive setup before any token write when the token will change.
+4. Add focused regression tests for:
+   - interactive early warning,
+   - non-interactive early failure,
+   - preflight classification.
+5. Live-check on the Linux SSH host.

--- a/docs/work/2026-04-17-linux-private-installer-validation-spec.md
+++ b/docs/work/2026-04-17-linux-private-installer-validation-spec.md
@@ -1,0 +1,23 @@
+## Linux Private Installer Validation
+
+Date: 2026-04-17
+
+### Scope
+
+Prove the unreleased Linux installer path on a real Linux machine by serving a private local `install.sh` plus a private local Linux install bundle and checksum over LAN.
+
+### Plan
+
+1. Build fresh snapshot binaries and install bundles locally.
+2. Serve only `install.sh`, the Linux `tar.gz` bundle, and its `.sha256` from a temporary local HTTP server.
+3. Run the real Linux `install.sh` flow on the remote Linux host with `HA_NOVA_BUNDLE_URL` and `HA_NOVA_BUNDLE_SHA256_URL` overrides.
+4. Verify runtime install root, public symlink, bundle metadata, and post-install CLI behavior on the remote host.
+5. Fix any installer or bundle noise surfaced by the Linux proof and rerun the same path.
+
+### Exit Criteria
+
+- The remote Linux host installs the unreleased bundle through the real `install.sh` path.
+- `~/.local/share/ha-nova` and `~/.local/bin/ha-nova` are created correctly.
+- `ha-nova version` works on the remote Linux host.
+- Non-interactive installer output is clean: no `/dev/tty` leak and no macOS xattr warning noise from the bundle.
+- No host-specific SSH or LAN details are committed to the repo.

--- a/docs/work/2026-04-17-linux-setup-followup-spec.md
+++ b/docs/work/2026-04-17-linux-setup-followup-spec.md
@@ -1,0 +1,25 @@
+## Linux Setup Follow-Up
+
+Date: 2026-04-17
+
+### Scope
+
+Fix the two live Linux setup failures found during the Hermes and private-bundle validation passes:
+
+1. setup fell through to a misleading `homeassistant.local` fallback even though the real Linux host exposed Home Assistant via Avahi mDNS
+2. setup failed with a raw Secret Service D-Bus error when secure token storage was unavailable
+
+### Plan
+
+1. Extend Linux Home Assistant discovery to use the real Avahi `_home-assistant._tcp` browse path.
+2. Parse Avahi browse output into a usable HA host/IP without requiring the macOS `dns-sd` lookup flow.
+3. Convert the specific Linux Secret Service unavailable class into a clear setup-facing recovery message.
+4. Keep other secure-storage failures loud.
+5. Add regression coverage and re-check behavior on the live Linux host.
+
+### Exit Criteria
+
+- Linux setup discovery can surface the real HA address from Avahi output.
+- Setup no longer dumps the raw `org.freedesktop.secrets` error when Secret Service is unavailable.
+- The new setup message tells the user what Linux prerequisite is missing and what command to rerun.
+- Existing macOS `dns-sd` discovery behavior stays intact.

--- a/docs/work/2026-04-17-linux-ssh-keyring-guidance-spec.md
+++ b/docs/work/2026-04-17-linux-ssh-keyring-guidance-spec.md
@@ -1,0 +1,23 @@
+# Linux SSH Keyring Guidance
+
+Date: 2026-04-17
+Status: implemented
+
+## Scope
+
+Tighten Linux setup messaging for the verified SSH/headless Secret Service recovery path without external shell workarounds.
+
+## Plan
+
+1. Keep the Linux keyring failure class strict; do not add insecure runtime fallback.
+2. Detect recoverable Linux Secret Service states precisely: `needs-init` vs `locked`.
+3. Recover those states inside setup with the built-in GNOME Keyring DBus flow so SSH/headless users can initialize or unlock local secure storage inline.
+4. Surface matching user guidance in interactive warnings and save-time errors.
+5. Cover the new behavior and wording in regression tests.
+
+## Exit Criteria
+
+- Linux setup/setup-save messaging still fails loud on blocked secure storage.
+- Recoverable Linux states are handled inline during setup for both fresh initialization and unlock.
+- SSH/headless users are guided through local secure storage creation or unlock without being told to run a shell command manually.
+- Regression tests cover the new wording and the recovery flow.

--- a/docs/work/2026-04-18-linux-secure-storage-recovery-spec.md
+++ b/docs/work/2026-04-18-linux-secure-storage-recovery-spec.md
@@ -1,0 +1,41 @@
+# Linux Secure Storage Recovery Spec
+
+Date: 2026-04-18
+Status: active
+
+## Goal
+
+Make Linux setup recoverable in the GNOME Keyring SSH/headless case when the active Secret Service owner is GNOME Keyring, including the true fresh-init state where no default collection exists yet, without adding insecure storage fallbacks, package-manager automation, or extra public CLI surface.
+
+## Scope
+
+- add one setup-only interactive recovery stage before host/token work
+- allow exactly one late persistence retry in the same run
+- keep non-interactive setup fail-loud, but append a precise interactive recovery hint for the recoverable class
+- split locked-vs-uninitialized Linux secure-storage states so the UX stays truthful
+- verify recovery with a real go-keyring probe, not just a Secret Service alias read
+- document the release-bound Linux real-machine validation lane
+
+## Non-Goals
+
+- no insecure token storage fallback
+- no automatic package installation
+- no generic recovery flow for all Linux keyring backends
+- no new public command or flag
+
+## Implementation Notes
+
+- detect recoverability only when the active `org.freedesktop.secrets` owner is GNOME Keyring
+- prompt for the existing local Linux keyring password only in interactive TTY setup for locked collections
+- prompt for a new local Linux keyring password plus confirmation when GNOME Keyring must create the default collection
+- zero password bytes after the recovery command returns
+- use GNOME Keyring's DBus internal password methods on one live session-bus connection instead of shelling out to `gnome-keyring-daemon --unlock`
+- after recovery, rerun saved-token detection and setup-state routing before continuing
+- if persistence hits the same recoverable keyring error later in the run, offer one retry only
+
+## Verification
+
+- targeted Go regressions for the recovery stage, late retry, no re-prompt, doctor hint, and non-interactive hint
+- full `cd cli && go test -count=1 -timeout 180s ./...`
+- Linux real-machine proof on a logged-in desktop user session, including fresh-init and locked-keyring recovery over SSH
+- release docs updated with the Linux real-machine onboarding proof lane

--- a/docs/work/2026-04-20-hermes-linux-feature-docs-spec.md
+++ b/docs/work/2026-04-20-hermes-linux-feature-docs-spec.md
@@ -1,0 +1,42 @@
+# Hermes Platform Evidence Docs Spec
+
+Date: 2026-04-20
+Status: implemented
+
+## Goal
+
+Reflect Hermes support and Linux secure-storage recovery with an explicit support-evidence model instead of scattered install notes or broad platform claims.
+
+## Scope
+
+- update the active next-release notes draft
+- tighten README and `.hermes/INSTALL.md` around supported path vs current proof
+- add a living Hermes platform validation reference doc
+- add a structured community validation issue template
+- align the Linux live-validation helper and release runbook on a generic default setup command
+- lock the new posture with onboarding/release contract tests
+- record the opinionated defaults in `docs/choices.md` and `docs/breadcrumbs.md`
+
+## Non-Goals
+
+- no new runtime behavior
+- no retroactive edits to already-published historical release bodies
+- no promise that every Linux Secret Service backend already has the same inline recovery coverage
+- no host-specific validation data in the repo
+
+## Planned Changes
+
+1. Keep Hermes support visible in README/release notes, but state the current maintainer-validated Linux proof explicitly.
+2. Rewrite `.hermes/INSTALL.md` around an evidence ladder: `Supported path`, `Maintainer-validated`, `Community validation`, `Known limitation`, `Planned / not yet validated`.
+3. Add `docs/reference/hermes-platform-validation.md` as the active per-platform truth source.
+4. Add `.github/ISSUE_TEMPLATE/hermes-platform-validation.yml` so community reports arrive in a structured, privacy-safe format.
+5. Make `scripts/smoke/linux-headless-setup-check.sh` default to generic `ha-nova setup`, with explicit `HA_NOVA_LIVE_SETUP_CMD` override for Hermes proofs.
+6. Update release/onboarding contract tests so future edits cannot silently drift back to vague or over-broad claims.
+
+## Exit Criteria
+
+- active release-notes draft names Hermes support and Linux GNOME Keyring recovery as user-facing features without overstating cross-platform proof
+- README and `.hermes/INSTALL.md` distinguish support intent from current maintainer evidence
+- active docs include a living Hermes validation matrix plus a community validation intake path
+- the Linux SSH/headless helper no longer assumes Hermes by default
+- targeted onboarding/release contract tests pass on the new wording and helper defaults

--- a/docs/work/2026-04-20-hermes-topology-wording-spec.md
+++ b/docs/work/2026-04-20-hermes-topology-wording-spec.md
@@ -1,0 +1,38 @@
+# Hermes Topology Wording Spec
+
+Date: 2026-04-20
+Status: implemented
+
+## Goal
+
+Explain Hermes as a local-first HA NOVA client without overclaiming `LAN-only`, while making the current VPS mismatch and safe remote/private-path story clear.
+
+## Scope
+
+- tighten public README wording around network/privacy posture
+- add Hermes-specific topology guidance in `.hermes/INSTALL.md`
+- keep wording English, user-facing, and low-jargon
+- avoid hard-promising Telegram or hosted remote access features
+
+## Non-Goals
+
+- no new runtime behavior
+- no new public feature promise for Telegram or VPS hosting
+- no topology deep dive in the main install flow
+
+## Planned Changes
+
+1. Soften the absolute README network claim into a local-first / no-cloud-relay statement.
+2. Add one short advanced-note sentence in README that separates private-path remote access from public exposure.
+3. Add a Hermes-specific network model section that explains:
+   - local-first default
+   - same LAN or private VPN/overlay as the practical path today
+   - VPS as an advanced mismatch, not the intended default
+   - remote entrypoints can later feed the same local executor model
+4. Record the wording defaults in `docs/choices.md` and `docs/breadcrumbs.md`.
+
+## Exit Criteria
+
+- public docs no longer imply a brittle permanent `nothing leaves your network` promise
+- Hermes docs explain local-first vs VPS in plain English
+- docs leave room for future remote entrypoints without promising a specific Telegram/VPS roadmap

--- a/docs/work/2026-04-22-release-note-polish-spec.md
+++ b/docs/work/2026-04-22-release-note-polish-spec.md
@@ -1,0 +1,27 @@
+# Release Note Polish Spec
+
+Date: 2026-04-22
+Status: merged
+
+## Goal
+
+Turn the active next-release notes draft into a short, publish-ready user-facing body.
+
+## Scope
+
+- tighten the active next-release draft
+- keep the fixed release-note headings
+- prefer user outcome over implementation detail
+- keep install commands unchanged
+
+## Non-Goals
+
+- no release version decision
+- no runtime behavior change
+- no expansion into a long changelog
+
+## Exit Criteria
+
+- the draft is short enough to publish directly
+- Hermes, Linux secure-storage recovery, promoted skills, Gemini sync, and the selective axios fix stay visible
+- the copy stays plain English and user-facing

--- a/docs/work/2026-04-23-readme-ground-rules-precision-spec.md
+++ b/docs/work/2026-04-23-readme-ground-rules-precision-spec.md
@@ -1,0 +1,28 @@
+# README Ground Rules Precision Spec
+
+Date: 2026-04-23
+Status: merged
+
+## Goal
+
+Make the README safety claims precise enough to match the shipped token model.
+
+## Scope
+
+- clarify that the Home Assistant token stays on the Home Assistant server
+- clarify that the local Relay token copy uses the OS credential store
+- scope the telemetry claim to HA NOVA
+- keep the section short and user-facing
+- add contract coverage for the precise wording
+
+## Non-Goals
+
+- no runtime behavior change
+- no expanded security whitepaper
+- no changes to setup flow
+
+## Exit Criteria
+
+- the README no longer implies every credential lives in the OS keychain
+- the README no longer implies every tool in the stack has no telemetry
+- the README still communicates the simple trust model quickly

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -121,6 +121,14 @@ if [[ -f "$version_file" ]]; then
   fi
 fi
 
+# Background auto-repair: silently reattach drifted clients (e.g., a Claude
+# Code update wiped the marketplace registration). Fire-and-forget so this
+# session starts immediately; the repair lands in time for the next session.
+if command -v ha-nova >/dev/null 2>&1; then
+  (ha-nova doctor --auto-repair --quiet >/dev/null 2>&1 || true) &
+  disown 2>/dev/null || true
+fi
+
 if [[ -n "$update_notice" ]]; then
   session_context="${update_notice}\\n${session_context}"
 fi

--- a/nova/DOCS.md
+++ b/nova/DOCS.md
@@ -60,7 +60,7 @@ Run the built-in health check:
 ha-nova doctor
 ```
 
-This verifies: config file, keychain token, relay reachability, WebSocket connection,
+This verifies: config file, local Relay token, relay reachability, WebSocket connection,
 and relay version.
 
 You can also check the relay directly:

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dev:install:claude-skill": "bash scripts/onboarding/install-local-skills.sh claude",
     "dev:install:opencode-skill": "bash scripts/onboarding/install-local-skills.sh opencode",
     "dev:install:gemini-skill": "bash scripts/onboarding/install-local-skills.sh gemini",
+    "dev:install:hermes-skill": "bash scripts/onboarding/install-local-skills.sh hermes",
     "dev:install:skills": "bash scripts/onboarding/install-local-skills.sh all",
     "dev:watch:claude-state": "bash scripts/dev/watch-claude-state.sh",
     "dev:validation:harness": "bash scripts/dev/start-local-validation-harness.sh",

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -93,7 +93,7 @@ fi
 
 # ── 8. Supported clients match install scripts ──
 echo "[8] Supported AI clients have install scripts"
-for client in claude codex opencode gemini; do
+for client in claude codex opencode gemini hermes; do
   SCRIPT_EXISTS=$(grep -c "install.*${client}" "$REPO_ROOT/package.json" 2>/dev/null || true)
   if (( SCRIPT_EXISTS > 0 )); then
     pass "Install script for ${client} found"

--- a/scripts/dev/windows-clean-test-state.ps1
+++ b/scripts/dev/windows-clean-test-state.ps1
@@ -240,7 +240,21 @@ function Remove-WingetTestInstall {
   }
 }
 
+function Remove-HermesWslSkills {
+  $wsl = Get-Command wsl.exe -ErrorAction SilentlyContinue
+  if ($null -eq $wsl) {
+    return
+  }
+
+  try {
+    & $wsl.Source sh -lc 'rm -rf ~/.hermes/skills/ha-nova' 2>$null | Out-Null
+  }
+  catch {
+  }
+}
+
 Remove-WingetTestInstall
+Remove-HermesWslSkills
 Remove-InstallRootWithRuntime -Root $InstallDir
 if ($LegacyInstallDir -ne $InstallDir) {
   Remove-InstallRootWithRuntime -Root $LegacyInstallDir
@@ -257,6 +271,7 @@ $paths = @(
   (Join-Path $HOME ".agents\skills\ha-nova"),
   (Join-Path $HOME ".config\opencode\skills\ha-nova"),
   (Join-Path $HOME ".gemini\skills\ha-nova"),
+  (Join-Path $HOME ".hermes\skills\ha-nova"),
   (Join-Path $HOME ".gemini\skills\ha-nova-dashboard"),
   (Join-Path $HOME ".gemini\skills\ha-nova-organize"),
   (Join-Path $HOME ".gemini\skills\ha-nova-history"),

--- a/scripts/legacy-uninstall.ps1
+++ b/scripts/legacy-uninstall.ps1
@@ -44,6 +44,15 @@ foreach ($path in $legacyPaths) {
   Remove-IfExists $path
 }
 
+$wsl = Get-Command wsl.exe -ErrorAction SilentlyContinue
+if ($null -ne $wsl) {
+  try {
+    & $wsl.Source sh -lc 'rm -rf ~/.hermes/skills/ha-nova' 2>$null | Out-Null
+  }
+  catch {
+  }
+}
+
 $legacyScriptsDir = Join-Path $InstallDir "scripts\onboarding"
 if ((Test-Path -LiteralPath $legacyScriptsDir) -and -not (Test-Path -LiteralPath (Join-Path $InstallDir "bundle.json"))) {
   Remove-Item -LiteralPath $InstallDir -Recurse -Force
@@ -53,6 +62,7 @@ $skillRoots = @(
   (Join-Path $HOME ".agents\skills"),
   (Join-Path $HOME ".config\opencode\skills"),
   (Join-Path $HOME ".gemini\skills"),
+  (Join-Path $HOME ".hermes\skills"),
   (Join-Path $HOME ".claude\skills")
 )
 

--- a/scripts/legacy-uninstall.sh
+++ b/scripts/legacy-uninstall.sh
@@ -38,6 +38,7 @@ fi
 remove_glob_matches "${HOME}/.agents/skills/ha-nova*"
 remove_glob_matches "${HOME}/.config/opencode/skills/ha-nova*"
 remove_glob_matches "${HOME}/.gemini/skills/ha-nova*"
+remove_glob_matches "${HOME}/.hermes/skills/ha-nova*"
 remove_glob_matches "${HOME}/.claude/skills/ha-nova*"
 
 echo "[ha-nova:legacy-uninstall] Legacy HA NOVA cleanup finished."

--- a/scripts/onboarding/lib/install-local-skills-claude.sh
+++ b/scripts/onboarding/lib/install-local-skills-claude.sh
@@ -27,7 +27,7 @@ claude_marketplace_record_present() {
 }
 
 claude_plugin_state_helper_required() {
-  claude_plugin_record_present || claude_marketplace_record_present
+  claude_plugin_record_present
 }
 
 require_claude_plugin_state_tool() {

--- a/scripts/onboarding/lib/install-local-skills-claude.sh
+++ b/scripts/onboarding/lib/install-local-skills-claude.sh
@@ -167,6 +167,14 @@ reset_local_claude_plugin_state() {
 restore_local_claude_state() {
   local previous_source="$1"
   local previous_plugin_installed="$2"
+  local previous_marketplace_present="${3:-0}"
+
+  if [[ "${previous_marketplace_present}" == "1" && -z "${previous_source}" && "${previous_plugin_installed}" != "1" ]]; then
+    # The original marketplace source is unknown (for example Node.js was
+    # unavailable for the state helper). Keep the current record instead of
+    # deleting user state we cannot restore.
+    return 1
+  fi
 
   claude plugin marketplace remove ha-nova >/dev/null 2>&1 || true
   if [[ "${previous_plugin_installed}" == "1" && -z "${previous_source}" ]]; then
@@ -191,8 +199,9 @@ fail_after_claude_restore_attempt() {
   local message="$1"
   local previous_source="$2"
   local previous_plugin_installed="$3"
+  local previous_marketplace_present="${4:-0}"
 
-  if ! restore_local_claude_state "${previous_source}" "${previous_plugin_installed}"; then
+  if ! restore_local_claude_state "${previous_source}" "${previous_plugin_installed}" "${previous_marketplace_present}"; then
     die "${message}; previous Claude state could not be restored automatically"
   fi
 
@@ -202,13 +211,21 @@ fail_after_claude_restore_attempt() {
 install_claude_plugin() {
   local previous_source=""
   local previous_plugin_installed="0"
+  local previous_marketplace_present="0"
 
+  if claude_marketplace_record_present; then
+    previous_marketplace_present="1"
+  fi
   if claude_plugin_state_helper_required; then
     require_claude_plugin_state_tool "[claude]" || exit 1
     previous_source="$(read_claude_marketplace_source)"
     if claude_plugin_installed; then
       previous_plugin_installed="1"
     fi
+  elif [[ "${previous_marketplace_present}" == "1" ]] && claude_plugin_state_runtime_ready; then
+    # Best effort: capture the original source when Node.js happens to be
+    # available, without requiring it for marketplace-only state.
+    previous_source="$(read_claude_marketplace_source)"
   fi
 
   local marketplace_root
@@ -219,16 +236,16 @@ install_claude_plugin() {
   if claude plugin marketplace add "${marketplace_root}" 2>/dev/null; then
     log "[claude] Marketplace registered: ${marketplace_root}"
   else
-    fail_after_claude_restore_attempt "[claude] Marketplace registration failed: ${marketplace_root}" "${previous_source}" "${previous_plugin_installed}"
+    fail_after_claude_restore_attempt "[claude] Marketplace registration failed: ${marketplace_root}" "${previous_source}" "${previous_plugin_installed}" "${previous_marketplace_present}"
   fi
 
   if ! reset_local_claude_plugin_state; then
-    fail_after_claude_restore_attempt "[claude] Plugin reset failed: ha-nova@ha-nova" "${previous_source}" "${previous_plugin_installed}"
+    fail_after_claude_restore_attempt "[claude] Plugin reset failed: ha-nova@ha-nova" "${previous_source}" "${previous_plugin_installed}" "${previous_marketplace_present}"
   fi
 
   if claude plugin install ha-nova@ha-nova 2>/dev/null; then
     log "[claude] Plugin installed: ha-nova@ha-nova"
   else
-    fail_after_claude_restore_attempt "[claude] Plugin install failed: ha-nova@ha-nova" "${previous_source}" "${previous_plugin_installed}"
+    fail_after_claude_restore_attempt "[claude] Plugin install failed: ha-nova@ha-nova" "${previous_source}" "${previous_plugin_installed}" "${previous_marketplace_present}"
   fi
 }

--- a/skills/ha-nova/update-guide.md
+++ b/skills/ha-nova/update-guide.md
@@ -13,7 +13,8 @@ The CLI auto-detects which client integrations are installed and refreshes each 
 Update routing is simple:
 - bundle and dev installs use the HA NOVA updater directly
 
-On Windows, the supported install path remains `install.ps1`, and `ha-nova update` keeps using the installed HA NOVA runtime directly.
+On native Windows, the supported HA NOVA install path remains `install.ps1`, and `ha-nova update` keeps using the installed HA NOVA runtime directly.
+Hermes on Windows is the exception: use the Linux/WSL HA NOVA install and run Hermes update/setup commands from inside that WSL shell.
 
 `ha-nova check-update` compares the installed version against the latest GitHub release and keeps the shared update cache fresh for follow-up commands.
 
@@ -48,9 +49,10 @@ HA NOVA uses three update archetypes depending on the client:
 | Codex | Linked/Copy | Refresh installed skill tree from the active HA NOVA install |
 | OpenCode | Linked/Copy | Refresh installed skill tree from the active HA NOVA install |
 | Gemini | Flat-copy | Rebuild flat markdown copies from the active HA NOVA install |
+| Hermes Agent | Namespaced copy | Rebuild the Hermes-local namespaced skill bundle from the active HA NOVA install |
 
 After client updates, shared tools are refreshed from the active HA NOVA install.
-On Windows, post-update client sync uses the installed HA NOVA runtime directly.
+On native Windows, post-update client sync uses the installed HA NOVA runtime directly. Hermes-on-Windows should be updated from the WSL2 install instead.
 
 ## Check Versions
 
@@ -77,4 +79,4 @@ When the agent detects `UPDATE AVAILABLE` in its session context, it can run the
 ha-nova update
 ```
 
-After a successful update, the user must start a new Claude session for the updated payload to take effect.
+After a successful update, the user must start a new client session for the updated payload to take effect.

--- a/tests/onboarding/_helpers.ts
+++ b/tests/onboarding/_helpers.ts
@@ -227,6 +227,7 @@ exit 0
     { mode: 0o755 },
   );
 
+  // --- hermes mock (fast no-op CLI) ---
   writeFileSync(join(binDir, "hermes"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
 
   return binDir;

--- a/tests/onboarding/client-install-docs-contract.test.ts
+++ b/tests/onboarding/client-install-docs-contract.test.ts
@@ -79,26 +79,59 @@ describe("client install docs contract", () => {
     expect(codexInstall).toContain("Install the Codex client separately");
     expect(codexInstall).toContain("ha-nova setup codex");
     expect(codexInstall).toContain("ha-nova check-update");
-    expect(codexInstall).toContain("still early and not fully tested yet");
+    expect(codexInstall).not.toContain("claude install");
+    expect(codexInstall).not.toContain("CLAUDE_CODE_GIT_BASH_PATH");
+    expect(codexInstall).not.toContain("Git Bash");
 
     expect(geminiInstall).toContain("Gemini CLI");
     expect(geminiInstall).toContain("Install the Gemini client separately");
     expect(geminiInstall).toContain("ha-nova setup gemini");
     expect(geminiInstall).toContain("ha-nova check-update");
-    expect(geminiInstall).toContain("basic Windows validation");
     expect(geminiInstall).toContain("Node.js");
     expect(geminiInstall).toContain("node --version");
     expect(geminiInstall).toContain("gemini --version");
     expect(geminiInstall).toContain("open a fresh PowerShell window");
     expect(geminiInstall).toContain("skips Gemini");
     expect(geminiInstall).toContain("~/.gemini/skills/ha-nova-*");
+    expect(geminiInstall).not.toContain("claude install");
+    expect(geminiInstall).not.toContain("CLAUDE_CODE_GIT_BASH_PATH");
+    expect(geminiInstall).not.toContain("Git Bash");
 
     expect(opencodeInstall).toContain("OpenCode");
     expect(opencodeInstall).toContain("Install the OpenCode client separately");
     expect(opencodeInstall).toContain("ha-nova setup opencode");
     expect(opencodeInstall).toContain("ha-nova check-update");
     expect(opencodeInstall).toContain("WSL");
-    expect(opencodeInstall).toContain("still early and not fully tested yet");
+    expect(opencodeInstall).not.toContain("claude install");
+    expect(opencodeInstall).not.toContain("CLAUDE_CODE_GIT_BASH_PATH");
+    expect(opencodeInstall).not.toContain("Git Bash");
+
+    expect(hermesInstall).toContain("Hermes Agent");
+    expect(hermesInstall).toContain("ha-nova setup hermes");
+    expect(hermesInstall).toContain("ha-nova check-update");
+    expect(hermesInstall).toContain("What Supported Means Here");
+    expect(hermesInstall).toContain("Platform Routing");
+    expect(hermesInstall).toContain("Network Model");
+    expect(hermesInstall).toContain("Supported with limitation");
+    expect(hermesInstall).toContain("Not supported");
+    expect(hermesInstall).toContain("Maintainer-validated");
+    expect(hermesInstall).toContain("Community validation");
+    expect(hermesInstall).toContain("GNOME Keyring");
+    expect(hermesInstall).toContain("WSL2");
+    expect(hermesInstall).toContain("Windows native");
+    expect(hermesInstall).toContain("local-first HA NOVA client");
+    expect(hermesInstall).toContain("same home network or a private VPN/overlay route");
+    expect(hermesInstall).toContain("generic public VPS");
+    expect(hermesInstall).toContain("Do not expose the HA NOVA Relay directly to the public internet.");
+    expect(hermesInstall).toContain("docs/reference/hermes-platform-validation.md");
+    expect(hermesInstall).toContain("~/.hermes/skills/ha-nova/");
+    expect(hermesInstall).toContain("ha-nova-read");
+    expect(hermesInstall).toContain("stays on this machine");
+    expect(hermesInstall).toContain("not your Relay token");
+    expect(hermesInstall).toContain("not sent to the Relay, Home Assistant, Hermes, or any AI provider");
+    expect(hermesInstall).toContain("doctor points you to `ha-nova setup hermes`");
+    expect(hermesInstall).toContain("skills_list");
+    expect(hermesInstall).toContain("skill_view");
 
     expect(hermesInstall).toContain("Hermes Agent");
     expect(hermesInstall).toContain("not part of the current stable release");
@@ -121,6 +154,8 @@ describe("client install docs contract", () => {
     expect(hermesInstall).not.toContain("HA_NOVA_CLAUDE_MARKETPLACE_LOCAL=1");
     expect(hermesInstall).not.toContain("CLAUDE_CODE_GIT_BASH_PATH");
     expect(hermesInstall).not.toContain("ha-nova setup claude");
+    expect(hermesInstall).not.toContain("ha-nova setup gemini");
+    expect(hermesInstall).not.toContain("ha-nova setup opencode");
     expect(hermesInstall).not.toContain("Git Bash");
   });
 
@@ -131,11 +166,16 @@ describe("client install docs contract", () => {
     expect(governance).toContain("point back to `README.md`");
   });
 
-  it("keeps README and Windows client overlays aligned on prerequisites and validation depth", () => {
-    expect(readme).toContain("Claude Code is the most tested client on Windows today");
-    expect(readme).toContain("Gemini CLI has basic validation");
-    expect(geminiInstall).toContain("Gemini has basic Windows validation for this release.");
-    expect(claudeInstall).toContain("Claude is the Windows path we have tested most for this release.");
+  it("keeps README and Windows client overlays aligned on prerequisites and Windows guidance", () => {
+    expect(readme).toContain("Windows");
+    expect(readme).toContain("Git for Windows / Git Bash");
+    expect(readme).toContain("Gemini CLI needs Node.js");
+    expect(claudeInstall).toContain("Windows Notes");
+    expect(geminiInstall).toContain("Windows Notes");
+    expect(geminiInstall).toContain("Node.js");
+    expect(geminiInstall).toContain("open a fresh PowerShell window");
+    expect(claudeInstall).toContain("Git for Windows");
+    expect(claudeInstall).toContain("Git Bash");
   });
 
   it("keeps Hermes in the release train without promoting the public README claim early", () => {

--- a/tests/onboarding/desktop-validation-contract.test.ts
+++ b/tests/onboarding/desktop-validation-contract.test.ts
@@ -202,6 +202,7 @@ describe("desktop validation helpers contract", () => {
     expect(windowsCleanup).toContain(".agents\\skills\\ha-nova");
     expect(windowsCleanup).toContain(".config\\opencode\\skills\\ha-nova");
     expect(windowsCleanup).toContain(".gemini\\skills\\ha-nova");
+    expect(windowsCleanup).toContain(".hermes\\skills\\ha-nova");
     expect(windowsCleanup).toContain(".claude\\plugins\\installed_plugins.json");
     expect(windowsCleanup).toContain('Join-Path $ConfigDir "claude-marketplace"');
     expect(windowsCleanup).toContain("Remove-ClaudePluginRecord");
@@ -210,6 +211,8 @@ describe("desktop validation helpers contract", () => {
     expect(windowsCleanup).toContain('Remove-Item -LiteralPath $marketplacesJson -Force -ErrorAction SilentlyContinue');
     expect(windowsCleanup).toContain("Remove-HANovaTestCredentials");
     expect(windowsCleanup).toContain("Remove-HANovaUserEnvironment");
+    expect(windowsCleanup).toContain("Remove-HermesWslSkills");
+    expect(windowsCleanup).toContain("wsl.exe");
     expect(windowsCleanup).toContain('HKCU:\\Environment\\$name');
     expect(windowsCleanup).toContain("HA_NOVA_KEYRING_SERVICE");
     expect(windowsCleanup).toContain("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING");

--- a/tests/onboarding/dev-sync-behavior.test.ts
+++ b/tests/onboarding/dev-sync-behavior.test.ts
@@ -309,4 +309,29 @@ describe("dev-sync behavior", () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr + result.stdout).toContain("[dev:sync] ERROR: Node.js not found in PATH");
   });
+
+  it("skips stale Claude marketplace-only metadata without requiring Node.js", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-dev-sync-claude-marketplace-only-"));
+    const claudeLogFile = join(home, "claude.log");
+    const binDir = createMockBinaries({ claudeLogFile });
+    writeFileSync(join(binDir, "node"), "#!/usr/bin/env bash\nexit 127\n", { mode: 0o755 });
+    mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "plugins", "known_marketplaces.json"),
+      '{"ha-nova":{"source":"https://github.com/markusleben/ha-nova"}}',
+    );
+
+    const result = spawnSync("bash", ["scripts/dev-sync.sh"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      timeout: 20000,
+      env: {
+        ...mockEnv(home, binDir),
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Claude Code: ha-nova plugin not installed");
+  });
 });

--- a/tests/onboarding/dev-sync-contract.test.ts
+++ b/tests/onboarding/dev-sync-contract.test.ts
@@ -10,6 +10,10 @@ describe("dev-sync contract", () => {
     expect(content).toContain('bash "${REPO_ROOT}/scripts/onboarding/install-local-skills.sh" "$target"');
     expect(content).toContain('refresh_file_client "$name" "$target"');
     expect(content).toContain('refresh_file_client "Gemini" "gemini"');
+    expect(content).toContain('CURRENT_PLATFORM_ID="$(detect_platform_id)"');
+    expect(content).toContain("sync_hermes()");
+    expect(content).toContain('sync_file_client "Hermes Agent" "${HOME}/.hermes/skills/ha-nova" "hermes"');
+    expect(content).toContain("native Windows sync not supported");
   });
 
   it("keeps legacy Gemini marker support during migration", () => {

--- a/tests/onboarding/install-skills-per-client.test.ts
+++ b/tests/onboarding/install-skills-per-client.test.ts
@@ -1,5 +1,5 @@
 /**
- * S-4: Client-specific skill installation (4 clients)
+ * S-4: Client-specific skill installation (5 clients)
  * S-5: Multi-client ("all")
  */
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, readlinkSync, statSync, writeFileSync } from "node:fs";
@@ -184,6 +184,18 @@ describe("S-4: client-specific skill installation", () => {
       const content = readFileSync(join(hermesRoot, installedName, "SKILL.md"), "utf8");
       expect(content).toContain(`name: ha-nova-${src}`);
       expectRepoRefsRewritten(content);
+
+      const companionFiles = readdirSync(join(REPO_ROOT, "skills", src))
+        .filter((file) => file.endsWith(".md") && file !== "SKILL.md");
+
+      for (const companion of companionFiles) {
+        const companionContent = readFileSync(
+          join(hermesRoot, installedName, companion),
+          "utf8",
+        );
+        expect(companionContent.length).toBeGreaterThan(0);
+        expectRepoRefsRewritten(companionContent);
+      }
     }
 
     const checks = readFileSync(join(hermesRoot, "ha-nova-review", "checks.md"), "utf8");
@@ -347,6 +359,37 @@ describe("S-4: client-specific skill installation", () => {
 
     expect(result.status).not.toBe(0);
     expect(result.stderr + result.stdout).toContain("[claude] Node.js not found in PATH");
+  });
+
+  it("installs Claude without Node.js when only a stale ha-nova marketplace record exists", () => {
+    const home = mkdtempSync(join(tmpdir(), "ha-nova-skill-claude-marketplace-only-"));
+    const claudeLogFile = join(home, "claude.log");
+    const binDir = createMockBinaries({ claudeLogFile });
+    writeFileSync(join(binDir, "node"), "#!/usr/bin/env bash\nexit 127\n", { mode: 0o755 });
+    mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "plugins", "known_marketplaces.json"),
+      '{"ha-nova":{"source":"https://github.com/markusleben/ha-nova"}}',
+    );
+
+    const result = spawnSync(
+      "bash",
+      ["scripts/onboarding/install-local-skills.sh", "claude"],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        timeout: 20000,
+        env: {
+          ...mockEnv(home, binDir),
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const claudeLog = readFileSync(claudeLogFile, "utf8");
+    expect(claudeLog).toContain("plugin marketplace add");
+    expect(claudeLog).toContain("plugin install ha-nova@ha-nova");
   });
 
   it("fails loudly when Claude install cannot restore a previous plugin without a marketplace source", () => {
@@ -536,6 +579,10 @@ describe("S-5: multi-client 'all' installation", () => {
         statSync(join(home, ".gemini/skills", sub, "SKILL.md")),
       ).not.toThrow();
     }
+
+    expect(() =>
+      statSync(join(home, ".hermes/skills/ha-nova/ha-nova/SKILL.md")),
+    ).not.toThrow();
 
     expect(() =>
       statSync(join(home, ".gemini/skills", "ha-nova-review", "checks.md")),

--- a/tests/onboarding/project-docs-contract.test.ts
+++ b/tests/onboarding/project-docs-contract.test.ts
@@ -68,6 +68,8 @@ describe("project docs contract", () => {
     expect(novaDocs).toContain("including `GET /health`");
     expect(novaDocs).toContain("Authorization: Bearer <token>");
     expect(novaDocs).toContain("[latest GitHub release](https://github.com/markusleben/ha-nova/releases/latest)");
+    expect(novaDocs).toContain("local Relay token");
+    expect(novaDocs).not.toContain("keychain token");
     expect(novaDocs).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.sh");
     expect(novaDocs).toContain('"ok": true');
     expect(novaDocs).toContain('"data": {');

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -5,9 +5,11 @@ import { describe, expect, it } from "vitest";
 describe("release contract", () => {
   const goreleaser = readFileSync(".goreleaser.yml", "utf8");
   const installer = readFileSync("install.ps1", "utf8");
+  const bundleBuilder = readFileSync("scripts/release/build-install-bundle.sh", "utf8");
   const releaseWorkflow = readFileSync(".github/workflows/release.yml", "utf8");
   const rcWorkflow = readFileSync(".github/workflows/release-candidate.yml", "utf8");
   const releasing = readFileSync("docs/releasing.md", "utf8");
+  const linuxHeadlessHelper = readFileSync("scripts/smoke/linux-headless-setup-check.sh", "utf8");
   const pkg = JSON.parse(readFileSync("package.json", "utf8")) as {
     scripts?: Record<string, string>;
   };
@@ -34,6 +36,10 @@ describe("release contract", () => {
     expect(existsSync("scripts/release/build-winget-manifest.sh")).toBe(false);
     expect(existsSync("scripts/release/prepare-winget-pkgs-submission.sh")).toBe(false);
     expect(existsSync("release/winget-publication-state.json")).toBe(false);
+  });
+
+  it("builds Unix install bundles without macOS copyfile metadata noise", () => {
+    expect(bundleBuilder).toContain('COPYFILE_DISABLE=1 tar --format ustar -czf "${output}" -C "${stage_dir}" ha-nova');
   });
 
   it("keeps the final release workflow free of winget artifacts and validation", () => {
@@ -75,15 +81,44 @@ describe("release contract", () => {
     expect(releasing).toContain("curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/<stable-tag>/install.sh | HA_NOVA_VERSION=vX.Y.Z bash");
     expect(releasing).toContain("irm https://raw.githubusercontent.com/markusleben/ha-nova/<stable-tag>/install.ps1 | iex");
     expect(releasing).toContain("stable release notes must publish tag-pinned install commands, never `main` bootstrap URLs");
-    expect(releasing).toContain("Desktop Validation Helpers");
-    expect(releasing).toContain("scripts/dev/start-local-validation-harness.sh");
-    expect(releasing).toContain("scripts/dev/windows-clean-test-state.ps1");
-    expect(releasing).toContain("scripts/dev/windows-private-rc-install.ps1");
-    expect(releasing).toContain("scripts/dev/windows-desktop-setup.ps1");
     expect(releasing).toContain("npm run dev:validation:harness");
     expect(releasing).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.sh");
     expect(releasing).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.ps1");
     expect(releasing).not.toContain("winget");
     expect(releasing).not.toContain("$ProgressPreference = 'SilentlyContinue'");
+  });
+
+  it("keeps the Linux real-machine onboarding lane documented for Linux setup changes", () => {
+    expect(releasing).toContain("Linux real-machine onboarding:");
+    expect(releasing).toContain("scripts/smoke/linux-headless-setup-check.sh");
+    expect(releasing).toContain("by default the helper runs `HA_NOVA_NO_BROWSER=1 ha-nova setup`");
+    expect(releasing).toContain("HA_NOVA_LIVE_SETUP_CMD='HA_NOVA_NO_BROWSER=1 ha-nova setup hermes'");
+    expect(releasing).toContain("HA_NOVA_LIVE_SETUP_CMD='HA_NOVA_NO_BROWSER=1 ha-nova setup --service hermes'");
+    expect(releasing).toContain("HA_NOVA_LIVE_SKIP_INSTALL=1");
+    expect(releasing).toContain("Secret Service");
+    expect(releasing).toContain("GNOME Keyring");
+    expect(releasing).toContain("non-GNOME");
+    expect(releasing).toContain("local Linux keyring password");
+    expect(releasing).toContain("headlessly over SSH");
+    expect(releasing).toContain("repairable Hermes mismatch");
+    expect(releasing).toContain("run `ha-nova setup hermes` and confirm the Hermes route repairs cleanly");
+    expect(releasing).toContain("run `ha-nova setup --service hermes`, then `ha-nova doctor`, then one authenticated relay call from a fresh SSH/service-like shell without an unlocked desktop keyring");
+    expect(releasing).toContain("confirm the service token file is removed");
+    expect(releasing).toContain("Hermes Agent ready now");
+    expect(releasing).toContain("when Linux setup or secure-storage behavior changes, the release-bound manual matrix must include the Linux real-machine onboarding lane above");
+  });
+
+  it("keeps the Linux live helper generic by default and Hermes-specific only by override", () => {
+    expect(linuxHeadlessHelper).toContain("default: HA_NOVA_NO_BROWSER=1 ha-nova setup");
+    expect(linuxHeadlessHelper).toContain("HA_NOVA_LIVE_SETUP_CMD='HA_NOVA_NO_BROWSER=1 ha-nova setup hermes'");
+    expect(linuxHeadlessHelper).toContain("release-lane proof");
+    expect(linuxHeadlessHelper).toContain("remote user D-Bus session");
+    expect(linuxHeadlessHelper).toContain("remote gdbus");
+    expect(linuxHeadlessHelper).toContain(
+      'setup_cmd="${HA_NOVA_LIVE_SETUP_CMD:-HA_NOVA_NO_BROWSER=1 ha-nova setup}"'
+    );
+    expect(linuxHeadlessHelper).not.toContain(
+      'setup_cmd="${HA_NOVA_LIVE_SETUP_CMD:-HA_NOVA_NO_BROWSER=1 ha-nova setup hermes}"'
+    );
   });
 });


### PR DESCRIPTION
## Summary
Ports the remaining unmerged feature train onto main:

- **Service credentials** (registry-declared): `ha-nova setup --service <client>` stores the Relay Auth Token in a hardened local token file (`~/.config/ha-nova/relay-token`, symlink/permission/owner-validated) for headless/SSH/systemd/gateway sessions. Hermes opts in via `clients/registry.json`; interactive setup offers the switch when the desktop keyring is blocked; `--service all` is rejected.
- **Issue #200 hardening**: token reads fail loud with a fix hint when the config is unreadable instead of silently falling back to the OS keyring (which can hang in Secret Service unlock prompts on headless Linux); `relay_token_file` is honored independently of `relay_base_url`; Linux read preflight short-circuits when a token file is configured. Writes/deletes treat unreadable config as not-configured so `ha-nova setup` stays a working repair path.
- **Claude attach hardening**: snapshots mark torn/unreadable plugin state (`StateUnreadable`) and never drive destructive repair from it; auto-repair re-validates the live snapshot immediately before mutating and is serialized across processes via a config-dir lock file; HA NOVA edits to Claude's state files go through atomic temp+rename writes.
- **Gemini/Hermes installer fix**: the Go rewriters now absolutize cross-skill refs into the source root exactly like the bash installer (dead same-skill guard removed), so installed flat/namespaced skills can reach agent templates and shared assets; parity pinned by regression tests.
- **Uninstall**: purge additionally clears a leftover OS-credential-store token best-effort after handling a service token file (desktop→service mode switches no longer leave secrets behind).
- **Docs**: Hermes service/gateway lane in `docs/releasing.md`, new `docs/reference/client-integration.md`, `.hermes/INSTALL.md` service path. The active Hermes release-claim gating is preserved: README stays release-conservative; the public claim flip remains reserved for the final release PR.

Fixes #200

## Verification
- `npm test`: 64 files / 497 tests green on the rebased branch
- `cd cli && go test ./...`: green (~138s)
- `scripts/check-docs.sh`: all claims verified; `gofmt` clean
- Port integrity: three-way delta application from the local train onto origin/main; per-file completeness check against the source tree; deliberately dropped only content superseded by origin (stale 0.4.0 manifests, April README rewrite, older variants of files origin had evolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)