### PR TITLE
feat(helper): promote the template config-entry family — 10th helper domain

### DIFF
--- a/docs/reference/ha-api-matrix.md
+++ b/docs/reference/ha-api-matrix.md
@@ -83,7 +83,7 @@ Observed locally on a real HA instance on 2026-03-19: raw WS `config_entries/flo
 
 **Helper-owned config-entry domains:** utility_meter, derivative, integration, min_max, threshold, tod, statistics, group, history_stats, template
 `group` is menu-driven; the live-proven end-to-end subtype is `sensor`, and other subtypes must stay anchored to the live step schema instead of guessed fields.
-**Fallback-owned flow helpers:** template, trend, random, filter, generic_thermostat, switch_as_x, generic_hygrostat
+**Fallback-owned flow helpers:** trend, random, filter, generic_thermostat, switch_as_x, generic_hygrostat
 
 ### Dashboard / Lovelace
 | WS Type | Purpose |

--- a/docs/reference/ha-api-matrix.md
+++ b/docs/reference/ha-api-matrix.md
@@ -81,7 +81,7 @@ Which HA operations require REST, WS, or filesystem?
 
 Observed locally on a real HA instance on 2026-03-19: raw WS `config_entries/flow` did not succeed in this session; relay `/core` returned the expected config-flow responses.
 
-**Helper-owned config-entry domains:** utility_meter, derivative, integration, min_max, threshold, tod, statistics, group, history_stats
+**Helper-owned config-entry domains:** utility_meter, derivative, integration, min_max, threshold, tod, statistics, group, history_stats, template
 `group` is menu-driven; the live-proven end-to-end subtype is `sensor`, and other subtypes must stay anchored to the live step schema instead of guessed fields.
 **Fallback-owned flow helpers:** template, trend, random, filter, generic_thermostat, switch_as_x, generic_hygrostat
 

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -288,7 +288,7 @@ Rules:
   - No domain reload needed
 
 - **Config-entry family**
-  - Types: `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`
+  - Types: `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`, `template`
   - Read/list: WS `config_entries/get` + WS `config/entity_registry/list`
   - Readback: current editable options snapshot when `supports_options: true`; metadata-only fallback otherwise
   - Mutation transport: relay `/core`

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -300,7 +300,6 @@ Rules:
   - `group` remains menu-driven; end-to-end support is proven for the `sensor` subtype, and other subtypes must stay anchored to the live step schema instead of guessed fields
 
 Still excluded from `ha-nova:helper`:
-- `template`
 - `trend`
 - `random`
 - `filter`

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -48,7 +48,7 @@ For every Relay-Ready call in this skill:
 | Automations CRUD | Covered | read / write |
 | Scripts CRUD | Covered | read / write |
 | Config Review | Covered | review |
-| Helpers (9 storage + 9 config-entry) | Covered | helper |
+| Helpers (9 storage + 10 config-entry) | Covered | helper |
 | Entity Search | Covered | entity-discovery |
 | Service Calls | Covered | service-call |
 | Relay Setup | Covered | onboarding |
@@ -70,7 +70,7 @@ For every Relay-Ready call in this skill:
 | Other Config-Entry Helpers | Relay-Ready | this skill |
 | Entity remove / Device config-entry detach | Relay-Ready | this skill |
 | Event Subscriptions | Roadmap Phase 1c | -- |
-| Template / YAML Sensors | Roadmap Phase 3 | -- |
+| YAML / REST / Command-Line Sensors | Roadmap Phase 3 | -- |
 | Backups (status, create, inspect, delete) | Covered | backup |
 | Updates (pending, release notes, install, skip) | Covered | updates |
 | Apps / Supervisor | External | -- |
@@ -219,14 +219,16 @@ Real-time event streams for state changes, automation triggers, and custom event
 **Status:** Coming in Phase 1c. Blocked by: No SSE streaming endpoint in Relay.
 **Workaround:** Poll entity state periodically via `GET /api/states/{entity_id}`.
 
-### Template / REST / Command-Line Sensors -- ROADMAP (Phase 3)
+### YAML / REST / Command-Line Sensors -- ROADMAP (Phase 3)
+
+Config-entry template helpers are covered by `ha-nova:helper` — this roadmap item is only about YAML-file, REST, and command-line sensors.
 
 Define custom sensors using Jinja2 templates, REST endpoints, or shell commands.
 
 **Search:** `home assistant template sensor yaml configuration 2026`
 
 **Status:** Coming in Phase 3. Blocked by: No filesystem access in Relay (sensors defined in YAML files).
-**Workaround:** Create via HA UI: Settings > Devices & Services > Helpers (for template helpers) or add YAML manually.
+**Workaround:** Add the YAML manually via the HA config files.
 
 ## External Features
 

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -158,7 +158,6 @@ Owned by `ha-nova:helper` now:
 
 Still handled here:
 
-- `template`
 - `trend`
 - `random`
 - `filter`
@@ -166,9 +165,9 @@ Still handled here:
 - `switch_as_x`
 - `generic_hygrostat`
 
-**Search:** `home assistant config entry flow helper template trend random filter generic_thermostat api 2026`
+**Search:** `home assistant config entry flow helper trend random filter generic_thermostat api 2026`
 
-**Supported types in this fallback section:** `template`, `trend`, `random`, `filter`, `generic_thermostat`, `switch_as_x`, `generic_hygrostat`
+**Supported types in this fallback section:** `trend`, `random`, `filter`, `generic_thermostat`, `switch_as_x`, `generic_hygrostat`
 
 **Experimental relay calls (no skill guardrails):**
 ```text

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -155,6 +155,7 @@ Owned by `ha-nova:helper` now:
 - `statistics`
 - `group`
 - `history_stats`
+- `template`
 
 Still handled here:
 

--- a/skills/ha-nova/best-practices.md
+++ b/skills/ha-nova/best-practices.md
@@ -84,7 +84,7 @@ Pick the right `mode` based on the automation's behavior:
 <!-- Copyright (c) Sergey Kadentsev (@sergeykad), Julien Lapointe (@julienld) -->
 
 When a user needs a derived/computed sensor, prefer built-in integrations over template sensors.
-All of these — including `template` itself when no built-in fits — are relay-backed config-entry helpers owned by `ha-nova:helper`.
+All the config-entry rows below — plus `template` itself when no built-in fits — are relay-backed config-entry helpers owned by `ha-nova:helper` (`schedule` is a storage-based helper, also `ha-nova:helper`, via the `schedule/create` WS flow, not the config-entry path).
 
 | Need | Use instead of template | Key benefit |
 |------|------------------------|-------------|

--- a/skills/ha-nova/best-practices.md
+++ b/skills/ha-nova/best-practices.md
@@ -84,7 +84,7 @@ Pick the right `mode` based on the automation's behavior:
 <!-- Copyright (c) Sergey Kadentsev (@sergeykad), Julien Lapointe (@julienld) -->
 
 When a user needs a derived/computed sensor, prefer built-in integrations over template sensors.
-These are configured via the HA UI (Settings → Helpers or Integrations), not via relay CRUD.
+All of these — including `template` itself when no built-in fits — are relay-backed config-entry helpers owned by `ha-nova:helper`.
 
 | Need | Use instead of template | Key benefit |
 |------|------------------------|-------------|
@@ -99,7 +99,7 @@ These are configured via the HA UI (Settings → Helpers or Integrations), not v
 | Weekly on/off schedule | `schedule` | UI-editable, creates binary sensor |
 | Time-of-day binary (morning/night) | `tod` | Supports sunrise/sunset offsets |
 
-> **Relay-backed config-entry flows are now supported** for the helper-owned domains listed above through `ha-nova:helper`. Keep guidance narrow: unsupported helper families still fall back to the HA UI or `ha-nova:fallback`, and `group` must follow the live menu/form flow instead of guessed fields.
+> **Relay-backed config-entry flows are supported** for the helper-owned domains listed above plus `template` through `ha-nova:helper`. Keep guidance narrow: unsupported helper families (trend, random, filter, ...) still fall back to the HA UI or `ha-nova:fallback`, and `group`/`template` must follow the live menu/form flow instead of guessed fields.
 
 ## Zigbee Button Patterns
 

--- a/skills/ha-nova/helper-flow-schemas.md
+++ b/skills/ha-nova/helper-flow-schemas.md
@@ -62,8 +62,8 @@ If enum semantics, required/optional behavior, or cross-field rules are uncertai
 
 Observed locally on a real HA instance on 2026-03-19:
 
-- all 9 create flows succeeded through relay `/core`
-- all 9 create flows produced loaded entries with `supports_options: true`
+- the original 9 domains: all create flows succeeded through relay `/core` (2026-03-19)
+- the original 9 domains: all create flows produced loaded entries with `supports_options: true`; `template` was observed separately (see its section)
 - raw WS `config_entries/flow` did not succeed in this session
 - field-level update verification required reopening the options flow
 - several domains reject partial required-field submits; helper update must merge requested changes over the current options snapshot
@@ -324,6 +324,7 @@ Observed locally on a real HA instance on 2026-03-19:
      - `device_class` (optional, select)
      - `state_class` (optional, select)
      - `device_id` (optional, device)
+     - `advanced_options` (optional, expandable — present on the create form too)
 - Observed update fields (options flow, `step_id: sensor`):
   - `state`
   - `unit_of_measurement`

--- a/skills/ha-nova/helper-flow-schemas.md
+++ b/skills/ha-nova/helper-flow-schemas.md
@@ -1,7 +1,7 @@
 # HA NOVA Config-Entry Helper Flow Schemas
 
 Reference for the config-entry helper family handled by `ha-nova:helper`.
-This file covers the full supported config-entry family (9 domains):
+This file covers the full supported config-entry family (10 domains):
 
 - `utility_meter`
 - `derivative`
@@ -12,6 +12,7 @@ This file covers the full supported config-entry family (9 domains):
 - `statistics`
 - `group`
 - `history_stats`
+- `template`
 
 This file is an observed field inventory, not a complete validation schema.
 Use it to confirm supported domains, flow shape, update expectations, and verification notes.
@@ -308,5 +309,31 @@ Observed locally on a real HA instance on 2026-03-19:
   - a valid submit must use exactly two of those three keys
   - live success was proven with `start + end`
   - if the requested change switches to a different valid pair, drop the previous third key explicitly before submit
+- Linked entity resolution:
+  - resolve by matching `config_entry_id` in entity registry
+
+## template
+
+- Handler: `template`
+- Observed create flow shape (menu-driven, like `group`):
+  1. `step_id: user`, `type: menu` — `menu_options` is the entity-type list (observed: `alarm_control_panel`, `binary_sensor`, `button`, `cover`, `device_tracker`, `event`, `fan`, `image`, `light`, `lock`, `number`, `select`, `sensor`, `switch`, `update`, `vacuum`, `weather`); submit `{"next_step_id":"<type>"}`
+  2. `step_id: sensor` (verified subtype), `type: form`:
+     - `name` (required, text)
+     - `state` (required, template)
+     - `unit_of_measurement` (optional, select)
+     - `device_class` (optional, select)
+     - `state_class` (optional, select)
+     - `device_id` (optional, device)
+- Observed update fields (options flow, `step_id: sensor`):
+  - `state`
+  - `unit_of_measurement`
+  - `device_class`
+  - `state_class`
+  - `device_id`
+  - `advanced_options`
+  - `name` is NOT editable via the options flow — renames go through the entity registry (`ha-nova:organize`)
+- Subtype notes:
+  - end-to-end support verified for `sensor`; other subtypes must anchor to the live step schema instead of guessed fields
+  - the `state` value is a Jinja template string; a broken template creates the entry but the entity renders `unavailable` — post-write verification must read the rendered state
 - Linked entity resolution:
   - resolve by matching `config_entry_id` in entity registry

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -298,7 +298,7 @@ Verification rules:
 
 Observed locally on a real HA instance on 2026-03-19:
 
-- all 9 supported domains completed real create/update/delete loops through relay `/core`
+- the original 9 domains completed real create/update/delete loops through relay `/core` (2026-03-19); `template` completed a live create/options-flow/delete loop on 2026-07-09
 - raw WS `config_entries/flow` did not succeed in this session
 - field-level update verification required reopening the options flow
 

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -230,6 +230,7 @@ Supported helper domains:
 - `statistics`
 - `group`
 - `history_stats`
+- `template`
 
 `group` is menu-driven; the live-proven end-to-end subtype is `sensor`, and other subtypes must stay anchored to the live step schema instead of guessed fields.
 

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -331,6 +331,7 @@ If multiple matches remain, present max 5 candidates and ask one blocking questi
    - do not invent values for fields the current step does not expose
    - for `history_stats`, preserve HA's two-key window invariant across `start`, `end`, and `duration`
    - for `history_stats`, if the requested change switches to a different valid window pair, drop the old third key explicitly so the submit body still contains exactly two of `start`, `end`, and `duration`
+   - for `template`, when the change touches the `state` template, resolve every entity ID referenced in the NEW template against the entity registry before submitting — a typo like `is_state('binary_sensor.typo','on')` renders a clean boolean, so the post-write rendered-state read cannot catch it; an unknown reference is a blocking question, not a submit
 7. Preview current vs proposed in the Changes slot with `ha-nova diff` (see `skills/ha-nova/write-safety.md` → Pre-Write Diff). Include an explicit not-saved-yet line and Options block (`apply`, `show yaml`, `cancel`).
 8. Ask for natural confirmation bound to this exact preview (see context skill → Active Preview Confirmation).
 9. Submit the current step:

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -11,14 +11,15 @@ description: Use when creating, updating, deleting, or listing Home Assistant he
 
 - **Storage-based family** — full CRUD for:
   - `input_boolean`, `input_number`, `input_text`, `input_select`, `input_datetime`, `input_button`, `counter`, `timer`, `schedule`
-- **Config-entry family** — CRUD support for 9 domains:
-  - `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`
+- **Config-entry family** — CRUD support for 10 domains:
+  - `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`, `template`
   - `group` note: handled through the live menu-driven flow; end-to-end support is verified for the `sensor` subtype, and other subtypes must stay anchored to the live step schema instead of guessed fields
+  - `template` note: same menu-driven flow (17 entity types); end-to-end support is verified for the `sensor` subtype. The `state` field is a Jinja template — author it per `skills/ha-nova/template-guidelines.md` and apply the template-level reliability checks (missing `float`/`int` defaults, boolean-string comparisons) BEFORE submitting; a broken template renders the entity `unavailable`, so post-write verification must read the rendered state, not just entry existence
 
 Not handled here:
 
 - other config-entry helper families:
-  - `template`, `trend`, `random`, `filter`, `generic_thermostat`, `switch_as_x`, `generic_hygrostat`
+  - `trend`, `random`, `filter`, `generic_thermostat`, `switch_as_x`, `generic_hygrostat`
 - `local_todo` list config entries (use `ha-nova:todo`)
 - automations/scripts config mutations (use `ha-nova:write`)
 
@@ -172,6 +173,7 @@ If the user gives only a linked `entity_id`, resolve it back to `config_entry_id
 - `statistics`
 - `group`
 - `history_stats`
+- `template`
 
 #### Listing helpers
 
@@ -354,7 +356,7 @@ If multiple matches remain, present max 5 candidates and ask one blocking questi
    - if multiple candidates remain after resolution, stop and ask one blocking question
    - never guess between duplicate titles or ambiguous linked-entity matches
 2. Enforce the helper-domain allowlist before any delete:
-   - allowed here: `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`
+   - allowed here: `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`, `template`
    - if the resolved `domain` is outside that allowlist, stop
    - do not call `DELETE /api/config/config_entries/entry/{entry_id}` for out-of-scope domains
    - hand off to `ha-nova:fallback` for any other config-entry domain

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -253,7 +253,7 @@ If multiple matches remain, present max 5 candidates and ask one blocking questi
    - for `group` or `template` with subtype `sensor`, include the required `next_step_id` menu choice and the observed final form
    - for any other `group` or `template` subtype, plan only the menu choice before the flow starts; inspect the live subtype form before promising the final field set
    - for `statistics` and `history_stats`, prepare every later step body before preview
-   - for `template`, resolve every entity ID referenced inside the `state` template against the entity registry before preview — an unknown reference is a blocking question, not a submit
+   - for `template`, resolve every entity ID referenced inside the `state` template before preview — check the entity registry, then fall back to `/api/states/<entity_id>` (the registry only tracks entities with a `unique_id`; YAML/manual entities are valid references but absent from it). Only a reference missing from BOTH is a blocking question, not a submit
 3. Preview with the shared write-preview shape:
    - title/name
    - domain
@@ -331,7 +331,7 @@ If multiple matches remain, present max 5 candidates and ask one blocking questi
    - do not invent values for fields the current step does not expose
    - for `history_stats`, preserve HA's two-key window invariant across `start`, `end`, and `duration`
    - for `history_stats`, if the requested change switches to a different valid window pair, drop the old third key explicitly so the submit body still contains exactly two of `start`, `end`, and `duration`
-   - for `template`, when the change touches the `state` template, resolve every entity ID referenced in the NEW template against the entity registry before submitting — a typo like `is_state('binary_sensor.typo','on')` renders a clean boolean, so the post-write rendered-state read cannot catch it; an unknown reference is a blocking question, not a submit
+   - for `template`, when the change touches the `state` template, resolve every entity ID referenced in the NEW template before submitting (entity registry, then `/api/states/<entity_id>` fallback — YAML/manual entities are absent from the registry but valid) — a typo like `is_state('binary_sensor.typo','on')` renders a clean boolean, so the post-write rendered-state read cannot catch it; a reference missing from both is a blocking question, not a submit
 7. Preview current vs proposed in the Changes slot with `ha-nova diff` (see `skills/ha-nova/write-safety.md` → Pre-Write Diff). Include an explicit not-saved-yet line and Options block (`apply`, `show yaml`, `cancel`).
 8. Ask for natural confirmation bound to this exact preview (see context skill → Active Preview Confirmation).
 9. Submit the current step:

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -111,7 +111,7 @@ If 0 results: try synonyms or shorter stems. Never dump entire domains.
    - No useful defaults inferable → silently skip.
 3. Preview the payload with the shared write-preview shape: compact summary, pre-write check when applicable, explicit not-saved-yet line, and Options block (`apply`, `show yaml`, `cancel`).
 4. Ask for natural confirmation bound to this exact preview (see context skill → Active Preview Confirmation).
-   - for unobserved `group` subtypes, this first confirmation authorizes only the non-persisting menu-step submit, not the final subtype-specific payload
+   - for unobserved `group` or `template` subtypes, this first confirmation authorizes only the non-persisting menu-step submit, not the final subtype-specific payload
 5. Execute:
    ```text
    ha-nova relay ws --data-file <payload-file>
@@ -187,7 +187,7 @@ If the user gives only a linked `entity_id`, resolve it back to `config_entry_id
    ha-nova relay ws --data-file <payload-file> --out <registry-file>
    ```
    with `{"type":"config/entity_registry/list"}`.
-3. Filter config entries to the nine supported domains.
+3. Filter config entries to the ten supported domains.
 4. Join linked entities by matching `config_entry_id`.
 5. Present a compact table with:
    - title
@@ -250,15 +250,16 @@ If multiple matches remain, present max 5 candidates and ask one blocking questi
    - if required field semantics remain uncertain, fail loud and ask one blocking question
 2. Prepare the full create plan using `skills/ha-nova/helper-flow-schemas.md`:
    - for one-step domains, the plan is one submit body
-   - for `group` with subtype `sensor`, include the required `next_step_id` menu choice and the observed final form
-   - for any other `group` subtype, plan only the menu choice before the flow starts; inspect the live subtype form before promising the final field set
+   - for `group` or `template` with subtype `sensor`, include the required `next_step_id` menu choice and the observed final form
+   - for any other `group` or `template` subtype, plan only the menu choice before the flow starts; inspect the live subtype form before promising the final field set
    - for `statistics` and `history_stats`, prepare every later step body before preview
+   - for `template`, resolve every entity ID referenced inside the `state` template against the entity registry before preview — an unknown reference is a blocking question, not a submit
 3. Preview with the shared write-preview shape:
    - title/name
    - domain
    - known step plan
    - all fields already known at this point
-   - for unobserved `group` subtypes, say that the final subtype form will be previewed after the menu step returns live fields
+   - for unobserved `group` or `template` subtypes, say that the final subtype form will be previewed after the menu step returns live fields
    - include an explicit not-saved-yet line and Options block (`apply`, `show yaml`, `cancel`)
 4. Ask for natural confirmation bound to this exact preview (see context skill → Active Preview Confirmation).
 5. Capture a pre-create baseline:
@@ -276,7 +277,7 @@ If multiple matches remain, present max 5 candidates and ask one blocking questi
    - fail loud if the start response did not return `flow_id`
 8. Iterate the flow until terminal success:
    - if the current response is a menu step, submit only the selected `next_step_id`
-   - if that menu step leads to an unobserved `group` subtype form, stop and preview the live subtype fields before the terminal submit
+   - if that menu step leads to an unobserved `group` or `template` subtype form, stop and preview the live subtype fields before the terminal submit
    - after that live subtype preview, ask for a second natural confirmation before sending the terminal subtype-specific payload
    - if the current response is a form step, submit only the fields exposed for that step
    - the submit body for a form step must contain form fields only
@@ -400,6 +401,7 @@ Instead, run the minimal config-entry post-write contract:
 1. **Verification**
    - create: config entry now exists and the requested `entry_id`/diff verification passed
    - update: the same `entry_id` still exists and the reopened options-flow snapshot reflects the requested field changes
+   - for `template` creates and `state`-changing updates, additionally read the linked entity via `GET /api/states/<entity_id>` — an `unavailable`/`unknown` rendered state means the template is broken; report it as a template defect while the config-entry write itself still counts as passed
    - delete: config entry is absent
 2. **Current editable snapshot**
    - if an options flow is available, summarize only the editable fields exposed by the final current step readback

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -401,7 +401,7 @@ Instead, run the minimal config-entry post-write contract:
 1. **Verification**
    - create: config entry now exists and the requested `entry_id`/diff verification passed
    - update: the same `entry_id` still exists and the reopened options-flow snapshot reflects the requested field changes
-   - for `template` creates and `state`-changing updates, additionally read the linked entity via `GET /api/states/<entity_id>` — an `unavailable`/`unknown` rendered state means the template is broken; report it as a template defect while the config-entry write itself still counts as passed
+   - for `template` creates and `state`-changing updates, additionally read the linked entity via `GET /api/states/<entity_id>`. A clean numeric/string render confirms the template works. Treat `unavailable`/`unknown` as INCONCLUSIVE, not proof of breakage — a source entity can be legitimately `unknown`, or the template may intentionally return a sentinel; only call it a template defect when the options-flow template or an HA error proves a failure. Either way the config-entry write itself still counts as passed
    - delete: config entry is absent
 2. **Current editable snapshot**
    - if an options flow is available, summarize only the editable fields exposed by the final current step readback

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -233,7 +233,7 @@ Traverse all `variables:` mappings in the config, not just the top-level block. 
   - in Step 2, derive collision candidates from `linked_entities[]`, not from config actions
   - run `search/related` on up to 3 linked entities
   - say explicitly that config-entry helper review does not use the storage-helper H rules
-  - for the `template` domain, also read the linked entity's rendered state (flag `unavailable`/`unknown`) and apply the template-level reliability checks to the `state` template when an options-flow readback exposes it
+  - for the `template` domain, also read the linked entity's rendered state (flag `unavailable`/`unknown`); to apply the template-level reliability checks, open the options flow for the entry first (non-persisting readback — the canonical metadata item does not carry the `state` template)
 - If an automation or script references helpers in actions or direct thresholds, also apply H-01..H-10 to those helpers
 - R-17 is an intra-config branch comparison only. Never emit it from collision scan or cross-automation conflict analysis.
 - R-18 applies only to sibling-variable references within one `variables:` mapping. Never emit it for cross-action or cross-scope references, script `fields`, HA builtins, or `{% set %}` locals inside the same template.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -233,7 +233,7 @@ Traverse all `variables:` mappings in the config, not just the top-level block. 
   - in Step 2, derive collision candidates from `linked_entities[]`, not from config actions
   - run `search/related` on up to 3 linked entities
   - say explicitly that config-entry helper review does not use the storage-helper H rules
-  - for the `template` domain, also read the linked entity's rendered state (flag `unavailable`/`unknown`); to apply the template-level reliability checks, open the options flow for the entry first (non-persisting readback — the canonical metadata item does not carry the `state` template)
+  - for the `template` domain, also read the linked entity's rendered state (`unavailable`/`unknown` is inconclusive, not proof of breakage — source state or an intentional sentinel); to apply the template-level reliability checks, open the options flow for the entry first (non-persisting readback — the canonical metadata item does not carry the `state` template)
 - If an automation or script references helpers in actions or direct thresholds, also apply H-01..H-10 to those helpers
 - R-17 is an intra-config branch comparison only. Never emit it from collision scan or cross-automation conflict analysis.
 - R-18 applies only to sibling-variable references within one `variables:` mapping. Never emit it for cross-action or cross-scope references, script `fields`, HA builtins, or `{% set %}` locals inside the same template.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -39,7 +39,7 @@ If user provides an exact automation/script `entity_id` (e.g., `automation.main_
 
 For helpers, resolve the family first:
 - storage-based family: entity_id domain is one of `input_boolean`, `input_number`, `input_text`, `input_select`, `input_datetime`, `input_button`, `counter`, `timer`, `schedule`
-- supported config-entry family: domain is one of `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`
+- supported config-entry family: domain is one of `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`, `template`
 - config-entry helper review remains minimal, but target resolution must still normalize to a real `entry_id`
 
 If the target config is not already in the thread context, resolve it yourself:

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -233,6 +233,7 @@ Traverse all `variables:` mappings in the config, not just the top-level block. 
   - in Step 2, derive collision candidates from `linked_entities[]`, not from config actions
   - run `search/related` on up to 3 linked entities
   - say explicitly that config-entry helper review does not use the storage-helper H rules
+  - for the `template` domain, also read the linked entity's rendered state (flag `unavailable`/`unknown`) and apply the template-level reliability checks to the `state` template when an options-flow readback exposes it
 - If an automation or script references helpers in actions or direct thresholds, also apply H-01..H-10 to those helpers
 - R-17 is an intra-config branch comparison only. Never emit it from collision scan or cross-automation conflict analysis.
 - R-18 applies only to sibling-variable references within one `variables:` mapping. Never emit it for cross-action or cross-scope references, script `fields`, HA builtins, or `{% set %}` locals inside the same template.

--- a/skills/review/checks.md
+++ b/skills/review/checks.md
@@ -193,7 +193,7 @@ Self-trigger / feedback loop = the automation triggers on an entity that it also
   - HA 2025.12 to 2026.5: deprecated, still functional — downgrade the finding to MEDIUM and recommend migrating before upgrading.
   - HA < 2025.12: the syntax is still current on that version (deprecation started in 2025.12) — keep MEDIUM, do not call it deprecated; say it will stop working once the instance upgrades to 2026.6+ and recommend migrating ahead of that upgrade.
   - Version unavailable: state the outcomes conditionally.
-- Do not confuse with the config-entry `template` helper domain (`ha-nova:fallback`) or with `trigger: template` triggers — this check is only about `platform: template` entity definitions.
+- Do not confuse with the config-entry `template` helper domain (`ha-nova:helper`) or with `trigger: template` triggers — this check is only about `platform: template` entity definitions.
 - When R-25 pulls a pasted template block into review scope, apply the template-level reliability checks (R-01, R-11, R-23) to its templates as well — those defects survive the migration to modern syntax.
 - Migration hint shape (do not rewrite automatically; show the target shape):
   ```yaml

--- a/tests/skills/best-practice-patterns-contract.test.ts
+++ b/tests/skills/best-practice-patterns-contract.test.ts
@@ -255,8 +255,8 @@ describe("best-practice patterns contract", () => {
 
     it("documents the current relay-backed config-entry helper support boundary", () => {
       content ??= readFileSync(file, "utf8");
-      expect(content).toContain("Relay-backed config-entry flows are now supported");
-      expect(content).toContain("unsupported helper families still fall back");
+      expect(content).toContain("Relay-backed config-entry flows are supported");
+      expect(content).toContain("unsupported helper families (trend, random, filter, ...) still fall back");
       expect(content).toContain("group");
       expect(content).toContain("live menu/form flow");
       expect(content).not.toContain("Relay support planned");

--- a/tests/skills/ha-nova-contract.test.ts
+++ b/tests/skills/ha-nova-contract.test.ts
@@ -346,13 +346,13 @@ describe("ha-nova contract", () => {
     );
 
     expect(architecture).toContain("Still excluded from `ha-nova:helper`:");
-    expect(architecture).toContain("- `template`");
     expect(architecture).toContain("- `trend`");
     expect(architecture).toContain("- `random`");
     expect(architecture).toContain("- `filter`");
     expect(architecture).toContain("- `generic_thermostat`");
     expect(architecture).toContain("- `switch_as_x`");
     expect(architecture).toContain("- `generic_hygrostat`");
+    expect(architecture).not.toContain("Still excluded from `ha-nova:helper`:\n- `template`");
     expect(architecture).not.toContain("Still excluded from `ha-nova:helper`:\n- `group`");
     expect(architecture).not.toContain("Still excluded from `ha-nova:helper`:\n- `statistics`");
     expect(architecture).not.toContain("Still excluded from `ha-nova:helper`:\n- `history_stats`");

--- a/tests/skills/helper-contract.test.ts
+++ b/tests/skills/helper-contract.test.ts
@@ -140,6 +140,8 @@ describe("helper contract", () => {
       expect(skillDoc).toContain("for any other `group` or `template` subtype, plan only the menu choice");
       // Pre-create resolution of entities inside the state template.
       expect(skillDoc).toContain("an unknown reference is a blocking question, not a submit");
+      // Reference resolution required on state updates too (typo renders clean).
+      expect(skillDoc).toContain("resolve every entity ID referenced in the NEW template against the entity registry before submitting");
       // Rendered-state verification is operationalized, not just promised.
       expect(skillDoc).toContain("Treat `unavailable`/`unknown` as INCONCLUSIVE, not proof of breakage");
       expect(skillDoc).toContain("only call it a template defect when the options-flow template or an HA error proves a failure");

--- a/tests/skills/helper-contract.test.ts
+++ b/tests/skills/helper-contract.test.ts
@@ -107,11 +107,11 @@ describe("helper contract", () => {
 
     it("references the dedicated config-entry flow schema doc", () => {
       expect(skillDoc).toContain("helper-flow-schemas.md");
-      expect(flowSchemasDoc).toContain("full supported config-entry family (9 domains)");
+      expect(flowSchemasDoc).toContain("full supported config-entry family (10 domains)");
       expect(flowSchemasDoc).toContain("Canonical write identity: `entry_id`");
     });
 
-    it("documents full config-entry helper ownership for the 9 supported domains", () => {
+    it("documents full config-entry helper ownership for the 10 supported domains", () => {
       for (const domain of [
         "utility_meter",
         "derivative",
@@ -122,14 +122,19 @@ describe("helper contract", () => {
         "statistics",
         "group",
         "history_stats",
+        "template",
       ]) {
         expect(skillDoc).toContain(domain);
         expect(flowSchemasDoc).toContain(domain);
       }
 
-      expect(skillDoc).toContain("CRUD support for 9 domains:");
+      expect(skillDoc).toContain("CRUD support for 10 domains:");
       expect(skillDoc).toContain("verified for the `sensor` subtype");
       expect(skillDoc).not.toContain("does **not** support update yet");
+      // Template authoring safety: broken templates render entities unavailable.
+      expect(skillDoc).toContain("skills/ha-nova/template-guidelines.md");
+      expect(skillDoc).toContain("post-write verification must read the rendered state");
+      expect(flowSchemasDoc).toContain("`name` is NOT editable via the options flow");
     });
 
     it("uses options-flow snapshots for config-entry readback", () => {
@@ -174,7 +179,7 @@ describe("helper contract", () => {
     it("enforces the config-entry helper allowlist before delete", () => {
       expect(skillDoc).toContain("Resolve target to the canonical config-entry helper item");
       expect(skillDoc).toContain("Enforce the helper-domain allowlist before any delete");
-      expect(skillDoc).toContain("allowed here: `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`");
+      expect(skillDoc).toContain("allowed here: `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`, `template`");
       expect(skillDoc).toContain("do not call `DELETE /api/config/config_entries/entry/{entry_id}` for out-of-scope domains");
       expect(skillDoc).toContain("hand off to `ha-nova:fallback` for any other config-entry domain");
       expect(skillDoc).toContain("`entry_id` only when needed to disambiguate duplicate titles/domains");
@@ -241,7 +246,6 @@ describe("helper contract", () => {
         .find((line) => line.includes("Supported types in this fallback section:"));
 
       expect(supportedTypesLine).toBeDefined();
-      expect(supportedTypesLine).toContain("`template`");
       expect(supportedTypesLine).toContain("`trend`");
       expect(supportedTypesLine).toContain("`random`");
       expect(supportedTypesLine).toContain("`filter`");
@@ -257,6 +261,7 @@ describe("helper contract", () => {
       expect(supportedTypesLine).not.toContain("`statistics`");
       expect(supportedTypesLine).not.toContain("`group`");
       expect(supportedTypesLine).not.toContain("`history_stats`");
+      expect(supportedTypesLine).not.toContain("`template`");
       expect(fallbackDoc).toContain("Delete unsupported config-entry helper by entry_id");
     });
   });

--- a/tests/skills/helper-contract.test.ts
+++ b/tests/skills/helper-contract.test.ts
@@ -141,7 +141,8 @@ describe("helper contract", () => {
       // Pre-create resolution of entities inside the state template.
       expect(skillDoc).toContain("an unknown reference is a blocking question, not a submit");
       // Rendered-state verification is operationalized, not just promised.
-      expect(skillDoc).toContain("report it as a template defect while the config-entry write itself still counts as passed");
+      expect(skillDoc).toContain("Treat `unavailable`/`unknown` as INCONCLUSIVE, not proof of breakage");
+      expect(skillDoc).toContain("only call it a template defect when the options-flow template or an HA error proves a failure");
     });
 
     it("uses options-flow snapshots for config-entry readback", () => {

--- a/tests/skills/helper-contract.test.ts
+++ b/tests/skills/helper-contract.test.ts
@@ -135,6 +135,13 @@ describe("helper contract", () => {
       expect(skillDoc).toContain("skills/ha-nova/template-guidelines.md");
       expect(skillDoc).toContain("post-write verification must read the rendered state");
       expect(flowSchemasDoc).toContain("`name` is NOT editable via the options flow");
+      // Menu-flow safety machinery covers template like group (16 unverified subtypes).
+      expect(skillDoc).toContain("for unobserved `group` or `template` subtypes, this first confirmation authorizes only the non-persisting menu-step submit");
+      expect(skillDoc).toContain("for any other `group` or `template` subtype, plan only the menu choice");
+      // Pre-create resolution of entities inside the state template.
+      expect(skillDoc).toContain("an unknown reference is a blocking question, not a submit");
+      // Rendered-state verification is operationalized, not just promised.
+      expect(skillDoc).toContain("report it as a template defect while the config-entry write itself still counts as passed");
     });
 
     it("uses options-flow snapshots for config-entry readback", () => {
@@ -199,13 +206,13 @@ describe("helper contract", () => {
     });
 
     it("documents multi-step create flows and required-field carry-forward for updates", () => {
-      expect(skillDoc).toContain("for `group` with subtype `sensor`, include the required `next_step_id` menu choice and the observed final form");
-      expect(skillDoc).toContain("for any other `group` subtype, plan only the menu choice before the flow starts");
+      expect(skillDoc).toContain("for `group` or `template` with subtype `sensor`, include the required `next_step_id` menu choice and the observed final form");
+      expect(skillDoc).toContain("for any other `group` or `template` subtype, plan only the menu choice before the flow starts");
       expect(flowSchemasDoc).toContain("end-to-end CRUD was proven locally for the `sensor` subtype only");
       expect(skillDoc).toContain("for `statistics` and `history_stats`, prepare every later step body before preview");
-      expect(skillDoc).toContain("for unobserved `group` subtypes, say that the final subtype form will be previewed after the menu step returns live fields");
+      expect(skillDoc).toContain("for unobserved `group` or `template` subtypes, say that the final subtype form will be previewed after the menu step returns live fields");
       expect(skillDoc).toContain("this first confirmation authorizes only the non-persisting menu-step submit");
-      expect(skillDoc).toContain("if that menu step leads to an unobserved `group` subtype form, stop and preview the live subtype fields before the terminal submit");
+      expect(skillDoc).toContain("if that menu step leads to an unobserved `group` or `template` subtype form, stop and preview the live subtype fields before the terminal submit");
       expect(skillDoc).toContain("ask for a second natural confirmation before sending the terminal subtype-specific payload");
       expect(skillDoc).toContain("carry forward unchanged required fields");
       expect(skillDoc).toContain("fail loud as unsupported update for that field on this HA version");

--- a/tests/skills/helper-contract.test.ts
+++ b/tests/skills/helper-contract.test.ts
@@ -139,9 +139,10 @@ describe("helper contract", () => {
       expect(skillDoc).toContain("for unobserved `group` or `template` subtypes, this first confirmation authorizes only the non-persisting menu-step submit");
       expect(skillDoc).toContain("for any other `group` or `template` subtype, plan only the menu choice");
       // Pre-create resolution of entities inside the state template.
-      expect(skillDoc).toContain("an unknown reference is a blocking question, not a submit");
+      expect(skillDoc).toContain("Only a reference missing from BOTH is a blocking question, not a submit");
       // Reference resolution required on state updates too (typo renders clean).
-      expect(skillDoc).toContain("resolve every entity ID referenced in the NEW template against the entity registry before submitting");
+      expect(skillDoc).toContain("resolve every entity ID referenced in the NEW template before submitting");
+      expect(skillDoc).toContain("YAML/manual entities are absent from the registry but valid");
       // Rendered-state verification is operationalized, not just promised.
       expect(skillDoc).toContain("Treat `unavailable`/`unknown` as INCONCLUSIVE, not proof of breakage");
       expect(skillDoc).toContain("only call it a template defect when the options-flow template or an HA error proves a failure");

--- a/tests/skills/review-contract.test.ts
+++ b/tests/skills/review-contract.test.ts
@@ -276,7 +276,7 @@ describe("review contract", () => {
     expect(reviewSkill).toContain("downgrade the idea into Questions to consider");
   });
   it("keeps standalone config-entry helper review aligned to the 9 helper-owned domains", () => {
-    expect(reviewSkill).toContain("supported config-entry family: domain is one of `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`");
+    expect(reviewSkill).toContain("supported config-entry family: domain is one of `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`, `template`");
     expect(reviewSkill).toContain("Helper (config-entry family): minimal config-entry review");
   });
 


### PR DESCRIPTION
## Summary

v0.10.0 gap-closer: the `template` config-entry helper family moves from fallback (web-search-first, experimental) into `ha-nova:helper` as the 10th supported domain. "Erstell mir einen Sensor, der den Durchschnitt von X zeigt" is one of the top helper asks.

- **Menu-driven flow like `group`** (17 entity types; `sensor` live-verified end-to-end). The menu-flow safety machinery — live subtype-form preview + second confirmation for unverified subtypes — is generalized from group-only to group|template (red-team blocker: 16 template subtypes would otherwise skip it).
- **Template authoring safety**: `state` templates follow `template-guidelines.md` + the template-level reliability checks BEFORE submit; entity IDs referenced inside the template are resolved against the registry pre-preview (unknown reference = blocking question, not a submit).
- **Rendered-state verification operationalized**: a broken template creates the entry but renders `unavailable` — the config-entry post-write contract now additionally reads the linked entity's state for template creates/updates and reports template defects separately from the passed write. The review skill's minimal config-entry lane gets the same template addition.
- **Flow schemas**: observed template schema (menu → sensor form → options flow; `name` not editable via options — renames route to the registry/`ha-nova:organize`).
- **Contradictions/stale counts fixed**: api-matrix double-ownership line, fallback capability count (9+10), Roadmap Phase 3 scoped to YAML/REST/command-line sensors only, "all 9" observation notes dated and scoped.

## Verification

- **Live E2E (real HA)**: create with template `{{ (21+23)/2 }}` → rendered state `22.0` (not just entity-exists), options-flow update → `23.0`, rename correctly routed to registry rename, allowlisted token delete, zero residue (entities + config entries).
- **Red-team review**: 14 findings triaged — 6 blockers fixed pre-ship (group-only machinery, self-contradicting api-matrix, stale counts/routing, unoperationalized rendered-state promise).
- Full `npm test`: 66 files / 592 tests green; docs fact-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyBRtwy2jvCoQFKiU8C8fC