### PR TITLE
feat(relay,cli): relay 0.2.6 hardening — truthful /health, version header, response caps, actionable errors

### DIFF
--- a/cli/relay.go
+++ b/cli/relay.go
@@ -15,11 +15,23 @@ import (
 	"time"
 )
 
-var httpClient = &http.Client{
-	Timeout: 15 * time.Second,
-	Transport: &http.Transport{
-		DialContext: (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
-	},
+const (
+	defaultRelayConnectTimeoutSeconds = 5
+	defaultRelayMaxTimeSeconds        = 15
+	// Mirrors the relay's own WS/REST response ceiling (256 MiB).
+	maxRelayResponseBytes = 256 << 20
+	relayVersionHeader    = "X-Ha-Nova-Relay-Version"
+)
+
+var httpClient = newRelayHTTPClient(defaultRelayConnectTimeoutSeconds, defaultRelayMaxTimeSeconds)
+
+func newRelayHTTPClient(connectTimeoutSeconds, maxTimeSeconds float64) *http.Client {
+	return &http.Client{
+		Timeout: time.Duration(maxTimeSeconds * float64(time.Second)),
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{Timeout: time.Duration(connectTimeoutSeconds * float64(time.Second))}).DialContext,
+		},
+	}
 }
 
 type relayRequestOptions struct {
@@ -41,7 +53,7 @@ func runRelayCommand(paths runtimePaths, args []string) int {
 
 	switch args[0] {
 	case "health":
-		return runHealth(paths)
+		return runHealth(paths, args[1:])
 	case "ws":
 		return runRelayProxy(paths, "ws", args[1:])
 	case "core":
@@ -185,12 +197,18 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		printErr("%s", err)
+		printErr("%s", relayConnectErrorMessage(cfg.RelayBaseURL, err))
 		return 1
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := io.ReadAll(resp.Body)
+	if notice := checkRelayVersionValue(paths, resp.Header.Get(relayVersionHeader)); !notice.empty() {
+		if shouldWarnRelayOutdated(paths) {
+			printHumanNotice(notice)
+		}
+	}
+
+	bodyBytes, err := readAllLimited(resp.Body, maxRelayResponseBytes)
 	if err != nil {
 		printErr("%s", err)
 		return 1
@@ -258,7 +276,38 @@ func relayCoreUpstreamExitStatus(body []byte, strict bool) int {
 	return 0
 }
 
-func runHealth(paths runtimePaths) int {
+type healthOptions struct {
+	ConnectTimeoutSeconds float64
+	MaxTimeSeconds        float64
+}
+
+// parseHealthFlags accepts curl-compatible flag names so callers (session-start
+// hook) can bound the probe; previously these args were silently discarded and
+// the default 5s dial / 15s total timeouts blocked synchronous hooks on a dead
+// relay.
+func parseHealthFlags(args []string) (healthOptions, error) {
+	fs := flag.NewFlagSet("relay health", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	opts := healthOptions{}
+	fs.Float64Var(&opts.ConnectTimeoutSeconds, "connect-timeout", defaultRelayConnectTimeoutSeconds, "connection timeout in seconds")
+	fs.Float64Var(&opts.MaxTimeSeconds, "max-time", defaultRelayMaxTimeSeconds, "total request timeout in seconds")
+	if err := fs.Parse(args); err != nil {
+		return opts, err
+	}
+	if opts.ConnectTimeoutSeconds <= 0 || opts.MaxTimeSeconds <= 0 {
+		return opts, errors.New("--connect-timeout and --max-time must be positive seconds")
+	}
+	return opts, nil
+}
+
+func runHealth(paths runtimePaths, args []string) int {
+	healthOpts, err := parseHealthFlags(args)
+	if err != nil {
+		printErr("%s", err)
+		return 1
+	}
+	client := newRelayHTTPClient(healthOpts.ConnectTimeoutSeconds, healthOpts.MaxTimeSeconds)
+
 	cfg, err := loadConfig(paths)
 	if err != nil {
 		printErr("%s", err)
@@ -280,14 +329,14 @@ func runHealth(paths runtimePaths) int {
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := httpClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		printErr("%s", err)
+		printErr("%s", relayConnectErrorMessage(cfg.RelayBaseURL, err))
 		return 1
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := readAllLimited(resp.Body, maxRelayResponseBytes)
 	if err != nil || len(bodyBytes) == 0 {
 		printErr("relay health check failed")
 		return 1
@@ -310,4 +359,42 @@ func runHealth(paths runtimePaths) int {
 		return 1
 	}
 	return 0
+}
+
+// readAllLimited mirrors the relay-side 256 MiB response ceiling so a
+// misbehaving upstream cannot make the CLI buffer unbounded output.
+func readAllLimited(r io.Reader, maxBytes int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("relay response exceeded the %d-byte limit — narrow the request (filter, pagination, or a more specific path)", maxBytes)
+	}
+	return data, nil
+}
+
+func relayConnectErrorMessage(baseURL string, err error) string {
+	return fmt.Sprintf(
+		"cannot reach the NOVA Relay at %s: %s\nCheck that the NOVA Relay App is running in Home Assistant, then run: ha-nova doctor",
+		strings.TrimRight(baseURL, "/"), err,
+	)
+}
+
+// shouldWarnRelayOutdated throttles the ws/core outdated-relay warning to one
+// per hour across CLI invocations; skill flows issue many relay calls in a
+// row and must not see the warning on every one. `relay health` and doctor
+// stay unthrottled as the explicit diagnostic paths.
+func shouldWarnRelayOutdated(paths runtimePaths) bool {
+	marker := filepath.Join(paths.CacheDir, "relay-outdated-warned")
+	if info, err := os.Stat(marker); err == nil && time.Since(info.ModTime()) < time.Hour {
+		return false
+	}
+	if err := os.MkdirAll(paths.CacheDir, 0o755); err != nil {
+		return true
+	}
+	if err := os.WriteFile(marker, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o644); err != nil {
+		return true
+	}
+	return true
 }

--- a/cli/relay_test.go
+++ b/cli/relay_test.go
@@ -206,3 +206,112 @@ func setupRelayProxyTest(t *testing.T, upstreamStatus int) runtimePaths {
 	}
 	return paths
 }
+
+func TestParseHealthFlagsDefaultsAndOverrides(t *testing.T) {
+	opts, err := parseHealthFlags(nil)
+	if err != nil {
+		t.Fatalf("parseHealthFlags(nil) error: %v", err)
+	}
+	if opts.ConnectTimeoutSeconds != defaultRelayConnectTimeoutSeconds || opts.MaxTimeSeconds != defaultRelayMaxTimeSeconds {
+		t.Fatalf("defaults = %+v, want connect %d / max %d", opts, defaultRelayConnectTimeoutSeconds, defaultRelayMaxTimeSeconds)
+	}
+
+	// curl-compatible flags from the session-start hook must take effect.
+	opts, err = parseHealthFlags([]string{"--connect-timeout", "1", "--max-time", "2"})
+	if err != nil {
+		t.Fatalf("parseHealthFlags(overrides) error: %v", err)
+	}
+	if opts.ConnectTimeoutSeconds != 1 || opts.MaxTimeSeconds != 2 {
+		t.Fatalf("overrides = %+v, want connect 1 / max 2", opts)
+	}
+
+	if _, err := parseHealthFlags([]string{"--max-time", "0"}); err == nil {
+		t.Fatal("parseHealthFlags(--max-time 0) expected error, got nil")
+	}
+}
+
+func TestReadAllLimitedEnforcesCeiling(t *testing.T) {
+	under, err := readAllLimited(strings.NewReader("abc"), 3)
+	if err != nil || string(under) != "abc" {
+		t.Fatalf("readAllLimited(at limit) = %q, %v; want abc, nil", under, err)
+	}
+
+	if _, err := readAllLimited(strings.NewReader("abcd"), 3); err == nil {
+		t.Fatal("readAllLimited(over limit) expected error, got nil")
+	} else if !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("readAllLimited(over limit) error = %v, want mention of exceeded limit", err)
+	}
+}
+
+func TestShouldWarnRelayOutdatedThrottlesRepeatWarnings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	if !shouldWarnRelayOutdated(paths) {
+		t.Fatal("first shouldWarnRelayOutdated() = false, want true")
+	}
+	if shouldWarnRelayOutdated(paths) {
+		t.Fatal("second shouldWarnRelayOutdated() = true, want throttled false")
+	}
+}
+
+func TestRelayProxyWarnsOnOutdatedRelayVersionHeader(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".test-relay-token"))
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(relayVersionHeader, "0.1.0")
+		w.Header().Set("content-type", "application/json")
+		_, _ = fmt.Fprint(w, `{"ok":true,"data":{"status":200,"body":{}}}`)
+	}))
+	t.Cleanup(relayServer.Close)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.VersionFile), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(paths.VersionFile, []byte(`{"skill_version":"0.8.0","min_relay_version":"0.2.0"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+	if err := saveConfig(paths, runtimeConfig{
+		HAHost:       "127.0.0.1",
+		HAURL:        "http://127.0.0.1:8123",
+		RelayBaseURL: relayServer.URL,
+	}); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := writeRelayAuthToken("test-token"); err != nil {
+		t.Fatalf("writeRelayAuthToken() error: %v", err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "core", []string{"--method", "GET", "--path", "/api/states"})
+	})
+	if exitCode != 0 {
+		t.Fatalf("runRelayProxy() exit = %d, want 0", exitCode)
+	}
+	if !strings.Contains(output, "Relay outdated: v0.1.0 is below minimum v0.2.0") {
+		t.Fatalf("expected outdated-relay warning in output, got: %q", output)
+	}
+
+	// Second call within the throttle window stays quiet.
+	exitCode, output = captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "core", []string{"--method", "GET", "--path", "/api/states"})
+	})
+	if exitCode != 0 {
+		t.Fatalf("second runRelayProxy() exit = %d, want 0", exitCode)
+	}
+	if strings.Contains(output, "Relay outdated") {
+		t.Fatalf("expected throttled second call without warning, got: %q", output)
+	}
+}

--- a/cli/version.go
+++ b/cli/version.go
@@ -219,25 +219,35 @@ func checkRelayVersion(paths runtimePaths, healthBody []byte) humanNotice {
 	if json.Unmarshal(healthBody, &health) != nil || health.Version == "" {
 		return humanNotice{}
 	}
+	return checkRelayVersionValue(paths, health.Version)
+}
+
+// checkRelayVersionValue compares a bare relay version (from the /health body
+// or the relay's version response header on /ws and /core) against
+// min_relay_version.
+func checkRelayVersionValue(paths runtimePaths, relayVersion string) humanNotice {
+	if strings.TrimSpace(relayVersion) == "" {
+		return humanNotice{}
+	}
 
 	v, err := readVersionJSON(paths.VersionFile)
 	if err != nil || v.MinRelayVersion == "" {
 		return humanNotice{}
 	}
 
-	cmp, err := compareReleaseVersions(health.Version, v.MinRelayVersion)
+	cmp, err := compareReleaseVersions(relayVersion, v.MinRelayVersion)
 	if err != nil {
 		return humanNotice{
 			level:   humanNoticeWarning,
 			kind:    humanNoticeKindRelayOutdated,
-			message: fmt.Sprintf("Relay version check unavailable: unsupported relay version format (relay v%s, minimum v%s). Inform the user: update the NOVA Relay App in Home Assistant.", health.Version, v.MinRelayVersion),
+			message: fmt.Sprintf("Relay version check unavailable: unsupported relay version format (relay v%s, minimum v%s). Inform the user: update the NOVA Relay App in Home Assistant.", relayVersion, v.MinRelayVersion),
 		}
 	}
 	if cmp < 0 {
 		return humanNotice{
 			level:   humanNoticeWarning,
 			kind:    humanNoticeKindRelayOutdated,
-			message: fmt.Sprintf("Relay outdated: v%s is below minimum v%s. Inform the user: update the NOVA Relay App in Home Assistant.", health.Version, v.MinRelayVersion),
+			message: fmt.Sprintf("Relay outdated: v%s is below minimum v%s. Inform the user: update the NOVA Relay App in Home Assistant.", relayVersion, v.MinRelayVersion),
 		}
 	}
 	return humanNotice{}

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -69,8 +69,8 @@ if [[ -f "$version_file" ]]; then
 
   # --- Relay version check ---
   if command -v ha-nova >/dev/null 2>&1; then
-    # Relay CLI sets --connect-timeout 5 --max-time 15 by default;
-    # curl uses last-occurrence, so these overrides take effect.
+    # `relay health` accepts curl-compatible --connect-timeout/--max-time
+    # (seconds); keep this probe tight so a dead relay never blocks session start.
     health_json="$(ha-nova relay health --connect-timeout 1 --max-time 2 2>/dev/null || true)"
     if [[ -z "$health_json" ]]; then
       version_warning="[ha-nova] WARNING: Relay unreachable. Check relay status or run: ha-nova doctor\\n"

--- a/nova/CHANGELOG.md
+++ b/nova/CHANGELOG.md
@@ -9,6 +9,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/) and [Semantic
 Recent changes are tracked in [GitHub releases](https://github.com/markusleben/ha-nova/releases)
 and merged PRs. This changelog will be updated with the next tagged relay version.
 
+## [Relay 0.2.6] - 2026-07-08
+
+### Fixed
+- **`/health` reports the real Home Assistant connection state** — `ha_ws_connected` previously only reflected whether a connection object existed; because the WebSocket client auto-reconnects, it stayed `true` while HA was down or restarting. The relay now tracks the connection's `ready`/`disconnected` events, so `/health` is truthful between requests without active probing.
+- **Bounded REST responses** — the `/core` proxy buffered upstream HA responses without a limit. Responses are now capped at the same 256 MiB ceiling as the WebSocket path, with an actionable error instead of unbounded memory growth.
+
+### Added
+- **Relay version response header** — `/ws` and `/core` responses carry `x-ha-nova-relay-version`, so the CLI can warn about an outdated relay during normal skill traffic (throttled), not only on explicit `relay health` runs.
+- **Supervisor watchdog** — the add-on config enables `watchdog: tcp://` port liveness so Home Assistant restarts a crashed relay automatically.
+
+### Changed
+- **Actionable upstream error text** — network failures toward HA (`UPSTREAM_HTTP_ERROR`) now include a remediation hint instead of only the raw fetch error.
+
 ## [Relay 0.2.5] - 2026-07-07
 
 ### Fixed

--- a/nova/DOCS.md
+++ b/nova/DOCS.md
@@ -84,7 +84,7 @@ A healthy response looks like:
   "data": {
     "status": "ok",
     "ha_ws_connected": true,
-    "version": "0.2.5",
+    "version": "0.2.6",
     "uptime_s": 3621
   }
 }

--- a/nova/config.yaml
+++ b/nova/config.yaml
@@ -1,5 +1,5 @@
 name: NOVA Relay
-version: "0.2.5"
+version: "0.2.6"
 slug: ha_nova_relay
 description: Thin Home Assistant relay for WS proxy and skill workflows
 url: https://github.com/markusleben/ha-nova
@@ -14,6 +14,8 @@ ports:
   8791/tcp: 8791
 ports_description:
   8791/tcp: Relay HTTP API
+# TCP liveness only: /health requires bearer auth, an HTTP watchdog would 401-loop.
+watchdog: tcp://[HOST]:[PORT:8791]
 homeassistant_api: true
 hassio_api: true
 hassio_role: default

--- a/nova/src/ha/rest-client.ts
+++ b/nova/src/ha/rest-client.ts
@@ -121,6 +121,9 @@ async function readBodyWithLimit(response: Response, maxBytes: number): Promise<
       }
       totalBytes += value.byteLength;
       if (totalBytes > maxBytes) {
+        // Cancel so undici tears down the upstream socket instead of keeping
+        // it open until HA finishes sending the oversized body.
+        await reader.cancel().catch(() => undefined);
         throw new HaRestClientError(
           "UPSTREAM_HTTP_ERROR",
           `HA response exceeded the ${maxBytes}-byte relay limit — narrow the request (filter, pagination, or a more specific path)`

--- a/nova/src/ha/rest-client.ts
+++ b/nova/src/ha/rest-client.ts
@@ -20,13 +20,18 @@ export interface HaRestClientOptions {
   baseUrl: string;
   token: string;
   requestTimeoutMs?: number;
+  maxResponseBytes?: number;
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+// Mirrors the WS payload ceiling (nova/src/ha/socket.ts) so both proxy paths
+// share one bound instead of the REST path buffering unbounded HA responses.
+const DEFAULT_MAX_RESPONSE_BYTES = 256 * 1024 * 1024;
 
 export function createHaRestClient(options: HaRestClientOptions): HaRestClient {
   const baseUrl = options.baseUrl.endsWith("/") ? options.baseUrl.slice(0, -1) : options.baseUrl;
   const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const maxResponseBytes = options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
 
   return {
     async request(input: CoreProxyRequest): Promise<CoreProxyResponse> {
@@ -50,7 +55,7 @@ export function createHaRestClient(options: HaRestClientOptions): HaRestClient {
 
             return {
               status: response.status,
-              body: await parseResponseBody(response)
+              body: await parseResponseBody(response, maxResponseBytes)
             };
           })(),
           requestTimeoutMs,
@@ -60,8 +65,14 @@ export function createHaRestClient(options: HaRestClientOptions): HaRestClient {
         if (error instanceof TimeoutError) {
           throw new HaRestClientError("UPSTREAM_HTTP_TIMEOUT", `HTTP request timed out after ${requestTimeoutMs}ms`);
         }
-        const message = error instanceof Error && error.message ? error.message : "Upstream HTTP request failed";
-        throw new HaRestClientError("UPSTREAM_HTTP_ERROR", message);
+        if (error instanceof HaRestClientError) {
+          throw error;
+        }
+        const detail = error instanceof Error && error.message ? error.message : "Upstream HTTP request failed";
+        throw new HaRestClientError(
+          "UPSTREAM_HTTP_ERROR",
+          `${detail} — check that Home Assistant is running and reachable from the NOVA Relay App`
+        );
       }
     }
   };
@@ -79,17 +90,47 @@ function buildHeaders(token: string, method: CoreProxyRequest["method"]): Header
   return headers;
 }
 
-async function parseResponseBody(response: Response): Promise<unknown> {
+async function parseResponseBody(response: Response, maxBytes: number): Promise<unknown> {
   const contentType = response.headers.get("content-type") ?? "";
+  const text = await readBodyWithLimit(response, maxBytes);
 
   if (contentType.toLowerCase().includes("application/json")) {
     try {
-      return (await response.json()) as unknown;
+      return JSON.parse(text) as unknown;
     } catch {
       return null;
     }
   }
 
-  const text = await response.text();
   return text.length > 0 ? text : null;
+}
+
+async function readBodyWithLimit(response: Response, maxBytes: number): Promise<string> {
+  if (!response.body) {
+    return "";
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  const reader = response.body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        throw new HaRestClientError(
+          "UPSTREAM_HTTP_ERROR",
+          `HA response exceeded the ${maxBytes}-byte relay limit — narrow the request (filter, pagination, or a more specific path)`
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return Buffer.concat(chunks).toString("utf8");
 }

--- a/nova/src/ha/ws-client.ts
+++ b/nova/src/ha/ws-client.ts
@@ -217,13 +217,20 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
       connected = true;
       // The connection reconnects on its own; only the tracked flag flips so
       // /health stays truthful between requests without extra probes.
-      connection.addEventListener?.("disconnected", () => {
-        connected = false;
+      // resetConnection() abandons rather than closes the old connection, so
+      // a stale one can keep firing events — guard on still being current.
+      const current = connection;
+      current.addEventListener?.("disconnected", () => {
+        if (connection === current) {
+          connected = false;
+        }
       });
-      connection.addEventListener?.("ready", () => {
-        connected = true;
+      current.addEventListener?.("ready", () => {
+        if (connection === current) {
+          connected = true;
+        }
       });
-      return connection;
+      return current;
     } catch (error) {
       throw new HaWsClientError(
         "UPSTREAM_WS_CONNECT_ERROR",

--- a/nova/src/ha/ws-client.ts
+++ b/nova/src/ha/ws-client.ts
@@ -18,6 +18,7 @@ export interface HaWsConnection {
     message: HaWsRequest,
     options?: { resubscribe?: boolean }
   ): Promise<() => void | Promise<void>>;
+  addEventListener?(event: "ready" | "disconnected", callback: () => void): void;
 }
 
 export interface HaWsClient {
@@ -52,6 +53,10 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
   const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   let connection: HaWsConnection | undefined;
   let connectingPromise: Promise<HaWsConnection> | undefined;
+  // Tracked live state, not object existence: the underlying connection
+  // auto-reconnects and outlives HA outages, so `connection !== undefined`
+  // would report connected while HA is down.
+  let connected = false;
 
   return {
     async sendMessage<T>(message: HaWsRequest): Promise<T> {
@@ -194,7 +199,7 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
       }
     },
     isConnected(): boolean {
-      return connection !== undefined;
+      return connected;
     }
   };
 
@@ -209,6 +214,15 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
 
     try {
       connection = await connectingPromise;
+      connected = true;
+      // The connection reconnects on its own; only the tracked flag flips so
+      // /health stays truthful between requests without extra probes.
+      connection.addEventListener?.("disconnected", () => {
+        connected = false;
+      });
+      connection.addEventListener?.("ready", () => {
+        connected = true;
+      });
       return connection;
     } catch (error) {
       throw new HaWsClientError(
@@ -223,6 +237,7 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
 
   function resetConnection(): void {
     connection = undefined;
+    connected = false;
   }
 }
 

--- a/nova/src/http/server.ts
+++ b/nova/src/http/server.ts
@@ -10,12 +10,20 @@ export interface HttpServerOptions {
   authToken: string;
   router: Router;
   maxJsonBodyBytes?: number;
+  version?: string;
 }
+
+// Lets CLI callers of /ws and /core detect an outdated relay without an
+// extra /health round-trip; /health remains the full health signal.
+export const RELAY_VERSION_HEADER = "x-ha-nova-relay-version";
 
 export function createHttpServer(options: HttpServerOptions): Server {
   const maxJsonBodyBytes = options.maxJsonBodyBytes ?? DEFAULT_MAX_JSON_BODY_BYTES;
 
   return createServer(async (request, response) => {
+    if (options.version) {
+      response.setHeader(RELAY_VERSION_HEADER, options.version);
+    }
     try {
       const authResult = authorizeRequest(request.headers.authorization, options.authToken);
       if (!authResult.ok) {

--- a/nova/src/index.ts
+++ b/nova/src/index.ts
@@ -70,7 +70,8 @@ export function createApp(options: AppOptions): App {
 
   const server = createHttpServer({
     authToken: options.authToken,
-    router
+    router,
+    version: options.version
   });
 
   return {

--- a/nova/src/runtime/start.ts
+++ b/nova/src/runtime/start.ts
@@ -137,7 +137,8 @@ export function createDefaultWsClient(input: RuntimeWsClientInput): HaWsClient {
       const wrapped: HaWsConnection = {
         sendMessagePromise: (message: HaWsRequest) => connection.sendMessagePromise(message),
         subscribeMessage: (callback, message, options) =>
-          connection.subscribeMessage(callback, message, options)
+          connection.subscribeMessage(callback, message, options),
+        addEventListener: (event, callback) => connection.addEventListener(event, callback)
       };
 
       return wrapped;

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
-# Bump skill_version across all skill version-bearing files.
-# Does NOT touch config.yaml (Relay version) — managed independently.
+# Bump skill_version across all skill version-bearing files,
+# or the Relay version (nova/config.yaml) with --relay.
 # Usage: bash scripts/bump-version.sh 0.2.0
+#        bash scripts/bump-version.sh --relay 0.2.6
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+MODE="skill"
+if [[ "${1:-}" == "--relay" ]]; then
+  MODE="relay"
+  shift
+fi
 NEW_VERSION="${1:-}"
 
 if [[ -z "$NEW_VERSION" ]]; then
-  echo "Usage: $0 <new-version>"
-  echo "Example: $0 0.2.0"
+  echo "Usage: $0 [--relay] <new-version>"
+  echo "Example: $0 0.2.0          # skill version"
+  echo "Example: $0 --relay 0.2.6  # relay version (nova/config.yaml)"
   exit 1
 fi
 
@@ -21,6 +29,24 @@ fi
 if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Error: version must be semver (MAJOR.MINOR.PATCH), got: $NEW_VERSION"
   exit 1
+fi
+
+if [[ "$MODE" == "relay" ]]; then
+  CONFIG_YAML="$REPO_ROOT/nova/config.yaml"
+  if ! grep -qE '^version: "[0-9]+\.[0-9]+\.[0-9]+"$' "$CONFIG_YAML"; then
+    echo "Error: could not find a 'version: \"X.Y.Z\"' line in nova/config.yaml"
+    exit 1
+  fi
+  tmp=$(mktemp)
+  sed -E "s|^version: \"[0-9]+\.[0-9]+\.[0-9]+\"$|version: \"$NEW_VERSION\"|" "$CONFIG_YAML" > "$tmp" && mv "$tmp" "$CONFIG_YAML"
+  echo ""
+  echo "Bumped Relay version to $NEW_VERSION in nova/config.yaml"
+  echo ""
+  echo "Reminders:"
+  echo "  1. Add a '## [Relay $NEW_VERSION]' section to nova/CHANGELOG.md"
+  echo "  2. If skills depend on new relay behavior, raise min_relay_version in version.json"
+  echo "  3. npm test"
+  exit 0
 fi
 
 # 1. version.json (source of truth)

--- a/tests/ha/rest-client.test.ts
+++ b/tests/ha/rest-client.test.ts
@@ -123,9 +123,19 @@ describe("ha rest client", () => {
     } satisfies Partial<HaRestClientError>);
   });
 
-  it("rejects upstream responses above the configured size ceiling", async () => {
+  it("rejects upstream responses above the configured size ceiling and cancels the body", async () => {
+    let upstreamCancelled = false;
+    const oversizedBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("x".repeat(64)));
+        // Never closes on its own — a cooperative upstream that keeps sending.
+      },
+      cancel() {
+        upstreamCancelled = true;
+      }
+    });
     const fetchMock = vi.fn(async () => {
-      return new Response("x".repeat(64), {
+      return new Response(oversizedBody, {
         status: 200,
         headers: {
           "content-type": "text/plain"
@@ -149,6 +159,8 @@ describe("ha rest client", () => {
       code: "UPSTREAM_HTTP_ERROR",
       message: "HA response exceeded the 32-byte relay limit — narrow the request (filter, pagination, or a more specific path)"
     } satisfies Partial<HaRestClientError>);
+    // The reader must cancel the stream so the upstream socket gets torn down.
+    expect(upstreamCancelled).toBe(true);
   });
 
   it("accepts upstream responses exactly at the size ceiling", async () => {

--- a/tests/ha/rest-client.test.ts
+++ b/tests/ha/rest-client.test.ts
@@ -118,8 +118,65 @@ describe("ha rest client", () => {
       })
     ).rejects.toMatchObject({
       code: "UPSTREAM_HTTP_ERROR",
-      message: "network down"
+      // The raw error stays first; the appended hint tells the agent what to check.
+      message: "network down — check that Home Assistant is running and reachable from the NOVA Relay App"
     } satisfies Partial<HaRestClientError>);
+  });
+
+  it("rejects upstream responses above the configured size ceiling", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response("x".repeat(64), {
+        status: 200,
+        headers: {
+          "content-type": "text/plain"
+        }
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createHaRestClient({
+      baseUrl: "http://ha.local",
+      token: "upstream-token",
+      maxResponseBytes: 32
+    });
+
+    await expect(
+      client.request({
+        method: "GET",
+        path: "/api/states"
+      })
+    ).rejects.toMatchObject({
+      code: "UPSTREAM_HTTP_ERROR",
+      message: "HA response exceeded the 32-byte relay limit — narrow the request (filter, pagination, or a more specific path)"
+    } satisfies Partial<HaRestClientError>);
+  });
+
+  it("accepts upstream responses exactly at the size ceiling", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response("x".repeat(32), {
+        status: 200,
+        headers: {
+          "content-type": "text/plain"
+        }
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createHaRestClient({
+      baseUrl: "http://ha.local",
+      token: "upstream-token",
+      maxResponseBytes: 32
+    });
+
+    const response = await client.request({
+      method: "GET",
+      path: "/api/states"
+    });
+
+    expect(response).toEqual({
+      status: 200,
+      body: "x".repeat(32)
+    });
   });
 
   it("maps stalled upstream requests to HaRestClientError timeout", async () => {

--- a/tests/ha/ws-client.test.ts
+++ b/tests/ha/ws-client.test.ts
@@ -29,6 +29,30 @@ describe("ha ws client", () => {
     expect(client.isConnected()).toBe(true);
   });
 
+  it("tracks upstream disconnected/ready events for isConnected", async () => {
+    const listeners: Record<string, () => void> = {};
+
+    const client = createHaWsClient({
+      createConnection: async () => ({
+        sendMessagePromise: async () => ({ ok: true }),
+        addEventListener: (event: "ready" | "disconnected", callback: () => void) => {
+          listeners[event] = callback;
+        }
+      })
+    });
+
+    await client.sendMessage({ type: "ping" });
+    expect(client.isConnected()).toBe(true);
+
+    // The underlying connection auto-reconnects and keeps its object alive
+    // through an HA outage — only the events may flip the health signal.
+    listeners["disconnected"]?.();
+    expect(client.isConnected()).toBe(false);
+
+    listeners["ready"]?.();
+    expect(client.isConnected()).toBe(true);
+  });
+
   it("maps connection failures to UPSTREAM_WS_CONNECT_ERROR", async () => {
     const client = createHaWsClient({
       createConnection: async () => {

--- a/tests/ha/ws-client.test.ts
+++ b/tests/ha/ws-client.test.ts
@@ -53,6 +53,54 @@ describe("ha ws client", () => {
     expect(client.isConnected()).toBe(true);
   });
 
+  it("ignores events from a stale connection after reset", async () => {
+    const listenersByConnection: Array<Record<string, () => void>> = [];
+    let failNext = false;
+
+    const client = createHaWsClient({
+      createConnection: async () => {
+        const listeners: Record<string, () => void> = {};
+        listenersByConnection.push(listeners);
+        return {
+          sendMessagePromise: async () => {
+            if (failNext) {
+              failNext = false;
+              throw new Error("transport gone");
+            }
+            return { ok: true };
+          },
+          addEventListener: (event: "ready" | "disconnected", callback: () => void) => {
+            listeners[event] = callback;
+          }
+        };
+      }
+    });
+
+    await client.sendMessage({ type: "ping" });
+    failNext = true;
+    await expect(client.sendMessage({ type: "ping" })).rejects.toMatchObject({
+      code: "UPSTREAM_WS_ERROR"
+    } satisfies Partial<HaWsClientError>);
+    expect(client.isConnected()).toBe(false);
+
+    // Second connection becomes current.
+    await client.sendMessage({ type: "ping" });
+    expect(client.isConnected()).toBe(true);
+
+    // The abandoned first connection auto-reconnects in the background and
+    // keeps firing events — those must not flip the active signal.
+    listenersByConnection[0]?.["disconnected"]?.();
+    expect(client.isConnected()).toBe(true);
+    listenersByConnection[0]?.["ready"]?.();
+    expect(client.isConnected()).toBe(true);
+
+    // Events from the current connection still work.
+    listenersByConnection[1]?.["disconnected"]?.();
+    expect(client.isConnected()).toBe(false);
+    listenersByConnection[1]?.["ready"]?.();
+    expect(client.isConnected()).toBe(true);
+  });
+
   it("maps connection failures to UPSTREAM_WS_CONNECT_ERROR", async () => {
     const client = createHaWsClient({
       createConnection: async () => {

--- a/tests/http/error-envelope.test.ts
+++ b/tests/http/error-envelope.test.ts
@@ -92,16 +92,43 @@ describe("error envelope", () => {
       }
     });
   });
+
+  it("stamps the relay version header on success and error responses", async () => {
+    const { baseUrl } = await startServer(
+      servers,
+      (router) => {
+        router.register("GET", "/health", () => ({ status: "ok" }));
+        return router;
+      },
+      "0.2.6"
+    );
+
+    const success = await fetch(`${baseUrl}/health`, {
+      headers: {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`
+      }
+    });
+    expect(success.status).toBe(200);
+    expect(success.headers.get("x-ha-nova-relay-version")).toBe("0.2.6");
+
+    // Error paths (including auth failures) carry the header too, so the CLI
+    // can always evaluate relay freshness.
+    const unauthorized = await fetch(`${baseUrl}/health`);
+    expect(unauthorized.status).toBe(401);
+    expect(unauthorized.headers.get("x-ha-nova-relay-version")).toBe("0.2.6");
+  });
 });
 
 async function startServer(
   servers: Array<ReturnType<typeof createHttpServer>>,
-  configure: (router: ReturnType<typeof createRouter>) => ReturnType<typeof createRouter>
+  configure: (router: ReturnType<typeof createRouter>) => ReturnType<typeof createRouter>,
+  version?: string
 ): Promise<{ baseUrl: string }> {
   const router = configure(createRouter());
   const server = createHttpServer({
     authToken: TEST_AUTH_TOKEN,
-    router
+    router,
+    ...(version !== undefined ? { version } : {})
   });
 
   servers.push(server);


### PR DESCRIPTION
## Summary

Relay/CLI hardening package from the 2026-07-08 audit — Relay bumps to **0.2.6**.

### Relay 0.2.6
- **Truthful `/health`**: `ha_ws_connected` previously reported object existence; the WS library auto-reconnects, so it stayed `true` while HA was down. Now the connection's `ready`/`disconnected` events drive a tracked flag — no health-path pings, no lazy-connect from probes, field name unchanged (DOCS/onboarding-contract consumers keep working).
- **Version response header**: `/ws` and `/core` responses carry `x-ha-nova-relay-version`, stamped on success and error paths.
- **Bounded REST responses**: `/core` buffered upstream bodies without limit; now capped at the same 256 MiB ceiling as the WS path (streamed count, `.json()` and `.text()` paths), with an actionable error.
- **Actionable `UPSTREAM_HTTP_ERROR`**: raw fetch errors get a remediation hint appended.
- **Supervisor watchdog**: `watchdog: tcp://[HOST]:[PORT:8791]` (deliberately not `http://…/health` — the endpoint requires bearer auth and would 401-restart-loop).

### CLI
- **`relay health` parses curl-compatible `--connect-timeout`/`--max-time`**: the session-start hook has always passed `--connect-timeout 1 --max-time 2`, but `runHealth` discarded all args, so a dead relay blocked session start for the full 5 s dial / 15 s total timeouts. Hook unchanged; its stale comment corrected.
- **Outdated-relay warning during normal traffic**: `relay ws|core` read the version header and warn via stderr, throttled to once per hour (skill flows issue many calls in a row); `relay health`/`doctor` stay unthrottled as explicit diagnostic paths. Skill JSON stdout/`--out` files stay clean.
- **CLI-side 256 MiB response limit** (`io.LimitReader` semantics with explicit over-limit error).
- **Actionable relay-connection errors** ("is the NOVA Relay App running… run: ha-nova doctor") instead of raw Go transport errors.
- **`bump-version.sh --relay`** (WP7 pulled forward): bumps `nova/config.yaml`, reminds about CHANGELOG + `min_relay_version`.

`min_relay_version` stays 0.2.5 — the header and health fix are additive; the CLI tolerates a missing header.

## Live verification (real HA instance, 2026-07-08)

- Deployed 0.2.6 via `ha-app-deploy`; `/health` showed `ha_ws_connected:false` on fresh start (lazy), `true` after first WS request.
- `ha core restart`: relay reported `false` **4 s** after the restart began and recovered to `true` **~75 s** later purely from the `ready` event — no request traffic involved; relay uptime continuous.
- Supervisor accepted the watchdog config; per-app watchdog toggle enabled and verified.
- New CLI binary live against the relay: `relay health --connect-timeout 1 --max-time 2` completes in 1.07 s (flags now actually parsed).
- `bump-version.sh --relay` executed (idempotent run, no diff).

## Testing

- Vitest 63 files / 568 tests green (new: WS event tracking, REST cap at/over boundary, version header on success+error responses)
- `go test -count=1 ./...` green (new: health flag parsing, `readAllLimited`, warning throttle, end-to-end outdated-header warning incl. throttled second call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyBRtwy2jvCoQFKiU8C8fC