### PR TITLE
fix(cli): verify post-update sync is clean — Updated must mean clean (v0.6.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.6.1"
+    "version": "0.6.2"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/cli/command_update.go
+++ b/cli/command_update.go
@@ -252,6 +252,11 @@ func postUpdateSync(paths runtimePaths) error {
 	residue := transientBackupResidue(paths, configured)
 	if len(failed) == 0 && !skipped && len(residue) == 0 {
 		state.ClientsVerifiedVersion = version
+	} else if len(residue) > 0 {
+		// Residue is definitive evidence the tree is stale, so a previously-matching
+		// marker is now wrong — clear it (do not merely skip re-stamping) so the
+		// self-heal, which short-circuits on a matching marker, actually re-runs.
+		state.ClientsVerifiedVersion = ""
 	}
 	if err := saveState(paths, state); err != nil {
 		return err

--- a/cli/command_update.go
+++ b/cli/command_update.go
@@ -201,12 +201,18 @@ func syncInstalledClientsForCurrentVersion(paths runtimePaths, currentVersion, t
 // ensureClientsVerifiedForCurrentVersion).
 //
 // The marker is stamped only when EVERY configured client was actually synced —
-// not when one was skipped because its runtime is absent in this environment, and
-// not when one failed. Otherwise a client skipped here (e.g. its CLI is not on
-// PATH right now) would be marked verified and then never repaired once its
-// runtime reappears, because the marker would already match. Leaving the marker
-// unset re-attempts those clients on the next check-update/doctor (which run at
-// most once per session), so the cost of an unresolvable client stays bounded.
+// not when one was skipped because its runtime is absent in this environment, not
+// when one failed, and not when the post-sync residue scan still finds a
+// transient-backup path in a synced tree. Otherwise a client skipped here (e.g.
+// its CLI is not on PATH right now) would be marked verified and then never
+// repaired once its runtime reappears, because the marker would already match.
+// Leaving the marker unset re-attempts those clients on the next
+// check-update/doctor (which run at most once per session), so the cost of an
+// unresolvable client stays bounded.
+//
+// The residue scan is the in-tool guarantee behind "Updated == clean": if a sync
+// ever resolves from a stale backup, the user gets a loud warning + recovery hint
+// instead of a silent success. For a fixed (>=0.6.2) binary it never fires.
 func postUpdateSync(paths runtimePaths) error {
 	detectedClients, err := detectInstalledClients(paths)
 	if err != nil {
@@ -240,11 +246,19 @@ func postUpdateSync(paths runtimePaths) error {
 	state.InstalledClients = configured
 	version := localVersion(paths)
 	state.Version = version
-	if len(failed) == 0 && !skipped {
+	// Verify the just-synced trees are actually clean before marking the version
+	// verified: a residue scan catches a sync that resolved from a transient backup
+	// (the pre-0.6.1 bug class), so "Updated" never silently means "updated-ish".
+	residue := transientBackupResidue(paths, configured)
+	if len(failed) == 0 && !skipped && len(residue) == 0 {
 		state.ClientsVerifiedVersion = version
 	}
 	if err := saveState(paths, state); err != nil {
 		return err
+	}
+	if len(residue) > 0 {
+		printHumanWarn("These clients still reference a temporary update backup and are not fully up to date: %s", strings.Join(normalizeClients(residue), ", "))
+		printHumanWarn("Run `ha-nova doctor` to refresh them.")
 	}
 	if len(failed) > 0 {
 		return fmt.Errorf("failed clients: %s", strings.Join(normalizeClients(failed), ", "))

--- a/cli/install_source_backup_test.go
+++ b/cli/install_source_backup_test.go
@@ -224,6 +224,17 @@ func TestPostUpdateSyncAfterRealSwapSyncsFromInstallRootNotBackup(t *testing.T) 
 	if !strings.HasPrefix(resolved, installRootResolved) {
 		t.Fatalf("Codex skill tree resolved to %q, want a path under the install root %q", resolved, installRootResolved)
 	}
+
+	// A clean post-swap sync (no skip/fail and no transient-backup residue) must
+	// stamp the verification marker, proving the residue scan does not false-flag a
+	// correctly synced tree.
+	healed, err := loadState(paths)
+	if err != nil {
+		t.Fatalf("loadState() error: %v", err)
+	}
+	if healed.ClientsVerifiedVersion != "0.6.1" {
+		t.Fatalf("clean post-swap sync must stamp the marker to 0.6.1, got %q", healed.ClientsVerifiedVersion)
+	}
 }
 
 func findTransientBackup(t *testing.T, parent string) string {

--- a/cli/post_update_verify.go
+++ b/cli/post_update_verify.go
@@ -20,31 +20,33 @@ import (
 func transientBackupResidue(paths runtimePaths, clients []string) []string {
 	dirty := []string{}
 	for _, client := range clients {
-		root := clientSkillTreeRoot(paths, client)
-		if root == "" {
-			continue
-		}
-		if pathHasTransientBackupResidue(root) {
-			dirty = append(dirty, client)
+		for _, root := range clientSkillTreeRoots(paths, client) {
+			if pathHasTransientBackupResidue(root) {
+				dirty = append(dirty, client)
+				break
+			}
 		}
 	}
 	return dirty
 }
 
-// clientSkillTreeRoot maps a client id to the on-disk root where its synced
-// skills live. Returns "" for clients without a scannable skill tree.
-func clientSkillTreeRoot(paths runtimePaths, client string) string {
+// clientSkillTreeRoots maps a client id to the on-disk root(s) where ITS synced
+// HA NOVA skills live. Returns nil for clients without a scannable skill tree.
+// Gemini uses a flat layout shared with the user's other skills, so only the
+// `ha-nova*` entries are ours — never scan unrelated Gemini skills.
+func clientSkillTreeRoots(paths runtimePaths, client string) []string {
 	switch client {
 	case "hermes":
-		return filepath.Join(paths.Home, ".hermes", "skills", "ha-nova")
+		return []string{filepath.Join(paths.Home, ".hermes", "skills", "ha-nova")}
 	case "codex":
-		return filepath.Join(paths.Home, ".agents", "skills", "ha-nova")
+		return []string{filepath.Join(paths.Home, ".agents", "skills", "ha-nova")}
 	case "opencode":
-		return filepath.Join(paths.Home, ".config", "opencode", "skills", "ha-nova")
+		return []string{filepath.Join(paths.Home, ".config", "opencode", "skills", "ha-nova")}
 	case "gemini":
-		return filepath.Join(paths.Home, ".gemini", "skills")
+		matches, _ := filepath.Glob(filepath.Join(paths.Home, ".gemini", "skills", "ha-nova*"))
+		return matches
 	default:
-		return ""
+		return nil
 	}
 }
 

--- a/cli/post_update_verify.go
+++ b/cli/post_update_verify.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// transientBackupResidue returns the configured file/skill-tree clients whose
+// just-synced artifacts still reference a transient update backup
+// (.ha-nova-old-/next-/failed-). A clean sync leaves none: the adapters
+// RemoveAll+rebuild from the resolved source root, so any residue means the sync
+// resolved its source from a stale, about-to-be-deleted backup (the pre-0.6.1
+// update bug) and the install is not actually up to date. It is the in-tool
+// version of `grep -R .ha-nova-old ~/.hermes/skills/ha-nova`.
+//
+// Claude is intentionally not scanned here (its marketplace registration is
+// re-derived from the source root and repaired by the session-start hook); this
+// targets the file/symlink skill trees where stale paths are baked into content.
+func transientBackupResidue(paths runtimePaths, clients []string) []string {
+	dirty := []string{}
+	for _, client := range clients {
+		root := clientSkillTreeRoot(paths, client)
+		if root == "" {
+			continue
+		}
+		if pathHasTransientBackupResidue(root) {
+			dirty = append(dirty, client)
+		}
+	}
+	return dirty
+}
+
+// clientSkillTreeRoot maps a client id to the on-disk root where its synced
+// skills live. Returns "" for clients without a scannable skill tree.
+func clientSkillTreeRoot(paths runtimePaths, client string) string {
+	switch client {
+	case "hermes":
+		return filepath.Join(paths.Home, ".hermes", "skills", "ha-nova")
+	case "codex":
+		return filepath.Join(paths.Home, ".agents", "skills", "ha-nova")
+	case "opencode":
+		return filepath.Join(paths.Home, ".config", "opencode", "skills", "ha-nova")
+	case "gemini":
+		return filepath.Join(paths.Home, ".gemini", "skills")
+	default:
+		return ""
+	}
+}
+
+// pathHasTransientBackupResidue reports whether the install at root still points
+// at, or was copied from, a transient update backup. Symlink installs
+// (codex/opencode) are residue when the link targets a backup or dangles; copy
+// installs (hermes/gemini) are residue when any synced markdown bakes a backup
+// path.
+func pathHasTransientBackupResidue(root string) bool {
+	info, err := os.Lstat(root)
+	if err != nil {
+		return false // not installed here; nothing to verify
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(root)
+		if err != nil {
+			return true
+		}
+		if pathMentionsTransientBackup(target) {
+			return true
+		}
+		if _, err := os.Stat(root); err != nil {
+			return true // dangling symlink (its backup target was deleted)
+		}
+		return false
+	}
+	found := false
+	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil || found {
+			return nil
+		}
+		if d.IsDir() || !strings.HasSuffix(p, ".md") {
+			return nil
+		}
+		data, readErr := os.ReadFile(p)
+		if readErr != nil {
+			return nil
+		}
+		if pathMentionsTransientBackup(string(data)) {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
+func pathMentionsTransientBackup(s string) bool {
+	return strings.Contains(s, installBackupPrefixOld) ||
+		strings.Contains(s, installBackupPrefixNext) ||
+		strings.Contains(s, installBackupPrefixFailed)
+}

--- a/cli/post_update_verify_test.go
+++ b/cli/post_update_verify_test.go
@@ -89,7 +89,9 @@ func TestPostUpdateSyncClearsMatchingMarkerOnResidue(t *testing.T) {
 	paths := setupHealableInstall(t)
 	// Codex runtime absent → it is skipped and keeps its pre-existing dirty symlink;
 	// Hermes present → re-synced clean.
+	origRuntime := clientRuntimeDetectedForStatus
 	clientRuntimeDetectedForStatus = func(id string) bool { return id != "codex" }
+	t.Cleanup(func() { clientRuntimeDetectedForStatus = origRuntime })
 
 	codexLink := filepath.Join(paths.Home, ".agents", "skills", "ha-nova")
 	if err := os.MkdirAll(filepath.Dir(codexLink), 0o755); err != nil {

--- a/cli/post_update_verify_test.go
+++ b/cli/post_update_verify_test.go
@@ -78,6 +78,50 @@ func TestTransientBackupResidueAggregatesDirtyClients(t *testing.T) {
 	}
 }
 
+// TestPostUpdateSyncClearsMatchingMarkerOnResidue guards Codex's P2: if the marker
+// already equals the running version but the residue scan finds a stale tree, the
+// marker must be CLEARED (not just left matching), or the self-heal would
+// short-circuit and never repair the stale client.
+func TestPostUpdateSyncClearsMatchingMarkerOnResidue(t *testing.T) {
+	if isWindowsRuntime() {
+		t.Skip("symlink residue is a non-Windows skill-tree concern")
+	}
+	paths := setupHealableInstall(t)
+	// Codex runtime absent → it is skipped and keeps its pre-existing dirty symlink;
+	// Hermes present → re-synced clean.
+	clientRuntimeDetectedForStatus = func(id string) bool { return id != "codex" }
+
+	codexLink := filepath.Join(paths.Home, ".agents", "skills", "ha-nova")
+	if err := os.MkdirAll(filepath.Dir(codexLink), 0o755); err != nil {
+		t.Fatalf("mkdir codex parent: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(paths.Home, ".local", "share", installBackupPrefixOld+"42", "skills"), codexLink); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// Marker already matches the running version (e.g. stamped by a prior run).
+	if err := saveState(paths, installState{
+		SchemaVersion:          stateSchemaVersion,
+		Version:                "0.6.1",
+		ClientsVerifiedVersion: "0.6.1",
+		InstalledClients:       []string{"hermes", "codex"},
+	}); err != nil {
+		t.Fatalf("saveState() error: %v", err)
+	}
+
+	if err := postUpdateSync(paths); err != nil {
+		t.Fatalf("postUpdateSync() error: %v", err)
+	}
+
+	state, err := loadState(paths)
+	if err != nil {
+		t.Fatalf("loadState() error: %v", err)
+	}
+	if state.ClientsVerifiedVersion != "" {
+		t.Fatalf("residue must clear the matching marker so the self-heal re-runs, got %q", state.ClientsVerifiedVersion)
+	}
+}
+
 func isWindowsRuntime() bool {
 	return os.PathSeparator == '\\'
 }

--- a/cli/post_update_verify_test.go
+++ b/cli/post_update_verify_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPathHasTransientBackupResidueCopyClient(t *testing.T) {
+	root := t.TempDir()
+	// A copy client whose synced markdown bakes a transient-backup path is residue.
+	writeBundleTestFile(t, filepath.Join(root, "ha-nova", "SKILL.md"),
+		"name: ha-nova\nSee `"+filepath.Join("/home/u", installBackupPrefixOld+"123", "docs", "reference", "x.md")+"`\n", 0o644)
+	if !pathHasTransientBackupResidue(root) {
+		t.Fatal("expected residue for a copy tree referencing a transient backup")
+	}
+
+	clean := t.TempDir()
+	writeBundleTestFile(t, filepath.Join(clean, "ha-nova", "SKILL.md"), "name: ha-nova\nSee `docs/reference/x.md`\n", 0o644)
+	if pathHasTransientBackupResidue(clean) {
+		t.Fatal("did not expect residue for a clean copy tree")
+	}
+}
+
+func TestPathHasTransientBackupResidueSymlinkClient(t *testing.T) {
+	if isWindowsRuntime() {
+		t.Skip("symlink residue is a non-Windows skill-tree concern")
+	}
+	parent := t.TempDir()
+
+	// Symlink whose target path points into a transient backup → residue.
+	intoBackup := filepath.Join(parent, "into-backup")
+	if err := os.Symlink(filepath.Join(parent, installBackupPrefixOld+"9", "skills"), intoBackup); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if !pathHasTransientBackupResidue(intoBackup) {
+		t.Fatal("expected residue for a symlink targeting a transient backup")
+	}
+
+	// Dangling symlink (target missing, not a backup name) → residue.
+	dangling := filepath.Join(parent, "dangling")
+	if err := os.Symlink(filepath.Join(parent, "gone", "skills"), dangling); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if !pathHasTransientBackupResidue(dangling) {
+		t.Fatal("expected residue for a dangling symlink")
+	}
+
+	// Valid symlink to a real, non-backup tree → clean.
+	realDir := filepath.Join(parent, "ha-nova", "skills")
+	writeBundleTestFile(t, filepath.Join(realDir, "SKILL.md"), "name: ha-nova\n", 0o644)
+	valid := filepath.Join(parent, "valid")
+	if err := os.Symlink(realDir, valid); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if pathHasTransientBackupResidue(valid) {
+		t.Fatal("did not expect residue for a valid symlink to a clean tree")
+	}
+}
+
+func TestTransientBackupResidueAggregatesDirtyClients(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	// Hermes (copy) clean.
+	writeBundleTestFile(t, filepath.Join(home, ".hermes", "skills", "ha-nova", "ha-nova", "SKILL.md"), "name: ha-nova\n", 0o644)
+	// Gemini (copy) dirty: a baked transient-backup path.
+	writeBundleTestFile(t, filepath.Join(home, ".gemini", "skills", "ha-nova", "SKILL.md"),
+		"name: ha-nova\n`"+filepath.Join(home, installBackupPrefixOld+"7", "docs")+"`\n", 0o644)
+
+	dirty := transientBackupResidue(paths, []string{"hermes", "gemini", "claude"})
+	if len(dirty) != 1 || dirty[0] != "gemini" {
+		t.Fatalf("expected only gemini flagged as residue, got %v", dirty)
+	}
+}
+
+func isWindowsRuntime() bool {
+	return os.PathSeparator == '\\'
+}

--- a/cli/self_heal_test.go
+++ b/cli/self_heal_test.go
@@ -97,7 +97,9 @@ func TestEnsureClientsVerifiedSelfHealsOnceThenNoOp(t *testing.T) {
 func TestPostUpdateSyncLeavesMarkerUnstampedWhenClientSkipped(t *testing.T) {
 	paths := setupHealableInstall(t)
 	// Override the runtime probe so the tracked client is skipped, not synced.
+	origRuntime := clientRuntimeDetectedForStatus
 	clientRuntimeDetectedForStatus = func(string) bool { return false }
+	t.Cleanup(func() { clientRuntimeDetectedForStatus = origRuntime })
 
 	if err := saveState(paths, installState{
 		SchemaVersion:    stateSchemaVersion,

--- a/docs/work/2026-06-18-v0.6.2-release-body.md
+++ b/docs/work/2026-06-18-v0.6.2-release-body.md
@@ -1,0 +1,20 @@
+## Bug Fixes
+
+- `ha-nova update` now verifies that the refreshed skills are actually clean. If any client still references a temporary update path, it warns and points you to `ha-nova doctor` instead of reporting a silent success — so "updated" always means a fully refreshed skill tree.
+
+## Install
+
+**macOS / Linux**
+```sh
+curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/v0.6.2/install.sh | HA_NOVA_VERSION=v0.6.2 bash
+```
+
+**Windows (PowerShell)**
+```powershell
+$env:HA_NOVA_VERSION = 'v0.6.2'
+irm https://raw.githubusercontent.com/markusleben/ha-nova/v0.6.2/install.ps1 | iex
+```
+
+## Already Installed?
+
+Run `ha-nova check-update` or `ha-nova update`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.6.1",
+  "skill_version": "0.6.2",
   "min_relay_version": "0.1.0"
 }


### PR DESCRIPTION
## Why

Live Linux feedback after v0.6.1: a user updated v0.6.0→v0.6.1, saw `Client synced: hermes` / `Updated to v0.6.1`, but the Hermes skills still contained stale `.ha-nova-old-…` paths until they manually ran `ha-nova doctor`. Root cause: the **old v0.6.0 binary** runs that in-process update and syncs from the soon-deleted backup — v0.6.1 cannot retro-fix an already-shipped binary, and with in-process updates the *new* binary only drives the sync from the **next** version onward. So `Updated` looked cleaner than reality.

## What

`postUpdateSync` now verifies its own output before reporting success — the in-tool version of `grep -R .ha-nova-old ~/.hermes/skills/ha-nova`:

- New `transientBackupResidue` scans each synced skill-tree client:
  - symlink clients (Codex/OpenCode): residue if the link targets a `.ha-nova-old-/next-/failed-` path or dangles because its backup was deleted;
  - copy clients (Hermes/Gemini): residue if any synced `*.md` bakes a transient-backup path.
- If residue is found: leave `ClientsVerifiedVersion` **unset** (so the self-heal retries) and print a loud warning + `ha-nova doctor` recovery hint **instead of a silent success**.
- Claude is covered by its marketplace re-registration + session-start hook, so it is excluded from the content scan.

Silent for a correct (≥0.6.2) binary; a forward guarantee + regression guard. CLI-only → skill bumped to **0.6.2**, relay stays **0.2.1**.

## Tests

- `post_update_verify_test.go`: copy-residue / clean copy, symlink-into-backup, dangling symlink, valid symlink, and `transientBackupResidue` aggregation (only the dirty client flagged).
- Real-swap E2E now also asserts a clean post-swap sync **stamps** the marker (residue scan does not false-flag a correct tree).
- Full `go test ./...` + `npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)