### PR TITLE
fix(e2e): treat any timestamped Codex logger line as transcript noise

### DIFF
--- a/scripts/e2e/codex-ha-nova-promoted-live-e2e.py
+++ b/scripts/e2e/codex-ha-nova-promoted-live-e2e.py
@@ -45,13 +45,13 @@ SCENARIO_ORDER = (
     "history_statistics",
 )
 KNOWN_JSONL_NOISE = ("Reading additional input from stdin...",)
+# Codex CLI writes timestamped logger lines (ERROR/WARN, changing logger
+# names across releases — e.g. codex_core::tools::router appeared in 0.142)
+# to the merged stream. Raw non-JSON lines are never scenario output: agent
+# messages and commands only arrive inside JSONL events, so timestamped log
+# lines are always transport noise.
 KNOWN_JSONL_NOISE_RE = (
-    re.compile(
-        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when UnexpectedContentType\(Some\(\"text/plain; body: upstream connect error or disconnect/reset before headers\..*\"\)\)$"
-    ),
-    re.compile(
-        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: .*$"
-    ),
+    re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+(?:ERROR|WARN)\s+\S+: .*$"),
 )
 HELPER_SCRIPT_RE = re.compile(r"^(?:\./)?scripts/(?:smoke|e2e|dev)/\S+$")
 DOCTOR_RE = re.compile(r"(^|[^\w./-])(?:ha-nova|[.]/cli/cli|cli/cli|scripts/onboarding/bin/ha-nova)(?:\s+[A-Za-z0-9_./-]+){0,2}\s+(?:doctor|ready|quick)(?=$|[^\w-])")

--- a/scripts/e2e/codex-ha-nova-scenarios-e2e.sh
+++ b/scripts/e2e/codex-ha-nova-scenarios-e2e.sh
@@ -50,13 +50,11 @@ with open(sys.argv[1], encoding="utf-8") as handle:
             continue
         if line == "Reading additional input from stdin...":
             continue
+        # Codex CLI writes timestamped logger lines (ERROR/WARN, logger names
+        # change across releases) to the merged stream; raw non-JSON lines are
+        # never scenario output.
         if re.match(
-            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when UnexpectedContentType\(Some\(\"text/plain; body: upstream connect error or disconnect/reset before headers\..*\"\)\)$",
-            line,
-        ):
-            continue
-        if re.match(
-            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: .*$",
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+(?:ERROR|WARN)\s+\S+: .*$",
             line,
         ):
             continue

--- a/tests/e2e/codex-skill-scenarios-contract.test.ts
+++ b/tests/e2e/codex-skill-scenarios-contract.test.ts
@@ -100,8 +100,9 @@ describe("codex skill scenario e2e contract", () => {
     expect(content).toContain("rule_code_marker_present");
     expect(content).toContain("json_array_values");
     expect(content).toContain('Reading additional input from stdin...');
-    expect(content).toContain("ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed");
-    expect(content).toContain("ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket:");
+    // Codex logger names change across releases; the harness filters any
+    // timestamped ERROR/WARN log line as transport noise.
+    expect(content).toContain("(?:ERROR|WARN)");
     expect(content).toContain("CLI_CMD_PATTERN='([[:alnum:]_./-]*ha-nova|[.]/cli/cli|cli/cli)'");
     expect(content).toContain('CLI_DOCTOR_PATTERN="${CLI_CMD_PATTERN}([[:space:]]+[[:alnum:]_./-]+){0,2}[[:space:]]+(doctor|ready|quick)"');
     expect(content).toContain("GO_RUN_PATTERN='go[[:space:]]+run([[:space:]]+[[:alnum:]_./-]+){1,4}'");


### PR DESCRIPTION
## Summary

Live-suite rerun after Relay 0.2.5 pinned the remaining `invalid_jsonl_transcript` failures: Codex CLI 0.142.5 interleaves timestamped logger lines with **new logger names** (`codex_core::tools::router`) into the merged stdout/stderr stream, and both harness noise filters pinned two specific old logger names.

Raw non-JSON lines are never scenario output (agent messages/commands only arrive inside JSONL events), so both filters — the promoted Python harness and the scenarios shell harness — now treat **any** `<timestamp> ERROR|WARN <logger>: …` line as transport noise instead of chasing logger names per Codex release. Regex validated against the observed 0.142.5 lines, both legacy lines, and JSONL/plain-noise negatives; contract-test pin updated.

Evidence from the rerun (post-0.2.5): `history_statistics` passes again; `organize_label_entity_flow` had 96 valid events and failed only on 2 such logger lines. (`dashboard_storage_lifecycle`'s `failed_command_exit` is a separate agent-behavior finding — a jq filter iterating `null` views — addressed separately.)

## Verification

- `npx vitest run tests/e2e/` green; `npm run verify` fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwG5AyesTyqdX8JjjJ316N