### PR TITLE
fix(cli): resolve Claude state via CLAUDE_CONFIG_DIR like the claude CLI itself

### DIFF
--- a/cli/claude_marketplace.go
+++ b/cli/claude_marketplace.go
@@ -367,7 +367,7 @@ func clearClaudeMarketplaceRegistration(home string) error {
 }
 
 func readClaudeMarketplaceSource(home string) (claudeMarketplaceSource, bool, error) {
-	path := filepath.Join(home, ".claude", "plugins", "known_marketplaces.json")
+	path := filepath.Join(claudeConfigRoot(home), "plugins", "known_marketplaces.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cli/claude_paths.go
+++ b/cli/claude_paths.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// claudeConfigRoot resolves the Claude Code state root exactly like the
+// claude CLI itself: CLAUDE_CONFIG_DIR when set, ~/.claude otherwise.
+// ha-nova spawns `claude` subprocesses that honor this variable — reading a
+// different root than they write makes every sync verify against the wrong
+// state and roll back (live-hit: `ha-nova update` inside a Claude Code
+// session, which exports CLAUDE_CONFIG_DIR).
+func claudeConfigRoot(home string) string {
+	if root := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR")); root != "" {
+		return root
+	}
+	return filepath.Join(home, ".claude")
+}
+
+// claudeConfigRootRedirected reports whether CLAUDE_CONFIG_DIR points the
+// claude CLI away from the default ~/.claude root.
+func claudeConfigRootRedirected(home string) bool {
+	return claudeConfigRoot(home) != filepath.Join(home, ".claude")
+}

--- a/cli/claude_paths_test.go
+++ b/cli/claude_paths_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Tests across this package build Claude state under temp HOMEs; a
+// CLAUDE_CONFIG_DIR inherited from the invoking shell (e.g. a Claude Code
+// session) would redirect every reader away from those fixtures.
+func TestMain(m *testing.M) {
+	os.Unsetenv("CLAUDE_CONFIG_DIR")
+	os.Exit(m.Run())
+}
+
+func TestClaudeConfigRootDefaultsToDotClaude(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home := t.TempDir()
+	if got, want := claudeConfigRoot(home), filepath.Join(home, ".claude"); got != want {
+		t.Fatalf("claudeConfigRoot() = %q, want %q", got, want)
+	}
+	if claudeConfigRootRedirected(home) {
+		t.Fatalf("claudeConfigRootRedirected() = true without CLAUDE_CONFIG_DIR")
+	}
+}
+
+func TestClaudeConfigRootHonorsClaudeConfigDir(t *testing.T) {
+	home := t.TempDir()
+	redirected := filepath.Join(t.TempDir(), "claude-profile")
+	t.Setenv("CLAUDE_CONFIG_DIR", redirected)
+	if got := claudeConfigRoot(home); got != redirected {
+		t.Fatalf("claudeConfigRoot() = %q, want %q", got, redirected)
+	}
+	if !claudeConfigRootRedirected(home) {
+		t.Fatalf("claudeConfigRootRedirected() = false with CLAUDE_CONFIG_DIR set")
+	}
+}
+
+func TestClaudePluginInstallStateFollowsClaudeConfigDir(t *testing.T) {
+	// Regression: `ha-nova update` inside a Claude Code session spawns
+	// `claude plugin install`, which writes plugin state to CLAUDE_CONFIG_DIR;
+	// the verifier must read the same root or every sync aborts + rolls back.
+	home := t.TempDir()
+	redirected := filepath.Join(t.TempDir(), "claude-profile")
+	t.Setenv("CLAUDE_CONFIG_DIR", redirected)
+
+	pluginsDir := filepath.Join(redirected, "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	installPath := filepath.Join(redirected, "plugins", "cache", "ha-nova", "ha-nova", "0.11.0")
+	if err := os.MkdirAll(installPath, 0o755); err != nil {
+		t.Fatalf("mkdir installPath: %v", err)
+	}
+	state := `{"plugins":{"ha-nova@ha-nova":[{"installPath":` + jsonQuote(installPath) + `,"scope":"user","version":"0.11.0"}]},"version":2}`
+	if err := os.WriteFile(filepath.Join(pluginsDir, "installed_plugins.json"), []byte(state), 0o644); err != nil {
+		t.Fatalf("write installed_plugins.json: %v", err)
+	}
+
+	found, usable := readClaudePluginInstallSnapshot(home)
+	if !found || !usable {
+		t.Fatalf("readClaudePluginInstallSnapshot() = (%v, %v), want (true, true) via CLAUDE_CONFIG_DIR", found, usable)
+	}
+
+	// Nothing under the default root: without the redirect the plugin is absent.
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	found, _ = readClaudePluginInstallSnapshot(home)
+	if found {
+		t.Fatalf("readClaudePluginInstallSnapshot() found plugin under default root unexpectedly")
+	}
+}
+
+func jsonQuote(s string) string {
+	quoted, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return string(quoted)
+}

--- a/cli/claude_project_memory.go
+++ b/cli/claude_project_memory.go
@@ -20,7 +20,7 @@ func removeClaudeProjectMemoryWithReport(home string, report *uninstallReport) e
 	if strings.TrimSpace(home) == "" {
 		return nil
 	}
-	projectsRoot := filepath.Join(home, ".claude", "projects")
+	projectsRoot := filepath.Join(claudeConfigRoot(home), "projects")
 	if _, err := os.Stat(projectsRoot); err != nil {
 		if isNotExist(err) {
 			return nil

--- a/cli/claude_snapshot.go
+++ b/cli/claude_snapshot.go
@@ -109,7 +109,7 @@ func readClaudePluginInstallState(home string) (found, usable, stateUnreadable b
 	if strings.TrimSpace(home) == "" {
 		return false, false, false
 	}
-	data, err := os.ReadFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))
+	data, err := os.ReadFile(filepath.Join(claudeConfigRoot(home), "plugins", "installed_plugins.json"))
 	if err != nil {
 		if isNotExist(err) {
 			return false, false, false

--- a/cli/client_claude.go
+++ b/cli/client_claude.go
@@ -71,6 +71,7 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 						return verifyErr
 					}
 					cleanupClaudeMarketplaceDevResidue(paths, marketplaceRoot)
+					warnClaudeProfileRedirect(paths.Home)
 					return nil
 				} else {
 					return restoreMarketplace(fmt.Errorf("claude plugin command failed: %s (%s)", strings.Join(installCmd.Args[1:], " "), strings.TrimSpace(string(installOutput))))
@@ -90,7 +91,18 @@ func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 	// Only after the sync fully verified: earlier failure paths roll back to
 	// the previous (possibly dev) registration, which still needs its symlink.
 	cleanupClaudeMarketplaceDevResidue(paths, marketplaceRoot)
+	warnClaudeProfileRedirect(paths.Home)
 	return nil
+}
+
+// warnClaudeProfileRedirect surfaces that the sync landed in a non-default
+// Claude profile so a redirected shell (e.g. inside a Claude Code session)
+// cannot silently leave the default install outdated.
+func warnClaudeProfileRedirect(home string) {
+	if !claudeConfigRootRedirected(home) {
+		return
+	}
+	printHumanWarn("Claude sync targeted the profile at %s (CLAUDE_CONFIG_DIR). A default Claude install at ~/.claude needs a separate `ha-nova setup claude` from a shell without CLAUDE_CONFIG_DIR.", claudeConfigRoot(home))
 }
 
 func verifyClaudePluginInstalled(home, desiredSource string) error {
@@ -176,7 +188,7 @@ func removeClaudeMarketplace(home string, report *uninstallReport) error {
 }
 
 func removeClaudeMarketplaceRecord(home string) (bool, error) {
-	path := filepath.Join(home, ".claude", "plugins", "known_marketplaces.json")
+	path := filepath.Join(claudeConfigRoot(home), "plugins", "known_marketplaces.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if isNotExist(err) {
@@ -201,7 +213,7 @@ func removeClaudeMarketplaceRecord(home string) (bool, error) {
 }
 
 func removeClaudePluginRecord(home string) error {
-	path := filepath.Join(home, ".claude", "plugins", "installed_plugins.json")
+	path := filepath.Join(claudeConfigRoot(home), "plugins", "installed_plugins.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if isNotExist(err) {
@@ -232,7 +244,7 @@ func unmarshalClaudeJSON(data []byte, target any) error {
 }
 
 func removeClaudePluginCache(home string) error {
-	cacheRoot := filepath.Join(home, ".claude", "plugins", "cache", "ha-nova")
+	cacheRoot := filepath.Join(claudeConfigRoot(home), "plugins", "cache", "ha-nova")
 	if err := os.RemoveAll(cacheRoot); err != nil {
 		return err
 	}
@@ -320,7 +332,7 @@ func readClaudePluginState(home string) (recordPresent bool, installed bool, kno
 	if strings.TrimSpace(home) == "" {
 		return false, false, true
 	}
-	data, err := os.ReadFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))
+	data, err := os.ReadFile(filepath.Join(claudeConfigRoot(home), "plugins", "installed_plugins.json"))
 	if err != nil {
 		if isNotExist(err) {
 			return false, false, true

--- a/cli/client_uninstall.go
+++ b/cli/client_uninstall.go
@@ -24,7 +24,7 @@ func removeInstalledClientsWithReport(paths runtimePaths, state installState, re
 	for _, client := range clients {
 		switch client {
 		case "claude":
-			if err := removeSkillEntriesWithReport(filepath.Join(paths.Home, ".claude", "skills"), report); err != nil {
+			if err := removeSkillEntriesWithReport(filepath.Join(claudeConfigRoot(paths.Home), "skills"), report); err != nil {
 				return err
 			}
 			if !claudePluginInstalled(paths.Home) {
@@ -34,7 +34,7 @@ func removeInstalledClientsWithReport(paths runtimePaths, state installState, re
 				if err := removeClaudeMarketplace(paths.Home, report); err != nil {
 					return err
 				}
-				if err := removePathWithReport(filepath.Join(paths.Home, ".claude", "plugins", "cache", "ha-nova"), report); err != nil {
+				if err := removePathWithReport(filepath.Join(claudeConfigRoot(paths.Home), "plugins", "cache", "ha-nova"), report); err != nil {
 					return err
 				}
 				continue
@@ -46,7 +46,7 @@ func removeInstalledClientsWithReport(paths runtimePaths, state installState, re
 				if err := removeClaudeMarketplace(paths.Home, report); err != nil {
 					return err
 				}
-				if err := removePathWithReport(filepath.Join(paths.Home, ".claude", "plugins", "cache", "ha-nova"), report); err != nil {
+				if err := removePathWithReport(filepath.Join(claudeConfigRoot(paths.Home), "plugins", "cache", "ha-nova"), report); err != nil {
 					return err
 				}
 				continue
@@ -61,7 +61,7 @@ func removeInstalledClientsWithReport(paths runtimePaths, state installState, re
 					if err := removeClaudeMarketplace(paths.Home, report); err != nil {
 						return err
 					}
-					if err := removePathWithReport(filepath.Join(paths.Home, ".claude", "plugins", "cache", "ha-nova"), report); err != nil {
+					if err := removePathWithReport(filepath.Join(claudeConfigRoot(paths.Home), "plugins", "cache", "ha-nova"), report); err != nil {
 						return err
 					}
 					continue
@@ -75,7 +75,7 @@ func removeInstalledClientsWithReport(paths runtimePaths, state installState, re
 			if err := removeClaudeMarketplace(paths.Home, report); err != nil {
 				return err
 			}
-			if err := removePathWithReport(filepath.Join(paths.Home, ".claude", "plugins", "cache", "ha-nova"), report); err != nil {
+			if err := removePathWithReport(filepath.Join(claudeConfigRoot(paths.Home), "plugins", "cache", "ha-nova"), report); err != nil {
 				return err
 			}
 		case "codex":


### PR DESCRIPTION
## Summary

Fixes the claude-client sync failing with `Claude plugin ha-nova@ha-nova not found after sync` (+ rollback) whenever `ha-nova update` / `ha-nova setup claude` runs in a shell that exports `CLAUDE_CONFIG_DIR` — most prominently: any shell inside a Claude Code session. The spawned `claude plugin ...` subprocesses honor the variable and write plugin state there, while ha-nova verified a hardcoded `~/.claude` → guaranteed mismatch.

- New `claudeConfigRoot(home)` helper (env when set, else `~/.claude`); all Claude state paths (plugin snapshot, known marketplaces, cache, skills residue, project-memory purge) now resolve through it — ha-nova and the claude CLI agree by construction.
- After a successful sync into a redirected profile, a notice tells the user their default `~/.claude` install needs a separate `ha-nova setup claude` from a non-redirected shell — no silent wrong-profile syncs.
- `TestMain` neutralizes an inherited `CLAUDE_CONFIG_DIR` for the whole package (temp-HOME fixtures would otherwise be bypassed on dev machines running inside a session); new tests cover default/redirected resolution and the redirected snapshot read.

## Verification

- `npm run verify` fully green (Go suite 137 s incl. new regression tests)
- Live on the affected machine: redirected `doctor` now evaluates the session profile consistently; `env -u CLAUDE_CONFIG_DIR` flows unchanged; real profile healed and green (`Claude Code ready now`)
- Controlled marker experiment confirmed the Go suite leaves real `~/.claude` state untouched

Release note candidate (v0.11.1): update/attach flow fix users can actually hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhefhWnMEyVLyYpU6LF4kf