### PR TITLE
docs(hermes): update the release-status note for the 0.5.0 reality

### DIFF
--- a/.hermes/INSTALL.md
+++ b/.hermes/INSTALL.md
@@ -1,6 +1,6 @@
 # Hermes Agent Install Overlay
 
-> **Release status:** Hermes support is implemented for the next HA NOVA release train, but it is not part of the current stable release until the final release PR, tag, and artifacts publish it. Until then, `README.md` remains the stable public product truth.
+> **Release status:** Hermes ships as early support (preview) starting with HA NOVA v0.5.0. The Linux route is maintainer-validated; macOS native and Windows WSL2 validation is tracked in [docs/reference/hermes-platform-validation.md](../docs/reference/hermes-platform-validation.md). `README.md` lists Hermes in the public client list once that validation matrix is complete.
 
 This page only covers Hermes-specific deltas.
 

--- a/.hermes/INSTALL.md
+++ b/.hermes/INSTALL.md
@@ -1,6 +1,6 @@
 # Hermes Agent Install Overlay
 
-> **Release status:** Hermes ships as early support (preview) starting with HA NOVA v0.5.0. The Linux route is maintainer-validated; macOS native and Windows WSL2 validation is tracked in [docs/reference/hermes-platform-validation.md](../docs/reference/hermes-platform-validation.md). `README.md` lists Hermes in the public client list once that validation matrix is complete.
+> **Release status:** Hermes ships as early support (preview) starting with HA NOVA v0.5.0. The Ubuntu/GNOME Keyring Linux route is maintainer-validated; validation for other Linux Secret Service backends, macOS native, and Windows WSL2 is tracked in [docs/reference/hermes-platform-validation.md](../docs/reference/hermes-platform-validation.md). `README.md` lists Hermes in the public client list once that validation matrix is complete.
 
 This page only covers Hermes-specific deltas.
 

--- a/docs/reference/hermes-platform-validation.md
+++ b/docs/reference/hermes-platform-validation.md
@@ -2,7 +2,7 @@
 
 This is the active truth source for Hermes support evidence in HA NOVA.
 
-> **Release status:** This matrix tracks the next release train. Hermes support is not part of the current stable release until the final release PR publishes matching README claims, release notes, tag, and artifacts.
+> **Release status:** Hermes ships as early support (preview) starting with HA NOVA v0.5.0. This matrix is the evidence truth for each route; the public `README.md` client-list claim follows once the full matrix below is maintainer-validated.
 
 Use it to answer two separate questions cleanly:
 

--- a/tests/onboarding/client-install-docs-contract.test.ts
+++ b/tests/onboarding/client-install-docs-contract.test.ts
@@ -134,7 +134,7 @@ describe("client install docs contract", () => {
     expect(hermesInstall).toContain("skill_view");
 
     expect(hermesInstall).toContain("Hermes Agent");
-    expect(hermesInstall).toContain("not part of the current stable release");
+    expect(hermesInstall).toContain("early support (preview) starting with HA NOVA v0.5.0");
     expect(hermesInstall).toContain("ha-nova setup hermes");
     expect(hermesInstall).toContain("ha-nova check-update");
     expect(hermesInstall).toContain("What Supported Means Here");
@@ -182,7 +182,7 @@ describe("client install docs contract", () => {
     expect(hermesReleaseGate).toContain("Status: active");
     expect(hermesReleaseGate).toContain("Keep public `README.md` release-conservative until the final release PR.");
     expect(hermesReleaseGate).toContain("restore the public Hermes claim in `README.md`, if release proof is complete");
-    expect(hermesInstall).toContain("not part of the current stable release until the final release PR");
+    expect(hermesInstall).toContain("once that validation matrix is complete");
     expect(readme).not.toContain("Hermes Agent");
   });
 });


### PR DESCRIPTION
## Summary
Pre-tag wording fix: the `.hermes/INSTALL.md` release-status note said Hermes is "not part of the current stable release until the final release PR" — accurate today, misleading the moment v0.5.0 ships. The note now states the post-release model directly: **early support (preview) since v0.5.0**, Linux maintainer-validated, macOS native + Windows WSL2 tracked in the validation matrix, and the public README claim follows the completed matrix (gating unchanged, README stays Hermes-free and contract-pinned).

## Verification
- `npm test`: 64 files / 499 tests green (two contract pins moved to the new wording)

🤖 Generated with [Claude Code](https://claude.com/claude-code)