### PR TITLE
chore(dependabot): group security updates and actions, exclude toolchain-risk deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,21 @@ updates:
     groups:
       npm-dev-minor-patch:
         dependency-type: development
+        exclude-patterns:
+          - vitest
+          - vite
+          - typescript
+          - tsx
+          - rollup
+          - rolldown
+          - esbuild
         update-types:
           - minor
           - patch
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: "/nova"
@@ -20,12 +32,28 @@ updates:
     groups:
       npm-dev-minor-patch:
         dependency-type: development
+        exclude-patterns:
+          - vitest
+          - vite
+          - typescript
+          - tsx
+          - rollup
+          - rolldown
+          - esbuild
         update-types:
           - minor
           - patch
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"

--- a/tests/onboarding/dependabot-automation-contract.test.ts
+++ b/tests/onboarding/dependabot-automation-contract.test.ts
@@ -64,10 +64,22 @@ describe("dependabot automation contract", () => {
     expect(dependabot).toContain('directory: "/nova"');
     expect(dependabot).toContain("npm-dev-minor-patch:");
     expect(dependabot).toContain("dependency-type: development");
+    expect(dependabot).toContain("exclude-patterns:");
+    for (const dependency of policy.dependabot_safe_lane.manual_review_dependencies) {
+      expect(dependabot).toContain(`- ${dependency}`);
+    }
     expect(dependabot).toContain("update-types:");
     expect(dependabot).toContain("- minor");
     expect(dependabot).toContain("- patch");
     expect(dependabot).not.toContain("npm-minor-patch:");
+  });
+
+  it("groups security updates and actions bumps to prevent single-dep PR deadlocks", () => {
+    expect(dependabot).toContain("npm-security:");
+    expect(dependabot).toContain("applies-to: security-updates");
+    expect(dependabot).toContain("github-actions-all:");
+    const securityGroups = dependabot.match(/npm-security:/g) ?? [];
+    expect(securityGroups.length).toBe(2);
   });
 
   it("limits code owner review to sensitive paths and leaves package manifests out of CODEOWNERS", () => {


### PR DESCRIPTION
## Summary
Structural hardening of the Dependabot pipeline so the backlog cannot deadlock again:

- **Security updates grouped** per npm ecosystem (`applies-to: security-updates`, all patterns): vulnerable deps arrive as one consolidated PR that can pass the repo-wide `npm audit` ci-gate. Single-dep security PRs previously blocked each other for weeks (resolved manually in #203).
- **GitHub Actions bumps grouped** into one PR instead of one per action.
- **Toolchain-risk dev deps excluded** from the safe-lane group (vitest, vite, typescript, tsx, rollup, rolldown, esbuild) so they arrive individually for manual review — aligns `dependabot.yml` with `.github/policy/repo-policy.json` (ports the uncommitted `codex/chore-dependabot-group-simplify` work).
- Contract test pins the new grouping structure.

Context: the safe-lane auto-merge chain previously failed because the `dependabot-safe:auto-merge` label did not exist in the repo (created now). With this PR the lane runs end to end: prepare approves + labels → auto-merge workflow merges after required checks.

## Verification
- `npm test`: 64 files / 498 tests green (incl. new grouping contract test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)