### PR TITLE
fix(cli): setup wizard UX — intro, version-agnostic deeplinks, IP-first discovery, host repair

### DIFF
--- a/cli/setup_discovery.go
+++ b/cli/setup_discovery.go
@@ -45,7 +45,7 @@ func detectDefaultHAHostChoice(cfg runtimeConfig) (string, string, bool) {
 			break
 		}
 		if _, err := resolveHAURLBaseWithinTimeoutForDiscovery(candidate, remaining); err == nil {
-			if ip := confirmedIPv4ForMDNSHost(candidate); ip != "" {
+			if ip := confirmedIPv4ForMDNSHost(candidate, time.Until(deadline)); ip != "" {
 				return ip, candidate, true
 			}
 			return candidate, "", true
@@ -54,15 +54,19 @@ func detectDefaultHAHostChoice(cfg runtimeConfig) (string, string, bool) {
 	return preferredUnverifiedHAHost(cfg), "", false
 }
 
-func confirmedIPv4ForMDNSHost(host string) string {
-	if !strings.HasSuffix(strings.ToLower(host), ".local") {
+func confirmedIPv4ForMDNSHost(host string, remaining time.Duration) string {
+	if remaining <= 0 {
 		return ""
 	}
-	ip := resolveHostToIPv4ForDiscovery(host, setupDiscoveryIPResolveTimeout)
+	trimmed := strings.TrimSuffix(strings.ToLower(host), ".")
+	if !strings.HasSuffix(trimmed, ".local") {
+		return ""
+	}
+	ip := resolveHostToIPv4ForDiscovery(host, min(setupDiscoveryIPResolveTimeout, remaining))
 	if ip == "" || ip == host {
 		return ""
 	}
-	if _, err := resolveHAURLBaseWithinTimeoutForDiscovery(ip, setupDiscoveryIPProbeTimeout); err != nil {
+	if _, err := resolveHAURLBaseWithinTimeoutForDiscovery(ip, min(setupDiscoveryIPProbeTimeout, remaining)); err != nil {
 		return ""
 	}
 	return ip

--- a/cli/setup_discovery.go
+++ b/cli/setup_discovery.go
@@ -19,13 +19,22 @@ var runMDNSLookupForDiscovery = runMDNSLookup
 var mdnsAvailableForDiscovery = defaultMDNSDiscoveryAvailable
 var setupDiscoveryPlatformOS = runtime.GOOS
 var setupDiscoveryOverallTimeout = 20 * time.Second
+var resolveHostToIPv4ForDiscovery = resolveHostToIPv4
+var setupDiscoveryIPResolveTimeout = 2 * time.Second
+var setupDiscoveryIPProbeTimeout = 3 * time.Second
 
 func detectDefaultHAHost(cfg runtimeConfig) string {
-	host, _ := detectDefaultHAHostChoice(cfg)
+	host, _, _ := detectDefaultHAHostChoice(cfg)
 	return host
 }
 
-func detectDefaultHAHostChoice(cfg runtimeConfig) (string, bool) {
+// detectDefaultHAHostChoice returns the best default Home Assistant host, the
+// mDNS name it was discovered through (empty unless the result was normalized
+// to an IP), and whether the host was confirmed reachable. mDNS names like
+// "homeassistant.local" are only used to FIND the instance — the offered and
+// later persisted default is the resolved IP whenever possible, because those
+// names can stop resolving mid-setup (notably on Windows).
+func detectDefaultHAHostChoice(cfg runtimeConfig) (string, string, bool) {
 	deadline := time.Now().Add(setupDiscoveryOverallTimeout)
 	for _, candidate := range collectCandidateHosts(cfg) {
 		if candidate == "" {
@@ -36,10 +45,42 @@ func detectDefaultHAHostChoice(cfg runtimeConfig) (string, bool) {
 			break
 		}
 		if _, err := resolveHAURLBaseWithinTimeoutForDiscovery(candidate, remaining); err == nil {
-			return candidate, true
+			if ip := confirmedIPv4ForMDNSHost(candidate); ip != "" {
+				return ip, candidate, true
+			}
+			return candidate, "", true
 		}
 	}
-	return preferredUnverifiedHAHost(cfg), false
+	return preferredUnverifiedHAHost(cfg), "", false
+}
+
+func confirmedIPv4ForMDNSHost(host string) string {
+	if !strings.HasSuffix(strings.ToLower(host), ".local") {
+		return ""
+	}
+	ip := resolveHostToIPv4ForDiscovery(host, setupDiscoveryIPResolveTimeout)
+	if ip == "" || ip == host {
+		return ""
+	}
+	if _, err := resolveHAURLBaseWithinTimeoutForDiscovery(ip, setupDiscoveryIPProbeTimeout); err != nil {
+		return ""
+	}
+	return ip
+}
+
+func resolveHostToIPv4(host string, timeout time.Duration) string {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	addrs, err := net.DefaultResolver.LookupIP(ctx, "ip4", host)
+	if err != nil {
+		return ""
+	}
+	for _, addr := range addrs {
+		if v4 := addr.To4(); v4 != nil {
+			return v4.String()
+		}
+	}
+	return ""
 }
 
 func collectCandidateHosts(cfg runtimeConfig) []string {

--- a/cli/setup_discovery_test.go
+++ b/cli/setup_discovery_test.go
@@ -84,10 +84,12 @@ func TestDetectDefaultHAHostTreatsReachableHomeassistantLocalAsConfirmed(t *test
 	originalResolve := resolveHAURLBaseWithinTimeoutForDiscovery
 	originalMDNS := discoverHAViaMDNSForDiscovery
 	originalARP := collectARPHostsForDiscovery
+	originalIPResolve := resolveHostToIPv4ForDiscovery
 	defer func() {
 		resolveHAURLBaseWithinTimeoutForDiscovery = originalResolve
 		discoverHAViaMDNSForDiscovery = originalMDNS
 		collectARPHostsForDiscovery = originalARP
+		resolveHostToIPv4ForDiscovery = originalIPResolve
 	}()
 
 	resolveHAURLBaseWithinTimeoutForDiscovery = func(input string, _ time.Duration) (string, error) {
@@ -98,10 +100,106 @@ func TestDetectDefaultHAHostTreatsReachableHomeassistantLocalAsConfirmed(t *test
 	}
 	discoverHAViaMDNSForDiscovery = func() string { return "" }
 	collectARPHostsForDiscovery = func() []string { return nil }
+	resolveHostToIPv4ForDiscovery = func(string, time.Duration) string { return "" }
 
-	host, discovered := detectDefaultHAHostChoice(runtimeConfig{})
-	if host != "homeassistant.local" || !discovered {
-		t.Fatalf("detectDefaultHAHostChoice() = (%q, %v), want (%q, true)", host, discovered, "homeassistant.local")
+	host, via, discovered := detectDefaultHAHostChoice(runtimeConfig{})
+	if host != "homeassistant.local" || via != "" || !discovered {
+		t.Fatalf("detectDefaultHAHostChoice() = (%q, %q, %v), want (%q, \"\", true)", host, via, discovered, "homeassistant.local")
+	}
+}
+
+func TestDetectDefaultHAHostChoicePrefersResolvedIPForMDNSName(t *testing.T) {
+	originalResolve := resolveHAURLBaseWithinTimeoutForDiscovery
+	originalMDNS := discoverHAViaMDNSForDiscovery
+	originalARP := collectARPHostsForDiscovery
+	originalIPResolve := resolveHostToIPv4ForDiscovery
+	defer func() {
+		resolveHAURLBaseWithinTimeoutForDiscovery = originalResolve
+		discoverHAViaMDNSForDiscovery = originalMDNS
+		collectARPHostsForDiscovery = originalARP
+		resolveHostToIPv4ForDiscovery = originalIPResolve
+	}()
+
+	resolveHAURLBaseWithinTimeoutForDiscovery = func(input string, _ time.Duration) (string, error) {
+		switch input {
+		case "homeassistant.local":
+			return "http://homeassistant.local:8123", nil
+		case "192.168.1.5":
+			return "http://192.168.1.5:8123", nil
+		}
+		return "", assertDiscoveryFailure{}
+	}
+	discoverHAViaMDNSForDiscovery = func() string { return "" }
+	collectARPHostsForDiscovery = func() []string { return nil }
+	resolveHostToIPv4ForDiscovery = func(host string, _ time.Duration) string {
+		if host == "homeassistant.local" {
+			return "192.168.1.5"
+		}
+		return ""
+	}
+
+	host, via, discovered := detectDefaultHAHostChoice(runtimeConfig{})
+	if host != "192.168.1.5" || via != "homeassistant.local" || !discovered {
+		t.Fatalf("detectDefaultHAHostChoice() = (%q, %q, %v), want (%q, %q, true)", host, via, discovered, "192.168.1.5", "homeassistant.local")
+	}
+}
+
+func TestDetectDefaultHAHostChoiceKeepsMDNSNameWhenResolvedIPDoesNotProbe(t *testing.T) {
+	originalResolve := resolveHAURLBaseWithinTimeoutForDiscovery
+	originalMDNS := discoverHAViaMDNSForDiscovery
+	originalARP := collectARPHostsForDiscovery
+	originalIPResolve := resolveHostToIPv4ForDiscovery
+	defer func() {
+		resolveHAURLBaseWithinTimeoutForDiscovery = originalResolve
+		discoverHAViaMDNSForDiscovery = originalMDNS
+		collectARPHostsForDiscovery = originalARP
+		resolveHostToIPv4ForDiscovery = originalIPResolve
+	}()
+
+	resolveHAURLBaseWithinTimeoutForDiscovery = func(input string, _ time.Duration) (string, error) {
+		if input == "homeassistant.local" {
+			return "http://homeassistant.local:8123", nil
+		}
+		return "", assertDiscoveryFailure{}
+	}
+	discoverHAViaMDNSForDiscovery = func() string { return "" }
+	collectARPHostsForDiscovery = func() []string { return nil }
+	resolveHostToIPv4ForDiscovery = func(string, time.Duration) string { return "192.168.1.66" }
+
+	host, via, discovered := detectDefaultHAHostChoice(runtimeConfig{})
+	if host != "homeassistant.local" || via != "" || !discovered {
+		t.Fatalf("detectDefaultHAHostChoice() = (%q, %q, %v), want (%q, \"\", true)", host, via, discovered, "homeassistant.local")
+	}
+}
+
+func TestDetectDefaultHAHostChoiceDoesNotResolveIPForNonMDNSHost(t *testing.T) {
+	originalResolve := resolveHAURLBaseWithinTimeoutForDiscovery
+	originalMDNS := discoverHAViaMDNSForDiscovery
+	originalARP := collectARPHostsForDiscovery
+	originalIPResolve := resolveHostToIPv4ForDiscovery
+	defer func() {
+		resolveHAURLBaseWithinTimeoutForDiscovery = originalResolve
+		discoverHAViaMDNSForDiscovery = originalMDNS
+		collectARPHostsForDiscovery = originalARP
+		resolveHostToIPv4ForDiscovery = originalIPResolve
+	}()
+
+	resolveHAURLBaseWithinTimeoutForDiscovery = func(input string, _ time.Duration) (string, error) {
+		if input == "ha.example.lan" {
+			return "http://ha.example.lan:8123", nil
+		}
+		return "", assertDiscoveryFailure{}
+	}
+	discoverHAViaMDNSForDiscovery = func() string { return "" }
+	collectARPHostsForDiscovery = func() []string { return nil }
+	resolveHostToIPv4ForDiscovery = func(string, time.Duration) string {
+		t.Fatal("resolveHostToIPv4ForDiscovery must not be called for non-.local hosts")
+		return ""
+	}
+
+	host, via, discovered := detectDefaultHAHostChoice(runtimeConfig{HAHost: "ha.example.lan"})
+	if host != "ha.example.lan" || via != "" || !discovered {
+		t.Fatalf("detectDefaultHAHostChoice() = (%q, %q, %v), want (%q, \"\", true)", host, via, discovered, "ha.example.lan")
 	}
 }
 
@@ -178,7 +276,7 @@ func TestDetectDefaultHAHostChoiceStopsAfterOverallTimeout(t *testing.T) {
 		return "", assertDiscoveryFailure{}
 	}
 
-	host, discovered := detectDefaultHAHostChoice(runtimeConfig{})
+	host, _, discovered := detectDefaultHAHostChoice(runtimeConfig{})
 	if host != "" || discovered {
 		t.Fatalf("detectDefaultHAHostChoice() = (%q, %v), want blank false result", host, discovered)
 	}
@@ -203,7 +301,7 @@ func TestDetectDefaultHAHostChoiceFallsBackToSavedAddressWhenNoHostWasConfirmed(
 	discoverHAViaMDNSForDiscovery = func() string { return "" }
 	collectARPHostsForDiscovery = func() []string { return nil }
 
-	host, discovered := detectDefaultHAHostChoice(runtimeConfig{HAURL: "http://saved-ha.local:8123"})
+	host, _, discovered := detectDefaultHAHostChoice(runtimeConfig{HAURL: "http://saved-ha.local:8123"})
 	if host != "saved-ha.local" || discovered {
 		t.Fatalf("detectDefaultHAHostChoice() = (%q, %v), want (%q, false)", host, discovered, "saved-ha.local")
 	}

--- a/cli/setup_discovery_ui.go
+++ b/cli/setup_discovery_ui.go
@@ -12,24 +12,25 @@ func detectDefaultHAHostWithFeedback(out io.Writer, cfg runtimeConfig) (string, 
 	if !resolveSetupUISession(out).animatesSpinner() {
 		fmt.Fprintf(out, "  Discovering Home Assistant on your network... (up to %ds)\n", int((setupDiscoveryOverallTimeout+time.Second-1)/time.Second))
 		fmt.Fprintln(out)
-		host, discovered := detectDefaultHAHostChoiceForSetup(cfg)
-		renderSetupDiscoveryResult(out, host, discovered)
+		host, via, discovered := detectDefaultHAHostChoiceForSetup(cfg)
+		renderSetupDiscoveryResult(out, host, via, discovered)
 		return host, discovered
 	}
 
 	found, err := runSetupCountdownSpinnerWithResult(out, "Discovering Home Assistant on your network...", setupDiscoveryOverallTimeout, setupDiscoveryMinimumVisibleDuration, func() (setupDiscoveryResult, error) {
-		host, discovered := detectDefaultHAHostChoiceForSetup(cfg)
-		return setupDiscoveryResult{host: host, discovered: discovered}, nil
+		host, via, discovered := detectDefaultHAHostChoiceForSetup(cfg)
+		return setupDiscoveryResult{host: host, via: via, discovered: discovered}, nil
 	})
 	armSetupNextPromptSkipsStaleBlankInput()
 	if err != nil {
 		return preferredUnverifiedHAHost(cfg), false
 	}
-	renderSetupDiscoveryResult(out, found.host, found.discovered)
+	renderSetupDiscoveryResult(out, found.host, found.via, found.discovered)
 	return found.host, found.discovered
 }
 
 type setupDiscoveryResult struct {
 	host       string
+	via        string
 	discovered bool
 }

--- a/cli/setup_discovery_ui_test.go
+++ b/cli/setup_discovery_ui_test.go
@@ -13,8 +13,8 @@ func TestDetectDefaultHAHostWithFeedbackReportsResultWithoutTTYSpinner(t *testin
 		detectDefaultHAHostChoiceForSetup = originalDetect
 	}()
 
-	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, bool) {
-		return "ha-box.local", true
+	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
+		return "ha-box.local", "", true
 	}
 
 	output := &strings.Builder{}
@@ -29,7 +29,8 @@ func TestDetectDefaultHAHostWithFeedbackReportsResultWithoutTTYSpinner(t *testin
 	rendered := output.String()
 	for _, want := range []string{
 		"Discovering Home Assistant on your network...",
-		"Found Home Assistant candidate: ha-box.local",
+		"Found Home Assistant via the network name ha-box.local",
+		"this name can stop working",
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("discovery output missing %q:\n%s", want, rendered)
@@ -43,8 +44,8 @@ func TestDetectDefaultHAHostWithFeedbackAsksForManualAddressWhenNothingWasConfir
 		detectDefaultHAHostChoiceForSetup = originalDetect
 	}()
 
-	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, bool) {
-		return "", false
+	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
+		return "", "", false
 	}
 
 	output := &strings.Builder{}
@@ -73,8 +74,8 @@ func TestDetectDefaultHAHostWithFeedbackDoesNotDelayFastTTYDiscovery(t *testing.
 		setupDiscoveryMinimumVisibleDuration = originalMin
 	}()
 
-	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, bool) {
-		return "192.168.1.123", true
+	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
+		return "192.168.1.123", "homeassistant.local", true
 	}
 	writerSupportsTTYForSetup = func(out io.Writer) bool {
 		return true
@@ -96,7 +97,7 @@ func TestDetectDefaultHAHostWithFeedbackDoesNotDelayFastTTYDiscovery(t *testing.
 	if elapsed >= 40*time.Millisecond {
 		t.Fatalf("elapsed = %s, want less than %s for a fast task", elapsed, 40*time.Millisecond)
 	}
-	if !strings.Contains(output.String(), "Found Home Assistant candidate: 192.168.1.123") {
+	if !strings.Contains(output.String(), "Found Home Assistant at 192.168.1.123 (discovered via homeassistant.local)") {
 		t.Fatalf("missing discovery result:\n%s", output.String())
 	}
 }
@@ -119,9 +120,9 @@ func TestDetectDefaultHAHostWithFeedbackShowsSpinnerAfterDebounceForSlowTTYDisco
 		setupDiscoveryOverallTimeout = originalTimeout
 	}()
 
-	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, bool) {
+	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
 		time.Sleep(1200 * time.Millisecond)
-		return "192.168.1.124", true
+		return "192.168.1.124", "", true
 	}
 	writerSupportsTTYForSetup = func(out io.Writer) bool {
 		return true
@@ -148,7 +149,7 @@ func TestDetectDefaultHAHostWithFeedbackShowsSpinnerAfterDebounceForSlowTTYDisco
 	if !strings.Contains(rendered, "2s left") || !strings.Contains(rendered, "1s left") {
 		t.Fatalf("missing countdown label updates:\n%s", rendered)
 	}
-	if !strings.Contains(rendered, "Found Home Assistant candidate: 192.168.1.124") {
+	if !strings.Contains(rendered, "Found Home Assistant at 192.168.1.124") {
 		t.Fatalf("missing discovery result:\n%s", rendered)
 	}
 }

--- a/cli/setup_endpoints.go
+++ b/cli/setup_endpoints.go
@@ -122,7 +122,7 @@ func promptValidHAHostFromReader(reader *bufio.Reader, out io.Writer, defaultHos
 		fmt.Fprintln(out, "  Make sure Home Assistant is running and reachable from this computer.")
 		if strings.HasSuffix(strings.ToLower(normalizeHostInput(input)), ".local") {
 			fmt.Fprintln(out, `  Tip: names like "homeassistant.local" can be unreliable (especially on Windows).`)
-			fmt.Fprintln(out, "  Try the IP address instead — find it in your router, or in HA under Settings > System > Network.")
+			fmt.Fprintln(out, "  Try the IP address instead — find it in your router, or in Home Assistant under Settings > System > Network.")
 		}
 		if resolveSetupUISession(out).animatesSpinner() {
 			armSetupNextPromptSkipsStaleBlankInput()
@@ -164,7 +164,9 @@ func applySelectedSetupHost(cfg runtimeConfig, host, haURL, relayURLOverride str
 		cfg.HAHost = normalizeHostInput(host)
 	}
 	if strings.TrimSpace(haURL) != "" {
-		cfg.HAURL = strings.TrimSpace(haURL)
+		// Trailing slashes would corrupt derived deeplinks like
+		// <HAURL>/_my_redirect/... into a double-slash path.
+		cfg.HAURL = strings.TrimRight(strings.TrimSpace(haURL), "/")
 	}
 	if strings.TrimSpace(relayURLOverride) != "" {
 		cfg.RelayBaseURL = strings.TrimSpace(relayURLOverride)

--- a/cli/setup_endpoints.go
+++ b/cli/setup_endpoints.go
@@ -91,7 +91,11 @@ func promptValidHAHost(in io.Reader, out io.Writer, defaultHost string) (string,
 func promptValidHAHostFromReader(reader *bufio.Reader, out io.Writer, defaultHost string) (string, string, error) {
 	currentDefault := defaultHost
 	for {
-		input, err := promptWizardLineFromReader(reader, out, "Home Assistant address (IP, hostname, or URL)", currentDefault)
+		label := "Home Assistant address (IP, hostname, or URL)"
+		if strings.TrimSpace(currentDefault) != "" {
+			label = "Home Assistant address (press Enter to use this, or type a different one)"
+		}
+		input, err := promptWizardLineFromReader(reader, out, label, currentDefault)
 		if err != nil {
 			return "", "", err
 		}
@@ -116,6 +120,10 @@ func promptValidHAHostFromReader(reader *bufio.Reader, out io.Writer, defaultHos
 
 		renderSetupErrorLine(out, "Could not reach Home Assistant at: %s", input)
 		fmt.Fprintln(out, "  Make sure Home Assistant is running and reachable from this computer.")
+		if strings.HasSuffix(strings.ToLower(normalizeHostInput(input)), ".local") {
+			fmt.Fprintln(out, `  Tip: names like "homeassistant.local" can be unreliable (especially on Windows).`)
+			fmt.Fprintln(out, "  Try the IP address instead — find it in your router, or in HA under Settings > System > Network.")
+		}
 		if resolveSetupUISession(out).animatesSpinner() {
 			armSetupNextPromptSkipsStaleBlankInput()
 		}

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -451,10 +451,16 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 					return 1
 				}
 				stage = setupStageVerify
-			case strings.TrimSpace(relayTokenFlag) != "":
-				hostChangeRetry = false
+			case strings.TrimSpace(relayTokenFlag) != "" && !hostChangeRetry:
 				stage = setupStageToken
 			default:
+				if hostChangeRetry {
+					// A fresh-flow host change abandons the flag-driven
+					// shortcut: the corrected address may be a different
+					// instance that still needs the repository/app install
+					// and the access-token walkthrough.
+					skipLLATWalkthrough = false
+				}
 				hostChangeRetry = false
 				stage = setupStageRelayInstall
 			}

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -105,6 +105,9 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 
 	reader := bufio.NewReader(os.Stdin)
 	renderSetupHeader(os.Stdout)
+	if target == "" {
+		renderSetupIntro(os.Stdout)
+	}
 	choices, err := buildSetupClientChoices(paths, state)
 	if err != nil {
 		printHumanErr("%s", err)
@@ -283,6 +286,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 
 	token := existingToken
 	tokenChanged := false
+	hostChangeRetry := false
 
 	for {
 		renderSetupHeader(os.Stdout)
@@ -394,7 +398,10 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			defaultHost, _ := detectDefaultHAHostWithFeedback(os.Stdout, cfg)
 			host, haURL, err := promptValidHAHostFromReader(reader, os.Stdout, defaultHost)
 			if err == errSetupBack {
-				if promptedClient {
+				if hostChangeRetry {
+					hostChangeRetry = false
+					stage = setupStageVerify
+				} else if promptedClient {
 					stage = setupStageClient
 				}
 				continue
@@ -408,19 +415,27 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				return 1
 			}
 			cfg = applySelectedSetupHost(cfg, host, haURL, relayURLFlag)
-			if strings.TrimSpace(relayTokenFlag) != "" {
+			switch {
+			case hostChangeRetry && strings.TrimSpace(token) != "":
+				// The relay app and tokens are already in place; only the
+				// address was wrong, so return straight to verification.
+				hostChangeRetry = false
+				stage = setupStageVerify
+			case strings.TrimSpace(relayTokenFlag) != "":
 				stage = setupStageToken
-			} else {
+			default:
+				hostChangeRetry = false
 				stage = setupStageRelayInstall
 			}
 
 		case setupStageRelayInstall:
 			steps := buildSetupWizardSteps(true)
 			renderSetupStep(os.Stdout, steps.RelayInstall, steps.Total, "Install NOVA Relay in Home Assistant")
+			repositoryURL := haAddRepositoryURL(cfg.HAURL)
 			renderSetupParagraph(os.Stdout,
-				"I'll open your browser to add the HA NOVA repository.",
-				`Just click "Open link" when prompted.`,
+				"Next, add the HA NOVA app repository to your Home Assistant.",
 			)
+			renderSetupParagraphTight(os.Stdout, "This will open: "+repositoryURL)
 			_, err := promptWizardLineFromReader(reader, os.Stdout, "Press Enter to open your browser", "")
 			if err == errSetupBack {
 				stage = setupStageHost
@@ -434,11 +449,9 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				printHumanErr("%s", err)
 				return 1
 			}
-			if err := openBrowserForSetup("https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmarkusleben%2Fha-nova"); err != nil {
-				printHumanWarn("Browser launch skipped; open this URL manually if needed: %s", "https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmarkusleben%2Fha-nova")
-			}
+			openBrowserShowingURL(os.Stdout, repositoryURL)
 			renderSetupIndentedBlock(os.Stdout, "Once the repository is added:", "    ",
-				"1. Go to Settings > Apps > App Store",
+				"1. Go to Settings > Apps > App Store (on older Home Assistant: Settings > Add-ons)",
 				`2. Search for "NOVA Relay"`,
 				"3. Click Install and wait for it to finish",
 				"(don't start the app yet — we'll set up the tokens first)",
@@ -546,9 +559,12 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 					if err := copyToClipboardForSetup(token); err == nil {
 						renderSetupSuccessLine(os.Stdout, "Copied to clipboard.")
 					}
-					if err := openBrowserForSetup(cfg.HAURL + "/hassio/addon/2368fcfa_ha_nova_relay/config"); err != nil {
-						printHumanWarn("Browser launch skipped; open this URL manually if needed: %s/hassio/addon/2368fcfa_ha_nova_relay/config", cfg.HAURL)
-					}
+					openBrowserShowingURL(os.Stdout, haRelayAppPageURL(cfg.HAURL))
+					renderSetupIndentedBlock(os.Stdout, "On the NOVA Relay page that just opened:", "    ",
+						`1. Open the "Configuration" tab`,
+						`2. Paste the token into the "Relay Auth Token" field ("relay_auth_token")`,
+						"3. Click Save",
+					)
 					_, err := promptWizardLineFromReader(reader, os.Stdout, "Press Enter after you saved the Relay Auth Token in NOVA Relay", "")
 					if err == errSetupBack {
 						continue
@@ -601,6 +617,9 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 
 			steps := buildSetupWizardSteps(!skipLLATWalkthrough && !verifyFirstReuseFlow)
 			renderSetupStep(os.Stdout, steps.Verify, steps.Total, "Verifying connection")
+			if verifyFirstReuseFlow {
+				renderSetupParagraphTight(os.Stdout, "Using saved Home Assistant address: "+cfg.HAURL)
+			}
 			issue, ok, err := verifySetupConnection(reader, os.Stdout, cfg, token, verifyFirstReuseFlow, relayTokenFlag == "")
 			if err == errSetupBack {
 				if !skipLLATWalkthrough && !verifyFirstReuseFlow {
@@ -614,6 +633,11 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			}
 			if err == errSetupRelayTokenStep {
 				stage = setupStageToken
+				continue
+			}
+			if err == errSetupHostStep {
+				hostChangeRetry = true
+				stage = setupStageHost
 				continue
 			}
 			if err == errSetupExit {

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -105,7 +105,11 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 
 	reader := bufio.NewReader(os.Stdin)
 	renderSetupHeader(os.Stdout)
-	if target == "" && strings.TrimSpace(cfg.HAHost) == "" && strings.TrimSpace(cfg.HAURL) == "" {
+	if target == "" && strings.TrimSpace(cfg.HAHost) == "" && strings.TrimSpace(cfg.HAURL) == "" &&
+		strings.TrimSpace(hostFlag) == "" && strings.TrimSpace(haURLFlag) == "" &&
+		strings.TrimSpace(relayURLFlag) == "" && strings.TrimSpace(relayTokenFlag) == "" {
+		// Flag-driven runs are not fully interactive first runs even before
+		// the overrides are applied to cfg below — skip the intro for them.
 		renderSetupIntro(os.Stdout)
 	}
 	choices, err := buildSetupClientChoices(paths, state)

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -105,7 +105,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 
 	reader := bufio.NewReader(os.Stdin)
 	renderSetupHeader(os.Stdout)
-	if target == "" {
+	if target == "" && strings.TrimSpace(cfg.HAHost) == "" && strings.TrimSpace(cfg.HAURL) == "" {
 		renderSetupIntro(os.Stdout)
 	}
 	choices, err := buildSetupClientChoices(paths, state)
@@ -395,7 +395,15 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			continue
 
 		case setupStageHost:
-			defaultHost, _ := detectDefaultHAHostWithFeedback(os.Stdout, cfg)
+			defaultHost := ""
+			if hostChangeRetry {
+				// The user just rejected the saved address — don't spend the
+				// discovery window re-confirming it or offer it back as the
+				// press-Enter default.
+				renderSetupParagraph(os.Stdout, fmt.Sprintf("The saved address %s could not be used. Enter a new one.", cfg.HAURL))
+			} else {
+				defaultHost, _ = detectDefaultHAHostWithFeedback(os.Stdout, cfg)
+			}
 			host, haURL, err := promptValidHAHostFromReader(reader, os.Stdout, defaultHost)
 			if err == errSetupBack {
 				if hostChangeRetry {
@@ -414,14 +422,31 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				printHumanErr("%s", err)
 				return 1
 			}
+			previousRelayURL := strings.TrimSpace(cfg.RelayBaseURL)
+			previousDerivedRelayURL := deriveRelayURLFromHA(cfg.HAURL, cfg.HAHost)
 			cfg = applySelectedSetupHost(cfg, host, haURL, relayURLFlag)
+			if strings.TrimSpace(relayURLFlag) == "" && previousRelayURL != "" &&
+				previousRelayURL != previousDerivedRelayURL && cfg.RelayBaseURL != previousRelayURL {
+				// A saved relay address that was NOT derived from the old host
+				// is a deliberate custom setting (proxy, other machine); a
+				// host change must not silently clobber it.
+				cfg.RelayBaseURL = previousRelayURL
+				renderSetupParagraphTight(os.Stdout, "Keeping your saved relay address: "+previousRelayURL)
+			}
 			switch {
 			case hostChangeRetry && strings.TrimSpace(token) != "":
 				// The relay app and tokens are already in place; only the
 				// address was wrong, so return straight to verification.
+				// Save the corrected address now so it survives an exit
+				// before verification succeeds.
 				hostChangeRetry = false
+				if err := saveConfig(paths, cfg); err != nil {
+					printHumanErr("cannot save config: %s", err)
+					return 1
+				}
 				stage = setupStageVerify
 			case strings.TrimSpace(relayTokenFlag) != "":
+				hostChangeRetry = false
 				stage = setupStageToken
 			default:
 				hostChangeRetry = false
@@ -450,6 +475,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				return 1
 			}
 			openBrowserShowingURL(os.Stdout, repositoryURL)
+			renderSetupParagraphTight(os.Stdout, `In the browser: log in to Home Assistant if asked, then click "Add" to confirm the repository.`)
 			renderSetupIndentedBlock(os.Stdout, "Once the repository is added:", "    ",
 				"1. Go to Settings > Apps > App Store (on older Home Assistant: Settings > Add-ons)",
 				`2. Search for "NOVA Relay"`,
@@ -559,13 +585,26 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 					if err := copyToClipboardForSetup(token); err == nil {
 						renderSetupSuccessLine(os.Stdout, "Copied to clipboard.")
 					}
-					openBrowserShowingURL(os.Stdout, haRelayAppPageURL(cfg.HAURL))
-					renderSetupIndentedBlock(os.Stdout, "On the NOVA Relay page that just opened:", "    ",
+					renderSetupIndentedBlock(os.Stdout, "Next, on the NOVA Relay page:", "    ",
 						`1. Open the "Configuration" tab`,
 						`2. Paste the token into the "Relay Auth Token" field ("relay_auth_token")`,
 						"3. Click Save",
 					)
-					_, err := promptWizardLineFromReader(reader, os.Stdout, "Press Enter after you saved the Relay Auth Token in NOVA Relay", "")
+					renderSetupParagraphTight(os.Stdout, "This will open: "+haRelayAppPageURL(cfg.HAURL))
+					_, err := promptWizardLineFromReader(reader, os.Stdout, "Press Enter to open your browser", "")
+					if err == errSetupBack {
+						continue
+					}
+					if err == errSetupExit {
+						printHumanInfo("Setup cancelled")
+						return 0
+					}
+					if err != nil {
+						printHumanErr("%s", err)
+						return 1
+					}
+					openBrowserShowingURL(os.Stdout, haRelayAppPageURL(cfg.HAURL))
+					_, err = promptWizardLineFromReader(reader, os.Stdout, "Press Enter after you saved the Relay Auth Token in NOVA Relay", "")
 					if err == errSetupBack {
 						continue
 					}
@@ -618,7 +657,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			steps := buildSetupWizardSteps(!skipLLATWalkthrough && !verifyFirstReuseFlow)
 			renderSetupStep(os.Stdout, steps.Verify, steps.Total, "Verifying connection")
 			if verifyFirstReuseFlow {
-				renderSetupParagraphTight(os.Stdout, "Using saved Home Assistant address: "+cfg.HAURL)
+				renderSetupParagraphTight(os.Stdout, "Using Home Assistant address: "+cfg.HAURL)
 			}
 			issue, ok, err := verifySetupConnection(reader, os.Stdout, cfg, token, verifyFirstReuseFlow, relayTokenFlag == "")
 			if err == errSetupBack {

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -438,12 +438,13 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				renderSetupParagraphTight(os.Stdout, "Keeping your saved relay address: "+previousRelayURL)
 			}
 			switch {
-			case hostChangeRetry && verifyFirstReuseFlow && strings.TrimSpace(token) != "":
-				// Reuse/resume flow: the relay app and tokens are already in
-				// place; only the address was wrong, so return straight to
-				// verification. Fresh-flow host changes fall through instead —
-				// the new address may be a different instance that never got
-				// the repository/app/token steps. Save the corrected address
+			case hostChangeRetry && verifyFirstReuseFlow && hadSavedTokenBeforeSetup && strings.TrimSpace(token) != "":
+				// Resume with saved state: the relay app and tokens are known
+				// to be in place; only the address was wrong, so return
+				// straight to verification. Fresh-flow host changes — including
+				// pasted-token fresh runs — fall through instead: the new
+				// address may be a different instance that never got the
+				// repository/app/token steps. Save the corrected address
 				// now so it survives an exit before verification succeeds.
 				hostChangeRetry = false
 				if err := saveConfig(paths, cfg); err != nil {
@@ -455,11 +456,12 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				stage = setupStageToken
 			default:
 				if hostChangeRetry {
-					// A fresh-flow host change abandons the flag-driven
-					// shortcut: the corrected address may be a different
-					// instance that still needs the repository/app install
-					// and the access-token walkthrough.
+					// A fresh-flow host change abandons the flag-driven or
+					// pasted-token shortcut: the corrected address may be a
+					// different instance that still needs the repository/app
+					// install and the access-token walkthrough.
 					skipLLATWalkthrough = false
+					verifyFirstReuseFlow = false
 				}
 				hostChangeRetry = false
 				stage = setupStageRelayInstall
@@ -689,6 +691,15 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			if err == errSetupHostStep {
 				hostChangeRetry = true
 				stage = setupStageHost
+				continue
+			}
+			if err == errSetupInstallStep {
+				// The user asked for full guidance from the repair menu:
+				// repository/app install, token, and access-token walkthrough
+				// for the current address.
+				skipLLATWalkthrough = false
+				verifyFirstReuseFlow = false
+				stage = setupStageRelayInstall
 				continue
 			}
 			if err == errSetupExit {

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -434,11 +434,13 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				renderSetupParagraphTight(os.Stdout, "Keeping your saved relay address: "+previousRelayURL)
 			}
 			switch {
-			case hostChangeRetry && strings.TrimSpace(token) != "":
-				// The relay app and tokens are already in place; only the
-				// address was wrong, so return straight to verification.
-				// Save the corrected address now so it survives an exit
-				// before verification succeeds.
+			case hostChangeRetry && verifyFirstReuseFlow && strings.TrimSpace(token) != "":
+				// Reuse/resume flow: the relay app and tokens are already in
+				// place; only the address was wrong, so return straight to
+				// verification. Fresh-flow host changes fall through instead —
+				// the new address may be a different instance that never got
+				// the repository/app/token steps. Save the corrected address
+				// now so it survives an exit before verification succeeds.
 				hostChangeRetry = false
 				if err := saveConfig(paths, cfg); err != nil {
 					printHumanErr("cannot save config: %s", err)

--- a/cli/setup_interactive_test.go
+++ b/cli/setup_interactive_test.go
@@ -2374,3 +2374,31 @@ func TestInteractiveSetupFreshHostChangeRoutesBackThroughInstallStepsNotStraight
 		t.Fatalf("saved.HAURL = %q, want %q", saved.HAURL, goodHAServer.URL)
 	}
 }
+
+func TestInteractiveSetupFlagDrivenRunSkipsIntroEvenWithoutClientTarget(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	// `ha-nova setup --host ...` with no client target and no saved config:
+	// the run is flag-driven, so the first-run intro must not render even
+	// though the flag overrides are applied after the intro check.
+	stdout, stderr := captureInteractiveSetupIO(t, joinSetupInputs([]string{"exit"}), func() int {
+		return interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "192.168.1.5", "", "", "", false)
+	})
+
+	output := stdout + stderr
+	if strings.Contains(output, "connects your AI assistant") {
+		t.Fatalf("flag-driven run must skip the intro:\n%s", output)
+	}
+	if !strings.Contains(output, "Setup cancelled") {
+		t.Fatalf("expected clean exit path in output:\n%s", output)
+	}
+}

--- a/cli/setup_interactive_test.go
+++ b/cli/setup_interactive_test.go
@@ -2336,10 +2336,11 @@ func TestInteractiveSetupFreshHostChangeRoutesBackThroughInstallStepsNotStraight
 	// First verify fails against the dead HA address; picking "Change Home
 	// Assistant address" (2) must NOT jump straight back to verification —
 	// the new address may be a different instance, so the wizard re-runs the
-	// token/LLAT steps for it (Codex P2 on the fresh-flow shortcut).
+	// install/token/LLAT steps for it (Codex P2 on the fresh-flow shortcut).
 	input := joinSetupInputs(
 		setupWizardLLATPrompts(),
 		[]string{"2", goodHAServer.URL},
+		[]string{"", ""},
 		setupWizardLLATPrompts(),
 	)
 
@@ -2356,6 +2357,7 @@ func TestInteractiveSetupFreshHostChangeRoutesBackThroughInstallStepsNotStraight
 	for _, want := range []string{
 		"Change Home Assistant address",
 		"could not be used. Enter a new one.",
+		"Install NOVA Relay in Home Assistant",
 		"Setup complete!",
 	} {
 		if !strings.Contains(output, want) {
@@ -2400,5 +2402,77 @@ func TestInteractiveSetupFlagDrivenRunSkipsIntroEvenWithoutClientTarget(t *testi
 	}
 	if !strings.Contains(output, "Setup cancelled") {
 		t.Fatalf("expected clean exit path in output:\n%s", output)
+	}
+}
+
+func TestInteractiveSetupFlaggedFreshHostChangeReenablesInstallAndLLATSteps(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	// Both HA addresses are reachable, but neither has a relay at the derived
+	// <host>:8791, so verification fails with the connection repair menu.
+	wrongHAServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer wrongHAServer.Close()
+
+	goodHAServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer goodHAServer.Close()
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	// `ha-nova setup antigravity --host <wrong> --relay-token <tok>`:
+	// skipLLATWalkthrough starts true. When the user interactively corrects
+	// the address, the flag-driven shortcut is abandoned — the wizard must
+	// re-run the install steps AND the access-token walkthrough for the new
+	// address instead of bouncing token → verify forever (Codex P2 round 3).
+	input := joinSetupInputs(
+		[]string{"2", goodHAServer.URL},
+		[]string{"", ""},
+		setupWizardLLATPrompts(),
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "antigravity", wrongHAServer.URL, "", "", "flagged-token", false)
+		return exitCode
+	})
+	// The corrected address still has no relay app either, so the run ends at
+	// the incomplete banner — the point is the guidance it showed on the way.
+	if exitCode != 1 {
+		t.Fatalf("interactiveSetup() exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	for _, want := range []string{
+		"Change Home Assistant address",
+		"Install NOVA Relay in Home Assistant",
+		"Create a Home Assistant Access Token in Home Assistant.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+	if got := strings.Count(output, "Set up Relay Auth Token"); got < 2 {
+		t.Fatalf("flagged fresh host change must re-run the token step; token step shown %d time(s):\n%s", got, output)
+	}
+
+	saved, err := loadRuntimeConfig(paths)
+	if err != nil {
+		t.Fatalf("loadRuntimeConfig() error: %v", err)
+	}
+	if saved.HAURL != goodHAServer.URL {
+		t.Fatalf("saved.HAURL = %q, want %q", saved.HAURL, goodHAServer.URL)
 	}
 }

--- a/cli/setup_interactive_test.go
+++ b/cli/setup_interactive_test.go
@@ -1969,7 +1969,7 @@ func TestInteractiveSetupContinueAnywayPersistsExplicitURL(t *testing.T) {
 		setupWizardRelayInstallPrompts(),
 		setupWizardGenerateRelayTokenPrompts(),
 		setupWizardLLATPrompts(),
-		[]string{"3"},
+		[]string{"4"},
 	)
 
 	exitCode := 0
@@ -2474,5 +2474,149 @@ func TestInteractiveSetupFlaggedFreshHostChangeReenablesInstallAndLLATSteps(t *t
 	}
 	if saved.HAURL != goodHAServer.URL {
 		t.Fatalf("saved.HAURL = %q, want %q", saved.HAURL, goodHAServer.URL)
+	}
+}
+
+func TestInteractiveSetupPastedTokenFreshHostChangeRoutesThroughInstallSteps(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	deadHAServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	deadHAURL := deadHAServer.URL
+	deadHAServer.Close()
+
+	goodHAServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer goodHAServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	defer relayServer.Close()
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	cfg := runtimeConfig{
+		HAHost:       normalizeHostInput(deadHAURL),
+		HAURL:        deadHAURL,
+		RelayBaseURL: relayServer.URL,
+	}
+
+	// Fresh run, NO saved state: the user pastes an existing token ("1"),
+	// verification fails against the dead address, and "Change Home Assistant
+	// address" (2) must route through the install steps for the corrected
+	// address — a pasted token is not resume state (Codex P2 round 4).
+	input := joinSetupInputs(
+		[]string{"1", "pasted-relay-token"},
+		[]string{"2", goodHAServer.URL},
+		[]string{"", ""},
+		[]string{"1", "pasted-relay-token"},
+		setupWizardLLATPrompts(),
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "antigravity", "", "", "", "", false)
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	for _, want := range []string{
+		"Change Home Assistant address",
+		"Install NOVA Relay in Home Assistant",
+		"Setup complete!",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+
+	saved, err := loadRuntimeConfig(paths)
+	if err != nil {
+		t.Fatalf("loadRuntimeConfig() error: %v", err)
+	}
+	if saved.HAURL != goodHAServer.URL {
+		t.Fatalf("saved.HAURL = %q, want %q", saved.HAURL, goodHAServer.URL)
+	}
+}
+
+func TestInteractiveSetupConnectionRepairMenuOffersFullInstallSteps(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	goodHAServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer goodHAServer.Close()
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	// Resume state (saved token) whose relay never becomes reachable — e.g.
+	// the app was uninstalled from the instance. The connection repair menu
+	// must offer "Run the app install steps for this address" (3) as a
+	// structural escape into the full guidance instead of a retry dead end.
+	cfg := runtimeConfig{
+		HAHost:       normalizeHostInput(goodHAServer.URL),
+		HAURL:        goodHAServer.URL,
+		RelayBaseURL: "http://127.0.0.1:1",
+	}
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := writeRelayAuthToken("saved-relay-token"); err != nil {
+		t.Fatalf("writeRelayAuthToken() error: %v", err)
+	}
+
+	input := joinSetupInputs(
+		[]string{"3"},
+		[]string{"", ""},
+		[]string{"1"},
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "antigravity", "", "", "", "", false)
+		return exitCode
+	})
+	if exitCode != 1 {
+		t.Fatalf("interactiveSetup() exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	for _, want := range []string{
+		"Run the app install steps for this address",
+		"Install NOVA Relay in Home Assistant",
+		"Keep saved token",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
 	}
 }

--- a/cli/setup_interactive_test.go
+++ b/cli/setup_interactive_test.go
@@ -2290,3 +2290,87 @@ func repoRootForSetupTest(t *testing.T) string {
 	}
 	return wd
 }
+
+func TestInteractiveSetupFreshHostChangeRoutesBackThroughInstallStepsNotStraightToVerify(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	deadHAServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	deadHAURL := deadHAServer.URL
+	deadHAServer.Close()
+
+	goodHAServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer goodHAServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	defer relayServer.Close()
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	cfg := runtimeConfig{
+		HAHost:       normalizeHostInput(deadHAURL),
+		HAURL:        deadHAURL,
+		RelayBaseURL: relayServer.URL,
+	}
+
+	// Fresh run with a --relay-token flag: no saved state, no saved token.
+	// First verify fails against the dead HA address; picking "Change Home
+	// Assistant address" (2) must NOT jump straight back to verification —
+	// the new address may be a different instance, so the wizard re-runs the
+	// token/LLAT steps for it (Codex P2 on the fresh-flow shortcut).
+	input := joinSetupInputs(
+		setupWizardLLATPrompts(),
+		[]string{"2", goodHAServer.URL},
+		setupWizardLLATPrompts(),
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "antigravity", "", "", "", "fresh-flag-token", false)
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	for _, want := range []string{
+		"Change Home Assistant address",
+		"could not be used. Enter a new one.",
+		"Setup complete!",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+	if got := strings.Count(output, "Set up Relay Auth Token"); got < 2 {
+		t.Fatalf("fresh-flow host change must re-run the token step for the new address; token step shown %d time(s):\n%s", got, output)
+	}
+
+	saved, err := loadRuntimeConfig(paths)
+	if err != nil {
+		t.Fatalf("loadRuntimeConfig() error: %v", err)
+	}
+	if saved.HAURL != goodHAServer.URL {
+		t.Fatalf("saved.HAURL = %q, want %q", saved.HAURL, goodHAServer.URL)
+	}
+}

--- a/cli/setup_interactive_test.go
+++ b/cli/setup_interactive_test.go
@@ -86,7 +86,7 @@ func TestInteractiveSetupFreshInstallShowsWizardAndInstallsAntigravitySkills(t *
 		"4) Google Antigravity",
 		"5) Hermes Agent",
 		"Discovering Home Assistant on your network...",
-		"I'll open your browser to add the HA NOVA repository.",
+		"Next, add the HA NOVA app repository to your Home Assistant.",
 		"Once the repository is added:",
 		`Search for "NOVA Relay"`,
 		"NOVA needs two passwords",
@@ -105,13 +105,14 @@ func TestInteractiveSetupFreshInstallShowsWizardAndInstallsAntigravitySkills(t *
 			t.Fatalf("wizard output missing %q:\n%s", want, output)
 		}
 	}
-	if !strings.Contains(output, "Found Home Assistant candidate:") &&
+	if !strings.Contains(output, "Found Home Assistant at ") &&
+		!strings.Contains(output, "Found Home Assistant via the network name ") &&
 		!strings.Contains(output, "No confirmed Home Assistant found automatically; enter the Home Assistant address manually") &&
 		!strings.Contains(output, "No confirmed Home Assistant found automatically; using your saved address as a starting point:") {
 		t.Fatalf("wizard output missing discovery result:\n%s", output)
 	}
 	discoveryIdx := strings.Index(output, "Discovering Home Assistant on your network...")
-	hostPromptIdx := strings.Index(output, "Home Assistant address (IP, hostname, or URL)")
+	hostPromptIdx := strings.Index(output, "Home Assistant address")
 	stepOneIdx := setupStepIndex(output, 1)
 	if discoveryIdx == -1 || hostPromptIdx == -1 || stepOneIdx == -1 {
 		t.Fatalf("missing discovery ordering markers:\n%s", output)
@@ -630,7 +631,7 @@ func TestInteractiveSetupRecoversSecureStorageBeforeHostStep(t *testing.T) {
 	if !strings.Contains(output, "Set up local secure storage now") {
 		t.Fatalf("expected recovery action prompt:\n%s", output)
 	}
-	if !strings.Contains(output, "Home Assistant address (IP, hostname, or URL)") {
+	if !strings.Contains(output, "Home Assistant address") {
 		t.Fatalf("expected setup to continue to host prompt after recovery:\n%s", output)
 	}
 	if recoveryCalls != 1 {
@@ -910,6 +911,100 @@ func TestInteractiveSetupRelayTokenFlagCanBackToHostAfterVerifyFailure(t *testin
 	}
 }
 
+func TestInteractiveSetupResumeCanChangeHostFromRepairMenuWithoutTokenRePrompt(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	deadHAServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	deadHAURL := deadHAServer.URL
+	deadHAServer.Close()
+
+	goodHAServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer goodHAServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	defer relayServer.Close()
+
+	originalDetect := detectDefaultHAHostChoiceForSetup
+	t.Cleanup(func() { detectDefaultHAHostChoiceForSetup = originalDetect })
+	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
+		return "", "", false
+	}
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	cfg := runtimeConfig{
+		HAHost:       normalizeHostInput(deadHAURL),
+		HAURL:        deadHAURL,
+		RelayBaseURL: relayServer.URL,
+	}
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := writeRelayAuthToken("test-relay-token"); err != nil {
+		t.Fatalf("writeRelayAuthToken() error: %v", err)
+	}
+
+	input := joinSetupInputs(
+		[]string{"2", goodHAServer.URL},
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "antigravity", "", "", relayServer.URL, "", false)
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	for _, want := range []string{
+		"Using saved Home Assistant address: " + deadHAURL,
+		"Change Home Assistant address",
+		"Setup complete!",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+	for _, unwanted := range []string{
+		"Choose how to set up the Relay Auth Token",
+		"Create a Home Assistant Access Token in Home Assistant.",
+	} {
+		if strings.Contains(output, unwanted) {
+			t.Fatalf("host change must not re-run token steps; found %q:\n%s", unwanted, output)
+		}
+	}
+
+	saved, err := loadRuntimeConfig(paths)
+	if err != nil {
+		t.Fatalf("loadRuntimeConfig() error: %v", err)
+	}
+	if saved.HAURL != goodHAServer.URL {
+		t.Fatalf("saved.HAURL = %q, want %q", saved.HAURL, goodHAServer.URL)
+	}
+}
+
 func TestInteractiveSetupExitAtTokenChoiceCancelsCleanly(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -966,8 +1061,8 @@ func TestInteractiveSetupExitAtTokenChoiceCancelsCleanly(t *testing.T) {
 func TestInteractiveSetupInitialClientPageAllowsRepeatedBack(t *testing.T) {
 	originalDetect := detectDefaultHAHostChoiceForSetup
 	t.Cleanup(func() { detectDefaultHAHostChoiceForSetup = originalDetect })
-	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, bool) {
-		return "", false
+	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
+		return "", "", false
 	}
 
 	home := t.TempDir()

--- a/cli/setup_interactive_test.go
+++ b/cli/setup_interactive_test.go
@@ -970,7 +970,7 @@ func TestInteractiveSetupResumeCanChangeHostFromRepairMenuWithoutTokenRePrompt(t
 
 	exitCode := 0
 	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
-		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "antigravity", "", "", relayServer.URL, "", false)
+		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "antigravity", "", "", "", "", false)
 		return exitCode
 	})
 	if exitCode != 0 {
@@ -979,8 +979,10 @@ func TestInteractiveSetupResumeCanChangeHostFromRepairMenuWithoutTokenRePrompt(t
 
 	output := stdout + stderr
 	for _, want := range []string{
-		"Using saved Home Assistant address: " + deadHAURL,
+		"Using Home Assistant address: " + deadHAURL,
 		"Change Home Assistant address",
+		"could not be used. Enter a new one.",
+		"Keeping your saved relay address: " + relayServer.URL,
 		"Setup complete!",
 	} {
 		if !strings.Contains(output, want) {
@@ -990,9 +992,10 @@ func TestInteractiveSetupResumeCanChangeHostFromRepairMenuWithoutTokenRePrompt(t
 	for _, unwanted := range []string{
 		"Choose how to set up the Relay Auth Token",
 		"Create a Home Assistant Access Token in Home Assistant.",
+		"Discovering Home Assistant on your network",
 	} {
 		if strings.Contains(output, unwanted) {
-			t.Fatalf("host change must not re-run token steps; found %q:\n%s", unwanted, output)
+			t.Fatalf("host change must not re-run token/discovery steps; found %q:\n%s", unwanted, output)
 		}
 	}
 
@@ -1002,6 +1005,82 @@ func TestInteractiveSetupResumeCanChangeHostFromRepairMenuWithoutTokenRePrompt(t
 	}
 	if saved.HAURL != goodHAServer.URL {
 		t.Fatalf("saved.HAURL = %q, want %q", saved.HAURL, goodHAServer.URL)
+	}
+	if saved.RelayBaseURL != relayServer.URL {
+		t.Fatalf("saved.RelayBaseURL = %q, want custom relay URL %q preserved across the host change", saved.RelayBaseURL, relayServer.URL)
+	}
+}
+
+func TestInteractiveSetupHostChangePersistsNewHostEvenWhenUserExitsBeforeVerifySucceeds(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	deadHAServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	deadHAURL := deadHAServer.URL
+	deadHAServer.Close()
+
+	goodHAServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer goodHAServer.Close()
+
+	failingRelayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer failingRelayServer.Close()
+
+	originalDetect := detectDefaultHAHostChoiceForSetup
+	t.Cleanup(func() { detectDefaultHAHostChoiceForSetup = originalDetect })
+	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
+		return "", "", false
+	}
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	cfg := runtimeConfig{
+		HAHost:       normalizeHostInput(deadHAURL),
+		HAURL:        deadHAURL,
+		RelayBaseURL: failingRelayServer.URL,
+	}
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := writeRelayAuthToken("test-relay-token"); err != nil {
+		t.Fatalf("writeRelayAuthToken() error: %v", err)
+	}
+
+	input := joinSetupInputs(
+		[]string{"2", goodHAServer.URL, "exit"},
+	)
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, cfg, loadStateOrDefault(paths), "antigravity", "", "", "", "", false)
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+	if !strings.Contains(stdout+stderr, "Setup cancelled") {
+		t.Fatalf("expected cancellation message:\n%s", stdout+stderr)
+	}
+
+	saved, err := loadRuntimeConfig(paths)
+	if err != nil {
+		t.Fatalf("loadRuntimeConfig() error: %v", err)
+	}
+	if saved.HAURL != goodHAServer.URL {
+		t.Fatalf("saved.HAURL = %q, want corrected host %q persisted despite exit", saved.HAURL, goodHAServer.URL)
 	}
 }
 
@@ -1890,7 +1969,7 @@ func TestInteractiveSetupContinueAnywayPersistsExplicitURL(t *testing.T) {
 		setupWizardRelayInstallPrompts(),
 		setupWizardGenerateRelayTokenPrompts(),
 		setupWizardLLATPrompts(),
-		[]string{"n"},
+		[]string{"3"},
 	)
 
 	exitCode := 0
@@ -1906,8 +1985,13 @@ func TestInteractiveSetupContinueAnywayPersistsExplicitURL(t *testing.T) {
 	if !strings.Contains(output, "Continue anyway (connection will be verified later)?") {
 		t.Fatalf("expected continue-anyway path in output:\n%s", output)
 	}
-	if !strings.Contains(output, "Retry connection check?") {
-		t.Fatalf("expected relay-unreachable retry prompt in output:\n%s", output)
+	for _, want := range []string{
+		"Change Home Assistant address",
+		"Stop for now (progress is saved)",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected connection repair menu with %q in output:\n%s", want, output)
+		}
 	}
 	if strings.Contains(output, "Retry WebSocket check?") {
 		t.Fatalf("did not expect WebSocket retry prompt for relay-unreachable path:\n%s", output)

--- a/cli/setup_interactive_test_helpers_test.go
+++ b/cli/setup_interactive_test_helpers_test.go
@@ -29,6 +29,7 @@ func setupWizardGenerateRelayTokenPrompts() []string {
 	return []string{
 		"",
 		"",
+		"",
 	}
 }
 

--- a/cli/setup_intro.go
+++ b/cli/setup_intro.go
@@ -1,0 +1,24 @@
+package main
+
+import "io"
+
+// renderSetupIntro explains what HA NOVA is and how the wizard behaves before
+// the first prompt. Shown only on fully interactive runs (no target/flags);
+// power users driving setup with arguments skip it.
+func renderSetupIntro(out io.Writer) {
+	renderSetupParagraph(out,
+		"Welcome! HA NOVA connects your AI assistant (like Claude Code) to Home Assistant,",
+		"so you can control your smart home and manage automations by simply asking.",
+	)
+	renderSetupIndentedBlock(out, "This setup walks you through:", "    ",
+		"1. Finding your Home Assistant on the network",
+		"2. Installing the NOVA Relay app in Home Assistant",
+		"3. Setting up two access tokens (guided, step by step)",
+		"4. Verifying the connection and installing the skills",
+	)
+	renderSetupParagraphTight(out,
+		"How it works: at several points you'll be asked to press Enter — that opens a",
+		"page in your web browser. Do the step there, then come back to this window.",
+	)
+	renderSetupParagraph(out, "You'll need: Home Assistant running on your network, and an admin login for it.")
+}

--- a/cli/setup_intro.go
+++ b/cli/setup_intro.go
@@ -3,18 +3,20 @@ package main
 import "io"
 
 // renderSetupIntro explains what HA NOVA is and how the wizard behaves before
-// the first prompt. Shown only on fully interactive runs (no target/flags);
-// power users driving setup with arguments skip it.
+// the first prompt. Shown only on fully interactive first-time runs (no
+// target/flags, no saved Home Assistant address); resumes and flag-driven
+// runs skip it.
 func renderSetupIntro(out io.Writer) {
 	renderSetupParagraph(out,
 		"Welcome! HA NOVA connects your AI assistant (like Claude Code) to Home Assistant,",
 		"so you can control your smart home and manage automations by simply asking.",
 	)
-	renderSetupIndentedBlock(out, "This setup walks you through:", "    ",
-		"1. Finding your Home Assistant on the network",
-		"2. Installing the NOVA Relay app in Home Assistant",
-		"3. Setting up two access tokens (guided, step by step)",
-		"4. Verifying the connection and installing the skills",
+	renderSetupIndentedBlock(out, "This setup will:", "    ",
+		"- ask which AI client you use",
+		"- find your Home Assistant on the network",
+		"- install the NOVA Relay app in Home Assistant",
+		"- set up two access tokens (guided, step by step)",
+		`- verify the connection and teach your AI assistant the Home Assistant commands (the "skills")`,
 	)
 	renderSetupParagraphTight(out,
 		"How it works: at several points you'll be asked to press Enter — that opens a",

--- a/cli/setup_intro_test.go
+++ b/cli/setup_intro_test.go
@@ -12,7 +12,8 @@ func TestRenderSetupIntroExplainsProjectAndBrowserBehavior(t *testing.T) {
 	rendered := output.String()
 	for _, want := range []string{
 		"connects your AI assistant",
-		"This setup walks you through:",
+		"This setup will:",
+		`the "skills"`,
 		"press Enter — that opens a",
 		"come back to this window",
 		"You'll need:",

--- a/cli/setup_intro_test.go
+++ b/cli/setup_intro_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderSetupIntroExplainsProjectAndBrowserBehavior(t *testing.T) {
+	output := &strings.Builder{}
+	renderSetupIntro(output)
+
+	rendered := output.String()
+	for _, want := range []string{
+		"connects your AI assistant",
+		"This setup walks you through:",
+		"press Enter — that opens a",
+		"come back to this window",
+		"You'll need:",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("intro missing %q:\n%s", want, rendered)
+		}
+	}
+}

--- a/cli/setup_llat.go
+++ b/cli/setup_llat.go
@@ -29,25 +29,24 @@ func runSetupLLATWalkthrough(reader *bufio.Reader, out io.Writer, cfg runtimeCon
 		)
 	}
 
+	renderSetupParagraphTight(out, "This will open: "+haProfileSecurityURL(cfg.HAURL))
 	if _, err := promptWizardLineFromReader(reader, out, "Press Enter to open your HA profile", ""); err != nil {
 		return err
 	}
-	if err := openBrowserForSetup(cfg.HAURL + "/profile/security"); err != nil {
-		printHumanWarn("Browser launch skipped; open this URL manually if needed: %s/profile/security", cfg.HAURL)
-	}
+	openBrowserShowingURL(out, haProfileSecurityURL(cfg.HAURL))
 
 	renderSetupParagraph(out, "Got it? Now I'll open the NOVA Relay settings so you can paste it.")
+	renderSetupParagraphTight(out, "This will open: "+haRelayAppPageURL(cfg.HAURL))
 	if _, err := promptWizardLineFromReader(reader, out, "Press Enter to open the relay settings", ""); err != nil {
 		return err
 	}
-	if err := openBrowserForSetup(cfg.HAURL + "/hassio/addon/2368fcfa_ha_nova_relay/config"); err != nil {
-		printHumanWarn("Browser launch skipped; open this URL manually if needed: %s/hassio/addon/2368fcfa_ha_nova_relay/config", cfg.HAURL)
-	}
+	openBrowserShowingURL(out, haRelayAppPageURL(cfg.HAURL))
 
 	renderSetupIndentedBlock(out, "Finish the relay configuration:", "    ",
-		`5. Paste the token into the "Home Assistant Access Token" field ("ha_llat")`,
-		"6. Click Save",
-		"7. Click Start (or Restart if already running)",
+		`5. Open the "Configuration" tab`,
+		`6. Paste the token into the "Home Assistant Access Token" field ("ha_llat")`,
+		"7. Click Save",
+		"8. Click Start (or Restart if already running)",
 	)
 
 	_, err := promptWizardLineFromReader(reader, out, "Press Enter when the app is running", "")

--- a/cli/setup_repair.go
+++ b/cli/setup_repair.go
@@ -25,6 +25,7 @@ const (
 	setupRepairActionBack              setupRepairAction = "back"
 	setupRepairActionBackToRelayToken  setupRepairAction = "relay_token"
 	setupRepairActionChangeHost        setupRepairAction = "change_host"
+	setupRepairActionStop              setupRepairAction = "stop"
 )
 
 type setupRepairChoice struct {
@@ -61,7 +62,7 @@ func relayHealthIssueLooksLikeRelayAuth(err error) bool {
 func runSetupRepairFlow(reader *bufio.Reader, out io.Writer, cfg runtimeConfig, readiness relayReadiness, issue string, allowRelayTokenStep bool) (setupRepairAction, error) {
 	mode := detectSetupRepairMode(readiness, issue)
 	for {
-		renderSetupRepairPage(out, mode)
+		renderSetupRepairPage(out, mode, cfg.HAHost)
 		action, err := promptSetupRepairActionInteractive(reader, out, mode, allowRelayTokenStep)
 		if err != nil {
 			return "", err
@@ -72,22 +73,28 @@ func runSetupRepairFlow(reader *bufio.Reader, out io.Writer, cfg runtimeConfig, 
 			openBrowserShowingURL(out, haProfileSecurityURL(cfg.HAURL))
 		case setupRepairActionOpenRelaySettings:
 			openBrowserShowingURL(out, haRelayAppPageURL(cfg.HAURL))
-		case setupRepairActionRetry, setupRepairActionBack, setupRepairActionBackToRelayToken, setupRepairActionChangeHost:
+			renderSetupParagraphTight(out, `The tokens live on the "Configuration" tab of that page.`)
+		case setupRepairActionRetry, setupRepairActionBack, setupRepairActionBackToRelayToken, setupRepairActionChangeHost, setupRepairActionStop:
 			return action, nil
 		}
 	}
 }
 
-func renderSetupRepairPage(out io.Writer, mode setupRepairMode) {
+func renderSetupRepairPage(out io.Writer, mode setupRepairMode, haHost string) {
 	renderSetupSectionTitle(out, "Repair this connection step")
 	switch mode {
 	case setupRepairModeConnection:
-		renderSetupParagraph(out,
+		lines := []string{
 			"Home Assistant or NOVA Relay is still unreachable from this device.",
 			"Fix the local connection first, then retry this step.",
-			`Tip: names like "homeassistant.local" can stop working (especially on Windows).`,
-			"Try the IP address instead — find it in your router, or in HA under Settings > System > Network.",
-		)
+		}
+		if strings.HasSuffix(strings.ToLower(strings.TrimSpace(haHost)), ".local") {
+			lines = append(lines,
+				`Tip: names like "homeassistant.local" can stop working (especially on Windows).`,
+				"Try the IP address instead — find it in your router, or in Home Assistant under Settings > System > Network.",
+			)
+		}
+		renderSetupParagraph(out, lines...)
 	case setupRepairModeLLAT:
 		renderSetupParagraph(out,
 			"This device's Relay Auth Token worked.",
@@ -147,7 +154,8 @@ func setupRepairChoices(mode setupRepairMode, allowRelayTokenStep bool) ([]setup
 		return []setupRepairChoice{
 			{Number: "1", Value: setupRepairActionRetry, Label: "Retry now"},
 			{Number: "2", Value: setupRepairActionChangeHost, Label: "Change Home Assistant address"},
-			{Number: "3", Value: setupRepairActionBack, Label: "Back"},
+			{Number: "3", Value: setupRepairActionStop, Label: "Stop for now (progress is saved)"},
+			{Number: "4", Value: setupRepairActionBack, Label: "Back"},
 		}, "1"
 	case setupRepairModeLLAT:
 		return []setupRepairChoice{

--- a/cli/setup_repair.go
+++ b/cli/setup_repair.go
@@ -24,6 +24,7 @@ const (
 	setupRepairActionRetry             setupRepairAction = "retry"
 	setupRepairActionBack              setupRepairAction = "back"
 	setupRepairActionBackToRelayToken  setupRepairAction = "relay_token"
+	setupRepairActionChangeHost        setupRepairAction = "change_host"
 )
 
 type setupRepairChoice struct {
@@ -68,14 +69,10 @@ func runSetupRepairFlow(reader *bufio.Reader, out io.Writer, cfg runtimeConfig, 
 
 		switch action {
 		case setupRepairActionOpenSecurity:
-			if err := openBrowserForSetup(cfg.HAURL + "/profile/security"); err != nil {
-				printHumanWarn("Browser launch skipped; open this URL manually if needed: %s/profile/security", cfg.HAURL)
-			}
+			openBrowserShowingURL(out, haProfileSecurityURL(cfg.HAURL))
 		case setupRepairActionOpenRelaySettings:
-			if err := openBrowserForSetup(cfg.HAURL + "/hassio/addon/2368fcfa_ha_nova_relay/config"); err != nil {
-				printHumanWarn("Browser launch skipped; open this URL manually if needed: %s/hassio/addon/2368fcfa_ha_nova_relay/config", cfg.HAURL)
-			}
-		case setupRepairActionRetry, setupRepairActionBack, setupRepairActionBackToRelayToken:
+			openBrowserShowingURL(out, haRelayAppPageURL(cfg.HAURL))
+		case setupRepairActionRetry, setupRepairActionBack, setupRepairActionBackToRelayToken, setupRepairActionChangeHost:
 			return action, nil
 		}
 	}
@@ -88,6 +85,8 @@ func renderSetupRepairPage(out io.Writer, mode setupRepairMode) {
 		renderSetupParagraph(out,
 			"Home Assistant or NOVA Relay is still unreachable from this device.",
 			"Fix the local connection first, then retry this step.",
+			`Tip: names like "homeassistant.local" can stop working (especially on Windows).`,
+			"Try the IP address instead — find it in your router, or in HA under Settings > System > Network.",
 		)
 	case setupRepairModeLLAT:
 		renderSetupParagraph(out,
@@ -147,7 +146,8 @@ func setupRepairChoices(mode setupRepairMode, allowRelayTokenStep bool) ([]setup
 	case setupRepairModeConnection:
 		return []setupRepairChoice{
 			{Number: "1", Value: setupRepairActionRetry, Label: "Retry now"},
-			{Number: "2", Value: setupRepairActionBack, Label: "Back"},
+			{Number: "2", Value: setupRepairActionChangeHost, Label: "Change Home Assistant address"},
+			{Number: "3", Value: setupRepairActionBack, Label: "Back"},
 		}, "1"
 	case setupRepairModeLLAT:
 		return []setupRepairChoice{

--- a/cli/setup_repair.go
+++ b/cli/setup_repair.go
@@ -25,6 +25,7 @@ const (
 	setupRepairActionBack              setupRepairAction = "back"
 	setupRepairActionBackToRelayToken  setupRepairAction = "relay_token"
 	setupRepairActionChangeHost        setupRepairAction = "change_host"
+	setupRepairActionRunInstall        setupRepairAction = "run_install"
 	setupRepairActionStop              setupRepairAction = "stop"
 )
 
@@ -74,7 +75,7 @@ func runSetupRepairFlow(reader *bufio.Reader, out io.Writer, cfg runtimeConfig, 
 		case setupRepairActionOpenRelaySettings:
 			openBrowserShowingURL(out, haRelayAppPageURL(cfg.HAURL))
 			renderSetupParagraphTight(out, `The tokens live on the "Configuration" tab of that page.`)
-		case setupRepairActionRetry, setupRepairActionBack, setupRepairActionBackToRelayToken, setupRepairActionChangeHost, setupRepairActionStop:
+		case setupRepairActionRetry, setupRepairActionBack, setupRepairActionBackToRelayToken, setupRepairActionChangeHost, setupRepairActionRunInstall, setupRepairActionStop:
 			return action, nil
 		}
 	}
@@ -154,8 +155,9 @@ func setupRepairChoices(mode setupRepairMode, allowRelayTokenStep bool) ([]setup
 		return []setupRepairChoice{
 			{Number: "1", Value: setupRepairActionRetry, Label: "Retry now"},
 			{Number: "2", Value: setupRepairActionChangeHost, Label: "Change Home Assistant address"},
-			{Number: "3", Value: setupRepairActionStop, Label: "Stop for now (progress is saved)"},
-			{Number: "4", Value: setupRepairActionBack, Label: "Back"},
+			{Number: "3", Value: setupRepairActionRunInstall, Label: "Run the app install steps for this address"},
+			{Number: "4", Value: setupRepairActionStop, Label: "Stop for now (progress is saved)"},
+			{Number: "5", Value: setupRepairActionBack, Label: "Back"},
 		}, "1"
 	case setupRepairModeLLAT:
 		return []setupRepairChoice{

--- a/cli/setup_secure_storage_recovery_test.go
+++ b/cli/setup_secure_storage_recovery_test.go
@@ -445,7 +445,7 @@ func TestInteractiveSetupRecoversWhenSavedTokenReadNeedsRecovery(t *testing.T) {
 
 	output := stdout + stderr
 	recoveryIdx := strings.Index(output, "Local secure storage is locked")
-	hostIdx := strings.Index(output, "Home Assistant address (IP, hostname, or URL)")
+	hostIdx := strings.Index(output, "Home Assistant address")
 	if recoveryIdx == -1 || hostIdx == -1 || recoveryIdx > hostIdx {
 		t.Fatalf("expected saved-token recovery before host prompt:\n%s", output)
 	}

--- a/cli/setup_ui.go
+++ b/cli/setup_ui.go
@@ -221,15 +221,18 @@ func renderSetupIncompleteBanner(out io.Writer, issue string) {
 	switch issue {
 	case setupIssueWSDegraded:
 		fmt.Fprintln(out, "  NOVA Relay is reachable, but Home Assistant WebSocket is not connected yet.")
-		fmt.Fprintln(out, "  Open Home Assistant > Settings > Apps > NOVA Relay, verify the app settings, and restart the App.")
+		fmt.Fprintln(out, "  Open Home Assistant > Settings > Apps > NOVA Relay (older Home Assistant: Settings > Add-ons), verify the app settings, and restart the App.")
 	case setupIssueRelayUnreachable:
 		fmt.Fprintln(out, "  HA NOVA saved your local setup, but the relay could not be verified yet.")
-		fmt.Fprintln(out, "  Open Home Assistant > Settings > Apps > NOVA Relay, start the app, then try again.")
+		fmt.Fprintln(out, "  Open Home Assistant > Settings > Apps > NOVA Relay (older Home Assistant: Settings > Add-ons) and start the app.")
 	case setupIssueSkillsInstall:
 		fmt.Fprintln(out, "  The Home Assistant connection is configured, but local skill installation still needs another run.")
 		fmt.Fprintln(out, "  Re-run setup or install the HA NOVA skills again for your client.")
 	default:
 		fmt.Fprintln(out, "  HA NOVA saved your local setup, but the system is not fully ready yet.")
+	}
+	if issue != setupIssueSkillsInstall {
+		fmt.Fprintln(out, `  Then run "ha-nova setup" again — it continues where you left off.`)
 	}
 	fmt.Fprintln(out)
 }

--- a/cli/setup_ui.go
+++ b/cli/setup_ui.go
@@ -167,10 +167,17 @@ func renderSetupStatusSummary(out io.Writer, state setupState) {
 	fmt.Fprintln(out)
 }
 
-func renderSetupDiscoveryResult(out io.Writer, host string, discovered bool) {
+func renderSetupDiscoveryResult(out io.Writer, host, via string, discovered bool) {
 	session := resolveSetupUISession(out)
-	if discovered {
-		fmt.Fprintf(out, "  %s Found Home Assistant candidate: %s\n", session.style("success", session.successMarker()), host)
+	if discovered && via != "" {
+		fmt.Fprintf(out, "  %s Found Home Assistant at %s (discovered via %s)\n", session.style("success", session.successMarker()), host, via)
+	} else if discovered && strings.HasSuffix(strings.ToLower(host), ".local") {
+		fmt.Fprintf(out, "  %s Found Home Assistant via the network name %s\n", session.style("warning", session.warningMarker()), host)
+		fmt.Fprintln(out, "    Heads-up: this name can stop working (especially on Windows).")
+		fmt.Fprintln(out, "    If you know the IP address, enter it below instead — you can find it in your")
+		fmt.Fprintln(out, "    router, or in Home Assistant under Settings > System > Network.")
+	} else if discovered {
+		fmt.Fprintf(out, "  %s Found Home Assistant at %s\n", session.style("success", session.successMarker()), host)
 	} else if strings.TrimSpace(host) != "" {
 		fmt.Fprintf(out, "  %s No confirmed Home Assistant found automatically; using your saved address as a starting point: %s\n", session.style("warning", session.warningMarker()), host)
 	} else {

--- a/cli/setup_urls.go
+++ b/cli/setup_urls.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+)
+
+const haNovaRelayAppSlug = "2368fcfa_ha_nova_relay"
+const haNovaRepositoryURL = "https://github.com/markusleben/ha-nova"
+
+// haRelayAppPageURL links to the NOVA Relay app page through the instance's
+// own my-redirect endpoint so every Home Assistant version resolves its own
+// panel path (older HA: /hassio/addon/<slug>/info, HA >= 2026.2 after the
+// add-on -> app rename: /config/app/<slug>/info). Never hardcode either
+// panel path here: the installed HA version is unknown at setup time.
+func haRelayAppPageURL(haURL string) string {
+	return haURL + "/_my_redirect/supervisor_addon?addon=" + haNovaRelayAppSlug
+}
+
+func haAddRepositoryURL(haURL string) string {
+	return haURL + "/_my_redirect/supervisor_add_addon_repository?repository_url=" + url.QueryEscape(haNovaRepositoryURL)
+}
+
+func haProfileSecurityURL(haURL string) string {
+	return haURL + "/profile/security"
+}
+
+func openBrowserShowingURL(out io.Writer, target string) {
+	fmt.Fprintf(out, "  Opening in your browser: %s\n", target)
+	if err := openBrowserForSetup(target); err != nil {
+		printHumanWarn("Could not open the browser automatically. Please open the link above yourself.")
+	}
+}

--- a/cli/setup_urls_test.go
+++ b/cli/setup_urls_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSetupDeeplinksUseInstanceLocalMyRedirect(t *testing.T) {
+	haURL := "http://192.168.1.5:8123"
+
+	appPage := haRelayAppPageURL(haURL)
+	if appPage != "http://192.168.1.5:8123/_my_redirect/supervisor_addon?addon=2368fcfa_ha_nova_relay" {
+		t.Fatalf("haRelayAppPageURL() = %q", appPage)
+	}
+
+	repo := haAddRepositoryURL(haURL)
+	if repo != "http://192.168.1.5:8123/_my_redirect/supervisor_add_addon_repository?repository_url=https%3A%2F%2Fgithub.com%2Fmarkusleben%2Fha-nova" {
+		t.Fatalf("haAddRepositoryURL() = %q", repo)
+	}
+
+	if got := haProfileSecurityURL(haURL); got != "http://192.168.1.5:8123/profile/security" {
+		t.Fatalf("haProfileSecurityURL() = %q", got)
+	}
+}
+
+func TestOpenBrowserShowingURLPrintsTargetBeforeOpening(t *testing.T) {
+	originalBrowser := openBrowserForSetup
+	t.Cleanup(func() { openBrowserForSetup = originalBrowser })
+	opened := ""
+	openBrowserForSetup = func(url string) error {
+		opened = url
+		return nil
+	}
+
+	output := &strings.Builder{}
+	openBrowserShowingURL(output, "http://ha.example:8123/profile/security")
+
+	if opened != "http://ha.example:8123/profile/security" {
+		t.Fatalf("opened = %q", opened)
+	}
+	if !strings.Contains(output.String(), "Opening in your browser: http://ha.example:8123/profile/security") {
+		t.Fatalf("missing URL line:\n%s", output.String())
+	}
+}

--- a/cli/setup_verify.go
+++ b/cli/setup_verify.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -20,6 +21,13 @@ func verifySetupConnection(reader *bufio.Reader, out io.Writer, cfg runtimeConfi
 		if reuseToken || issue == setupIssueRelayUnreachable {
 			action, repairErr := runSetupRepairFlow(reader, out, cfg, readiness, issue, allowRelayTokenStep)
 			if repairErr != nil {
+				if errors.Is(repairErr, io.EOF) || errors.Is(repairErr, io.ErrUnexpectedEOF) {
+					// Input ended at the repair prompt (piped/aborted stdin).
+					// Behave like "Stop for now": the caller persists progress
+					// and shows the incomplete banner instead of a hard error
+					// that would skip saving tokens/config gathered so far.
+					return issue, false, nil
+				}
 				return "", false, repairErr
 			}
 			switch action {

--- a/cli/setup_verify.go
+++ b/cli/setup_verify.go
@@ -24,6 +24,8 @@ func verifySetupConnection(reader *bufio.Reader, out io.Writer, cfg runtimeConfi
 				continue
 			case setupRepairActionBackToRelayToken:
 				return issue, false, errSetupRelayTokenStep
+			case setupRepairActionChangeHost:
+				return issue, false, errSetupHostStep
 			case setupRepairActionBack:
 				return issue, false, errSetupBack
 			default:

--- a/cli/setup_verify.go
+++ b/cli/setup_verify.go
@@ -37,6 +37,8 @@ func verifySetupConnection(reader *bufio.Reader, out io.Writer, cfg runtimeConfi
 				return issue, false, errSetupRelayTokenStep
 			case setupRepairActionChangeHost:
 				return issue, false, errSetupHostStep
+			case setupRepairActionRunInstall:
+				return issue, false, errSetupInstallStep
 			case setupRepairActionStop:
 				return issue, false, nil
 			case setupRepairActionBack:

--- a/cli/setup_verify.go
+++ b/cli/setup_verify.go
@@ -14,7 +14,10 @@ func verifySetupConnection(reader *bufio.Reader, out io.Writer, cfg runtimeConfi
 			return "", true, nil
 		}
 		lastIssue = issue
-		if reuseToken {
+		// Connection-level failures get the repair menu on first runs too, so
+		// a wrong/stale Home Assistant address is recoverable right where it
+		// fails instead of only via multi-step back navigation.
+		if reuseToken || issue == setupIssueRelayUnreachable {
 			action, repairErr := runSetupRepairFlow(reader, out, cfg, readiness, issue, allowRelayTokenStep)
 			if repairErr != nil {
 				return "", false, repairErr
@@ -26,6 +29,8 @@ func verifySetupConnection(reader *bufio.Reader, out io.Writer, cfg runtimeConfi
 				return issue, false, errSetupRelayTokenStep
 			case setupRepairActionChangeHost:
 				return issue, false, errSetupHostStep
+			case setupRepairActionStop:
+				return issue, false, nil
 			case setupRepairActionBack:
 				return issue, false, errSetupBack
 			default:

--- a/cli/setup_verify_test.go
+++ b/cli/setup_verify_test.go
@@ -253,3 +253,44 @@ func TestVerifySetupConnectionReuseTokenAmbiguousIssueUsesFallbackRepairPage(t *
 		}
 	}
 }
+
+func TestVerifySetupConnectionRepairPromptInputEndStopsWithProgressSaved(t *testing.T) {
+	originalProbeHTTP := probeHTTPForSetup
+	originalFetchRelayHealth := fetchRelayHealthForSetup
+	originalProbeRelayWSPing := probeRelayWSPingForSetup
+	defer func() {
+		probeHTTPForSetup = originalProbeHTTP
+		fetchRelayHealthForSetup = originalFetchRelayHealth
+		probeRelayWSPingForSetup = originalProbeRelayWSPing
+	}()
+
+	probeHTTPForSetup = func(string) error { return errors.New("no such host") }
+	fetchRelayHealthForSetup = func(string, string) ([]byte, error) {
+		return nil, errors.New("unreachable")
+	}
+	probeRelayWSPingForSetup = func(string, string) (relayWSPingResponse, error) {
+		return relayWSPingResponse{}, nil
+	}
+
+	output := &bytes.Buffer{}
+	// Fresh run (reuseToken=false): "n" is not a valid repair choice, the
+	// re-prompt then hits end of input. That must behave like "Stop for now"
+	// (issue reported, no error) so the caller persists tokens/config instead
+	// of exiting through the hard-error path without saving.
+	issue, ok, err := verifySetupConnection(bufio.NewReader(strings.NewReader("n\n")), output, runtimeConfig{
+		HAURL:        "http://ha",
+		RelayBaseURL: "http://relay",
+	}, "token", false, true)
+	if err != nil {
+		t.Fatalf("expected stop-for-now (nil error) on input end, got %v", err)
+	}
+	if ok {
+		t.Fatal("did not expect ready state")
+	}
+	if issue != setupIssueRelayUnreachable {
+		t.Fatalf("expected relay unreachable issue, got %q", issue)
+	}
+	if !strings.Contains(output.String(), "Invalid choice.") {
+		t.Fatalf("expected invalid-choice re-prompt before input end:\n%s", output.String())
+	}
+}

--- a/cli/setup_verify_test.go
+++ b/cli/setup_verify_test.go
@@ -127,6 +127,48 @@ func TestVerifySetupConnectionReuseTokenRelayAuthIssueCanRouteBackToTokenStep(t 
 	}
 }
 
+func TestVerifySetupConnectionReuseTokenConnectionIssueCanRouteToHostStep(t *testing.T) {
+	originalProbeHTTP := probeHTTPForSetup
+	originalFetchRelayHealth := fetchRelayHealthForSetup
+	originalProbeRelayWSPing := probeRelayWSPingForSetup
+	defer func() {
+		probeHTTPForSetup = originalProbeHTTP
+		fetchRelayHealthForSetup = originalFetchRelayHealth
+		probeRelayWSPingForSetup = originalProbeRelayWSPing
+	}()
+
+	probeHTTPForSetup = func(string) error { return errors.New("no such host") }
+	fetchRelayHealthForSetup = func(string, string) ([]byte, error) {
+		return nil, errors.New("unreachable")
+	}
+	probeRelayWSPingForSetup = func(string, string) (relayWSPingResponse, error) {
+		return relayWSPingResponse{}, nil
+	}
+
+	output := &bytes.Buffer{}
+	issue, ok, err := verifySetupConnection(bufio.NewReader(strings.NewReader("2\n")), output, runtimeConfig{
+		HAURL:        "http://homeassistant.local:8123",
+		RelayBaseURL: "http://homeassistant.local:8791",
+	}, "token", true, true)
+	if err != errSetupHostStep {
+		t.Fatalf("expected errSetupHostStep, got %v", err)
+	}
+	if ok {
+		t.Fatal("did not expect ready state")
+	}
+	if issue != setupIssueRelayUnreachable {
+		t.Fatalf("expected relay unreachable issue, got %q", issue)
+	}
+	for _, want := range []string{
+		"Change Home Assistant address",
+		`names like "homeassistant.local" can stop working`,
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("expected %q in output:\n%s", want, output.String())
+		}
+	}
+}
+
 func TestVerifySetupConnectionReuseTokenRelayUnreachableKeepsRepairCopyTruthful(t *testing.T) {
 	originalProbeHTTP := probeHTTPForSetup
 	originalFetchRelayHealth := fetchRelayHealthForSetup

--- a/cli/setup_verify_test.go
+++ b/cli/setup_verify_test.go
@@ -147,6 +147,7 @@ func TestVerifySetupConnectionReuseTokenConnectionIssueCanRouteToHostStep(t *tes
 
 	output := &bytes.Buffer{}
 	issue, ok, err := verifySetupConnection(bufio.NewReader(strings.NewReader("2\n")), output, runtimeConfig{
+		HAHost:       "homeassistant.local",
 		HAURL:        "http://homeassistant.local:8123",
 		RelayBaseURL: "http://homeassistant.local:8791",
 	}, "token", true, true)

--- a/cli/setup_wizard_navigation.go
+++ b/cli/setup_wizard_navigation.go
@@ -11,6 +11,7 @@ import (
 var errSetupBack = errors.New("setup back")
 var errSetupExit = errors.New("setup exit")
 var errSetupRelayTokenStep = errors.New("setup relay token step")
+var errSetupHostStep = errors.New("setup host step")
 
 func promptWizardLineFromReader(reader *bufio.Reader, out io.Writer, label, defaultValue string) (string, error) {
 	fmt.Fprintln(out)

--- a/cli/setup_wizard_navigation.go
+++ b/cli/setup_wizard_navigation.go
@@ -12,6 +12,7 @@ var errSetupBack = errors.New("setup back")
 var errSetupExit = errors.New("setup exit")
 var errSetupRelayTokenStep = errors.New("setup relay token step")
 var errSetupHostStep = errors.New("setup host step")
+var errSetupInstallStep = errors.New("setup relay install step")
 
 func promptWizardLineFromReader(reader *bufio.Reader, out io.Writer, label, defaultValue string) (string, error) {
 	fmt.Fprintln(out)

--- a/cli/uninstall_preflight.go
+++ b/cli/uninstall_preflight.go
@@ -106,7 +106,7 @@ func preflightNoteLines(preflight uninstallPreflight) []string {
 	}
 	notes := []string{
 		"Note: The NOVA Relay app is still running in Home Assistant.",
-		"To remove it: Settings > Apps > NOVA Relay > Uninstall",
+		"To remove it: Settings > Apps > NOVA Relay > Uninstall (older Home Assistant: Settings > Add-ons)",
 	}
 	if preflight.tokenUnavailable != "" {
 		notes = append(notes, preflight.tokenUnavailable)

--- a/nova/DOCS.md
+++ b/nova/DOCS.md
@@ -20,6 +20,11 @@ in the relay.
 | **Relay Auth Token** | Shared secret between your AI client and this relay. Generated automatically during setup. The relay and your AI client must use the exact same value. |
 | **Home Assistant Access Token** | A Long-Lived Access Token from your HA profile. Create one at: **Profile > Security > Long-Lived Access Tokens**. |
 
+> **Where is this page?** Home Assistant 2026.2 renamed Add-ons to Apps: this
+> page moved from `/hassio/addon/<slug>/info` to `/config/app/<slug>/info`
+> (Settings > Apps > NOVA Relay). The setup wizard links through HA's own
+> `/_my_redirect/` endpoint, so its links work on both old and new versions.
+
 ### Network
 
 | Port | Description |

--- a/skills/ha-nova/update-guide.md
+++ b/skills/ha-nova/update-guide.md
@@ -37,7 +37,7 @@ On Windows, the HA NOVA core path is verified; individual client coverage still 
 
 ## Relay (Home Assistant App)
 
-HA Settings > Apps > NOVA Relay > Update (or reinstall from App Store).
+HA Settings > Apps > NOVA Relay > Update (or reinstall from App Store). On Home Assistant older than 2026.2, Apps are still called Add-ons (Settings > Add-ons).
 
 ## How Update Works
 


### PR DESCRIPTION
## Summary

Setup-wizard UX fixes from a real colleague-install session (2026-07-06), hardened by a triple-agent review round (UX / state-machine / adversarial):

- **Intro screen** (`cli/setup_intro.go`): shown only on fully interactive first runs; flagged runs skip it.
- **Version-agnostic app deeplinks**: HA 2026.2 renamed Add-ons → Apps and moved the panel from `/hassio/addon/<slug>` to `/config/app/<slug>/info`. All wizard links now go through the instance-local `<HAURL>/_my_redirect/<key>` endpoint (`supervisor_addon`, `supervisor_add_addon_repository`), which each HA version resolves to its own panel path — also removes the external my.home-assistant.io "Open link" interstitial.
- **IP-first discovery**: `.local` mDNS names are only used to FIND the instance; the offered/persisted host is the probed IPv4 (2s resolve / 3s probe), with an explicit warning when only the name works. Windows mDNS flakiness broke a real install with no way back.
- **Host repair**: "Change Home Assistant address" in the connection-mode repair menu; repair menu now also appears on first-run connection failures with a "Stop for now (progress is saved)" choice; corrected host persists immediately; custom RelayBaseURL survives a host change; the rejected address is never re-offered.
- **Hardening from the review round**: token step announces + Enter-gates its browser open, `--ha-url` trailing slash trimmed (would break `/_my_redirect`), discovery IP-confirm clamped to the 20s budget, incomplete banners show a resume hint + older-HA naming.
- **Docs**: `nova/DOCS.md` note where the app page lives on 2026.2+; `update-guide.md` mentions the pre-2026.2 Add-ons naming.

Known support note: HA 2026.2–2026.4 **Container** installs show a broken page for supervisor my-redirects (fixed in HA 2026.5; the old hardcoded URL was equally broken there).

## Verification

- `go test ./...` full CLI suite green, uncached (140s)
- Pre-push hook: typecheck, 549 vitest tests, build, docs fact-check — all green
- Live-tested against a real install session (colleague feedback drove the fixes)

## Merge note

Touches `skills/ha-nova/update-guide.md`, which PR #239 moves to `docs/reference/` — whichever merges second needs a trivial rebase of that one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwG5AyesTyqdX8JjjJ316N