### PR TITLE
fix(installer): survive an antivirus file lock during PowerShell cleanup (v0.6.0 blocker)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -20,6 +20,25 @@ $LegacyConfigDir = Join-Path $HOME ".config\ha-nova"
 $LegacyInstallDir = Join-Path $HOME ".local\share\ha-nova"
 $UsePlainUi = $false
 
+# Best-effort path removal that never aborts the installer. Antivirus (Defender
+# real-time) or an indexer can briefly hold an exclusive handle on a freshly
+# written, unsigned file. `Remove-Item -Recurse` then throws a TERMINATING
+# Win32Exception ("Access is denied") that -ErrorAction SilentlyContinue does NOT
+# suppress under Set-StrictMode + $ErrorActionPreference = "Stop", which would
+# abort a successful install before PATH/setup. The try/catch swallows it; temp,
+# backup, and status-marker paths are reaped by Windows regardless.
+function Remove-PathQuiet {
+  param([Parameter(Mandatory = $true)][string]$Path)
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return
+  }
+  try {
+    Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
+  }
+  catch {
+  }
+}
+
 function Test-PlainUi {
   if ($env:HA_NOVA_PLAIN_UI -eq "1") {
     return $true
@@ -302,7 +321,7 @@ function Get-UninstallRecoveryState {
     $bundleRuntimePresent = Test-Path -LiteralPath (Join-Path $InstallDir "ha-nova.exe")
     $pathResidue = Test-UserPathContainsEntry -TargetPath $InstallDir
     if (-not $bundleRuntimePresent -and -not $pathResidue) {
-      Remove-Item -LiteralPath $UninstallStatusPath -Force -ErrorAction SilentlyContinue
+      Remove-PathQuiet -Path $UninstallStatusPath
       return $null
     }
     return [pscustomobject]@{
@@ -316,7 +335,7 @@ function Get-UninstallRecoveryState {
   }
 
   if ((Get-UninstallStatusField -Status $status -Name "status") -eq "success") {
-    Remove-Item -LiteralPath $UninstallStatusPath -Force -ErrorAction SilentlyContinue
+    Remove-PathQuiet -Path $UninstallStatusPath
     return $null
   }
 
@@ -373,7 +392,7 @@ function Get-UninstallRecoveryState {
     }
 
     if (-not $runtimePresent -and -not $pathResidue -and $remainingPaths.Count -eq 0) {
-      Remove-Item -LiteralPath $UninstallStatusPath -Force -ErrorAction SilentlyContinue
+      Remove-PathQuiet -Path $UninstallStatusPath
       return $null
     }
 
@@ -389,7 +408,7 @@ function Get-UninstallRecoveryState {
 
   if ((Get-UninstallStatusField -Status $status -Name "status") -eq "failed") {
     if (-not $runtimePresent -and -not $pathResidue -and $remainingPaths.Count -eq 0) {
-      Remove-Item -LiteralPath $UninstallStatusPath -Force -ErrorAction SilentlyContinue
+      Remove-PathQuiet -Path $UninstallStatusPath
       return $null
     }
 
@@ -564,7 +583,7 @@ function Install-Bundle {
         Move-Item -LiteralPath $InstallDir -Destination $backupRoot -Force
       }
       catch {
-        Remove-Item -LiteralPath $nextRoot -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-PathQuiet -Path $nextRoot
         Fail "Could not replace the existing HA NOVA install - a ha-nova process may still be running. Close it (and any running relay), then run the installer again."
       }
     }
@@ -575,7 +594,7 @@ function Install-Bundle {
         # The new runtime is already live in $InstallDir; deleting the old copy
         # is best-effort. A locked file here (same antivirus race as below) must
         # not throw into the catch, which would roll back the successful swap.
-        Remove-Item -LiteralPath $backupRoot -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-PathQuiet -Path $backupRoot
       }
       return [ordered]@{ Version = $bundleVersion }
     }
@@ -587,15 +606,13 @@ function Install-Bundle {
     }
   }
   finally {
-    if (Test-Path -LiteralPath $tempRoot) {
-      # Best-effort cleanup: antivirus (Defender real-time) can briefly hold an
-      # exclusive handle on the freshly extracted, unsigned ha-nova.exe. Under
-      # $ErrorActionPreference = "Stop" a throw here would abort the installer
-      # AFTER a successful install but BEFORE PATH setup and setup launch,
-      # leaving HA NOVA installed yet unreachable. The temp dir lives under
-      # %TEMP% and is reaped by Windows regardless.
-      Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
-    }
+    # Best-effort cleanup: antivirus (Defender real-time) can briefly hold an
+    # exclusive handle on the freshly extracted, unsigned ha-nova.exe. A throw here
+    # would abort the installer AFTER a successful install but BEFORE PATH setup and
+    # setup launch, leaving HA NOVA installed yet unreachable. Remove-PathQuiet
+    # swallows the terminating "Access is denied"; the temp dir lives under %TEMP%
+    # and is reaped by Windows regardless.
+    Remove-PathQuiet -Path $tempRoot
   }
 }
 

--- a/scripts/legacy-uninstall.ps1
+++ b/scripts/legacy-uninstall.ps1
@@ -16,11 +16,19 @@ function Fail([string]$Message) {
 }
 
 function Remove-IfExists([string]$Path) {
-  if (Test-Path -LiteralPath $Path) {
-    # Best-effort: a locked legacy file (running relay.exe, AV handle) must not
-    # abort the whole cleanup under Stop mode and trap the user in a loop where
-    # the installer still detects legacy residue.
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return
+  }
+  # Best-effort: a locked legacy file (running relay.exe, AV handle) must not abort
+  # the whole cleanup under Stop mode and trap the user in a loop where the
+  # installer still detects legacy residue. `Remove-Item -Recurse` throws a
+  # TERMINATING Win32Exception ("Access is denied") that -ErrorAction SilentlyContinue
+  # does NOT suppress, so wrap it in try/catch. The blocker-residue check below still
+  # fails loudly if a real blocker survives, so this never hides a stuck cleanup.
+  try {
     Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
+  }
+  catch {
   }
 }
 
@@ -58,7 +66,7 @@ if ($null -ne $wsl) {
 
 $legacyScriptsDir = Join-Path $InstallDir "scripts\onboarding"
 if ((Test-Path -LiteralPath $legacyScriptsDir) -and -not (Test-Path -LiteralPath (Join-Path $InstallDir "bundle.json"))) {
-  Remove-Item -LiteralPath $InstallDir -Recurse -Force -ErrorAction SilentlyContinue
+  Remove-IfExists $InstallDir
 }
 
 $skillRoots = @(
@@ -74,7 +82,7 @@ foreach ($root in $skillRoots) {
     continue
   }
   Get-ChildItem -LiteralPath $root -Filter "ha-nova*" -ErrorAction SilentlyContinue | ForEach-Object {
-    Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-IfExists $_.FullName
   }
 }
 

--- a/tests/onboarding/legacy-cleanup-contract.test.ts
+++ b/tests/onboarding/legacy-cleanup-contract.test.ts
@@ -37,15 +37,16 @@ describe("legacy cleanup contract", () => {
     // on a locked legacy file (running relay.exe, antivirus handle) aborts the
     // whole cleanup, leaving residue the installer still detects -> the user is
     // stuck in a re-run loop. Every Remove-Item must tolerate a failed delete.
-    expect(content).toContain(
-      "Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue",
+    // Remove-IfExists is the single best-effort deleter: it wraps Remove-Item in
+    // try/catch so a TERMINATING Win32Exception ("Access is denied") - which
+    // -ErrorAction SilentlyContinue does NOT suppress under Stop mode - cannot abort
+    // the cleanup.
+    expect(content).toMatch(
+      /function Remove-IfExists[\s\S]*?try\s*\{[\s\S]*?Remove-Item -LiteralPath \$Path -Recurse -Force -ErrorAction SilentlyContinue[\s\S]*?\}\s*\r?\n\s*catch\s*\{/,
     );
-    expect(content).toContain(
-      "Remove-Item -LiteralPath $InstallDir -Recurse -Force -ErrorAction SilentlyContinue",
-    );
-    expect(content).toContain(
-      "Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue",
-    );
+    // Every recursive delete routes through that helper, not a bare Remove-Item.
+    expect(content).toContain("Remove-IfExists $InstallDir");
+    expect(content).toContain("Remove-IfExists $_.FullName");
     expect(content).not.toMatch(/-Recurse -Force(?! -ErrorAction)/);
     // ...but a locked BLOCKER file must not slip through as a false success: the
     // script verifies the install.ps1 Test-LegacyInstall blockers are actually

--- a/tests/onboarding/windows-installer-contract.test.ts
+++ b/tests/onboarding/windows-installer-contract.test.ts
@@ -115,27 +115,28 @@ describe("install.ps1 contract", () => {
     );
   });
 
-  it("makes post-install directory cleanup best-effort so an antivirus file lock cannot abort the install", () => {
-    // Regression: a fresh install completed (runtime live in InstallDir) but the
-    // installer still crashed with a Win32 "Access is denied" on
-    // `Remove-Item $tempRoot`, because Defender briefly holds a handle on the
-    // freshly extracted unsigned ha-nova.exe and $ErrorActionPreference="Stop"
-    // turns the failed delete into a terminating error - AFTER install yet
-    // BEFORE PATH setup / setup launch. Both the temp dir and the old backup are
-    // disposable post-swap, so their deletes must tolerate a lock.
+  it("makes post-install directory cleanup survive an antivirus file lock without aborting the install", () => {
+    // Regression (live RC proof): a fresh install completed (runtime live in
+    // InstallDir) but the installer still crashed with a Win32 "Access is denied"
+    // on `Remove-Item $tempRoot`, because Defender briefly holds a handle on the
+    // freshly extracted unsigned ha-nova.exe and `Remove-Item -Recurse` then throws
+    // a TERMINATING Win32Exception that -ErrorAction SilentlyContinue does NOT
+    // suppress under Set-StrictMode + $ErrorActionPreference="Stop" - AFTER install
+    // yet BEFORE PATH setup / setup launch. The best-effort deletes must therefore
+    // go through a try/catch helper, not a bare -ErrorAction.
     expect(content).toContain('$ErrorActionPreference = "Stop"');
-    expect(content).toContain(
-      "Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue",
+    // The helper wraps Remove-Item in try/catch so the terminating exception is
+    // swallowed - the -ErrorAction-only form was insufficient and crashed the live install.
+    expect(content).toMatch(
+      /function Remove-PathQuiet[\s\S]*?try\s*\{[\s\S]*?Remove-Item -LiteralPath \$Path -Recurse -Force -ErrorAction SilentlyContinue[\s\S]*?\}\s*\r?\n\s*catch\s*\{/,
     );
-    expect(content).toContain(
-      "Remove-Item -LiteralPath $backupRoot -Recurse -Force -ErrorAction SilentlyContinue",
-    );
-    expect(content).not.toMatch(
-      /Remove-Item -LiteralPath \$tempRoot -Recurse -Force(?! -ErrorAction)/,
-    );
-    expect(content).not.toMatch(
-      /Remove-Item -LiteralPath \$backupRoot -Recurse -Force(?! -ErrorAction)/,
-    );
+    // The disposable post-swap deletes route through the helper, not a bare Remove-Item.
+    expect(content).toContain("Remove-PathQuiet -Path $tempRoot");
+    expect(content).toContain("Remove-PathQuiet -Path $backupRoot");
+    // No bare Remove-Item on these roots survives - the -ErrorAction-only form
+    // crashed the live install, so it must be gone.
+    expect(content).not.toMatch(/Remove-Item -LiteralPath \$tempRoot/);
+    expect(content).not.toMatch(/Remove-Item -LiteralPath \$backupRoot/);
   });
 
   it("hardens install-time edge cases (legacy migration, running exe, empty checksum, PATH dedup, recovery null)", () => {


### PR DESCRIPTION
## Why

The v0.6.0-rc1 live proof on a fresh Win11 snapshot crashed the Windows install with a Win32 "Access is denied" at the post-install \`\$tempRoot\` cleanup — the exact class that also breaks the current public v0.5.0 Windows install.

Defender briefly holds a handle on the freshly extracted unsigned \`ha-nova.exe\`, and \`Remove-Item -Recurse\` then throws a TERMINATING Win32Exception that \`-ErrorAction SilentlyContinue\` does NOT suppress under \`Set-StrictMode\` + \`\$ErrorActionPreference = "Stop"\` — aborting a *successful* install before PATH setup. (The earlier deterministic repro produced a non-terminating error, so \`-ErrorAction\` looked sufficient; only the live RC proof surfaced the real terminating behavior.)

## What

- \`Remove-PathQuiet\` helper wraps \`Remove-Item\` in \`try/catch\`; every best-effort cleanup (temp/backup/next/status-marker) routes through it.
- \`legacy-uninstall.ps1\`'s \`Remove-IfExists\` hardened the same way (blocker-residue Fail check unchanged).
- Contract tests updated to assert the \`try/catch\` form (not just \`-ErrorAction\`).

## Validation

Privately validated end-to-end on a fresh Win11 VM against the real Defender lock (local bundle harness, byte-identical install.ps1): install completes with no "Access is denied", \`ha-nova version\` -> 0.6.0, relay onboarding connects. \`npm run verify\` green, full \`npm test\` 508 green, both PS files parse via pwsh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)