### PR TITLE
fix(cli): report the staged target version; clean dev marketplace symlink on release sync

### DIFF
--- a/cli/claude_marketplace.go
+++ b/cli/claude_marketplace.go
@@ -167,6 +167,26 @@ func replaceClaudeMarketplaceRoot(targetRoot, stagedRoot string) error {
 	return nil
 }
 
+// cleanupClaudeMarketplaceDevResidue removes the dev-sync symlink at the
+// marketplace base root once a NON-dev (release snapshot) registration is
+// active. The symlink points at a developer checkout; the release
+// registration never uses it, and leaving it behind makes a restored
+// release install look dev-wired (issue #245). When the dev registration
+// itself is active (activeRoot == base root), the symlink IS the install
+// and stays untouched.
+func cleanupClaudeMarketplaceDevResidue(paths runtimePaths, activeRoot string) {
+	base := claudeMarketplaceBaseRoot(paths)
+	if filepath.Clean(activeRoot) == filepath.Clean(base) {
+		return
+	}
+	link := filepath.Join(base, "ha-nova")
+	info, err := os.Lstat(link)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		return
+	}
+	_ = os.Remove(link)
+}
+
 func cleanupClaudeMarketplaceBackup(targetRoot string) error {
 	backupRoot := filepath.Clean(targetRoot) + ".backup"
 	if err := os.RemoveAll(backupRoot); err != nil && !os.IsNotExist(err) {

--- a/cli/claude_marketplace_test.go
+++ b/cli/claude_marketplace_test.go
@@ -628,3 +628,51 @@ func installClaudeMarketplaceMock(t *testing.T, logPath, failCommand string) str
 	}
 	return binDir
 }
+
+func TestCleanupClaudeMarketplaceDevResidue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	base := claudeMarketplaceBaseRoot(paths)
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatalf("MkdirAll(base) error: %v", err)
+	}
+	repo := t.TempDir()
+	link := filepath.Join(base, "ha-nova")
+	if err := os.Symlink(repo, link); err != nil {
+		t.Fatalf("Symlink() error: %v", err)
+	}
+	releaseRoot := filepath.Join(base, "releases", "v9.9.9")
+
+	// Release registration active: the dev symlink is residue and goes away.
+	cleanupClaudeMarketplaceDevResidue(paths, releaseRoot)
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("expected dev symlink removed after release registration, err=%v", err)
+	}
+
+	// Dev registration active (activeRoot == base): the symlink IS the
+	// install and must survive.
+	if err := os.Symlink(repo, link); err != nil {
+		t.Fatalf("Symlink() error: %v", err)
+	}
+	cleanupClaudeMarketplaceDevResidue(paths, base)
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("expected dev symlink kept for dev registration, err=%v", err)
+	}
+
+	// A real directory at the link path is never touched.
+	if err := os.Remove(link); err != nil {
+		t.Fatalf("Remove() error: %v", err)
+	}
+	if err := os.MkdirAll(link, 0o755); err != nil {
+		t.Fatalf("MkdirAll(dir) error: %v", err)
+	}
+	cleanupClaudeMarketplaceDevResidue(paths, releaseRoot)
+	if info, err := os.Stat(link); err != nil || !info.IsDir() {
+		t.Fatalf("expected real directory untouched, err=%v", err)
+	}
+}

--- a/cli/client_claude.go
+++ b/cli/client_claude.go
@@ -44,7 +44,6 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 	if err := ensureClaudeMarketplaceRegistration(paths.Home, marketplaceRoot); err != nil {
 		return restoreMarketplace(err)
 	}
-	cleanupClaudeMarketplaceDevResidue(paths, marketplaceRoot)
 
 	refreshArgs := []string{"plugin", "install", "ha-nova@ha-nova"}
 	alreadyInstalled := claudePluginInstalled(paths.Home)
@@ -68,7 +67,11 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 			if strings.Contains(strings.ToLower(text), "not found") || strings.Contains(strings.ToLower(text), "not installed") {
 				installCmd := exec.Command("claude", "plugin", "install", "ha-nova@ha-nova")
 				if installOutput, installErr := installCmd.CombinedOutput(); installErr == nil {
-					return verifyClaudePluginInstalled(paths.Home, marketplaceRoot)
+					if verifyErr := verifyClaudePluginInstalled(paths.Home, marketplaceRoot); verifyErr != nil {
+						return verifyErr
+					}
+					cleanupClaudeMarketplaceDevResidue(paths, marketplaceRoot)
+					return nil
 				} else {
 					return restoreMarketplace(fmt.Errorf("claude plugin command failed: %s (%s)", strings.Join(installCmd.Args[1:], " "), strings.TrimSpace(string(installOutput))))
 				}
@@ -84,6 +87,9 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 			printHumanWarn("Claude marketplace backup cleanup skipped: %s", err)
 		}
 	}
+	// Only after the sync fully verified: earlier failure paths roll back to
+	// the previous (possibly dev) registration, which still needs its symlink.
+	cleanupClaudeMarketplaceDevResidue(paths, marketplaceRoot)
 	return nil
 }
 

--- a/cli/client_claude.go
+++ b/cli/client_claude.go
@@ -44,6 +44,7 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 	if err := ensureClaudeMarketplaceRegistration(paths.Home, marketplaceRoot); err != nil {
 		return restoreMarketplace(err)
 	}
+	cleanupClaudeMarketplaceDevResidue(paths, marketplaceRoot)
 
 	refreshArgs := []string{"plugin", "install", "ha-nova@ha-nova"}
 	alreadyInstalled := claudePluginInstalled(paths.Home)

--- a/cli/command_update.go
+++ b/cli/command_update.go
@@ -123,9 +123,12 @@ func runUpdate(paths runtimePaths, args []string) int {
 		return 1
 	}
 	if err := commitInstall(); err != nil {
-		printHumanWarn("updated to v%s, but could not remove the previous install backup: %s", localVersion(paths), err)
+		printHumanWarn("updated to v%s, but could not remove the previous install backup: %s", targetVersion, err)
 	}
-	printHumanInfo("Updated to v%s", localVersion(paths))
+	// Report the staged target, not localVersion(): the still-running process
+	// may be the OLD (dev) binary whose compiled-in version predates the
+	// update (issue #245 showed "Updated to v0.7.1" while installing 0.8.0).
+	printHumanInfo("Updated to v%s", targetVersion)
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Fixes the two user-visible symptoms of #245 (found during the v0.8.0 release validation on a dev-synced maintainer machine):

- **Wrong success label**: `ha-nova update` printed `Updated to v0.7.1` while actually installing 0.8.0 — the message used `localVersion()` of the still-running OLD dev binary (compiled-in version predates the update). The message now names the staged `targetVersion`.
- **Dev residue after release restore**: after `update --force` restored the release, the dev-sync symlink at the Claude marketplace base root kept pointing at the repo checkout, making the install look dev-wired (the release registration never uses that symlink — it registers `releases/vX` directly). A release-snapshot registration now removes the stale symlink; the dev registration keeps it (it IS the install there), and a real directory at that path is never touched.

Diagnosis detail in #245. The doctor-detection ask from the issue becomes moot: every release-side client sync (update, check-update self-heal, doctor) now clears the residue itself.

## Verification

- New regression test `TestCleanupClaudeMarketplaceDevResidue` (remove on release registration / keep on dev registration / never touch a real dir)
- Existing end-to-end update tests already pin `Updated to v<target>` and stay green
- Full Go suite (143s) + `npm run verify` green

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwG5AyesTyqdX8JjjJ316N