### PR TITLE
fix(skills): dashboard jq filters must null-guard absent structure keys

### DIFF
--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -98,6 +98,7 @@ Critical behavior:
    - content update / card operation:
      - read the current dashboard config with `lovelace/config`
      - build a compact inventory of views, cards, badges, and header cards
+     - jq filters must null-guard absent structure keys: empty dashboards have no `views` — iterate `(.views // [])[]`, never bare `.views[]`; same for `.cards` and `.badges`
      - resolve the exact target by view, title/heading text, entity reference, card type, or explicit position
      - merge the requested change in memory
      - preview a concise diff/excerpt


### PR DESCRIPTION
## Summary

The promoted live E2E (`dashboard_storage_lifecycle`) caught a real agent wobble graded as `failed_command_exit`: the agent iterated bare `.views[]` against a freshly created storage dashboard config and hit `cannot iterate over: null` (fresh/empty dashboards have no `views` key), then had to self-correct.

The dashboard skill's inventory step now teaches the guard explicitly: iterate `(.views // [])[]` — never bare `.views[]` — and the same for `.cards` and `.badges`.

## Verification

- `npx vitest run tests/skills/` — 182 passed (incl. the 1000-word conciseness limit)
- `npm run verify` green via pre-push hook
- Live re-proof: promoted smoke rerun follows once this is on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwG5AyesTyqdX8JjjJ316N