### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.8.0"
+    "version": "0.9.0"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,16 +85,19 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## New Features
 
-    - Setup wizard rework: a friendly intro on first run, a connection repair menu when verification fails (retry, change the Home Assistant address, run the install steps for this address, or stop with progress saved), and Home Assistant links that work before and after the 2026.2 "Add-ons to Apps" rename.
-    - Network discovery now prefers a verified IP address over fragile `.local` names, so setup survives Windows mDNS hiccups.
+    - Three new skills: **Scenes** (create, edit, delete — including "save this room as a scene" with proper light-color capture), **To-do lists** (manage items and shopping lists, create Local To-do lists, provider-aware), and **Backups** (check status, create a backup — also as a safety net before far-reaching changes — inspect and delete; restore deliberately stays in the Home Assistant UI).
+    - The review skill now catches configs silently broken by Home Assistant 2026.6's removal of the legacy template platform syntax, and gently suggests modernizing pre-2024.10 automation keys.
+    - Clearer safety story: skills without an undo say so up front and can offer a real backup first for far-reaching changes — never for routine small edits.
 
     ## Bug Fixes
 
-    - NOVA Relay 0.2.5: large Home Assistant instances no longer lose the relay connection on big responses (for example full entity registry lists), and Home Assistant's real error messages now reach the client instead of a generic "WS request failed".
+    - NOVA Relay 0.2.6: health reporting is now truthful while Home Assistant restarts (no more "connected" when it is not), large REST responses are bounded, and connection errors tell you what to check.
+    - Starting a client session no longer hangs for up to 15 seconds when the relay is unreachable.
+    - Setup wizard polish and update-flow fixes ("Updated to..." now names the version you actually got).
 
     ## What To Watch
 
-    - Update the NOVA Relay app in Home Assistant (Settings > Apps > NOVA Relay > Update) to 0.2.5 — the skills warn when the running relay is older than required.
+    - Update the NOVA Relay app in Home Assistant (Settings > Apps > NOVA Relay > Update) to 0.2.6 — the relay also restarts itself automatically now if it ever crashes (watchdog).
 
     Stable install commands are release-pinned for this tag.
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ HA NOVA is early — and that's the point. Here's where it's going:
 
 ## 🧩 Skills
 
-13 task skills plus the HA NOVA context skill, each a markdown file you can read and edit.
+16 task skills plus the HA NOVA context skill, each a markdown file you can read and edit.
 
 | Skill | What it does |
 |:------|:-------------|
@@ -164,10 +164,13 @@ HA NOVA is early — and that's the point. Here's where it's going:
 | 📖 **read** | Inspect configs and debug why an automation didn't fire |
 | 🔍 **review** | Audit your setup for mistakes, conflicts, and reliability gaps |
 | 🧱 **dashboard** | Edit dashboards, cards, and Lovelace resources safely |
+| 🎬 **scene** | Create and manage scenes, including "save this room as a scene" |
 | 🗂️ **organize** | Manage areas, floors, labels, and entity metadata |
 | 🕒 **history** | Query history, logbook timelines, and long-term stats |
 | 🏠 **health** | Summarize Home Assistant status, repairs, integrations, system health, and noisy entities |
 | 📅 **calendar** | Read calendars and bounded event windows |
+| ✅ **todo** | Manage to-do and shopping-list items, create Local To-do lists |
+| 💾 **backup** | Check backup status, create backups — also as a safety net before risky changes |
 | 🎛️ **service-call** | Control lights, climate, covers, switches, and media players |
 | 🔎 **entity-discovery** | Find entities by name, room, area, or label |
 | 🧩 **helper** | Create and manage helpers: counters, timers, input booleans, more |

--- a/docs/work/2026-07-08-v0.9.0-release-body.md
+++ b/docs/work/2026-07-08-v0.9.0-release-body.md
@@ -1,0 +1,23 @@
+# v0.9.0 Release Body (working draft)
+
+Status: shipping with the v0.9.0 release-prep PR (the normative body lives in `.goreleaser.yml`)
+
+## New Features
+
+- Three new skills: **Scenes** (create, edit, delete — including "save this room as a scene" with proper light-color capture), **To-do lists** (manage items and shopping lists, create Local To-do lists, provider-aware), and **Backups** (check status, create a backup — also as a safety net before far-reaching changes — inspect and delete; restore deliberately stays in the Home Assistant UI).
+- The review skill now catches configs silently broken by Home Assistant 2026.6's removal of the legacy template platform syntax, and gently suggests modernizing pre-2024.10 automation keys.
+- Clearer safety story: skills without an undo say so up front and can offer a real backup first for far-reaching changes — never for routine small edits.
+
+## Bug Fixes
+
+- NOVA Relay 0.2.6: health reporting is now truthful while Home Assistant restarts (no more "connected" when it is not), large REST responses are bounded, and connection errors tell you what to check.
+- Starting a client session no longer hangs for up to 15 seconds when the relay is unreachable.
+- Setup wizard polish and update-flow fixes ("Updated to..." now names the version you actually got).
+
+## What To Watch
+
+- Update the NOVA Relay app in Home Assistant (Settings > Apps > NOVA Relay > Update) to 0.2.6 — the relay also restarts itself automatically now if it ever crashes (watchdog).
+
+## Included PRs (not in the public notes)
+
+#248 wizard layout, #250 dashboard null-guard, #251 update display/sync, #253 consolidation, #254 R-25/M-05 review checks, #255 guardrail consistency, #256 relay 0.2.6 + CLI hardening, #257 scene skill, #258 todo skill, #259 backup skill.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -53,13 +53,14 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
-  it("keeps v0.8.0 release-facing wording user-centric", () => {
+  it("keeps v0.9.0 release-facing wording user-centric", () => {
     // Shipped release-note bodies are archived (docs/archive/work/) and
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
-    expect(goreleaser).toContain("Setup wizard rework");
-    expect(goreleaser).toContain("run the install steps for this address, or stop with progress saved");
-    expect(goreleaser).toContain("NOVA Relay 0.2.5");
+    expect(goreleaser).toContain("Three new skills");
+    expect(goreleaser).toContain('"save this room as a scene"');
+    expect(goreleaser).toContain("restore deliberately stays in the Home Assistant UI");
+    expect(goreleaser).toContain("NOVA Relay 0.2.6");
     expect(goreleaser).toContain("Settings > Apps > NOVA Relay > Update");
     expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");
   });

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.8.0",
+  "skill_version": "0.9.0",
   "min_relay_version": "0.2.5"
 }


### PR DESCRIPTION
## Summary

Release-prep for **v0.9.0** (skill) + **Relay 0.2.6** (App). Collects: #248 wizard layout, #250 dashboard null-guard, #251 update display/sync, #253 consolidation, #254 R-25/M-05 review checks, #255 guardrail consistency, #256 relay 0.2.6 + CLI hardening, #257 scene skill, #258 todo skill, #259 backup skill.

- Version bump 0.8.0 → 0.9.0 via `bump-version.sh` (version.json, package.json, package-lock, plugin.json, marketplace.json); `min_relay_version` stays 0.2.5 — relay 0.2.6 features are additive and the CLI tolerates older relays.
- Release notes in `.goreleaser.yml` (short, user-centric: New Features / Bug Fixes / What To Watch) + working draft in `docs/work/2026-07-08-v0.9.0-release-body.md`.
- README (release-bound edits only): 13 → 16 task skills, three new table rows.
- `release-contract.test.ts` wording pins moved to the active v0.9.0 template.

## Preflight

Open-PR audit done: 6 Dependabot PRs, all classified "separate later" (tsx/vitest toolchain-risk, @types/node major, axios red, actions/checkout workflow-PR) — none pulled in.

## Testing

Full `npm test`: 66 files / 592 tests green; docs fact-check green.

Merging this PR starts the RC/final tag sequence immediately per the release runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyBRtwy2jvCoQFKiU8C8fC