### PR TITLE
fix(update): detect new releases promptly via conditional revalidation

### DIFF
--- a/cli/paths.go
+++ b/cli/paths.go
@@ -9,11 +9,17 @@ import (
 )
 
 const (
-	configSchemaVersion        = 1
-	stateSchemaVersion         = 1
-	bundleFormatVersion        = 1
-	keyringServiceName         = "ha-nova.relay-auth-token"
-	updateCacheTTLSeconds      = 24 * 60 * 60
+	configSchemaVersion = 1
+	stateSchemaVersion  = 1
+	bundleFormatVersion = 1
+	keyringServiceName  = "ha-nova.relay-auth-token"
+	// Short cache floor: within this window check-update reuses the cached
+	// result without touching the network. Beyond it, fetchLatestRelease
+	// revalidates with a conditional request (If-None-Match), so a freshly
+	// published release is detected within the hour instead of being hidden for
+	// a full day. Keep this small — a long TTL means users stay blind to a new
+	// release until it expires.
+	updateCacheTTLSeconds      = 60 * 60
 	windowsInstallRootEnv      = "HA_NOVA_INSTALL_ROOT"
 	windowsInstallRootAllowEnv = "HA_NOVA_ALLOW_INSTALL_ROOT_OVERRIDE"
 )

--- a/cli/release.go
+++ b/cli/release.go
@@ -38,10 +38,11 @@ func rawBinaryAssetName() string {
 }
 
 func fetchLatestRelease(paths runtimePaths, quiet bool, allowCache bool) (releaseInfo, error) {
-	if allowCache {
-		if cached, ok := loadCachedRelease(paths); ok {
-			return cached, nil
-		}
+	cached, cacheStatus := inspectCachedRelease(paths)
+	hasCache := cacheStatus != "miss" && cached.Version != ""
+	// Within the short TTL floor, reuse the cache without touching the network.
+	if allowCache && cacheStatus == "fresh" {
+		return cached, nil
 	}
 
 	req, err := http.NewRequest("GET", latestReleaseURL, nil)
@@ -50,13 +51,35 @@ func fetchLatestRelease(paths runtimePaths, quiet bool, allowCache bool) (releas
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "ha-nova/"+localVersion(paths))
+	// Revalidate cheaply: an unchanged release answers 304 (off the rate limit);
+	// a new release answers 200 and is picked up immediately.
+	if allowCache && hasCache && cached.ETag != "" {
+		req.Header.Set("If-None-Match", cached.ETag)
+	}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
+		// Offline or transient failure: a known release beats a hard error.
+		if allowCache && hasCache {
+			return cached, nil
+		}
 		return releaseInfo{}, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotModified && hasCache {
+		// Nothing changed; refresh the cache window so later checks stay cheap.
+		cacheReleaseInfo(paths, cached)
+		if !quiet {
+			printHumanInfo("Latest release: v%s", cached.Version)
+		}
+		return cached, nil
+	}
+
 	if resp.StatusCode >= 400 {
+		if allowCache && hasCache {
+			return cached, nil
+		}
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return releaseInfo{}, fmt.Errorf("GitHub latest release lookup failed: %s", strings.TrimSpace(string(body)))
 	}
@@ -72,7 +95,12 @@ func fetchLatestRelease(paths runtimePaths, quiet bool, allowCache bool) (releas
 	if _, err := parseReleaseVersion(version); err != nil {
 		return releaseInfo{}, fmt.Errorf("latest release tag invalid: %w", err)
 	}
-	info := releaseInfo{Version: version, HTMLURL: release.HTMLURL, AssetName: bundleAssetName()}
+	info := releaseInfo{
+		Version:   version,
+		HTMLURL:   release.HTMLURL,
+		AssetName: bundleAssetName(),
+		ETag:      strings.TrimSpace(resp.Header.Get("ETag")),
+	}
 	cacheReleaseInfo(paths, info)
 	if !quiet {
 		printHumanInfo("Latest release: v%s", version)

--- a/cli/update_freshness_test.go
+++ b/cli/update_freshness_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// staleCache writes a cached release and ages it past the TTL floor so the next
+// fetch revalidates over the network instead of returning the cache directly.
+func staleCache(t *testing.T, paths runtimePaths, info releaseInfo) {
+	t.Helper()
+	cacheReleaseInfo(paths, info)
+	old := time.Now().Add(-2 * time.Duration(updateCacheTTLSeconds) * time.Second)
+	if err := os.Chtimes(paths.UpdateCacheFile, old, old); err != nil {
+		t.Fatalf("age cache: %v", err)
+	}
+	if _, status := inspectCachedRelease(paths); status != "stale" {
+		t.Fatalf("cache status = %q, want stale", status)
+	}
+}
+
+func readCachedRelease(t *testing.T, paths runtimePaths) releaseInfo {
+	t.Helper()
+	data, err := os.ReadFile(paths.UpdateCacheFile)
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
+	}
+	var info releaseInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		t.Fatalf("unmarshal cache: %v", err)
+	}
+	return info
+}
+
+func TestFetchLatestReleaseRevalidatesWithETagAnd304(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	staleCache(t, paths, releaseInfo{Version: "0.4.2", ETag: `"etag-v042"`})
+
+	originalHTTPClient := httpClient
+	defer func() { httpClient = originalHTTPClient }()
+	var sawConditional bool
+	httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Header.Get("If-None-Match") == `"etag-v042"` {
+				sawConditional = true
+			}
+			return &http.Response{
+				StatusCode: http.StatusNotModified,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	info, err := fetchLatestRelease(paths, true, true)
+	if err != nil {
+		t.Fatalf("fetchLatestRelease() error: %v", err)
+	}
+	if !sawConditional {
+		t.Fatalf("expected a conditional request carrying the cached ETag")
+	}
+	if info.Version != "0.4.2" {
+		t.Fatalf("version = %q, want 0.4.2", info.Version)
+	}
+	if _, status := inspectCachedRelease(paths); status != "fresh" {
+		t.Fatalf("cache status after 304 = %q, want fresh (TTL window refreshed)", status)
+	}
+}
+
+func TestFetchLatestReleaseStoresNewVersionAndETagOn200(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	staleCache(t, paths, releaseInfo{Version: "0.4.2", ETag: `"old"`})
+
+	originalHTTPClient := httpClient
+	defer func() { httpClient = originalHTTPClient }()
+	httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			header := make(http.Header)
+			header.Set("ETag", `"etag-v050"`)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"tag_name":"v0.5.0","html_url":"https://example.test/v0.5.0"}`)),
+				Header:     header,
+			}, nil
+		}),
+	}
+
+	info, err := fetchLatestRelease(paths, true, true)
+	if err != nil {
+		t.Fatalf("fetchLatestRelease() error: %v", err)
+	}
+	if info.Version != "0.5.0" {
+		t.Fatalf("version = %q, want 0.5.0", info.Version)
+	}
+	cached := readCachedRelease(t, paths)
+	if cached.Version != "0.5.0" {
+		t.Fatalf("cached version = %q, want 0.5.0", cached.Version)
+	}
+	if cached.ETag != `"etag-v050"` {
+		t.Fatalf("cached etag = %q, want %q", cached.ETag, `"etag-v050"`)
+	}
+}
+
+func TestFetchLatestReleaseFreshCacheSkipsNetwork(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	cacheReleaseInfo(paths, releaseInfo{Version: "0.4.2"}) // mtime now -> fresh
+
+	originalHTTPClient := httpClient
+	defer func() { httpClient = originalHTTPClient }()
+	httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Errorf("unexpected network call while cache is fresh: %s", req.URL)
+			return nil, io.EOF
+		}),
+	}
+
+	info, err := fetchLatestRelease(paths, true, true)
+	if err != nil {
+		t.Fatalf("fetchLatestRelease() error: %v", err)
+	}
+	if info.Version != "0.4.2" {
+		t.Fatalf("version = %q, want 0.4.2", info.Version)
+	}
+}
+
+func TestFetchLatestReleaseOfflineFallsBackToCache(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	staleCache(t, paths, releaseInfo{Version: "0.4.2", ETag: `"e"`})
+
+	originalHTTPClient := httpClient
+	defer func() { httpClient = originalHTTPClient }()
+	httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, io.ErrUnexpectedEOF // simulate offline / transient failure
+		}),
+	}
+
+	info, err := fetchLatestRelease(paths, true, true)
+	if err != nil {
+		t.Fatalf("fetchLatestRelease() should fall back to cache offline, got error: %v", err)
+	}
+	if info.Version != "0.4.2" {
+		t.Fatalf("version = %q, want cached 0.4.2", info.Version)
+	}
+}
+
+// Guard against silently regressing to a long TTL, which is what hid a freshly
+// published release from check-update for up to a day.
+func TestUpdateCacheTTLStaysShort(t *testing.T) {
+	if updateCacheTTLSeconds > 60*60 {
+		t.Fatalf("updateCacheTTLSeconds = %d, want <= 3600 (short floor + conditional revalidation)", updateCacheTTLSeconds)
+	}
+}

--- a/cli/version.go
+++ b/cli/version.go
@@ -20,6 +20,10 @@ type releaseInfo struct {
 	Version   string `json:"version"`
 	HTMLURL   string `json:"html_url,omitempty"`
 	AssetName string `json:"asset_name,omitempty"`
+	// ETag from the GitHub latest-release response. Sent back as If-None-Match
+	// so an unchanged release returns a cheap 304 (off the rate limit) while a
+	// new release returns 200 and is detected immediately.
+	ETag string `json:"etag,omitempty"`
 }
 
 type updateCheckResult struct {
@@ -240,11 +244,6 @@ func inspectCachedRelease(paths runtimePaths) (releaseInfo, string) {
 		return cached, "stale"
 	}
 	return cached, "fresh"
-}
-
-func loadCachedRelease(paths runtimePaths) (releaseInfo, bool) {
-	cached, status := inspectCachedRelease(paths)
-	return cached, status == "fresh"
 }
 
 func cacheReleaseInfo(paths runtimePaths, info releaseInfo) {

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -83,10 +83,14 @@ if [[ -f "$version_file" ]]; then
   fi
   # No relay CLI = not onboarded yet, skip silently
 
-  # --- Cached release update check (stale-while-revalidate via CLI, TTL 24h) ---
+  # --- Cached release update check (stale-while-revalidate via CLI) ---
+  # This TTL only throttles how often we spawn the background CLI refresh; the
+  # CLI owns real freshness (short floor + conditional revalidation). Keep it
+  # <= the CLI's updateCacheTTLSeconds (cli/paths.go), otherwise a new release
+  # stays hidden from the session banner until this longer window expires.
   update_cache_dir="${HOME}/.cache/ha-nova"
   update_cache_file="${update_cache_dir}/latest-release.json"
-  update_ttl=86400
+  update_ttl=3600
 
   needs_refresh="1"
   if [[ -f "$update_cache_file" ]]; then

--- a/skills/ha-nova/update-guide.md
+++ b/skills/ha-nova/update-guide.md
@@ -64,7 +64,7 @@ On native Windows, post-update client sync uses the installed HA NOVA runtime di
 
 Two checks run automatically:
 
-1. **Skill update check** — `ha-nova check-update` compares the installed version against the latest GitHub release (cached 24h). Claude Code SessionStart reads the same shared release cache and can trigger a background CLI refresh when the cache is stale. Other clients should run the quiet check once on the first HA NOVA skill use in a session.
+1. **Skill update check** — `ha-nova check-update` compares the installed version against the latest GitHub release. The result is cached briefly, then revalidated against GitHub with a conditional request, so a newly published release is detected promptly instead of being hidden until a long cache expires. Claude Code SessionStart reads the same shared release cache and can trigger a background CLI refresh when the cache is stale. Other clients should run the quiet check once on the first HA NOVA skill use in a session.
 2. **Relay compat check** — `ha-nova relay health` compares Relay version against `min_relay_version`. Claude Code SessionStart context can surface the same warning independently.
 
 The `doctor` command runs both checks synchronously and also refreshes the update cache.

--- a/tests/hooks/session-start.test.ts
+++ b/tests/hooks/session-start.test.ts
@@ -80,6 +80,24 @@ describe("S-6: session-start hook", () => {
     expect(hookContent).not.toContain("api.github.com/repos/markusleben/ha-nova/releases/latest");
   });
 
+  it("keeps the SessionStart refresh throttle within the CLI freshness floor", () => {
+    // The hook's spawn throttle must stay <= the CLI's release-cache TTL, or a
+    // newly published release stays hidden from the session banner until the
+    // longer window expires (this is exactly how the 24h cache hid v0.5.0).
+    const hook = readFileSync("hooks/session-start", "utf8");
+    const paths = readFileSync("cli/paths.go", "utf8");
+
+    const hookTtl = Number(hook.match(/update_ttl=(\d+)/)?.[1]);
+    const cliExpr = paths.match(/updateCacheTTLSeconds\s*=\s*([0-9*\s]+)/)?.[1] ?? "";
+    const cliTtl = cliExpr.split("*").reduce((acc, part) => acc * Number(part.trim()), 1);
+
+    expect(hookTtl).toBeGreaterThan(0);
+    expect(cliTtl).toBeGreaterThan(0);
+    expect(hookTtl).toBeLessThanOrEqual(cliTtl);
+    expect(cliTtl).toBeLessThanOrEqual(3600);
+    expect(hook).not.toContain("update_ttl=86400");
+  });
+
   it("does not leak secrets in JSON output", () => {
     const result = spawnSync("bash", ["hooks/session-start"], {
       cwd: REPO_ROOT,


### PR DESCRIPTION
## Why

This is the root cause of "Hermes/clients don't see the new release" after v0.5.0 shipped: `ha-nova check-update` cached the GitHub latest-release lookup for **24h**, so every existing install kept reporting *no update* until that cache expired. Observed live — the local cache held `0.4.2` (written ~8 min before the v0.5.0 publish). GitHub itself served v0.5.0 correctly; `ha-nova update` was never affected (it already bypasses the cache).

## What

- **Short TTL floor (24h → 1h)** + **conditional revalidation** beyond it: send `If-None-Match` with the cached ETag. An unchanged release answers `304` (cheap, off the rate limit); a new release answers `200` and is detected immediately. The ETag is stored in `latest-release.json`.
- **Offline resilience**: a transient/offline failure now falls back to the cached release instead of failing the check.
- `ha-nova update` semantics unchanged (still a direct, authoritative fetch).
- Old caches without an ETag self-heal on the next refresh.
- Skill `update-guide.md` wording corrected; dead `loadCachedRelease` removed.

## Verification

- New regression tests: 304 reuse + cache-window refresh, 200 stores new version+ETag, fresh cache skips the network entirely, offline falls back to cache, and a guard that the TTL stays short (≤1h) so it can't silently regress to a day.
- Full Go suite green (`go test ./...`), `npm test` 504/504, `gofmt`/`go vet`/`check-docs` clean.

No manifest/dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)