### PR TITLE
chore(release): prepare v0.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,19 +85,13 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## New Features
 
-    - Three new skills: **Scenes** (create, edit, delete — including "save this room as a scene" with proper light-color capture), **To-do lists** (manage items and shopping lists, create Local To-do lists, provider-aware), and **Backups** (check status, create a backup — also as a safety net before far-reaching changes — inspect and delete; restore deliberately stays in the Home Assistant UI).
-    - The review skill now catches configs silently broken by Home Assistant 2026.6's removal of the legacy template platform syntax, and gently suggests modernizing pre-2024.10 automation keys.
-    - Clearer safety story: skills without an undo say so up front and can offer a real backup first for far-reaching changes — never for routine small edits.
-
-    ## Bug Fixes
-
-    - NOVA Relay 0.2.6: health reporting is now truthful while Home Assistant restarts (no more "connected" when it is not), large REST responses are bounded, and connection errors tell you what to check.
-    - Starting a client session no longer hangs for up to 15 seconds when the relay is unreachable.
-    - Setup wizard polish and update-flow fixes ("Updated to..." now names the version you actually got).
+    - New **Updates** skill: see what is pending (Home Assistant Core/OS, Apps, integrations, device firmware), read the release notes, and install with the right safety gates — a full backup is offered before far-reaching Core/OS updates, and it knows updating the NOVA Relay App restarts the relay itself.
+    - **Template sensors** are now first-class: "make me a sensor that shows the average of these two" builds and edits a real template helper with the same preview-and-verify safety as every other write (referenced entities are checked before it saves).
+    - Assistants can now read data-returning services like the weather forecast, calendar events, and to-do items directly.
 
     ## What To Watch
 
-    - Update the NOVA Relay app in Home Assistant (Settings > Apps > NOVA Relay > Update) to 0.2.6 — the relay also restarts itself automatically now if it ever crashes (watchdog).
+    - No NOVA Relay App update needed for this release — it stays on 0.2.6.
 
     Stable install commands are release-pinned for this tag.
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ HA NOVA is early — and that's the point. Here's where it's going:
 
 ## 🧩 Skills
 
-18 task skills plus the HA NOVA context skill, each a markdown file you can read and edit.
+17 task skills plus the HA NOVA context skill, each a markdown file you can read and edit.
 
 | Skill | What it does |
 |:------|:-------------|

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ HA NOVA is early — and that's the point. Here's where it's going:
 
 ## 🧩 Skills
 
-16 task skills plus the HA NOVA context skill, each a markdown file you can read and edit.
+18 task skills plus the HA NOVA context skill, each a markdown file you can read and edit.
 
 | Skill | What it does |
 |:------|:-------------|
@@ -171,9 +171,10 @@ HA NOVA is early — and that's the point. Here's where it's going:
 | 📅 **calendar** | Read calendars and bounded event windows |
 | ✅ **todo** | Manage to-do and shopping-list items, create Local To-do lists |
 | 💾 **backup** | Check backup status, create backups — also as a safety net before risky changes |
+| ⬆️ **updates** | See pending updates, read release notes, and install them with safety gates |
 | 🎛️ **service-call** | Control lights, climate, covers, switches, and media players |
 | 🔎 **entity-discovery** | Find entities by name, room, area, or label |
-| 🧩 **helper** | Create and manage helpers: counters, timers, input booleans, more |
+| 🧩 **helper** | Create and manage helpers: counters, timers, template sensors, and more |
 | 🛡️ **fallback** | Safety net for blueprints, zones, energy, and advanced ops |
 | 🚀 **onboarding** | Diagnose setup issues and troubleshoot connections |
 

--- a/docs/work/2026-07-09-v0.10.0-release-body.md
+++ b/docs/work/2026-07-09-v0.10.0-release-body.md
@@ -1,0 +1,21 @@
+# v0.10.0 Release Body (working draft)
+
+Status: shipping with the v0.10.0 release-prep PR (the normative body lives in `.goreleaser.yml`)
+
+## New Features
+
+- New **Updates** skill: see what is pending (Home Assistant Core/OS, Apps, integrations, device firmware), read the release notes, and install with the right safety gates — a full backup is offered before far-reaching Core/OS updates, and it knows updating the NOVA Relay App restarts the relay itself.
+- **Template sensors** are now first-class: "make me a sensor that shows the average of these two" builds and edits a real template helper with the same preview-and-verify safety as every other write (referenced entities are checked before it saves).
+- Assistants can now read data-returning services like the weather forecast, calendar events, and to-do items directly.
+
+## What To Watch
+
+- No NOVA Relay App update needed for this release — it stays on 0.2.6.
+
+## Included PRs (not in the public notes)
+
+#262 updates skill, #263 service-call response services, #264 template config-entry helper family.
+
+## Notes
+
+Skill-only release (18 sub-skills, 10 config-entry helper domains). Relay unchanged at 0.2.6; `min_relay_version` stays 0.2.5.

--- a/docs/work/2026-07-09-v0.10.0-release-body.md
+++ b/docs/work/2026-07-09-v0.10.0-release-body.md
@@ -18,4 +18,4 @@ Status: shipping with the v0.10.0 release-prep PR (the normative body lives in `
 
 ## Notes
 
-Skill-only release (18 sub-skills, 10 config-entry helper domains). Relay unchanged at 0.2.6; `min_relay_version` stays 0.2.5.
+Skill-only release (17 sub-skills, 10 config-entry helper domains). Relay unchanged at 0.2.6; `min_relay_version` stays 0.2.5.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -53,15 +53,14 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
-  it("keeps v0.9.0 release-facing wording user-centric", () => {
+  it("keeps v0.10.0 release-facing wording user-centric", () => {
     // Shipped release-note bodies are archived (docs/archive/work/) and
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
-    expect(goreleaser).toContain("Three new skills");
-    expect(goreleaser).toContain('"save this room as a scene"');
-    expect(goreleaser).toContain("restore deliberately stays in the Home Assistant UI");
-    expect(goreleaser).toContain("NOVA Relay 0.2.6");
-    expect(goreleaser).toContain("Settings > Apps > NOVA Relay > Update");
+    expect(goreleaser).toContain("New **Updates** skill");
+    expect(goreleaser).toContain("**Template sensors** are now first-class");
+    expect(goreleaser).toContain("data-returning services like the weather forecast");
+    expect(goreleaser).toContain("No NOVA Relay App update needed for this release — it stays on 0.2.6");
     expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");
   });
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.9.0",
+  "skill_version": "0.10.0",
   "min_relay_version": "0.2.5"
 }


### PR DESCRIPTION
## Summary

Release-prep for **v0.10.0** (skill-only; Relay stays 0.2.6). Collects: #262 updates skill, #263 service-call response services, #264 template config-entry helper family.

- Version bump 0.9.0 → 0.10.0 via `bump-version.sh` (version.json, package.json, package-lock, plugin.json, marketplace.json); `min_relay_version` stays 0.2.5 — no relay change this release.
- Release notes in `.goreleaser.yml` (New Features / What To Watch) + working draft in `docs/work/2026-07-09-v0.10.0-release-body.md`.
- README (release-bound edits only): 16 → 18 task skills, new updates row, helper mentions template sensors.
- `release-contract.test.ts` wording pins moved to the active v0.10.0 template.

## Preflight

Open-PR audit done: 6 Dependabot PRs, all classified "separate later" (tsx/vitest toolchain-risk, @types/node major, axios red, actions/checkout workflow-PR) — none pulled in.

## Testing

Full `npm test`: 67 files / 601 tests green; docs fact-check green.

Merging this PR starts the RC/final tag sequence immediately per the release runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyBRtwy2jvCoQFKiU8C8fC