### PR TITLE
chore: release 0.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.4.2"
+    "version": "0.5.0"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/docs/work/2026-04-09-next-release-notes-draft.md
+++ b/docs/work/2026-04-09-next-release-notes-draft.md
@@ -1,13 +1,15 @@
 ## New Features
 
-- Hermes Agent is now a first-class HA NOVA client path. HA NOVA now installs the bundled Hermes skill set directly, supports native macOS/Linux plus WSL2 on Windows, and can repair older Hermes installs with the simple `ha-nova doctor` -> `ha-nova setup hermes` flow.
-- Linux setup can now recover a locked or fresh GNOME Keyring inline during `ha-nova setup`, including SSH into the same logged-in desktop session.
-- HA NOVA now ships dedicated `dashboard`, `organize`, and `history` skills, making those workflows easier to discover and safer to use.
-- Gemini now picks up newly shipped HA NOVA sub-skills automatically during install and sync.
+- Service / gateway mode for headless setups: `ha-nova setup --service hermes` stores the relay token in a hardened local file instead of the desktop keyring — built for SSH, systemd, and gateway sessions. Running plain `ha-nova setup hermes` later migrates the token back into the OS keyring automatically and cleans the file up.
+- Hermes Agent early support (preview): HA NOVA installs its bundled Hermes skill set with both desktop and service setup paths, and `ha-nova doctor` points straight to the repair command when an older Hermes install drifts. Linux is validated today; macOS native and Windows WSL2 validation is tracked in `docs/reference/hermes-platform-validation.md`.
+- Linux keyring recovery: `ha-nova setup` can now unlock or initialize a locked/fresh GNOME Keyring inline — including over SSH into the same logged-in desktop session.
+- Self-healing client attachment: when a Claude Code update detaches HA NOVA, it reattaches itself automatically in the background — no manual repair needed.
+- Smarter automation reviews: new checks catch restore branches that can fire without their save step ever running, and restart-recovery designs built on storage that does not survive a reboot.
 
 ## Bug Fixes
 
-- Updated `axios` to `1.15.0` in both the main app and the Relay package to close critical production dependency findings.
+- Headless Linux: the CLI no longer hangs in Secret Service unlock prompts when a relay token file is configured, and unreadable configs fail loud with a fix hint instead of silently falling back to the keyring.
+- Security: updated `axios` to `1.17.0` and `ws` to `8.21.0` in both the main app and the Relay package, closing all open dependency alerts.
 
 ## Install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.4.2",
+  "skill_version": "0.5.0",
   "min_relay_version": "0.1.0"
 }


### PR DESCRIPTION
## Summary
Version bump to **0.5.0** (version.json, package.json + lock, plugin.json, marketplace.json) plus a refreshed release-notes draft.

Notes highlights (kept short and user-centric per release-notes policy):
- Service/gateway token mode (`ha-nova setup --service hermes`) incl. automatic migration back to the OS keyring
- Hermes early support framed as preview — README claim stays gated per `docs/work/2026-04-24-hermes-release-claim-gating.md`; Linux validated, macOS/WSL2 tracked in the validation matrix
- Linux GNOME Keyring inline recovery, Claude self-healing attachment, new review checks
- Security: axios 1.17.0 / ws 8.21.0 (all dependency alerts closed)

Release-bound: final tag/publish only after the manual validation matrix passes (Linux real-machine lane mandatory for this release per `docs/releasing.md`).

## Verification
- `npm run verify:next-release-version -- v0.5.0`: OK (newer than v0.4.2)
- `npm test`: 64 files / 498 tests green; `cd cli && go test ./...`: green
- Automated minimum release gate ran green on base main

🤖 Generated with [Claude Code](https://claude.com/claude-code)