### PR TITLE
fix(relay): use ws client for HA WebSocket — undici deflate limit dropped large command results (Relay 0.2.5)

### DIFF
--- a/nova/CHANGELOG.md
+++ b/nova/CHANGELOG.md
@@ -9,6 +9,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/) and [Semantic
 Recent changes are tracked in [GitHub releases](https://github.com/markusleben/ha-nova/releases)
 and merged PRs. This changelog will be updated with the next tagged relay version.
 
+## [Relay 0.2.5] - 2026-07-07
+
+### Fixed
+- **Large WS command results no longer drop the connection** — the Node global WebSocket (undici) negotiates permessage-deflate and enforces a max decompressed message size; big responses such as `config/entity_registry/list` on instances with thousands of entities exceeded it and the connection died with an opaque `connection lost`. The relay now connects with the `ws` client (compression disabled, explicit 256 MiB payload ceiling) via a custom authenticated socket.
+
 ## [Relay 0.2.4] - 2026-07-07
 
 ### Fixed

--- a/nova/config.yaml
+++ b/nova/config.yaml
@@ -1,5 +1,5 @@
 name: NOVA Relay
-version: "0.2.4"
+version: "0.2.5"
 slug: ha_nova_relay
 description: Thin Home Assistant relay for WS proxy and skill workflows
 url: https://github.com/markusleben/ha-nova

--- a/nova/package-lock.json
+++ b/nova/package-lock.json
@@ -6,10 +6,12 @@
     "": {
       "name": "ha-nova-relay",
       "dependencies": {
-        "home-assistant-js-websocket": "^9.6.0"
+        "home-assistant-js-websocket": "^9.6.0",
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.3",
+        "@types/ws": "^8.18.1",
         "typescript": "^6.0.3"
       }
     },
@@ -21,6 +23,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/home-assistant-js-websocket": {
@@ -49,6 +61,27 @@
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/nova/package.json
+++ b/nova/package.json
@@ -6,10 +6,12 @@
     "build": "node --input-type=module -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true });\" && tsc -p tsconfig.json"
   },
   "dependencies": {
-    "home-assistant-js-websocket": "^9.6.0"
+    "home-assistant-js-websocket": "^9.6.0",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",
+    "@types/ws": "^8.18.1",
     "typescript": "^6.0.3"
   }
 }

--- a/nova/src/ha/socket.ts
+++ b/nova/src/ha/socket.ts
@@ -79,6 +79,17 @@ export function createAuthenticatedHaSocket(
         case MSG_TYPE_AUTH_OK: {
           settled = true;
           removeHandshakeListeners();
+          // ws sockets are EventEmitters: a post-auth transport error with no
+          // 'error' listener would crash the Node process. Swallow it and
+          // close — the close event drives home-assistant-js-websocket's
+          // reconnect path (it only attaches message/close handlers itself).
+          socket.addEventListener("error", () => {
+            try {
+              socket.close();
+            } catch {
+              // Socket may already be closed.
+            }
+          });
           socket.haVersion = typeof message.ha_version === "string" ? message.ha_version : "unknown";
           resolve(socket);
           return;

--- a/nova/src/ha/socket.ts
+++ b/nova/src/ha/socket.ts
@@ -1,0 +1,110 @@
+import { WebSocket } from "ws";
+
+// Custom createSocket for home-assistant-js-websocket.
+//
+// The Node global WebSocket (undici) negotiates permessage-deflate and
+// enforces a max *decompressed* message size. Large registry responses
+// (e.g. `config/entity_registry/list` on instances with thousands of
+// entities) exceed that limit; undici then kills the connection with an
+// opaque close (code 1006, "Max decompressed message size exceeded" only
+// visible on the error event). The `ws` client lets us disable compression
+// entirely and set an explicit payload ceiling, so large command results
+// arrive intact.
+const MAX_PAYLOAD_BYTES = 256 * 1024 * 1024;
+
+const MSG_TYPE_AUTH_REQUIRED = "auth_required";
+const MSG_TYPE_AUTH_INVALID = "auth_invalid";
+const MSG_TYPE_AUTH_OK = "auth_ok";
+
+export interface AuthenticatedHaSocketOptions {
+  haUrl: string;
+  token: string;
+  webSocketImpl?: typeof WebSocket;
+}
+
+export class HaSocketAuthError extends Error {}
+export class HaSocketConnectError extends Error {}
+
+export function haWebSocketUrl(haUrl: string): string {
+  return haUrl.replace(/^http/, "ws").replace(/\/$/, "") + "/api/websocket";
+}
+
+// Performs the HA auth handshake and resolves with an authenticated socket
+// carrying `haVersion`, matching the shape home-assistant-js-websocket
+// expects from its `createSocket` option.
+export function createAuthenticatedHaSocket(
+  options: AuthenticatedHaSocketOptions
+): Promise<WebSocket & { haVersion: string }> {
+  const WebSocketImpl = options.webSocketImpl ?? WebSocket;
+  const url = haWebSocketUrl(options.haUrl);
+
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocketImpl(url, {
+      perMessageDeflate: false,
+      maxPayload: MAX_PAYLOAD_BYTES
+    }) as WebSocket & { haVersion: string };
+
+    let settled = false;
+
+    const settleReject = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      removeHandshakeListeners();
+      try {
+        socket.close();
+      } catch {
+        // Socket may already be closed.
+      }
+      reject(error);
+    };
+
+    const onMessage = (event: { data: unknown }) => {
+      let message: { type?: unknown; ha_version?: unknown };
+      try {
+        message = JSON.parse(String(event.data)) as { type?: unknown; ha_version?: unknown };
+      } catch {
+        settleReject(new HaSocketConnectError("HA sent an unparseable handshake message"));
+        return;
+      }
+
+      switch (message.type) {
+        case MSG_TYPE_AUTH_REQUIRED:
+          socket.send(JSON.stringify({ type: "auth", access_token: options.token }));
+          return;
+        case MSG_TYPE_AUTH_INVALID:
+          settleReject(new HaSocketAuthError("HA rejected the long-lived access token"));
+          return;
+        case MSG_TYPE_AUTH_OK: {
+          settled = true;
+          removeHandshakeListeners();
+          socket.haVersion = typeof message.ha_version === "string" ? message.ha_version : "unknown";
+          resolve(socket);
+          return;
+        }
+        default:
+          // Ignore anything else during the handshake phase.
+          return;
+      }
+    };
+
+    const onClose = () => {
+      settleReject(new HaSocketConnectError("HA WebSocket closed during the auth handshake"));
+    };
+
+    const onError = () => {
+      settleReject(new HaSocketConnectError("HA WebSocket errored during the auth handshake"));
+    };
+
+    const removeHandshakeListeners = () => {
+      socket.removeEventListener("message", onMessage);
+      socket.removeEventListener("close", onClose);
+      socket.removeEventListener("error", onError);
+    };
+
+    socket.addEventListener("message", onMessage);
+    socket.addEventListener("close", onClose);
+    socket.addEventListener("error", onError);
+  });
+}

--- a/nova/src/runtime/start.ts
+++ b/nova/src/runtime/start.ts
@@ -1,10 +1,11 @@
 import { type Server } from "node:http";
 
-import { createConnection, createLongLivedTokenAuth } from "home-assistant-js-websocket";
+import { createConnection, createLongLivedTokenAuth, type HaWebSocket } from "home-assistant-js-websocket";
 
 import { createApp, type App } from "../index.js";
 import { readAppOptions, type AppOptions } from "../config/app-options.js";
 import { loadEnv, type EnvConfig, type LogLevel } from "../config/env.js";
+import { createAuthenticatedHaSocket } from "../ha/socket.js";
 import { createHaRestClient, type HaRestClient } from "../ha/rest-client.js";
 import { createHaWsClient, type HaWsClient, type HaWsConnection, type HaWsRequest } from "../ha/ws-client.js";
 import type { CoreProxyRequest, CoreProxyResponse } from "../types/api.js";
@@ -116,14 +117,22 @@ export function createDefaultWsClient(input: RuntimeWsClientInput): HaWsClient {
 
   return createHaWsClient({
     createConnection: async () => {
-      if (typeof WebSocket === "undefined") {
-        throw new Error(
-          "Global WebSocket is unavailable in this Node runtime. Use Node runtime with WebSocket support."
-        );
-      }
-
       const auth = createLongLivedTokenAuth(input.env.haUrl, token);
-      const connection = await createConnection({ auth });
+      // Use the `ws` client instead of the Node global WebSocket (undici):
+      // undici's permessage-deflate path enforces a max decompressed message
+      // size and drops the connection on large command results such as
+      // `config/entity_registry/list` on big instances (see nova/src/ha/socket.ts).
+      const connection = await createConnection({
+        auth,
+        // The ws socket is API-compatible with the browser WebSocket surface
+        // home-assistant-js-websocket uses (addEventListener/send/close), but
+        // the TS types differ structurally — hence the unknown-cast.
+        createSocket: async () =>
+          (await createAuthenticatedHaSocket({
+            haUrl: input.env.haUrl,
+            token
+          })) as unknown as HaWebSocket
+      });
 
       const wrapped: HaWsConnection = {
         sendMessagePromise: (message: HaWsRequest) => connection.sendMessagePromise(message),

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.9.3",
+        "@types/ws": "^8.18.1",
         "husky": "^9.1.7",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3",
@@ -852,6 +853,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.3",
+    "@types/ws": "^8.18.1",
     "husky": "^9.1.7",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",

--- a/scripts/test/safe-core-files.json
+++ b/scripts/test/safe-core-files.json
@@ -17,6 +17,7 @@
   "tests/e2e/codex-skill-scenarios-contract.test.ts",
   "tests/e2e/codex-skill-write-review-live-contract.test.ts",
   "tests/ha/rest-client.test.ts",
+  "tests/ha/socket.test.ts",
   "tests/ha/ws-client.test.ts",
   "tests/hooks/session-start.test.ts",
   "tests/http/core-proxy.test.ts",

--- a/tests/ha/socket.test.ts
+++ b/tests/ha/socket.test.ts
@@ -110,3 +110,29 @@ describe("ha authenticated socket", () => {
     }
   });
 });
+
+describe("ha authenticated socket post-auth error safety", () => {
+  it("keeps an error listener after auth so transport errors cannot crash the process", async () => {
+    const server = await startServer((socket) => {
+      socket.send(JSON.stringify({ type: "auth_required" }));
+      socket.on("message", () => {
+        socket.send(JSON.stringify({ type: "auth_ok", ha_version: "2026.6.4" }));
+      });
+    });
+
+    try {
+      const socket = await createAuthenticatedHaSocket({ haUrl: server.url, token: "t" });
+      // ws sockets are EventEmitters: with zero 'error' listeners this emit
+      // would throw synchronously (and crash the process outside tests).
+      expect(() => {
+        (socket as unknown as { emit: (event: string, error: Error) => boolean }).emit(
+          "error",
+          new Error("simulated post-auth transport error")
+        );
+      }).not.toThrow();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/tests/ha/socket.test.ts
+++ b/tests/ha/socket.test.ts
@@ -1,0 +1,112 @@
+import { AddressInfo } from "node:net";
+
+import { describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+
+import {
+  HaSocketAuthError,
+  HaSocketConnectError,
+  createAuthenticatedHaSocket,
+  haWebSocketUrl
+} from "../../nova/src/ha/socket.js";
+
+function startServer(handler: (socket: import("ws").WebSocket, request: import("node:http").IncomingMessage) => void): Promise<{ url: string; close: () => void }> {
+  return new Promise((resolve) => {
+    const server = new WebSocketServer({ port: 0 });
+    server.on("connection", handler);
+    server.on("listening", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => server.close() });
+    });
+  });
+}
+
+describe("ha authenticated socket", () => {
+  it("builds the HA websocket URL from the base URL", () => {
+    expect(haWebSocketUrl("http://homeassistant:8123")).toBe("ws://homeassistant:8123/api/websocket");
+    expect(haWebSocketUrl("https://ha.example/")).toBe("wss://ha.example/api/websocket");
+  });
+
+  it("completes the auth handshake without negotiating compression", async () => {
+    let sawExtensions: string | undefined = "unset";
+    const server = await startServer((socket, request) => {
+      sawExtensions = request.headers["sec-websocket-extensions"] as string | undefined;
+      socket.send(JSON.stringify({ type: "auth_required" }));
+      socket.on("message", (raw) => {
+        const message = JSON.parse(String(raw)) as { type?: string; access_token?: string };
+        if (message.type === "auth" && message.access_token === "token-1") {
+          socket.send(JSON.stringify({ type: "auth_ok", ha_version: "2026.6.4" }));
+        } else {
+          socket.send(JSON.stringify({ type: "auth_invalid" }));
+        }
+      });
+    });
+
+    try {
+      const socket = await createAuthenticatedHaSocket({ haUrl: server.url, token: "token-1" });
+      expect(socket.haVersion).toBe("2026.6.4");
+      // permessage-deflate must NOT be offered — the undici deflate path is
+      // exactly what truncated large registry responses.
+      expect(sawExtensions).toBeUndefined();
+      socket.close();
+    } finally {
+      server.close();
+    }
+  });
+
+  it("delivers multi-megabyte messages after the handshake", async () => {
+    const bigPayload = JSON.stringify({ id: 1, type: "result", success: true, result: "x".repeat(8 * 1024 * 1024) });
+    const server = await startServer((socket) => {
+      socket.send(JSON.stringify({ type: "auth_required" }));
+      socket.on("message", (raw) => {
+        const message = JSON.parse(String(raw)) as { type?: string };
+        if (message.type === "auth") {
+          socket.send(JSON.stringify({ type: "auth_ok", ha_version: "2026.6.4" }));
+          socket.send(bigPayload);
+        }
+      });
+    });
+
+    try {
+      const socket = await createAuthenticatedHaSocket({ haUrl: server.url, token: "token-1" });
+      const received = await new Promise<string>((resolve) => {
+        socket.addEventListener("message", (event) => resolve(String(event.data)));
+      });
+      expect(received.length).toBe(bigPayload.length);
+      socket.close();
+    } finally {
+      server.close();
+    }
+  });
+
+  it("rejects with an auth error when HA declines the token", async () => {
+    const server = await startServer((socket) => {
+      socket.send(JSON.stringify({ type: "auth_required" }));
+      socket.on("message", () => {
+        socket.send(JSON.stringify({ type: "auth_invalid" }));
+      });
+    });
+
+    try {
+      await expect(createAuthenticatedHaSocket({ haUrl: server.url, token: "bad" })).rejects.toBeInstanceOf(
+        HaSocketAuthError
+      );
+    } finally {
+      server.close();
+    }
+  });
+
+  it("rejects with a connect error when the socket closes mid-handshake", async () => {
+    const server = await startServer((socket) => {
+      socket.close();
+    });
+
+    try {
+      await expect(createAuthenticatedHaSocket({ haUrl: server.url, token: "t" })).rejects.toBeInstanceOf(
+        HaSocketConnectError
+      );
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Root cause of the `config/entity_registry/list` failure on a real ~3.5k-entity instance, pinned by a live diagnostic inside the relay container (possible only after #242 made upstream errors visible):

The Node global WebSocket (undici 6.24.1) negotiates **permessage-deflate** and enforces a max **decompressed** message size. HA compresses the large registry response, undici hits the limit and kills the connection — error event `Max decompressed message size exceeded`, close 1006. A 2.4 MB `get_states` passes; the bigger registry list dies. This matches the long-known ecosystem pattern of WS clients failing on large HA responses (Node-RED, supervisor proxy).

Fix:
- `nova/src/ha/socket.ts`: authenticated HA socket built on the **`ws` client** — `perMessageDeflate: false` (no decompression path at all) and an explicit 256 MiB `maxPayload`; performs the HA auth handshake and plugs into `home-assistant-js-websocket` via its `createSocket` hook.
- Drops the global-WebSocket runtime requirement in `start.ts`.
- `ws` returns as a real, justified dependency (it was removed as *unused* in #239 — it is now actually used, with the reasoning documented in the module header).
- Relay 0.2.5 + changelog. `min_relay_version` unchanged.

## Verification

- 5 new tests in `tests/ha/socket.test.ts`: handshake, **no `Sec-WebSocket-Extensions` offered**, 8 MiB payload delivered intact, auth-invalid and mid-handshake-close rejections — against a real local `ws` server
- `npm run verify` fully green
- Live validation on the real instance follows right after merge (deploy + `config/entity_registry/list` must return ~3.5k entities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwG5AyesTyqdX8JjjJ316N