### PR TITLE
docs: archive the shipped v0.9.0 release-body draft

### DIFF
--- a/docs/archive/work/2026-07-08-v0.9.0-release-body.md
+++ b/docs/archive/work/2026-07-08-v0.9.0-release-body.md
@@ -1,6 +1,6 @@
 # v0.9.0 Release Body (working draft)
 
-Status: shipping with the v0.9.0 release-prep PR (the normative body lives in `.goreleaser.yml`)
+Status: shipped (v0.9.0 released 2026-07-08; the normative body lives in `.goreleaser.yml`)
 
 ## New Features
 


### PR DESCRIPTION
Post-release housekeeping per docs/releasing.md — the draft moves to docs/archive/work/ with a shipped status line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyBRtwy2jvCoQFKiU8C8fC