### PR TITLE
fix: harden installer downloads

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,26 +83,14 @@ release:
     ```
 
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
-    {{ else }}## New Features
+    {{ else }}## Bug Fixes
 
-    - Home Assistant status checks summarize repairs, integrations, System Health, entity availability, and low-battery signals.
-    - Calendar reads can list calendars and fetch bounded event windows.
-    - `ha-nova trace latest` finds the newest automation or script trace without guessing run IDs.
-    - Google Antigravity is now the current Google client path; `ha-nova setup gemini` remains a legacy alias.
-    - Install/status JSON gives clearer support data for local debugging.
-
-    ## Bug Fixes
-
-    - Review catches boolean-like templates compared to string `"True"` / `"False"` values.
-    - Review warns about same-block `variables:` dependencies regardless of key order.
-    - Review flags capacity-like variables that may accidentally use current `available_energy` instead of maximum or nominal capacity.
-    - Write previews are clearer in terminal clients and keep notification title/message changes visible.
-    - Deletes treat verified absence as success and avoid unsafe alternate delete retries.
+    - Windows installer downloads are more resilient on fresh Windows systems: the installer sets modern TLS defaults, sends GitHub-friendly headers, retries release assets with native fallback transports, and retries the ZIP download when a proxy or partial transfer produces content that fails SHA256 verification.
 
     ## What To Watch
 
-    - Current skills require NOVA Relay `0.2.3` or newer.
-    - Google Antigravity detection is intentionally narrow: standard Windows per-user Desktop install or `agy`, and Linux `agy` / `antigravity` / `antigravity-ide` on `PATH`.
+    - If a network, proxy, or firewall blocks GitHub Release downloads entirely, install still cannot complete, but the installer now reports one HA NOVA download error with the attempted transports instead of leaking a raw `Invoke-WebRequest` stack trace.
+    - The already-published `v0.7.0` tag is immutable. Use `v0.7.1` or the latest release command below for this Windows installer fix.
 
     Stable install commands are release-pinned for this tag.
 

--- a/cli/asset_download.go
+++ b/cli/asset_download.go
@@ -29,6 +29,10 @@ const assetDownloadAttempts = 3
 // assetRetryDelay is a variable so tests can run the retry loop without sleeps.
 var assetRetryDelay = time.Second
 
+// assetBodyIdleTimeout bounds stalled body reads without imposing a total
+// download timeout. Slow downloads can continue as long as bytes keep arriving.
+var assetBodyIdleTimeout = 30 * time.Second
+
 func downloadAssetFile(url, dest string) error {
 	return downloadAssetFileWithVerify(url, dest, "")
 }
@@ -87,7 +91,7 @@ func downloadAssetFileOnce(url, dest string) (retryable bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	written, copyErr := io.Copy(out, resp.Body)
+	written, copyErr := copyWithIdleTimeout(out, resp.Body, assetBodyIdleTimeout)
 	closeErr := out.Close()
 	if copyErr != nil {
 		_ = os.Remove(dest)
@@ -102,4 +106,47 @@ func downloadAssetFileOnce(url, dest string) (retryable bool, err error) {
 		return true, fmt.Errorf("download produced no data")
 	}
 	return false, nil
+}
+
+func copyWithIdleTimeout(dst io.Writer, src io.ReadCloser, timeout time.Duration) (int64, error) {
+	if timeout <= 0 {
+		return io.Copy(dst, src)
+	}
+
+	buf := make([]byte, 32*1024)
+	var written int64
+	for {
+		type readResult struct {
+			n   int
+			err error
+		}
+		resultCh := make(chan readResult, 1)
+		go func() {
+			n, err := src.Read(buf)
+			resultCh <- readResult{n: n, err: err}
+		}()
+
+		select {
+		case result := <-resultCh:
+			if result.n > 0 {
+				nw, err := dst.Write(buf[:result.n])
+				written += int64(nw)
+				if err != nil {
+					return written, err
+				}
+				if nw != result.n {
+					return written, io.ErrShortWrite
+				}
+			}
+			if result.err != nil {
+				if result.err == io.EOF {
+					return written, nil
+				}
+				return written, result.err
+			}
+		case <-time.After(timeout):
+			_ = src.Close()
+			return written, fmt.Errorf("download body idle timeout after %s", timeout)
+		}
+	}
 }

--- a/cli/asset_download.go
+++ b/cli/asset_download.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// assetHTTPClient downloads release assets (bundle + checksum). It is separate
+// from the relay httpClient on purpose: that client caps the ENTIRE response at
+// 15 seconds, which aborts any bundle download on a slow connection. Release
+// assets may legitimately take minutes, so this client has no total timeout;
+// stalls are still bounded per phase (dial, TLS handshake, response headers).
+var assetHTTPClient = &http.Client{
+	Transport: &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: 15 * time.Second}).DialContext,
+		TLSHandshakeTimeout:   15 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+	},
+}
+
+const assetDownloadAttempts = 3
+
+// assetRetryDelay is a variable so tests can run the retry loop without sleeps.
+var assetRetryDelay = time.Second
+
+func downloadAssetFile(url, dest string) error {
+	return downloadAssetFileWithVerify(url, dest, "")
+}
+
+func downloadAssetFileVerified(url, dest, checksumManifest string) error {
+	return downloadAssetFileWithVerify(url, dest, checksumManifest)
+}
+
+func downloadAssetFileWithVerify(url, dest, checksumManifest string) error {
+	var attemptErrors []string
+	for attempt := 1; attempt <= assetDownloadAttempts; attempt++ {
+		if attempt > 1 {
+			time.Sleep(assetRetryDelay * time.Duration(attempt-1))
+		}
+		retryable, err := downloadAssetFileOnce(url, dest)
+		if err == nil && checksumManifest != "" {
+			if verifyErr := verifyFileChecksum(dest, checksumManifest); verifyErr != nil {
+				// A 200 response with wrong bytes (proxy substitution, captive
+				// portal, truncated cache) is transient from the next transport's
+				// point of view: discard and re-download instead of giving up.
+				_ = os.Remove(dest)
+				retryable, err = true, verifyErr
+			}
+		}
+		if err == nil {
+			return nil
+		}
+		attemptErrors = append(attemptErrors, fmt.Sprintf("attempt %d: %s", attempt, err))
+		if !retryable {
+			break
+		}
+	}
+	_ = os.Remove(dest)
+	return fmt.Errorf("could not download release asset %s (%s)", url, strings.Join(attemptErrors, "; "))
+}
+
+func downloadAssetFileOnce(url, dest string) (retryable bool, err error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("User-Agent", "ha-nova-installer")
+	req.Header.Set("Accept", "application/octet-stream")
+
+	resp, err := assetHTTPClient.Do(req)
+	if err != nil {
+		return true, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		retryable := resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests
+		return retryable, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return false, err
+	}
+	written, copyErr := io.Copy(out, resp.Body)
+	closeErr := out.Close()
+	if copyErr != nil {
+		_ = os.Remove(dest)
+		return true, copyErr
+	}
+	if closeErr != nil {
+		_ = os.Remove(dest)
+		return false, closeErr
+	}
+	if written == 0 {
+		_ = os.Remove(dest)
+		return true, fmt.Errorf("download produced no data")
+	}
+	return false, nil
+}

--- a/cli/asset_download_test.go
+++ b/cli/asset_download_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func disableAssetRetryDelay(t *testing.T) {
@@ -95,6 +96,45 @@ func TestDownloadAssetFileRetriesEmptyBody(t *testing.T) {
 	}
 	if got := calls.Load(); got != 2 {
 		t.Fatalf("server calls = %d, want 2", got)
+	}
+}
+
+func TestDownloadAssetFileRetriesStalledBodyRead(t *testing.T) {
+	disableAssetRetryDelay(t)
+	originalIdleTimeout := assetBodyIdleTimeout
+	assetBodyIdleTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { assetBodyIdleTimeout = originalIdleTimeout })
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				http.Error(w, "flush unavailable", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			flusher.Flush()
+			time.Sleep(200 * time.Millisecond)
+			return
+		}
+		fmt.Fprint(w, "payload")
+	}))
+	defer server.Close()
+
+	dest := filepath.Join(t.TempDir(), "asset")
+	if err := downloadAssetFile(server.URL, dest); err != nil {
+		t.Fatalf("downloadAssetFile() error: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("server calls = %d, want 2", got)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(data) != "payload" {
+		t.Fatalf("dest content = %q, want payload", data)
 	}
 }
 

--- a/cli/asset_download_test.go
+++ b/cli/asset_download_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func disableAssetRetryDelay(t *testing.T) {
+	t.Helper()
+	original := assetRetryDelay
+	assetRetryDelay = 0
+	t.Cleanup(func() { assetRetryDelay = original })
+}
+
+func TestAssetHTTPClientHasNoTotalTimeout(t *testing.T) {
+	// The relay httpClient enforces a 15s TOTAL response timeout, which aborts
+	// any bundle download slower than 15 seconds. The asset client must bound
+	// stalls per phase (dial/TLS/headers) instead of capping the whole body.
+	if assetHTTPClient.Timeout != 0 {
+		t.Fatalf("assetHTTPClient.Timeout = %v, want 0 (no total timeout)", assetHTTPClient.Timeout)
+	}
+}
+
+func TestDownloadAssetFileRetriesTransientServerError(t *testing.T) {
+	disableAssetRetryDelay(t)
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			http.Error(w, "flaky", http.StatusBadGateway)
+			return
+		}
+		fmt.Fprint(w, "payload")
+	}))
+	defer server.Close()
+
+	dest := filepath.Join(t.TempDir(), "asset")
+	if err := downloadAssetFile(server.URL, dest); err != nil {
+		t.Fatalf("downloadAssetFile() error: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("server calls = %d, want 2", got)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(data) != "payload" {
+		t.Fatalf("dest content = %q, want payload", data)
+	}
+}
+
+func TestDownloadAssetFileFailsFastOnNotFound(t *testing.T) {
+	disableAssetRetryDelay(t)
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	err := downloadAssetFile(server.URL, filepath.Join(t.TempDir(), "asset"))
+	if err == nil {
+		t.Fatal("expected 404 to fail")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("server calls = %d, want 1 (no retries on 404)", got)
+	}
+	if !strings.Contains(err.Error(), server.URL) {
+		t.Fatalf("error should name the asset URL, got %q", err)
+	}
+}
+
+func TestDownloadAssetFileRetriesEmptyBody(t *testing.T) {
+	disableAssetRetryDelay(t)
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			// 200 with an empty body: a broken proxy/captive portal artifact.
+			return
+		}
+		fmt.Fprint(w, "payload")
+	}))
+	defer server.Close()
+
+	dest := filepath.Join(t.TempDir(), "asset")
+	if err := downloadAssetFile(server.URL, dest); err != nil {
+		t.Fatalf("downloadAssetFile() error: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("server calls = %d, want 2", got)
+	}
+}
+
+func TestDownloadAssetFileSendsInstallerHeaders(t *testing.T) {
+	disableAssetRetryDelay(t)
+	var userAgent, accept string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent = r.Header.Get("User-Agent")
+		accept = r.Header.Get("Accept")
+		fmt.Fprint(w, "payload")
+	}))
+	defer server.Close()
+
+	if err := downloadAssetFile(server.URL, filepath.Join(t.TempDir(), "asset")); err != nil {
+		t.Fatalf("downloadAssetFile() error: %v", err)
+	}
+	if userAgent != "ha-nova-installer" {
+		t.Fatalf("User-Agent = %q, want ha-nova-installer", userAgent)
+	}
+	if accept != "application/octet-stream" {
+		t.Fatalf("Accept = %q, want application/octet-stream", accept)
+	}
+}
+
+func TestDownloadAssetFileVerifiedRedownloadsOnChecksumMismatch(t *testing.T) {
+	disableAssetRetryDelay(t)
+	payload := []byte("bundle-bytes")
+	sum := sha256.Sum256(payload)
+	manifest := fmt.Sprintf("%x  bundle", sum)
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			// Wrong bytes with 200 OK: proxy substitution / truncated cache.
+			fmt.Fprint(w, "<html>not the bundle</html>")
+			return
+		}
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	dest := filepath.Join(t.TempDir(), "bundle")
+	if err := downloadAssetFileVerified(server.URL, dest, manifest); err != nil {
+		t.Fatalf("downloadAssetFileVerified() error: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("server calls = %d, want 2", got)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(data) != string(payload) {
+		t.Fatalf("dest content mismatch after verified retry")
+	}
+}
+
+func TestDownloadAssetFileVerifiedFailsWithAggregatedAttempts(t *testing.T) {
+	disableAssetRetryDelay(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "always wrong")
+	}))
+	defer server.Close()
+
+	dest := filepath.Join(t.TempDir(), "bundle")
+	err := downloadAssetFileVerified(server.URL, dest, "deadbeef  bundle")
+	if err == nil {
+		t.Fatal("expected persistent checksum mismatch to fail")
+	}
+	if !strings.Contains(err.Error(), server.URL) {
+		t.Fatalf("error should name the asset URL, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("error should mention the checksum mismatch, got %q", err)
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatalf("mismatched download must not be left on disk (stat err: %v)", statErr)
+	}
+}
+
+func TestStageBundleSurvivesSlowClientAndFlakyFirstDownload(t *testing.T) {
+	disableAssetRetryDelay(t)
+	archivePath, checksumPath := createTestBundleArchive(t, "0.3.1")
+
+	var bundleCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/bundle":
+			if bundleCalls.Add(1) == 1 {
+				http.Error(w, "flaky", http.StatusServiceUnavailable)
+				return
+			}
+			http.ServeFile(w, r, archivePath)
+		case "/bundle.sha256":
+			http.ServeFile(w, r, checksumPath)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("HA_NOVA_BUNDLE_URL", server.URL+"/bundle")
+	t.Setenv("HA_NOVA_BUNDLE_SHA256_URL", server.URL+"/bundle.sha256")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	stageRoot, err := stageBundle(paths, "0.3.1")
+	if err != nil {
+		t.Fatalf("stageBundle() error: %v", err)
+	}
+	defer cleanupStagedBundle(stageRoot)
+	if got := bundleCalls.Load(); got != 2 {
+		t.Fatalf("bundle calls = %d, want 2 (retry after 503)", got)
+	}
+	if _, err := os.Stat(filepath.Join(stageRoot, "bundle.json")); err != nil {
+		t.Fatalf("staged bundle metadata missing: %v", err)
+	}
+}

--- a/cli/bundle_apply.go
+++ b/cli/bundle_apply.go
@@ -51,38 +51,18 @@ func stageBundle(paths runtimePaths, version string) (string, error) {
 	if checksumURL == "" {
 		checksumURL = downloadURL + ".sha256"
 	}
-	resp, err := httpClient.Get(downloadURL)
+	// Checksum first: it is the ground truth for whether a bundle download is
+	// usable, so a wrong-bytes bundle (proxy page, truncated cache) can be
+	// discarded and re-downloaded instead of failing the update outright.
+	checksumPath := archivePath + ".sha256"
+	if err := downloadAssetFile(checksumURL, checksumPath); err != nil {
+		return "", err
+	}
+	manifestBytes, err := os.ReadFile(checksumPath)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		return "", fmt.Errorf("download failed: HTTP %d", resp.StatusCode)
-	}
-	out, err := os.Create(archivePath)
-	if err != nil {
-		return "", err
-	}
-	if _, err := io.Copy(out, resp.Body); err != nil {
-		out.Close()
-		return "", err
-	}
-	if err := out.Close(); err != nil {
-		return "", err
-	}
-	checksumResp, err := httpClient.Get(checksumURL)
-	if err != nil {
-		return "", err
-	}
-	defer checksumResp.Body.Close()
-	if checksumResp.StatusCode >= 400 {
-		return "", fmt.Errorf("checksum download failed: HTTP %d", checksumResp.StatusCode)
-	}
-	manifestBytes, err := io.ReadAll(checksumResp.Body)
-	if err != nil {
-		return "", err
-	}
-	if err := verifyFileChecksum(archivePath, string(manifestBytes)); err != nil {
+	if err := downloadAssetFileVerified(downloadURL, archivePath, string(manifestBytes)); err != nil {
 		return "", err
 	}
 

--- a/docs/work/2026-07-06-v0.7.1-release-body.md
+++ b/docs/work/2026-07-06-v0.7.1-release-body.md
@@ -1,0 +1,35 @@
+# v0.7.1 Release Body
+
+## Bug Fixes
+
+- Windows installer downloads are more resilient on fresh Windows systems: the installer sets modern TLS defaults, sends GitHub-friendly headers, retries release assets with native fallback transports, and retries the ZIP download when content fails SHA256 verification.
+- `ha-nova update` no longer aborts on slow connections: the bundle download previously ran through a client with a hard 15-second total timeout. Downloads now have no overall time cap (stalled connections still fail fast), retry transient errors, and re-download once when content fails SHA256 verification.
+- The macOS/Linux installer now retries transient download errors with a connect timeout, verifies the checksum before trusting the bundle bytes, re-downloads once on SHA256 mismatch, and reports one clear HA NOVA error naming the asset URL instead of a raw curl abort.
+
+## What To Watch
+
+- If a network, proxy, or firewall blocks GitHub Release downloads entirely, install still cannot complete, but the installer now reports one HA NOVA download error with the attempted transports instead of leaking a raw `Invoke-WebRequest` stack trace.
+- The already-published `v0.7.0` tag is immutable. Use `v0.7.1` or the latest release command for this Windows installer fix.
+
+## Install
+
+macOS / Linux:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/v0.7.1/install.sh | HA_NOVA_VERSION=v0.7.1 bash
+```
+
+Windows:
+
+```powershell
+$env:HA_NOVA_VERSION = 'v0.7.1'
+irm https://raw.githubusercontent.com/markusleben/ha-nova/v0.7.1/install.ps1 | iex
+```
+
+## Already Installed?
+
+Run:
+
+```sh
+ha-nova update
+```

--- a/docs/work/2026-07-06-windows-installer-download-resilience-spec.md
+++ b/docs/work/2026-07-06-windows-installer-download-resilience-spec.md
@@ -1,0 +1,89 @@
+# Installer & Update Download Resilience Spec
+
+## Problem
+
+The documented Windows one-liner can load `install.ps1` from `raw.githubusercontent.com`
+but then fail during the release bundle download with a raw `Invoke-WebRequest`
+connection exception. The README command must be robust on fresh Windows systems
+and must not expose an unhandled PowerShell stack trace for the normal asset
+download path.
+
+The same fragility exists on the two other download surfaces users hit in the
+shipped product:
+
+- `ha-nova update` (all platforms) downloads the release bundle through the
+  relay API `httpClient`, which has a hard 15-second TOTAL response timeout.
+  Any bundle download slower than 15 seconds aborts the update. The path has
+  no retry, no re-download on checksum mismatch, and no User-Agent.
+- `install.sh` (macOS/Linux) uses bare `curl -fsSL` with no retries, no
+  connect timeout, downloads the bundle before the checksum, and surfaces raw
+  curl errors instead of an HA NOVA message.
+
+## Scope
+
+- Harden `install.ps1` release asset downloads.
+- Harden the Go bundle download in `stageBundle` (`cli/bundle_apply.go`) with
+  a dedicated asset download client; the relay API client and release
+  metadata lookup (`fetchLatestRelease` with its cache fallback) stay unchanged.
+- Harden `install.sh` downloads to parity with `install.ps1`.
+- Preserve checksum verification and bundle metadata validation everywhere.
+- Keep the public commands and the `HA_NOVA_BUNDLE_URL` /
+  `HA_NOVA_BUNDLE_SHA256_URL` overrides unchanged.
+- Add focused installer contract and behavior tests.
+
+## Design
+
+- Initialize modern TLS protocols best-effort before GitHub API or asset calls.
+- Use consistent download headers including a User-Agent.
+- Keep progress suppression scoped to file downloads.
+- Try multiple native Windows download transports before failing:
+  1. `Invoke-WebRequest` with `-UseBasicParsing` when supported.
+  2. .NET `HttpClient`.
+  3. BITS transfer when available.
+- Download the checksum first, then retry the ZIP by transport until the SHA256
+  matches. A proxy HTML page, zero-byte file, partial ZIP, or captive-portal
+  body from the first transport must not prevent trying the next transport.
+- If all transports fail, fail with one HA NOVA error message that includes the
+  asset URL and all attempted transport errors instead of leaking a raw cmdlet stack.
+- Keep a test-only export guard so PowerShell behavior tests can dot-source the
+  installer functions without running the full installer.
+
+### Go update path (`cli/asset_download.go`)
+
+- Dedicated `assetHTTPClient` with NO total timeout: a slow but progressing
+  bundle download must never abort. Stalls stay bounded via dial, TLS
+  handshake, and response-header timeouts.
+- `downloadAssetFile`: streams to disk, sends `ha-nova-installer` User-Agent
+  and octet-stream Accept, retries transient failures (network errors,
+  HTTP 5xx, HTTP 429) with a short backoff, fails fast on other 4xx. A
+  zero-byte result counts as a failed attempt.
+- `stageBundle` downloads the checksum FIRST, then the bundle verified
+  against it; a checksum mismatch discards the file and re-downloads before
+  failing. Attempt errors are aggregated into one message.
+- Retry pacing lives in a package variable so tests run without real sleeps.
+
+### install.sh (macOS/Linux)
+
+- One `fetch_url` download helper: `--fail --silent --show-error --location`
+  plus `--connect-timeout` and `--retry` with `--retry-all-errors` when the
+  local curl supports it (probed once; older curl falls back to plain retry).
+- Checksum downloads first, then the bundle; on SHA256 mismatch the bundle is
+  re-downloaded once before failing.
+- Download failures produce one HA NOVA error message that names the asset
+  URL instead of a raw curl abort.
+- Test-only export guard (`HA_NOVA_INSTALLER_TEST_EXPORT=1`) so behavior
+  tests can source the installer functions without running the installer.
+
+## Verification
+
+- `git diff --check`
+- focused Vitest installer contracts (`installer-contract`,
+  `windows-installer-contract`, `release-contract`)
+- PowerShell parser check for `install.ps1`; `bash -n install.sh`
+- behavior test (Windows): hash-mismatched first transport retries and
+  succeeds with the next transport
+- behavior test (Unix): flaky-then-healthy download server; checksum-mismatch
+  first response then clean re-download succeeds
+- `gofmt -l cli` clean and `go test ./...` in `cli/`, including new tests:
+  transient 5xx then success, checksum mismatch then re-download success,
+  hard 404 fails without retries, asset client has no total timeout

--- a/install.ps1
+++ b/install.ps1
@@ -106,6 +106,94 @@ function Fail([string]$Message) {
   throw $Message
 }
 
+function Initialize-WebSecurity {
+  try {
+    $protocols = [Net.SecurityProtocolType]::Tls12
+    if ([Enum]::GetNames([Net.SecurityProtocolType]) -contains "Tls13") {
+      $protocols = $protocols -bor [Net.SecurityProtocolType]::Tls13
+    }
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor $protocols
+  }
+  catch {
+  }
+}
+
+function Get-DownloadHeaders {
+  return @{
+    Accept = "application/octet-stream"
+    "User-Agent" = "ha-nova-installer"
+  }
+}
+
+function Get-DownloadMethods {
+  $methods = @("Invoke-WebRequest", "HttpClient")
+  if (Get-Command Start-BitsTransfer -ErrorAction SilentlyContinue) {
+    $methods += "BITS"
+  }
+  return $methods
+}
+
+function Invoke-GitHubJson {
+  param(
+    [Parameter(Mandatory = $true)][string]$Uri
+  )
+
+  $errors = @()
+  try {
+    $params = @{
+      Uri = $Uri
+      Headers = @{
+        Accept = "application/vnd.github+json"
+        "User-Agent" = "ha-nova-installer"
+      }
+    }
+    if ((Get-Command Invoke-RestMethod).Parameters.ContainsKey("UseBasicParsing")) {
+      $params.UseBasicParsing = $true
+    }
+    return Invoke-RestMethod @params
+  }
+  catch {
+    $errors += "Invoke-RestMethod: $($_.Exception.Message)"
+  }
+
+  try {
+    Add-Type -AssemblyName System.Net.Http
+    $handler = [System.Net.Http.HttpClientHandler]::new()
+    $handler.AllowAutoRedirect = $true
+    $handler.UseProxy = $true
+    $defaultProxy = [System.Net.WebRequest]::DefaultWebProxy
+    if ($defaultProxy) {
+      $defaultProxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials
+      $handler.Proxy = $defaultProxy
+    }
+    try {
+      $handler.DefaultProxyCredentials = [System.Net.CredentialCache]::DefaultCredentials
+    }
+    catch {
+    }
+    $client = [System.Net.Http.HttpClient]::new($handler)
+    try {
+      $client.Timeout = [TimeSpan]::FromMinutes(2)
+      $client.DefaultRequestHeaders.UserAgent.ParseAdd("ha-nova-installer")
+      $client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json")
+      $response = $client.GetAsync($Uri).GetAwaiter().GetResult()
+      if (-not $response.IsSuccessStatusCode) {
+        throw "HTTP $([int]$response.StatusCode) $($response.ReasonPhrase)"
+      }
+      return ($response.Content.ReadAsStringAsync().GetAwaiter().GetResult() | ConvertFrom-Json)
+    }
+    finally {
+      $client.Dispose()
+      $handler.Dispose()
+    }
+  }
+  catch {
+    $errors += "HttpClient: $($_.Exception.Message)"
+  }
+
+  Fail "Could not read the latest HA NOVA release from GitHub: $Uri`nAttempts:`n- $($errors -join "`n- ")`nSet HA_NOVA_VERSION to an exact version or check that this Windows session can reach api.github.com."
+}
+
 function Test-InteractiveSession {
   try {
     return -not [Console]::IsInputRedirected
@@ -137,10 +225,7 @@ function Get-ExpectedInstallVersion {
 }
 
 function Get-LatestInstallVersion {
-  $release = Invoke-RestMethod -Uri $LatestReleaseUrl -Headers @{
-    Accept = "application/vnd.github+json"
-    "User-Agent" = "ha-nova-installer"
-  }
+  $release = Invoke-GitHubJson -Uri $LatestReleaseUrl
   if (-not $release.tag_name) {
     Fail "Could not determine the latest HA NOVA release."
   }
@@ -483,6 +568,77 @@ Then run this installer again.
 "@
 }
 
+function Invoke-DownloadFileWithMethod {
+  param(
+    [Parameter(Mandatory = $true)][string]$Method,
+    [Parameter(Mandatory = $true)][string]$Uri,
+    [Parameter(Mandatory = $true)][string]$OutFile
+  )
+
+  try {
+    Remove-Item -LiteralPath $OutFile -Force -ErrorAction SilentlyContinue
+  }
+  catch {
+  }
+
+  switch ($Method) {
+    "Invoke-WebRequest" {
+      $params = @{
+        Uri = $Uri
+        OutFile = $OutFile
+        Headers = Get-DownloadHeaders
+        MaximumRedirection = 10
+      }
+      if ((Get-Command Invoke-WebRequest).Parameters.ContainsKey("UseBasicParsing")) {
+        $params.UseBasicParsing = $true
+      }
+      Invoke-WebRequest @params
+    }
+    "HttpClient" {
+      Add-Type -AssemblyName System.Net.Http
+      $handler = [System.Net.Http.HttpClientHandler]::new()
+      $handler.AllowAutoRedirect = $true
+      $handler.UseProxy = $true
+      $defaultProxy = [System.Net.WebRequest]::DefaultWebProxy
+      if ($defaultProxy) {
+        $defaultProxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials
+        $handler.Proxy = $defaultProxy
+      }
+      try {
+        $handler.DefaultProxyCredentials = [System.Net.CredentialCache]::DefaultCredentials
+      }
+      catch {
+      }
+      $handler.AutomaticDecompression = [System.Net.DecompressionMethods]::GZip -bor [System.Net.DecompressionMethods]::Deflate
+      $client = [System.Net.Http.HttpClient]::new($handler)
+      try {
+        $client.Timeout = [TimeSpan]::FromMinutes(10)
+        $client.DefaultRequestHeaders.UserAgent.ParseAdd("ha-nova-installer")
+        $client.DefaultRequestHeaders.Accept.ParseAdd("application/octet-stream")
+        $response = $client.GetAsync($Uri).GetAwaiter().GetResult()
+        if (-not $response.IsSuccessStatusCode) {
+          throw "HTTP $([int]$response.StatusCode) $($response.ReasonPhrase)"
+        }
+        [System.IO.File]::WriteAllBytes($OutFile, $response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult())
+      }
+      finally {
+        $client.Dispose()
+        $handler.Dispose()
+      }
+    }
+    "BITS" {
+      Start-BitsTransfer -Source $Uri -Destination $OutFile -TransferType Download -ErrorAction Stop
+    }
+    default {
+      throw "Unsupported download method: $Method"
+    }
+  }
+
+  if (-not (Test-Path -LiteralPath $OutFile) -or ((Get-Item -LiteralPath $OutFile).Length -le 0)) {
+    throw "download produced no file"
+  }
+}
+
 function Invoke-DownloadFile {
   param(
     [Parameter(Mandatory = $true)][string]$Uri,
@@ -490,9 +646,52 @@ function Invoke-DownloadFile {
   )
 
   $previousProgressPreference = $global:ProgressPreference
+  $errors = @()
   try {
     $global:ProgressPreference = "SilentlyContinue"
-    Invoke-WebRequest -Uri $Uri -OutFile $OutFile
+    foreach ($method in @(Get-DownloadMethods)) {
+      try {
+        Invoke-DownloadFileWithMethod -Method $method -Uri $Uri -OutFile $OutFile
+        return
+      }
+      catch {
+        $errors += "${method}: $($_.Exception.Message)"
+      }
+    }
+
+    Fail "Could not download HA NOVA release asset: $Uri`nAttempts:`n- $($errors -join "`n- ")`nCheck that this Windows session can reach github.com release downloads, then rerun the README install command."
+  }
+  finally {
+    $global:ProgressPreference = $previousProgressPreference
+  }
+}
+
+function Invoke-DownloadFileVerified {
+  param(
+    [Parameter(Mandatory = $true)][string]$Uri,
+    [Parameter(Mandatory = $true)][string]$OutFile,
+    [Parameter(Mandatory = $true)][string]$ExpectedSha256
+  )
+
+  $previousProgressPreference = $global:ProgressPreference
+  $errors = @()
+  try {
+    $global:ProgressPreference = "SilentlyContinue"
+    foreach ($method in @(Get-DownloadMethods)) {
+      try {
+        Invoke-DownloadFileWithMethod -Method $method -Uri $Uri -OutFile $OutFile
+        $actualHash = (Get-FileHash -LiteralPath $OutFile -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actualHash -eq $ExpectedSha256.ToLowerInvariant()) {
+          return
+        }
+        $errors += "${method}: checksum mismatch ($actualHash)"
+      }
+      catch {
+        $errors += "${method}: $($_.Exception.Message)"
+      }
+    }
+
+    Fail "Could not download and verify HA NOVA release asset: $Uri`nAttempts:`n- $($errors -join "`n- ")`nCheck that this Windows session can reach github.com release downloads, then rerun the README install command."
   }
   finally {
     $global:ProgressPreference = $previousProgressPreference
@@ -516,17 +715,16 @@ function Install-Bundle {
   New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
 
   try {
-    Invoke-DownloadFile -Uri $bundleUrl -OutFile $archivePath
     Invoke-DownloadFile -Uri (Get-BundleChecksumUrl -Version $Version) -OutFile $checksumPath
     $checksumRaw = Get-Content -LiteralPath $checksumPath -Raw
     if (-not $checksumRaw) {
       Fail "Downloaded bundle checksum verification failed."
     }
     $expectedHash = $checksumRaw.Trim().Split()[0]
-    $actualHash = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
-    if (-not $expectedHash -or $actualHash -ne $expectedHash.ToLowerInvariant()) {
+    if (-not $expectedHash) {
       Fail "Downloaded bundle checksum verification failed."
     }
+    Invoke-DownloadFileVerified -Uri $bundleUrl -OutFile $archivePath -ExpectedSha256 $expectedHash
     Expand-Archive -LiteralPath $archivePath -DestinationPath $extractDir -Force
 
     $bundleRoot = Join-Path $extractDir "ha-nova"
@@ -673,8 +871,13 @@ function Start-Setup {
   & $BinaryPath setup
 }
 
+if ($env:HA_NOVA_INSTALLER_TEST_EXPORT -eq "1") {
+  return
+}
+
 $UsePlainUi = Test-PlainUi
 Write-Banner
+Initialize-WebSecurity
 
 $expectedVersion = Get-ExpectedInstallVersion
 $version = Get-DownloadInstallVersion

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,7 @@ CONFIG_DIR="${HOME}/.config/ha-nova"
 PATH_BLOCK_HEADER="# Added by HA NOVA"
 PATH_RC_FILE=""
 TMP_DIR=""
+CURL_RETRY_ALL="__unset__"
 PLAIN_UI="0"
 UI_RESET=""
 UI_BOLD=""
@@ -152,6 +153,33 @@ require_interactive_tty() {
   fail "Interactive input required. Re-run in a terminal."
 }
 
+# Single download path for every remote asset. Bare `curl -fsSL` gives up on
+# the first transient hiccup (flaky WLAN, throttling CDN edge, HTTP 5xx) and
+# surfaces a raw curl abort. Retries with a connect timeout keep the README
+# one-liner working on the connections real users actually have.
+fetch_url() {
+  local url="$1"
+  local out="$2"
+
+  if [[ "${CURL_RETRY_ALL}" == "__unset__" ]]; then
+    CURL_RETRY_ALL=""
+    # --retry-all-errors needs curl >= 7.71; probe without touching the
+    # network (unknown option makes curl fail before --version prints).
+    if curl --retry-all-errors --version >/dev/null 2>&1; then
+      CURL_RETRY_ALL="--retry-all-errors"
+    fi
+  fi
+
+  # shellcheck disable=SC2086
+  curl -fsSL --connect-timeout 15 --retry 4 --retry-delay 1 ${CURL_RETRY_ALL} "${url}" -o "${out}"
+}
+
+fail_download() {
+  local label="$1"
+  local url="$2"
+  fail "Could not download ${label}: ${url} — check that this machine can reach github.com release downloads, then rerun the install command."
+}
+
 extract_json_string() {
   local key="$1"
   local json_file="$2"
@@ -260,7 +288,9 @@ expected_version_tag() {
 
 fetch_latest_version_tag() {
   local json_file="${TMP_DIR}/latest-release.json"
-  curl -fsSL "${LATEST_RELEASE_API}" -o "${json_file}"
+  if ! fetch_url "${LATEST_RELEASE_API}" "${json_file}"; then
+    fail "Could not read the latest HA NOVA release from ${LATEST_RELEASE_API} — set HA_NOVA_VERSION to an exact version or check that this machine can reach api.github.com."
+  fi
 
   local tag
   tag="$(extract_json_string "tag_name" "${json_file}")"
@@ -326,20 +356,40 @@ bundle_version_tag() {
   normalize_version_tag "${version}"
 }
 
+# Checksum first: it is the ground truth for whether a bundle download is
+# usable, so a wrong-bytes archive (proxy HTML page, captive portal, truncated
+# cache) gets one clean re-download instead of failing the install outright.
+download_bundle_archive() {
+  local archive_url="$1"
+  local checksum_url="$2"
+  local archive_path="$3"
+  local checksum_path="$4"
+  local expected actual
+
+  fetch_url "${checksum_url}" "${checksum_path}" || fail_download "the HA NOVA bundle checksum" "${checksum_url}"
+  expected="$(awk '{print $1}' "${checksum_path}" | head -1)"
+  [[ -n "${expected}" ]] || fail "Downloaded bundle checksum verification failed."
+
+  fetch_url "${archive_url}" "${archive_path}" || fail_download "the HA NOVA release bundle" "${archive_url}"
+  actual="$(compute_sha256 "${archive_path}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    rm -f "${archive_path}"
+    fetch_url "${archive_url}" "${archive_path}" || fail_download "the HA NOVA release bundle" "${archive_url}"
+    actual="$(compute_sha256 "${archive_path}")"
+  fi
+  [[ "${actual}" == "${expected}" ]] || fail "Downloaded bundle checksum verification failed for ${archive_url}."
+}
+
 download_bundle() {
   local version_tag="$1"
-  local archive_name archive_path checksum_path extract_dir bundle_root expected actual bundle_os bundle_arch bundle_binary
+  local archive_name archive_path checksum_path extract_dir bundle_root bundle_os bundle_arch bundle_binary
   archive_name="$(bundle_name)"
   archive_path="${TMP_DIR}/${archive_name}"
   checksum_path="${archive_path}.sha256"
   extract_dir="${TMP_DIR}/extract"
 
   mkdir -p "${extract_dir}"
-  curl -fsSL "$(bundle_download_url "${version_tag}")" -o "${archive_path}"
-  curl -fsSL "$(bundle_checksum_url "${version_tag}")" -o "${checksum_path}"
-  expected="$(awk '{print $1}' "${checksum_path}" | head -1)"
-  actual="$(compute_sha256 "${archive_path}")"
-  [[ -n "${expected}" && "${actual}" == "${expected}" ]] || fail "Downloaded bundle checksum verification failed."
+  download_bundle_archive "$(bundle_download_url "${version_tag}")" "$(bundle_checksum_url "${version_tag}")" "${archive_path}" "${checksum_path}"
   tar -xzf "${archive_path}" -C "${extract_dir}"
 
   bundle_root="${extract_dir}/ha-nova"
@@ -456,5 +506,12 @@ main() {
   note "Need help later? Run: ha-nova doctor"
   run_setup "${BIN_LINK}"
 }
+
+# Test-only export guard: behavior tests source the installer functions
+# without running the installer (mirrors HA_NOVA_INSTALLER_TEST_EXPORT in
+# install.ps1).
+if [[ "${HA_NOVA_INSTALLER_TEST_EXPORT:-0}" == "1" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
 
 main "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/dev-sync-behavior.test.ts
+++ b/tests/onboarding/dev-sync-behavior.test.ts
@@ -197,7 +197,10 @@ describe("dev-sync behavior", () => {
     expect(syncedRegistry).toContain('"id": "antigravity"');
     expect(syncedRegistry).toContain('"label": "Google Antigravity"');
     expect(syncedRegistry).not.toContain('"id":"gemini"');
-    expect(syncedBundle).toContain('"version": "0.7.0"');
+    // Read the expected version from the repo manifest so a release bump
+    // cannot silently break this behavior test.
+    const repoVersion = JSON.parse(readFileSync(join(REPO_ROOT, "version.json"), "utf8")).skill_version;
+    expect(syncedBundle).toContain(`"version": "${repoVersion}"`);
     expect(syncedBundle).toContain('"bundle_format_version": 1');
     expect(existsSync(join(runtimeDir, "skills", "calendar", "SKILL.md"))).toBe(true);
     expect(existsSync(join(runtimeDir, "skills", "health", "SKILL.md"))).toBe(true);

--- a/tests/onboarding/installer-contract.test.ts
+++ b/tests/onboarding/installer-contract.test.ts
@@ -1,6 +1,39 @@
-import { constants, readFileSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { execFile, execFileSync } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { constants, mkdtempSync, readFileSync, statSync } from "node:fs";
 
 import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+function hasBash(): boolean {
+  try {
+    execFileSync("bash", ["-c", "exit 0"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listen(server: Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("test server did not expose a port");
+  }
+  return address.port;
+}
+
+async function runInstallerFunctions(script: string): Promise<void> {
+  await execFileAsync("bash", [
+    "-c",
+    `set -euo pipefail; export HA_NOVA_INSTALLER_TEST_EXPORT=1 HA_NOVA_PLAIN_UI=1; source install.sh; ${script}`,
+  ]);
+}
 
 describe("install.sh contract", () => {
   const content = readFileSync("install.sh", "utf8");
@@ -103,6 +136,88 @@ describe("install.sh contract", () => {
     expect(content).toContain("Next step: ha-nova setup");
     expect(content).toContain("Need help later? Run: ha-nova doctor");
   });
+
+  it("uses resilient curl downloads with checksum-first verification", () => {
+    expect(content).toContain("fetch_url()");
+    expect(content).toContain("--connect-timeout 15");
+    expect(content).toContain("--retry 4");
+    expect(content).toContain("--retry-all-errors");
+    expect(content).toContain("download_bundle_archive()");
+    expect(content).toContain('fail_download "the HA NOVA release bundle"');
+    expect(content).toContain('fail_download "the HA NOVA bundle checksum"');
+    expect(content).toContain("Could not read the latest HA NOVA release from");
+    expect(content).toContain("HA_NOVA_INSTALLER_TEST_EXPORT");
+    // Checksum is downloaded before the bundle so a wrong-bytes archive can be
+    // discarded and re-downloaded once before failing.
+    const helper = content.slice(content.indexOf("download_bundle_archive()"));
+    expect(helper.indexOf("${checksum_url}")).toBeLessThan(helper.indexOf("${archive_url}"));
+    expect(helper).toContain('rm -f "${archive_path}"');
+  });
+
+  it("retries a transient server error during download", async () => {
+    if (!hasBash()) {
+      return;
+    }
+
+    let calls = 0;
+    const server = createServer((req, res) => {
+      calls += 1;
+      if (calls === 1) {
+        res.writeHead(503).end("flaky");
+        return;
+      }
+      res.writeHead(200).end("payload");
+    });
+    const port = await listen(server);
+    const outFile = join(mkdtempSync(join(tmpdir(), "ha-nova-installer-test-")), "asset");
+
+    try {
+      await runInstallerFunctions(`fetch_url "http://127.0.0.1:${port}/asset" "${outFile}"`);
+    } finally {
+      server.close();
+    }
+
+    expect(calls).toBe(2);
+    expect(readFileSync(outFile, "utf8")).toBe("payload");
+  }, 30_000);
+
+  it("re-downloads the bundle once when the checksum does not match", async () => {
+    if (!hasBash()) {
+      return;
+    }
+
+    const payload = "verified bundle payload";
+    const expectedHash = createHash("sha256").update(payload).digest("hex");
+    let bundleCalls = 0;
+    const server = createServer((req, res) => {
+      if (req.url === "/bundle.sha256") {
+        res.writeHead(200).end(`${expectedHash}  bundle\n`);
+        return;
+      }
+      bundleCalls += 1;
+      if (bundleCalls === 1) {
+        // 200 OK with wrong bytes: proxy substitution / captive portal.
+        res.writeHead(200).end("<html>not the bundle</html>");
+        return;
+      }
+      res.writeHead(200).end(payload);
+    });
+    const port = await listen(server);
+    const tempDir = mkdtempSync(join(tmpdir(), "ha-nova-installer-test-"));
+    const archiveFile = join(tempDir, "bundle.tar.gz");
+    const checksumFile = `${archiveFile}.sha256`;
+
+    try {
+      await runInstallerFunctions(
+        `download_bundle_archive "http://127.0.0.1:${port}/bundle" "http://127.0.0.1:${port}/bundle.sha256" "${archiveFile}" "${checksumFile}"`,
+      );
+    } finally {
+      server.close();
+    }
+
+    expect(bundleCalls).toBe(2);
+    expect(readFileSync(archiveFile, "utf8")).toBe(payload);
+  }, 30_000);
 
   it("does not use sudo or eval", () => {
     expect(content).not.toContain("sudo ");

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -10,6 +10,7 @@ describe("release contract", () => {
   const rcWorkflow = readFileSync(".github/workflows/release-candidate.yml", "utf8");
   const releasing = readFileSync("docs/releasing.md", "utf8");
   const releaseBody = readFileSync("docs/work/2026-06-22-v0.7.0-release-body.md", "utf8");
+  const hotfixBody = readFileSync("docs/work/2026-07-06-v0.7.1-release-body.md", "utf8");
   const linuxHeadlessHelper = readFileSync("scripts/smoke/linux-headless-setup-check.sh", "utf8");
   const pkg = JSON.parse(readFileSync("package.json", "utf8")) as {
     scripts?: Record<string, string>;
@@ -55,13 +56,18 @@ describe("release contract", () => {
   });
 
   it("keeps v0.7.0 release-facing wording user-facing", () => {
-    expect(goreleaser).toContain("Home Assistant status checks");
-    expect(goreleaser).not.toContain("Home Status checks");
     expect(releaseBody).toContain("Home Assistant status checks");
     expect(releaseBody).not.toContain("Home Status skill");
-    expect(goreleaser).toContain("Google Antigravity is now the current Google client path");
-    expect(goreleaser).toContain("`ha-nova setup gemini` remains a legacy alias");
     expect(releaseBody).toContain("Google Antigravity support replaces the old Gemini-facing client surface");
+  });
+
+  it("keeps v0.7.1 release-facing wording scoped to the Windows installer hotfix", () => {
+    expect(goreleaser).toContain("Windows installer downloads are more resilient");
+    expect(goreleaser).toContain("raw `Invoke-WebRequest` stack trace");
+    expect(goreleaser).toContain("Use `v0.7.1` or the latest release command");
+    expect(hotfixBody).toContain("Windows installer downloads are more resilient");
+    expect(hotfixBody).toContain("`v0.7.0` tag is immutable");
+    expect(hotfixBody).not.toContain("Home Status skill");
   });
 
   it("pins the GoReleaser release tag to the triggering workflow ref", () => {

--- a/tests/onboarding/windows-installer-contract.test.ts
+++ b/tests/onboarding/windows-installer-contract.test.ts
@@ -1,4 +1,8 @@
-import { constants, readFileSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { constants, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 
 import { describe, expect, it } from "vitest";
 
@@ -66,6 +70,88 @@ describe("install.ps1 contract", () => {
     );
     expect(content).not.toContain(
       "$ProgressPreference = 'SilentlyContinue'",
+    );
+  });
+
+  it("uses resilient native downloads for GitHub release assets", () => {
+    expect(content).toContain("function Initialize-WebSecurity");
+    expect(content).toContain("function Invoke-GitHubJson");
+    expect(content).toContain("[Net.SecurityProtocolType]::Tls12");
+    expect(content).toContain("function Get-DownloadHeaders");
+    expect(content).toContain("function Invoke-DownloadFileWithMethod");
+    expect(content).toContain("function Invoke-DownloadFileVerified");
+    expect(content).toContain('"User-Agent" = "ha-nova-installer"');
+    expect(content).toContain("UseBasicParsing");
+    expect(content).toContain("MaximumRedirection = 10");
+    expect(content).toContain("[System.Net.Http.HttpClient]");
+    expect(content).toContain("DefaultProxyCredentials");
+    expect(content).toContain("Start-BitsTransfer");
+    expect(content).toContain("Could not download HA NOVA release asset");
+    expect(content).toContain("Could not download and verify HA NOVA release asset");
+    expect(content).toContain("Could not read the latest HA NOVA release from GitHub");
+    expect(content).toContain("github.com release downloads");
+    expect(content).toContain("$release = Invoke-GitHubJson -Uri $LatestReleaseUrl");
+    expect(content).toContain("Initialize-WebSecurity\n\n$expectedVersion");
+    expect(content).toContain("HA_NOVA_INSTALLER_TEST_EXPORT");
+  });
+
+  it("retries a hash-mismatched primary download with the next transport", async () => {
+    try {
+      execFileSync("pwsh", ["-NoProfile", "-Command", "exit 0"], { stdio: "ignore" });
+    } catch {
+      return;
+    }
+
+    const payload = Buffer.from("verified fallback payload", "utf8");
+    const expectedHash = createHash("sha256").update(payload).digest("hex");
+    const tempDir = mkdtempSync(join(tmpdir(), "ha-nova-installer-test-"));
+    const outFile = join(tempDir, "bundle.zip");
+    const probe = join(tempDir, "probe.ps1");
+    const installScript = join(process.cwd(), "install.ps1").replaceAll("'", "''");
+    const escapedOutFile = outFile.replaceAll("'", "''");
+    writeFileSync(
+      probe,
+      `
+$ErrorActionPreference = "Stop"
+$env:HA_NOVA_INSTALLER_TEST_EXPORT = "1"
+. '${installScript}'
+function Get-DownloadMethods {
+  return @("Invoke-WebRequest", "HttpClient", "BITS")
+}
+function Invoke-DownloadFileWithMethod {
+  param(
+    [string]$Method,
+    [string]$Uri,
+    [string]$OutFile
+  )
+  $script:methods += $Method
+  if ($Method -eq "Invoke-WebRequest") {
+    Set-Content -LiteralPath $OutFile -Value "not the expected archive" -NoNewline
+    return
+  }
+  if ($Method -eq "HttpClient") {
+    Set-Content -LiteralPath $OutFile -Value "verified fallback payload" -NoNewline
+    return
+  }
+  throw "BITS should not run after verified HttpClient success"
+}
+$script:methods = @()
+Invoke-DownloadFileVerified -Uri "https://example.invalid/bundle.zip" -OutFile '${escapedOutFile}' -ExpectedSha256 "${expectedHash}"
+$actual = [System.IO.File]::ReadAllText('${escapedOutFile}')
+if (-not $actual.Contains("verified fallback payload")) {
+  throw "fallback did not replace the mismatched primary download"
+}
+if (($script:methods -join ",") -ne "Invoke-WebRequest,HttpClient") {
+  throw "unexpected download method sequence: $($script:methods -join ',')"
+}
+`,
+      "utf8",
+    );
+
+    execFileSync(
+      "pwsh",
+      ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", probe],
+      { stdio: "pipe" },
     );
   });
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.7.0",
+  "skill_version": "0.7.1",
   "min_relay_version": "0.2.3"
 }


### PR DESCRIPTION
## Summary
- harden Windows installer GitHub API and release asset downloads with TLS/header setup and native fallback transports
- retry release ZIP downloads until SHA256 verification succeeds, so partial/proxy/captive-portal content can fall through to the next transport
- add v0.7.1 metadata and hotfix release wording

## Verification
- git diff --check
- PowerShell parse check for install.ps1
- TMPDIR=/tmp npx vitest run tests/onboarding/windows-installer-contract.test.ts tests/onboarding/installer-contract.test.ts tests/onboarding/release-contract.test.ts tests/onboarding/dev-sync-behavior.test.ts tests/onboarding/client-install-docs-contract.test.ts
- cd cli && go test ./...
- pre-push hook: typecheck, 62 test files / 550 tests, build, docs fact-check

## Risk
- Cannot bypass a real network/proxy/firewall block of GitHub Release downloads; installer now reports a single HA NOVA download error with attempted transports.