### PR TITLE
chore(release): prepare v0.8.0 — skill 0.8.0, min_relay_version 0.2.5, release notes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.7.1"
+    "version": "0.8.0"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,14 +83,18 @@ release:
     ```
 
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
-    {{ else }}## Bug Fixes
+    {{ else }}## New Features
 
-    - Windows installer downloads are more resilient on fresh Windows systems: the installer sets modern TLS defaults, sends GitHub-friendly headers, retries release assets with native fallback transports, and retries the ZIP download when a proxy or partial transfer produces content that fails SHA256 verification.
+    - Setup wizard rework: a friendly intro on first run, a connection repair menu when verification fails (retry, change the Home Assistant address, run the install steps for this address, or stop with progress saved), and Home Assistant links that work before and after the 2026.2 "Add-ons to Apps" rename.
+    - Network discovery now prefers a verified IP address over fragile `.local` names, so setup survives Windows mDNS hiccups.
+
+    ## Bug Fixes
+
+    - NOVA Relay 0.2.5: large Home Assistant instances no longer lose the relay connection on big responses (for example full entity registry lists), and Home Assistant's real error messages now reach the client instead of a generic "WS request failed".
 
     ## What To Watch
 
-    - If a network, proxy, or firewall blocks GitHub Release downloads entirely, install still cannot complete, but the installer now reports one HA NOVA download error with the attempted transports instead of leaking a raw `Invoke-WebRequest` stack trace.
-    - The already-published `v0.7.0` tag is immutable. Use `v0.7.1` or the latest release command below for this Windows installer fix.
+    - Update the NOVA Relay app in Home Assistant (Settings > Apps > NOVA Relay > Update) to 0.2.5 — the skills warn when the running relay is older than required.
 
     Stable install commands are release-pinned for this tag.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ Work style: Be radically precise. No fluff. Pure information only (drop grammar;
 - **One topic, one branch:** avoid mixed runtime/docs/release/installer branches unless the behavior truly cannot be separated.
 - **Dirty legacy worktrees are read-only source material:** port changes explicitly into clean branches; do not PR or release directly from them.
 - **README is stable release truth:** do not add future feature claims to `README.md`; keep planned or unreleased claims in active `docs/work/*` notes until release.
+- **No concrete version-number claims in README:** version requirements live in `version.json` (SSOT) and surface via the built-in runtime warning; the README references the mechanism, never a number that can drift ahead of the stable tag.
+- **Release-prep merge starts the tag sequence:** a merged release-prep PR (version bump + release notes + release-bound README edits) must be followed immediately by the RC/final tag flow on that commit; release-bound README changes go only into that PR to keep the main-ahead-of-stable window at minutes, not days.
 - **Local PR checkpoint:** before creating any PR, show the user `git status --short --branch`, `git diff --stat`, public-claim diffs such as `README.md`, targeted tests run, and remaining risks.
 - **KISS process rule:** prefer fewer rules and fewer files; add process docs/scripts only when they remove a recurring real problem.
 - **Review clearance is commit-specific:** any new relevant delta after the last bot-reviewed commit invalidates prior review clearance.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ HA NOVA is early — and that's the point. Here's where it's going:
 
 Want to add a new capability? → [CONTRIBUTING.md](CONTRIBUTING.md)
 
-Current skills require NOVA Relay `0.2.3` or newer.
+Current skills require NOVA Relay `0.2.5` or newer.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ HA NOVA is early — and that's the point. Here's where it's going:
 
 Want to add a new capability? → [CONTRIBUTING.md](CONTRIBUTING.md)
 
-Current skills require NOVA Relay `0.2.5` or newer.
+The skills declare the NOVA Relay version they need (see `version.json`) and warn at runtime when the installed relay app is older — update it in Home Assistant under **Settings > Apps > NOVA Relay**.
 
 ---
 

--- a/docs/reference/bridge-architecture.md
+++ b/docs/reference/bridge-architecture.md
@@ -54,7 +54,7 @@ Response 200:
   "data": {
     "status": "ok",
     "ha_ws_connected": true,
-    "version": "0.2.3",
+    "version": "0.2.5",
     "uptime_s": 3600
   }
 }

--- a/docs/work/2026-07-07-v0.8.0-release-body.md
+++ b/docs/work/2026-07-07-v0.8.0-release-body.md
@@ -1,0 +1,16 @@
+# v0.8.0 Release Body (working draft)
+
+Status: active (delete/archive after the v0.8.0 release ships; the normative body lives in `.goreleaser.yml`)
+
+## New Features
+
+- Setup wizard rework: a friendly intro on first run, a connection repair menu when verification fails (retry, change the Home Assistant address, run the install steps for this address, or stop with progress saved), and Home Assistant links that work before and after the 2026.2 "Add-ons to Apps" rename.
+- Network discovery now prefers a verified IP address over fragile `.local` names, so setup survives Windows mDNS hiccups.
+
+## Bug Fixes
+
+- NOVA Relay 0.2.5: large Home Assistant instances no longer lose the relay connection on big responses (for example full entity registry lists), and Home Assistant's real error messages now reach the client instead of a generic "WS request failed".
+
+## What To Watch
+
+- Update the NOVA Relay app in Home Assistant (Settings > Apps > NOVA Relay > Update) to 0.2.5 — the skills warn when the running relay is older than required.

--- a/nova/DOCS.md
+++ b/nova/DOCS.md
@@ -84,7 +84,7 @@ A healthy response looks like:
   "data": {
     "status": "ok",
     "ha_ws_connected": true,
-    "version": "0.2.3",
+    "version": "0.2.5",
     "uptime_s": 3621
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -53,13 +53,15 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
-  it("keeps v0.7.1 release-facing wording scoped to the Windows installer hotfix", () => {
+  it("keeps v0.8.0 release-facing wording user-centric", () => {
     // Shipped release-note bodies are archived (docs/archive/work/) and
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
-    expect(goreleaser).toContain("Windows installer downloads are more resilient");
-    expect(goreleaser).toContain("raw `Invoke-WebRequest` stack trace");
-    expect(goreleaser).toContain("Use `v0.7.1` or the latest release command");
+    expect(goreleaser).toContain("Setup wizard rework");
+    expect(goreleaser).toContain("run the install steps for this address, or stop with progress saved");
+    expect(goreleaser).toContain("NOVA Relay 0.2.5");
+    expect(goreleaser).toContain("Settings > Apps > NOVA Relay > Update");
+    expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");
   });
 
   it("pins the GoReleaser release tag to the triggering workflow ref", () => {

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.7.1",
-  "min_relay_version": "0.2.3"
+  "skill_version": "0.8.0",
+  "min_relay_version": "0.2.5"
 }


### PR DESCRIPTION
## Summary

Release preparation for **v0.8.0** (first tag after today's five merges):

- `bump-version.sh 0.8.0` — package.json, package-lock.json, plugin.json, marketplace.json, version.json
- `min_relay_version` → **0.2.5**: the skills rely on the relay large-message fix (`config/entity_registry/list` on big instances) and error transparency; older relays now trigger the built-in update warning
- `.goreleaser.yml` stable release body rewritten for v0.8.0 (user-centric: wizard rework + IP-first discovery as features, relay 0.2.5 as bug fix, one What-To-Watch item) — replaces the v0.7.1 hotfix copy; release-contract test updated accordingly
- Working draft in `docs/work/2026-07-07-v0.8.0-release-body.md` (status: active until the release ships)

Release preflight done: all 6 open Dependabot/workflow PRs classified as "separate later" (toolchain-risk rule for tsx/vitest, red checks on @types/node & axios, workflow PR never right before publish). #234 (axios in /nova) auto-closed after the dependency removal.

## Verification

- `npm run verify` fully green
- Targeted: release-contract, config-contract (0.2.5 ≥ min_relay_version), bump-version tests

## After merge

1. `HA_NOVA_RELEASE_AUDIT_REQUIRE_BYPASS=1 bash scripts/release/verify-release-pipeline.sh` (strict, maintainer)
2. Maintainer pushes `v0.8.0-rc1` on the merge commit (tag-first rehearsal) → smoke matrix + fresh-VM Windows validation of the reworked wizard
3. Final `v0.8.0` on the same commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwG5AyesTyqdX8JjjJ316N