### PR TITLE
feat(skills): consistent write-safety guardrails — backup pointers, read-back verify, availability table

### DIFF
--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -140,7 +140,7 @@ For create/update/delete:
 - `Verification`
 - `Next step`
 
-Use stable localized slot labels in this order for previews; omit empty slots, but do not invent ad-hoc headings.
+Use stable localized slot labels in this order; omit empty slots, do not invent ad-hoc headings.
 
 Do not dump the full dashboard JSON/YAML by default.
 
@@ -148,8 +148,8 @@ Do not dump the full dashboard JSON/YAML by default.
 
 - No guessed `url_path` or `dashboard_id` values.
 - Create/update uses natural confirmation after preview, bound to the exact displayed payload/diff (see context skill → Active Preview Confirmation).
-- Dashboard/resource/card delete uses exact token confirmation only, even for items created earlier in the same session.
-- If the requested change would require a broad re-layout instead of a targeted edit, say so before writing.
+- Dashboard/resource/card delete uses exact token confirmation only, even for items created earlier in the same session. Dashboard writes have no `revert`; the recovery path is Home Assistant Backups.
+- If the change needs a broad re-layout instead of a targeted edit, say so before writing.
 
 ## Guardrails
 
@@ -159,4 +159,4 @@ Do not dump the full dashboard JSON/YAML by default.
 - Never verify only by save success; always read back the dashboard.
 - Never probe a different dashboard's config just to infer behavior for the target dashboard.
 - Never invent a new custom-card schema just because a resource exists.
-- If the dashboard target is still ambiguous after one clarification, stop and explain the remaining ambiguity.
+- If the target stays ambiguous after one clarification, stop and explain.

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -267,8 +267,8 @@ Rules for all experimental relay calls in this skill:
 
 - Always preview the full payload before execution
 - Read before write: fetch current state first for any destructive operation
-- **Full-document overwrites** (e.g., `lovelace/config/save`): MUST read full config, merge changes in memory, preview merged result, then write. There is no partial update endpoint — the entire config is replaced.
-- **Field-level list replacements** (e.g., `energy/save_prefs`): omitted top-level keys are preserved, but each provided key replaces its entire list. To add one item, read the existing list first, append, then save back the full list.
+- **Full-document overwrites** (e.g., `lovelace/config/save`): MUST read full config, merge changes in memory, preview merged result, then write. There is no partial update endpoint — the entire config is replaced. After the write, read the document back and verify both the intended change and the survival of unrelated content (views, cards, sources) before reporting success.
+- **Field-level list replacements** (e.g., `energy/save_prefs`): omitted top-level keys are preserved, but each provided key replaces its entire list. To add one item, read the existing list first, append, then save back the full list. After the write, read the prefs back and verify the pre-existing list items survived alongside the new one.
 - **Web search before write**: always search for current payload schema before constructing any write payload. HA APIs evolve across versions — the examples in this skill are starting points, not authoritative schemas.
 - Every experimental call must show: "EXPERIMENTAL: No dedicated subskill schema guardrails. Proceed with caution."
 - **No diff or auto-undo here**: these writes have no `## Changes` preview or `revert`. When a write may be hard to reverse, say so plainly and point to Home Assistant Backups (Settings > System > Backups) as the safety net before confirming.
@@ -282,8 +282,8 @@ Rules for all experimental relay calls in this skill:
 
 | Type | Behavior | Safe pattern | Examples |
 |------|----------|-------------|----------|
-| Full-document overwrite | Entire config replaced | Read → modify → save full document | `lovelace/config/save` |
-| Field-level list replace | Omitted keys preserved, provided keys fully replaced | Read existing list → append/modify → save full list | `energy/save_prefs` |
+| Full-document overwrite | Entire config replaced | Read → modify → save full document → read back and verify unrelated content survived | `lovelace/config/save` |
+| Field-level list replace | Omitted keys preserved, provided keys fully replaced | Read existing list → append/modify → save full list → read back and verify pre-existing items survived | `energy/save_prefs` |
 | Merge/patch | Only provided fields updated | Send only changed fields | `config/area_registry/update`, `config/entity_registry/update` |
 | Delete | Irreversible for areas/zones/labels; soft-delete (30 days) for entities | Always `search/related` first, tokenized confirmation | `config/area_registry/delete`, `config/entity_registry/remove` |
 

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -206,3 +206,18 @@ Use `ha-nova snapshot show` to read the stored record (including
 - `revert` restores the captured config through the normal write path; it does
   not replay HA's exact byte-for-byte formatting. For a guaranteed point-in-time
   restore, Home Assistant Backups is the source of truth.
+
+## Safety-Mechanism Availability by Skill
+
+Diff and revert coverage is deliberately uneven. Never imply a mechanism a
+skill does not have; when only Backups remain, say so before the write.
+
+| Skill / family | Pre-write diff | Update-revert | Fallback recovery path |
+|---|---|---|---|
+| `write` (automation/script) | yes (`ha-nova diff`) | yes (verified updates, N=1) | HA Backups |
+| `helper` storage family | yes | yes (verified updates, N=1) | HA Backups |
+| `helper` config-entry family | diff only | no (multi-step options flow) | HA Backups |
+| `dashboard` | preview + read-back verify | no | HA Backups |
+| `organize` | field preview | no (registry deletes irreversible) | HA Backups |
+| `service-call` | state-delta preview | no (runtime action, not config) | re-run corrective service call |
+| `fallback` (experimental writes) | payload preview + read-back verify | no | HA Backups |

--- a/skills/organize/SKILL.md
+++ b/skills/organize/SKILL.md
@@ -126,3 +126,4 @@ Default to a compact field summary, not raw registry JSON.
 - Metadata updates only; no destructive registry admin beyond area/floor/label/category delete.
 - Verify the changed field values, not just the WS success response.
 - If a delete impact preview is incomplete, say so explicitly before asking for confirmation.
+- Registry deletes are irreversible and have no `revert`. Before confirming a delete, say so plainly and point to Home Assistant Backups (Settings > System > Backups) as the recovery path.

--- a/tests/skills/write-delete-safety-contract.test.ts
+++ b/tests/skills/write-delete-safety-contract.test.ts
@@ -45,6 +45,23 @@ describe("write delete safety contract", () => {
     expect(writeSafety).toContain("Home Assistant Backups");
   });
 
+  it("documents safety-mechanism availability per skill and backup pointers where revert is absent", () => {
+    const organizeSkill = readFileSync("skills/organize/SKILL.md", "utf8");
+    const dashboardSkill = readFileSync("skills/dashboard/SKILL.md", "utf8");
+    const fallbackSkill = readFileSync("skills/fallback/SKILL.md", "utf8");
+    // The diff/revert asymmetry is documented, not implicit.
+    expect(writeSafety).toContain("## Safety-Mechanism Availability by Skill");
+    expect(writeSafety).toContain("Never imply a mechanism a");
+    // Skills without revert point to HA Backups before destructive writes.
+    expect(organizeSkill).toContain("Registry deletes are irreversible");
+    expect(organizeSkill).toContain("Home Assistant Backups (Settings > System > Backups)");
+    expect(dashboardSkill).toContain("Dashboard writes have no `revert`");
+    expect(dashboardSkill).toContain("the recovery path is Home Assistant Backups");
+    // Fallback full-replace writes verify survival of unrelated content after write.
+    expect(fallbackSkill).toContain("verify both the intended change and the survival of unrelated content");
+    expect(fallbackSkill).toContain("verify the pre-existing list items survived");
+  });
+
   it("forbids surfacing internal bookkeeping in write previews/results", () => {
     expect(writeSafety).toContain("Output hygiene");
     // The live test leaked a raw config-id and "Best-Practice-Snapshot is older".


### PR DESCRIPTION
## Summary

Guardrail-consistency package from the 2026-07-08 audit. The audit found the safety mechanics (diff/revert/backup pointers) unevenly signposted: skills without a revert path did not tell the user what the recovery path is, and the fallback skill's full-replace writes verified nothing after writing.

- **`organize`**: registry deletes (areas/floors/labels/categories) are irreversible and had no recovery pointer — the guardrails now state plainly that there is no `revert` and name Home Assistant Backups (Settings > System > Backups) as the recovery path before confirmation.
- **`dashboard`**: the token-confirmation line now states that dashboard writes have no `revert` and names HA Backups as the recovery path (kept within the 1000-word skill budget by tightening unpinned lines).
- **`fallback`**: full-document overwrites (`lovelace/config/save`) and field-level list replacements (`energy/save_prefs`) must now read the document back after writing and verify both the intended change and the survival of unrelated content — previously protection ended at the pre-write merge.
- **`write-safety.md`**: new "Safety-Mechanism Availability by Skill" table documents the deliberate diff/revert asymmetry (which skill has diff, revert, or verify-only, and the fallback recovery path) so no skill implies a mechanism it does not have.
- Contract test pins the new guardrails.

## Testing

- Full `npm test`: 63 files / 564 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyBRtwy2jvCoQFKiU8C8fC