### PR TITLE
fix(cli): consistent setup wizard layout — single blank-line rhythm, clean URL lines, framed status output

### DIFF
--- a/cli/setup_discovery_ui.go
+++ b/cli/setup_discovery_ui.go
@@ -10,6 +10,7 @@ var detectDefaultHAHostChoiceForSetup = detectDefaultHAHostChoice
 
 func detectDefaultHAHostWithFeedback(out io.Writer, cfg runtimeConfig) (string, bool) {
 	if !resolveSetupUISession(out).animatesSpinner() {
+		fmt.Fprintln(out)
 		fmt.Fprintf(out, "  Discovering Home Assistant on your network... (up to %ds)\n", int((setupDiscoveryOverallTimeout+time.Second-1)/time.Second))
 		fmt.Fprintln(out)
 		host, via, discovered := detectDefaultHAHostChoiceForSetup(cfg)

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -52,12 +52,12 @@ func maybeHandleInteractiveSetupCurrentState(reader *bufio.Reader, out io.Writer
 		return true, 0
 	}
 	if summary := current.SkipSummary(); summary != "" {
-		fmt.Fprintf(out, "  Already done: %s\n\n", summary)
+		fmt.Fprintf(out, "  Already done: %s\n", summary)
 	}
 	if writerSupportsTTYForSetup(out) {
 		_, err := promptWizardLineFromReader(reader, out, "Press Enter to continue setup", "")
 		if err == errSetupExit {
-			printHumanInfo("Setup cancelled")
+			renderSetupCancelledNote(os.Stdout)
 			return true, 0
 		}
 		if err != nil && err != errSetupBack {
@@ -135,7 +135,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				continue
 			}
 			if err == errSetupExit {
-				printHumanInfo("Setup cancelled")
+				renderSetupCancelledNote(os.Stdout)
 				return 0
 			}
 			if err != nil {
@@ -203,7 +203,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 		if hasServiceCredentials && shouldOfferServiceCredentials(tokenStoragePreflightErr) {
 			useServiceCredentials, err := promptSetupServiceCredentialsInteractive(reader, os.Stdout, serviceCredentials, serviceClientID)
 			if err == errSetupExit {
-				printHumanInfo("Setup cancelled")
+				renderSetupCancelledNote(os.Stdout)
 				return 0
 			}
 			if err != nil {
@@ -302,7 +302,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				continue
 			}
 			if err == errSetupExit {
-				printHumanInfo("Setup cancelled")
+				renderSetupCancelledNote(os.Stdout)
 				return 0
 			}
 			if err != nil {
@@ -328,11 +328,11 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 					stage = setupStageClient
 					continue
 				}
-				printHumanInfo("Setup cancelled")
+				renderSetupCancelledNote(os.Stdout)
 				return 0
 			}
 			if err == errSetupExit {
-				printHumanInfo("Setup cancelled")
+				renderSetupCancelledNote(os.Stdout)
 				return 0
 			}
 			if err != nil {
@@ -419,7 +419,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				continue
 			}
 			if err == errSetupExit {
-				printHumanInfo("Setup cancelled")
+				renderSetupCancelledNote(os.Stdout)
 				return 0
 			}
 			if err != nil {
@@ -474,27 +474,27 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			renderSetupParagraph(os.Stdout,
 				"Next, add the HA NOVA app repository to your Home Assistant.",
 			)
-			renderSetupParagraphTight(os.Stdout, "This will open: "+repositoryURL)
+			renderSetupLink(os.Stdout, "This will open:", repositoryURL)
 			_, err := promptWizardLineFromReader(reader, os.Stdout, "Press Enter to open your browser", "")
 			if err == errSetupBack {
 				stage = setupStageHost
 				continue
 			}
 			if err == errSetupExit {
-				printHumanInfo("Setup cancelled")
+				renderSetupCancelledNote(os.Stdout)
 				return 0
 			}
 			if err != nil {
 				printHumanErr("%s", err)
 				return 1
 			}
-			openBrowserShowingURL(os.Stdout, repositoryURL)
+			openAnnouncedBrowserURL(os.Stdout, repositoryURL)
 			renderSetupParagraphTight(os.Stdout, `In the browser: log in to Home Assistant if asked, then click "Add" to confirm the repository.`)
 			renderSetupIndentedBlock(os.Stdout, "Once the repository is added:", "    ",
 				"1. Go to Settings > Apps > App Store (on older Home Assistant: Settings > Add-ons)",
 				`2. Search for "NOVA Relay"`,
 				"3. Click Install and wait for it to finish",
-				"(don't start the app yet — we'll set up the tokens first)",
+				"   (don't start the app yet — we'll set up the tokens first)",
 			)
 			_, err = promptWizardLineFromReader(reader, os.Stdout, "Press Enter when the installation is complete", "")
 			if err == errSetupBack {
@@ -502,7 +502,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				continue
 			}
 			if err == errSetupExit {
-				printHumanInfo("Setup cancelled")
+				renderSetupCancelledNote(os.Stdout)
 				return 0
 			}
 			if err != nil {
@@ -532,7 +532,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				"a) Relay token — keeps the connection between this computer and Home Assistant private",
 				"b) HA access token — allows the relay to control your devices and automations",
 			)
-			renderSetupParagraphTight(os.Stdout, "This step is only for the Relay Auth Token. The Home Assistant Access Token comes next as its own step.")
+			renderSetupParagraph(os.Stdout, "This step is only for the Relay Auth Token. The Home Assistant Access Token comes next as its own step.")
 			if relayTokenFlag != "" {
 				renderSetupParagraphTight(os.Stdout, "Using the Relay Auth Token you already provided.")
 			} else if resumeWSRecovery {
@@ -550,7 +550,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 					continue
 				}
 				if err == errSetupExit {
-					printHumanInfo("Setup cancelled")
+					renderSetupCancelledNote(os.Stdout)
 					return 0
 				}
 				if err != nil {
@@ -570,7 +570,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 						continue
 					}
 					if err == errSetupExit {
-						printHumanInfo("Setup cancelled")
+						renderSetupCancelledNote(os.Stdout)
 						return 0
 					}
 					if err != nil {
@@ -604,26 +604,26 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 						`2. Paste the token into the "Relay Auth Token" field ("relay_auth_token")`,
 						"3. Click Save",
 					)
-					renderSetupParagraphTight(os.Stdout, "This will open: "+haRelayAppPageURL(cfg.HAURL))
+					renderSetupLink(os.Stdout, "This will open:", haRelayAppPageURL(cfg.HAURL))
 					_, err := promptWizardLineFromReader(reader, os.Stdout, "Press Enter to open your browser", "")
 					if err == errSetupBack {
 						continue
 					}
 					if err == errSetupExit {
-						printHumanInfo("Setup cancelled")
+						renderSetupCancelledNote(os.Stdout)
 						return 0
 					}
 					if err != nil {
 						printHumanErr("%s", err)
 						return 1
 					}
-					openBrowserShowingURL(os.Stdout, haRelayAppPageURL(cfg.HAURL))
+					openAnnouncedBrowserURL(os.Stdout, haRelayAppPageURL(cfg.HAURL))
 					_, err = promptWizardLineFromReader(reader, os.Stdout, "Press Enter after you saved the Relay Auth Token in NOVA Relay", "")
 					if err == errSetupBack {
 						continue
 					}
 					if err == errSetupExit {
-						printHumanInfo("Setup cancelled")
+						renderSetupCancelledNote(os.Stdout)
 						return 0
 					}
 					if err != nil {
@@ -655,7 +655,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 					continue
 				}
 				if err == errSetupExit {
-					printHumanInfo("Setup cancelled")
+					renderSetupCancelledNote(os.Stdout)
 					return 0
 				}
 				printHumanErr("%s", err)
@@ -703,7 +703,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 				continue
 			}
 			if err == errSetupExit {
-				printHumanInfo("Setup cancelled")
+				renderSetupCancelledNote(os.Stdout)
 				return 0
 			}
 			if err != nil {

--- a/cli/setup_intro.go
+++ b/cli/setup_intro.go
@@ -18,7 +18,7 @@ func renderSetupIntro(out io.Writer) {
 		"- set up two access tokens (guided, step by step)",
 		`- verify the connection and teach your AI assistant the Home Assistant commands (the "skills")`,
 	)
-	renderSetupParagraphTight(out,
+	renderSetupParagraph(out,
 		"How it works: at several points you'll be asked to press Enter — that opens a",
 		"page in your web browser. Do the step there, then come back to this window.",
 	)

--- a/cli/setup_layout.go
+++ b/cli/setup_layout.go
@@ -47,7 +47,18 @@ func renderSetupIndentedBlock(out io.Writer, title, indent string, lines ...stri
 		fmt.Fprintln(out)
 	}
 	renderSetupIndentedLines(out, indent, lines...)
+}
+
+// renderSetupLink prints a label with its URL on an own indented line, so a
+// long URL wraps at a clean boundary instead of mid-sentence.
+func renderSetupLink(out io.Writer, label, target string) {
 	fmt.Fprintln(out)
+	fmt.Fprintf(out, "  %s\n", label)
+	fmt.Fprintf(out, "      %s\n", target)
+}
+
+func renderSetupCancelledNote(out io.Writer) {
+	renderSetupParagraph(out, "Setup cancelled.")
 }
 
 func renderSetupStatusLine(out io.Writer, role, format string, args ...interface{}) {
@@ -75,7 +86,6 @@ func renderSetupMutedNoteBlock(out io.Writer, title string, lines ...string) {
 	for _, line := range lines {
 		fmt.Fprintf(out, "  %s\n", session.style("muted", "  "+line))
 	}
-	fmt.Fprintln(out)
 }
 
 func renderSetupSuccessLine(out io.Writer, format string, args ...interface{}) {

--- a/cli/setup_llat.go
+++ b/cli/setup_llat.go
@@ -29,18 +29,18 @@ func runSetupLLATWalkthrough(reader *bufio.Reader, out io.Writer, cfg runtimeCon
 		)
 	}
 
-	renderSetupParagraphTight(out, "This will open: "+haProfileSecurityURL(cfg.HAURL))
+	renderSetupLink(out, "This will open:", haProfileSecurityURL(cfg.HAURL))
 	if _, err := promptWizardLineFromReader(reader, out, "Press Enter to open your HA profile", ""); err != nil {
 		return err
 	}
-	openBrowserShowingURL(out, haProfileSecurityURL(cfg.HAURL))
+	openAnnouncedBrowserURL(out, haProfileSecurityURL(cfg.HAURL))
 
 	renderSetupParagraph(out, "Got it? Now I'll open the NOVA Relay settings so you can paste it.")
-	renderSetupParagraphTight(out, "This will open: "+haRelayAppPageURL(cfg.HAURL))
+	renderSetupLink(out, "This will open:", haRelayAppPageURL(cfg.HAURL))
 	if _, err := promptWizardLineFromReader(reader, out, "Press Enter to open the relay settings", ""); err != nil {
 		return err
 	}
-	openBrowserShowingURL(out, haRelayAppPageURL(cfg.HAURL))
+	openAnnouncedBrowserURL(out, haRelayAppPageURL(cfg.HAURL))
 
 	renderSetupIndentedBlock(out, "Finish the relay configuration:", "    ",
 		`5. Open the "Configuration" tab`,

--- a/cli/setup_ui.go
+++ b/cli/setup_ui.go
@@ -183,12 +183,12 @@ func renderSetupDiscoveryResult(out io.Writer, host, via string, discovered bool
 	} else {
 		fmt.Fprintf(out, "  %s No confirmed Home Assistant found automatically; enter the Home Assistant address manually\n", session.style("warning", session.warningMarker()))
 	}
-	fmt.Fprintln(out)
 }
 
 func renderSetupCompleteBanner(out io.Writer, clients []string) {
 	session := resolveSetupUISession(out)
 	renderSetupHeader(out)
+	fmt.Fprintln(out)
 	fmt.Fprintf(out, "  %s Setup complete!\n", session.style("success", session.successMarker()))
 	fmt.Fprintln(out)
 	if labels := setupClientLabels(clients); labels != "" {
@@ -207,6 +207,7 @@ func renderSetupCompleteBanner(out io.Writer, clients []string) {
 func renderSetupAlreadyDoneBanner(out io.Writer) {
 	session := resolveSetupUISession(out)
 	renderSetupHeader(out)
+	fmt.Fprintln(out)
 	fmt.Fprintf(out, "  %s Everything is already set up!\n", session.style("success", session.successMarker()))
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "  Run 'ha-nova doctor' for full diagnostics.")

--- a/cli/setup_urls.go
+++ b/cli/setup_urls.go
@@ -27,8 +27,17 @@ func haProfileSecurityURL(haURL string) string {
 }
 
 func openBrowserShowingURL(out io.Writer, target string) {
-	fmt.Fprintf(out, "  Opening in your browser: %s\n", target)
+	renderSetupLink(out, "Opening in your browser:", target)
 	if err := openBrowserForSetup(target); err != nil {
 		printHumanWarn("Could not open the browser automatically. Please open the link above yourself.")
+	}
+}
+
+// openAnnouncedBrowserURL opens a target whose URL the wizard has just
+// announced; it deliberately does not repeat the URL.
+func openAnnouncedBrowserURL(out io.Writer, target string) {
+	fmt.Fprintln(out, "  Opening in your browser...")
+	if err := openBrowserForSetup(target); err != nil {
+		printHumanWarn("Could not open the browser automatically. Please open the link shown above yourself.")
 	}
 }

--- a/cli/setup_urls_test.go
+++ b/cli/setup_urls_test.go
@@ -38,7 +38,11 @@ func TestOpenBrowserShowingURLPrintsTargetBeforeOpening(t *testing.T) {
 	if opened != "http://ha.example:8123/profile/security" {
 		t.Fatalf("opened = %q", opened)
 	}
-	if !strings.Contains(output.String(), "Opening in your browser: http://ha.example:8123/profile/security") {
+	if !strings.Contains(output.String(), "Opening in your browser:") {
+		t.Fatalf("missing announcement line:\n%s", output.String())
+	}
+	// The URL gets its own indented line so long links wrap cleanly.
+	if !strings.Contains(output.String(), "\n      http://ha.example:8123/profile/security\n") {
 		t.Fatalf("missing URL line:\n%s", output.String())
 	}
 }

--- a/cli/setup_verify.go
+++ b/cli/setup_verify.go
@@ -80,13 +80,13 @@ func verifySetupConnectionOnce(out io.Writer, cfg runtimeConfig, token string) (
 		return readiness, setupIssueRelayUnreachable, false
 	}
 
-	printHumanInfo("Home Assistant reachable: %s", cfg.HAURL)
-	printHumanInfo("Relay health reachable: %s/health", cfg.RelayBaseURL)
+	renderSetupSuccessLine(out, "Home Assistant reachable: %s", cfg.HAURL)
+	renderSetupSuccessLine(out, "Relay health reachable: %s/health", cfg.RelayBaseURL)
 	if readiness.UsedWSPing && readiness.WSReady {
-		printHumanInfo("Relay /ws ping succeeded")
+		renderSetupSuccessLine(out, "Relay /ws ping succeeded")
 	}
 	if readiness.WSReady {
-		printHumanInfo("Connected to Home Assistant")
+		renderSetupSuccessLine(out, "Connected to Home Assistant")
 		return readiness, "", true
 	}
 

--- a/cli/ui_style.go
+++ b/cli/ui_style.go
@@ -23,7 +23,6 @@ func renderSimpleHeader(out io.Writer, session uiSession, title string) {
 	if session.plain() {
 		fmt.Fprintf(out, "  %s\n", title)
 		fmt.Fprintf(out, "  %s\n", strings.Repeat("-", len(title)))
-		fmt.Fprintln(out)
 		return
 	}
 


### PR DESCRIPTION
## Summary

User feedback from the Windows v0.8.0 validation: the wizard output looked "wild and untidy". A live-transcript audit of **every** wizard screen (happy path, intro, resume/already-done, repair menu, stop/incomplete banners) surfaced the drift; this PR normalizes it:

- **URLs**: `This will open:` now puts the URL on its own indented line (long `_my_redirect` links wrap at a clean boundary), and after Enter the wizard prints `Opening in your browser...` **without repeating the URL**. Un-announced opens (repair menu actions) use the same two-line link format.
- **Blank-line rhythm**: exactly one blank line between blocks. Removed the stacked double gaps after headers, indented list blocks, the muted `[ Only if needed ]` note, the discovery result, and the `Already done:` summary; the complete/already-done banners no longer hug the header underline.
- **Framed status**: verify probes render as `  [ok] Home Assistant reachable: …` inside the wizard frame instead of `[ha-nova]`-prefixed log lines; cancellation prints an indented `Setup cancelled.`
- **Step 1 list**: the `(don't start the app yet …)` note indents under item 3 instead of posing as a list item.

## Verification

- Before/after transcripts of all four wizard flows captured against local mock HA/relay servers (fresh happy path incl. token generation + LLAT walkthrough, intro + client menu, resume/already-done, broken-address repair menu + stop banner)
- Full Go suite green (140s); `npm run verify` green
- One test pin updated (`setup_urls_test.go`: new two-line link format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwG5AyesTyqdX8JjjJ316N