### PR TITLE
fix(release): pin GoReleaser to the triggering tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
           args: release --clean --skip=sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # RC and final tags can point at the same commit; without this pin
+          # GoReleaser auto-detects the tag and may publish onto the wrong release.
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Build install bundles
         run: bash scripts/release/build-install-bundle.sh "${GITHUB_REF_NAME#v}"

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -53,6 +53,10 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
+  it("pins the GoReleaser release tag to the triggering workflow ref", () => {
+    expect(releaseWorkflow).toContain("GORELEASER_CURRENT_TAG: ${{ github.ref_name }}");
+  });
+
   it("keeps the RC workflow free of winget artifacts and guidance", () => {
     expect(rcWorkflow).toContain("Build install bundles");
     expect(rcWorkflow).toContain("Upload RC artifacts");


### PR DESCRIPTION
## Problem

The v0.5.0 stable publish failed live (run 27421731937): `v0.5.0-rc1` and `v0.5.0` point at the same reviewed commit, GoReleaser auto-detected the rc tag and tried to publish the stable artifacts onto the rc release — every asset upload hit `422 already_exists`, no stable release was created (rc1 stayed intact).

## Fix

Pin `GORELEASER_CURRENT_TAG` to `github.ref_name` in the GoReleaser step of `release.yml`, so the release step always operates on the tag that triggered the workflow. A release-contract test pins the env var so it cannot regress silently.

## Verification

- `npx vitest run tests/onboarding/release-contract.test.ts` — 10/10 green (includes the new pin)
- Release-bound: after merge, `v0.5.0` will be re-tagged onto the merge commit and the pipeline re-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)