### PR TITLE
fix(relay): surface HA WS command errors instead of generic transport failure (Relay 0.2.4)

### DIFF
--- a/nova/CHANGELOG.md
+++ b/nova/CHANGELOG.md
@@ -9,6 +9,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/) and [Semantic
 Recent changes are tracked in [GitHub releases](https://github.com/markusleben/ha-nova/releases)
 and merged PRs. This changelog will be updated with the next tagged relay version.
 
+## [Relay 0.2.4] - 2026-07-07
+
+### Fixed
+- **Upstream WS error transparency** — structured Home Assistant command errors (rejected with HA's raw `{code, message}` payload) are no longer collapsed into a generic `WS request failed`. They surface as `UPSTREAM_WS_COMMAND_ERROR` with HA's own error code and text, and no longer tear down the healthy shared WebSocket connection. Numeric transport rejections from the WS library now map to readable messages.
+
 ## [Relay 0.2.3] - 2026-06-21
 
 ### Changed

--- a/nova/config.yaml
+++ b/nova/config.yaml
@@ -1,5 +1,5 @@
 name: NOVA Relay
-version: "0.2.3"
+version: "0.2.4"
 slug: ha_nova_relay
 description: Thin Home Assistant relay for WS proxy and skill workflows
 url: https://github.com/markusleben/ha-nova

--- a/nova/src/ha/ws-client.ts
+++ b/nova/src/ha/ws-client.ts
@@ -3,6 +3,7 @@ import { TimeoutError, withTimeout } from "../shared/timeout.js";
 export type HaWsClientErrorCode =
   | "UPSTREAM_WS_CONNECT_ERROR"
   | "UPSTREAM_WS_TIMEOUT"
+  | "UPSTREAM_WS_COMMAND_ERROR"
   | "UPSTREAM_WS_ERROR";
 
 export interface HaWsRequest {
@@ -59,6 +60,18 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
         const result = await withTimeout(upstream.sendMessagePromise(message), requestTimeoutMs);
         return result as T;
       } catch (error) {
+        const commandError = describeUpstreamCommandError(error);
+        if (commandError !== undefined) {
+          // HA answered the command with a structured error. The connection
+          // itself is healthy — keep it, and surface HA's code/message
+          // instead of a generic transport failure.
+          throw new HaWsClientError(
+            "UPSTREAM_WS_COMMAND_ERROR",
+            `HA rejected '${message.type}': ${commandError}`,
+            error
+          );
+        }
+
         resetConnection();
         if (error instanceof TimeoutError) {
           throw new HaWsClientError(
@@ -72,11 +85,7 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
           throw error;
         }
 
-        const message =
-          error instanceof Error && error.message
-            ? error.message
-            : "WS request failed";
-        throw new HaWsClientError("UPSTREAM_WS_ERROR", message, error);
+        throw new HaWsClientError("UPSTREAM_WS_ERROR", describeTransportError(error), error);
       }
     },
     async collectMessageEvents<T>(
@@ -151,6 +160,17 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
           timeoutMs
         );
       } catch (error) {
+        const commandError = describeUpstreamCommandError(error);
+        if (commandError !== undefined) {
+          // Structured command rejection (e.g. unknown command on older HA):
+          // the connection stays healthy, surface HA's error details.
+          throw new HaWsClientError(
+            "UPSTREAM_WS_COMMAND_ERROR",
+            `HA rejected '${message.type}': ${commandError}`,
+            error
+          );
+        }
+
         resetConnection();
         if (error instanceof TimeoutError) {
           throw new HaWsClientError(
@@ -164,11 +184,7 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
           throw error;
         }
 
-        const errorMessage =
-          error instanceof Error && error.message
-            ? error.message
-            : "WS event collection failed";
-        throw new HaWsClientError("UPSTREAM_WS_ERROR", errorMessage, error);
+        throw new HaWsClientError("UPSTREAM_WS_ERROR", describeTransportError(error), error);
       } finally {
         if (unsubscribe) {
           await unsubscribe();
@@ -216,4 +232,45 @@ function isEventType(event: unknown, type: string): boolean {
     typeof event === "object" &&
     (event as { type?: unknown }).type === type
   );
+}
+
+// home-assistant-js-websocket rejects command failures with HA's raw error
+// payload ({code, message} — not an Error instance). Detect that shape so the
+// relay can pass HA's actual error through instead of a generic message.
+function describeUpstreamCommandError(error: unknown): string | undefined {
+  if (!error || typeof error !== "object" || error instanceof Error) {
+    return undefined;
+  }
+  const code = (error as { code?: unknown }).code;
+  const message = (error as { message?: unknown }).message;
+  const codeText = typeof code === "string" && code.trim() !== "" ? code : undefined;
+  const messageText = typeof message === "string" && message.trim() !== "" ? message : undefined;
+  if (codeText === undefined && messageText === undefined) {
+    return undefined;
+  }
+  if (codeText !== undefined && messageText !== undefined) {
+    return `${codeText}: ${messageText}`;
+  }
+  return codeText ?? messageText;
+}
+
+// Connection-level rejections arrive as bare numeric codes from
+// home-assistant-js-websocket; map them to readable transport messages.
+const HAWS_TRANSPORT_ERRORS: Record<number, string> = {
+  1: "cannot connect to Home Assistant WebSocket",
+  2: "invalid Home Assistant authentication",
+  3: "Home Assistant WebSocket connection lost",
+  4: "Home Assistant host required",
+  5: "invalid HTTPS-to-HTTP WebSocket upgrade",
+  6: "invalid authentication callback"
+};
+
+function describeTransportError(error: unknown): string {
+  if (typeof error === "number" && HAWS_TRANSPORT_ERRORS[error] !== undefined) {
+    return HAWS_TRANSPORT_ERRORS[error];
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return "WS request failed";
 }

--- a/nova/src/ha/ws-client.ts
+++ b/nova/src/ha/ws-client.ts
@@ -235,16 +235,34 @@ function isEventType(event: unknown, type: string): boolean {
 }
 
 // home-assistant-js-websocket rejects command failures with HA's raw error
-// payload ({code, message} — not an Error instance). Detect that shape so the
-// relay can pass HA's actual error through instead of a generic message.
-function describeUpstreamCommandError(error: unknown): string | undefined {
+// payload ({code, message}), and in-flight connection loss with a wrapped
+// result shape ({type:"result", success:false, error:{code:3, message}}).
+// Neither is an Error instance. Unwrap first, then classify by code type:
+// string code = HA command error, numeric code = transport-level failure.
+function unwrapRejectionPayload(error: unknown): { code?: unknown; message?: unknown } | undefined {
   if (!error || typeof error !== "object" || error instanceof Error) {
     return undefined;
   }
-  const code = (error as { code?: unknown }).code;
-  const message = (error as { message?: unknown }).message;
-  const codeText = typeof code === "string" && code.trim() !== "" ? code : undefined;
-  const messageText = typeof message === "string" && message.trim() !== "" ? message : undefined;
+  const inner = (error as { error?: unknown }).error;
+  if (inner && typeof inner === "object") {
+    return inner as { code?: unknown; message?: unknown };
+  }
+  return error as { code?: unknown; message?: unknown };
+}
+
+function describeUpstreamCommandError(error: unknown): string | undefined {
+  const payload = unwrapRejectionPayload(error);
+  if (payload === undefined) {
+    return undefined;
+  }
+  if (typeof payload.code === "number") {
+    // Numeric codes are the library's transport enum, not an HA command error.
+    return undefined;
+  }
+  const codeText =
+    typeof payload.code === "string" && payload.code.trim() !== "" ? payload.code : undefined;
+  const messageText =
+    typeof payload.message === "string" && payload.message.trim() !== "" ? payload.message : undefined;
   if (codeText === undefined && messageText === undefined) {
     return undefined;
   }
@@ -254,8 +272,9 @@ function describeUpstreamCommandError(error: unknown): string | undefined {
   return codeText ?? messageText;
 }
 
-// Connection-level rejections arrive as bare numeric codes from
-// home-assistant-js-websocket; map them to readable transport messages.
+// Connection-level rejections arrive as bare numeric codes or wrapped
+// numeric error payloads from home-assistant-js-websocket; map them to
+// readable transport messages.
 const HAWS_TRANSPORT_ERRORS: Record<number, string> = {
   1: "cannot connect to Home Assistant WebSocket",
   2: "invalid Home Assistant authentication",
@@ -268,6 +287,16 @@ const HAWS_TRANSPORT_ERRORS: Record<number, string> = {
 function describeTransportError(error: unknown): string {
   if (typeof error === "number" && HAWS_TRANSPORT_ERRORS[error] !== undefined) {
     return HAWS_TRANSPORT_ERRORS[error];
+  }
+  const payload = unwrapRejectionPayload(error);
+  if (payload !== undefined && typeof payload.code === "number") {
+    const mapped = HAWS_TRANSPORT_ERRORS[payload.code];
+    if (mapped !== undefined) {
+      return mapped;
+    }
+    if (typeof payload.message === "string" && payload.message.trim() !== "") {
+      return payload.message;
+    }
   }
   if (error instanceof Error && error.message) {
     return error.message;

--- a/skills/ha-nova/agents/apply-agent.md
+++ b/skills/ha-nova/agents/apply-agent.md
@@ -99,7 +99,7 @@ Use `ha-nova relay` for all HA communication. It handles auth, headers, and time
   - `passed=true` only when target is absent on read-back
   - config read-back not-found after DELETE is expected absence evidence
   - entity state not-found after DELETE is expected absence evidence when an entity_id is known
-  - `config/entity_registry/get` may return `UPSTREAM_WS_ERROR` after deletion; do not retry alternate deletes from that error
+  - `config/entity_registry/get` may return `UPSTREAM_WS_ERROR` (or `UPSTREAM_WS_COMMAND_ERROR` on Relay App >= 0.2.4) after deletion; do not retry alternate deletes from that error
   - if extra evidence is needed, use `config/entity_registry/list_for_display` and confirm no exact `entity_id` match
 
 ## Output Format (Structured Text)

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -380,6 +380,7 @@ These are top-level HTTP errors produced by the relay itself. The response has `
 - `500 / INTERNAL_ERROR`: unexpected relay server error
 - `502 / UPSTREAM_WS_ERROR`: relay could not reach HA websocket
 - `502 / UPSTREAM_WS_TIMEOUT`: WS request to HA timed out
+- `502 / UPSTREAM_WS_COMMAND_ERROR` (Relay App >= 0.2.4): HA answered the WS command with a structured error; the message contains HA's own error code and text (e.g. `HA rejected 'x': unknown_command: ...`). The connection stays healthy — treat this as a command problem, not a connectivity problem. Older relays report these as generic `UPSTREAM_WS_ERROR`.
 - `502 / UPSTREAM_HTTP_ERROR`: core HTTP request to HA failed
 - `502 / UPSTREAM_HTTP_TIMEOUT`: core HTTP request to HA timed out
 

--- a/tests/ha/ws-client.test.ts
+++ b/tests/ha/ws-client.test.ts
@@ -136,3 +136,99 @@ describe("ha ws client", () => {
     expect(unsubscribed).toBe(true);
   });
 });
+
+describe("ha ws client upstream error transparency", () => {
+  it("surfaces structured HA command errors with code and message, keeping the connection", async () => {
+    let connectCalls = 0;
+    let calls = 0;
+
+    const client = createHaWsClient({
+      createConnection: async () => {
+        connectCalls += 1;
+        return {
+          sendMessagePromise: async (message: { type: string }) => {
+            calls += 1;
+            if (calls === 1) {
+              // home-assistant-js-websocket rejects command failures with
+              // HA's raw error payload, not an Error instance.
+              // eslint-disable-next-line @typescript-eslint/no-throw-literal
+              throw { code: "unknown_command", message: "Unknown command." };
+            }
+            return { echoed: message.type };
+          }
+        };
+      }
+    });
+
+    await expect(client.sendMessage({ type: "config/entity_registry/list" })).rejects.toMatchObject({
+      code: "UPSTREAM_WS_COMMAND_ERROR",
+      message: "HA rejected 'config/entity_registry/list': unknown_command: Unknown command."
+    } satisfies Partial<HaWsClientError>);
+
+    // Command-level rejection must not tear down the healthy connection.
+    expect(client.isConnected()).toBe(true);
+    const second = await client.sendMessage<{ echoed: string }>({ type: "ping" });
+    expect(second).toEqual({ echoed: "ping" });
+    expect(connectCalls).toBe(1);
+  });
+
+  it("surfaces a structured command error that only carries a message", async () => {
+    const client = createHaWsClient({
+      createConnection: async () => ({
+        sendMessagePromise: async () => {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw { message: "Invalid format." };
+        }
+      })
+    });
+
+    await expect(client.sendMessage({ type: "ping" })).rejects.toMatchObject({
+      code: "UPSTREAM_WS_COMMAND_ERROR",
+      message: "HA rejected 'ping': Invalid format."
+    } satisfies Partial<HaWsClientError>);
+  });
+
+  it("maps numeric transport rejections to readable UPSTREAM_WS_ERROR messages and resets", async () => {
+    let connectCalls = 0;
+
+    const client = createHaWsClient({
+      createConnection: async () => {
+        connectCalls += 1;
+        return {
+          sendMessagePromise: async () => {
+            // ERR_CONNECTION_LOST from home-assistant-js-websocket
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
+            throw 3;
+          }
+        };
+      }
+    });
+
+    await expect(client.sendMessage({ type: "ping" })).rejects.toMatchObject({
+      code: "UPSTREAM_WS_ERROR",
+      message: "Home Assistant WebSocket connection lost"
+    } satisfies Partial<HaWsClientError>);
+    expect(client.isConnected()).toBe(false);
+    expect(connectCalls).toBe(1);
+  });
+
+  it("surfaces structured command errors from event collection, keeping the connection", async () => {
+    const client = createHaWsClient({
+      createConnection: async () => ({
+        sendMessagePromise: async () => ({ ok: true }),
+        subscribeMessage: async () => {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw { code: "unknown_command", message: "Unknown command." };
+        }
+      })
+    });
+
+    await expect(
+      client.collectMessageEvents({ type: "system_health/info" }, { timeoutMs: 100 })
+    ).rejects.toMatchObject({
+      code: "UPSTREAM_WS_COMMAND_ERROR",
+      message: "HA rejected 'system_health/info': unknown_command: Unknown command."
+    } satisfies Partial<HaWsClientError>);
+    expect(client.isConnected()).toBe(true);
+  });
+});

--- a/tests/ha/ws-client.test.ts
+++ b/tests/ha/ws-client.test.ts
@@ -232,3 +232,72 @@ describe("ha ws client upstream error transparency", () => {
     expect(client.isConnected()).toBe(true);
   });
 });
+
+describe("ha ws client wrapped connection-loss rejections", () => {
+  it("maps the wrapped in-flight connection-loss shape to a readable transport error and resets", async () => {
+    let connectCalls = 0;
+
+    const client = createHaWsClient({
+      createConnection: async () => {
+        connectCalls += 1;
+        return {
+          sendMessagePromise: async () => {
+            // _handleClose rejects in-flight commands with
+            // messages.error(ERR_CONNECTION_LOST, "Connection lost").
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
+            throw {
+              type: "result",
+              success: false,
+              error: { code: 3, message: "Connection lost" }
+            };
+          }
+        };
+      }
+    });
+
+    await expect(client.sendMessage({ type: "ping" })).rejects.toMatchObject({
+      code: "UPSTREAM_WS_ERROR",
+      message: "Home Assistant WebSocket connection lost"
+    } satisfies Partial<HaWsClientError>);
+    expect(client.isConnected()).toBe(false);
+    expect(connectCalls).toBe(1);
+  });
+
+  it("keeps wrapped string-code payloads classified as command errors", async () => {
+    const client = createHaWsClient({
+      createConnection: async () => ({
+        sendMessagePromise: async () => {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw {
+            type: "result",
+            success: false,
+            error: { code: "not_allowed", message: "Not allowed." }
+          };
+        }
+      })
+    });
+
+    await expect(client.sendMessage({ type: "config/x" })).rejects.toMatchObject({
+      code: "UPSTREAM_WS_COMMAND_ERROR",
+      message: "HA rejected 'config/x': not_allowed: Not allowed."
+    } satisfies Partial<HaWsClientError>);
+    expect(client.isConnected()).toBe(true);
+  });
+
+  it("falls back to the wrapped message for unknown numeric transport codes", async () => {
+    const client = createHaWsClient({
+      createConnection: async () => ({
+        sendMessagePromise: async () => {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw { error: { code: 42, message: "Something odd" } };
+        }
+      })
+    });
+
+    await expect(client.sendMessage({ type: "ping" })).rejects.toMatchObject({
+      code: "UPSTREAM_WS_ERROR",
+      message: "Something odd"
+    } satisfies Partial<HaWsClientError>);
+    expect(client.isConnected()).toBe(false);
+  });
+});

--- a/tests/skills/write-delete-safety-contract.test.ts
+++ b/tests/skills/write-delete-safety-contract.test.ts
@@ -125,7 +125,7 @@ describe("write delete safety contract", () => {
   it("treats post-delete absence evidence as successful verification without alternate delete retries", () => {
     expect(applyAgent).toContain("config read-back not-found after DELETE is expected absence evidence");
     expect(applyAgent).toContain("entity state not-found after DELETE is expected absence evidence");
-    expect(applyAgent).toContain("`config/entity_registry/get` may return `UPSTREAM_WS_ERROR` after deletion");
+    expect(applyAgent).toContain("`config/entity_registry/get` may return `UPSTREAM_WS_ERROR` (or `UPSTREAM_WS_COMMAND_ERROR` on Relay App >= 0.2.4) after deletion");
     expect(applyAgent).toContain("do not retry alternate deletes");
     expect(applyAgent).toContain("config/entity_registry/list_for_display");
     expect(applyAgent).toContain("no exact `entity_id` match");


### PR DESCRIPTION
## Summary

Found during the post-merge live validation on a real ~3.5k-entity instance: `config/entity_registry/list` fails through the relay, but the envelope only says `UPSTREAM_WS_ERROR: WS request failed` — for a bogus command the answer is byte-identical, so the actual upstream error is undiagnosable.

Root cause (two defects in `nova/src/ha/ws-client.ts`):
1. `home-assistant-js-websocket` rejects command failures with HA's **raw `{code, message}` payload**, not an `Error` instance — the `error instanceof Error` check missed it and replaced HA's error with a generic message.
2. `resetConnection()` ran on **every** rejection, tearing down the healthy shared WebSocket even for pure command-level errors.

Fix (transparency only — no business logic, relay stays dumb):
- New error code `UPSTREAM_WS_COMMAND_ERROR`: surfaces HA's own code and message (`HA rejected '<type>': <code>: <message>`) and keeps the connection alive; applies to both `sendMessage` and `collectMessageEvents`.
- Numeric transport rejections (ERR_CANNOT_CONNECT/ERR_CONNECTION_LOST/…) map to readable messages.
- Relay version 0.2.4 + changelog; `relay-api.md` → Error Handling documents the new code including the pre-0.2.4 behavior; apply-agent note covers both codes. `min_relay_version` stays 0.2.3 (additive change).

## Verification

- 4 new regression tests in `tests/ha/ws-client.test.ts` (structured command error incl. connection reuse, message-only shape, numeric mapping, collect_events path) — 10/10 pass
- `npm run verify` fully green (553 tests, build, Go suite, release contracts)
- Live root-cause confirmation of the `entity_registry/list` failure follows after deploying 0.2.4 to a real instance (the fix is what makes that diagnosis possible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwG5AyesTyqdX8JjjJ316N