### PR TITLE
feat(service-call): teach response services — the mandatory ?return_response query parameter

### DIFF
--- a/skills/service-call/SKILL.md
+++ b/skills/service-call/SKILL.md
@@ -33,7 +33,7 @@ Use file-based payloads for service writes:
 
 ## Response services
 
-Some services return data (`weather.get_forecasts`, `calendar.get_events`, `todo.get_items`, ...) and REQUIRE the `?return_response` query parameter — without it HA returns 400 "requires responses". Path shape: `/api/services/<domain>/<service>?return_response`; the data lives under `.data.body.service_response`. These calls are reads — no write confirmation needed; summarize the data compactly.
+Some services return data (`weather.get_forecasts`, `calendar.get_events`, `todo.get_items`, ...) and REQUIRE the `?return_response` query parameter — without it HA returns 400 "requires responses". Path shape: `/api/services/<domain>/<service>?return_response`; the data lives under `.data.body.service_response`. Pure data services (the examples above) are reads — no write confirmation. A response-capable ACTION service (for example direct `script.<script_id>`) still follows the full preview/confirmation flow below — the parameter only adds the response, it never downgrades an action to a read.
 
 ## Flow
 

--- a/skills/service-call/SKILL.md
+++ b/skills/service-call/SKILL.md
@@ -31,6 +31,10 @@ Use file-based payloads for service writes:
 - `ha-nova relay core --method GET --path /api/states/<entity_id>`
 - `--out <result-file>` when the response is large
 
+## Response services
+
+Some services return data (`weather.get_forecasts`, `calendar.get_events`, `todo.get_items`, ...) and REQUIRE the `?return_response` query parameter — without it HA returns 400 "requires responses". Path shape: `/api/services/<domain>/<service>?return_response`; the data lives under `.data.body.service_response`. These calls are reads — no write confirmation needed; summarize the data compactly.
+
 ## Flow
 
 1. Resolve target entity (use entity discovery if name is ambiguous).

--- a/tests/skills/service-call-contract.test.ts
+++ b/tests/skills/service-call-contract.test.ts
@@ -114,6 +114,16 @@ describe("service call contract", () => {
     });
   });
 
+  describe("response services", () => {
+    it("teaches the mandatory return_response query parameter", () => {
+      // Live-verified: weather.get_forecasts returns 400 without it.
+      expect(skillDoc).toContain("## Response services");
+      expect(skillDoc).toContain("REQUIRE the `?return_response` query parameter");
+      expect(skillDoc).toContain("`.data.body.service_response`");
+      expect(skillDoc).toContain("These calls are reads — no write confirmation needed");
+    });
+  });
+
   describe("broad-target ambiguity", () => {
     it("requires clarification when area-wide targeting may be too broad", () => {
       expect(skillDoc).toContain("room/area");

--- a/tests/skills/service-call-contract.test.ts
+++ b/tests/skills/service-call-contract.test.ts
@@ -120,7 +120,8 @@ describe("service call contract", () => {
       expect(skillDoc).toContain("## Response services");
       expect(skillDoc).toContain("REQUIRE the `?return_response` query parameter");
       expect(skillDoc).toContain("`.data.body.service_response`");
-      expect(skillDoc).toContain("These calls are reads — no write confirmation needed");
+      expect(skillDoc).toContain("Pure data services (the examples above) are reads — no write confirmation");
+      expect(skillDoc).toContain("it never downgrades an action to a read");
     });
   });
 


### PR DESCRIPTION
## Summary

Small v0.10.0 unlock: the service-call skill never taught response-returning services, so "Wie wird das Wetter?" (`weather.get_forecasts`), `calendar.get_events` and friends failed with HA's 400 "Service call requires responses but caller did not ask for responses" — the todo skill had learned this only for itself.

New compact "Response services" section: the `?return_response` path shape, the `.data.body.service_response` envelope location, and the read semantics (no write confirmation).

## Verification

Live against real HA: `weather.get_forecasts` without the parameter → 400 with the exact documented error; with it → 6-day forecast delivered. Contract test pins the section. Full `npm test`: 66 files / 593 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyBRtwy2jvCoQFKiU8C8fC