### PR TITLE
chore(release): prepare v0.11.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.11.0"
+    "version": "0.11.1"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,10 +83,9 @@ release:
     ```
 
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
-    {{ else }}## New Features
+    {{ else }}## Bug Fixes
 
-    - New **Energy** skill: ask about consumption, solar, battery, and per-device costs over any period — "what did the dryer cost last month?" — with the same numbers your Energy dashboard shows, dynamic electricity prices included. It can also safely add or remove tracked devices and energy sources, with preview and verification.
-    - New **Maintenance** skill: repair broken long-term statistics (orphaned entries, unit mismatches, sum spikes), trim recorder history, and clean up dead entities — grouped previews and typed confirmation before anything destructive, and it never touches data that is merely offline.
+    - `ha-nova update` and `ha-nova setup claude` no longer fail with "plugin not found after sync" when run from a shell that redirects Claude Code's config (`CLAUDE_CONFIG_DIR` — for example a terminal inside a Claude Code session). ha-nova now reads and writes the same Claude profile as the `claude` CLI it drives, and tells you when a sync targeted a non-default profile.
 
     ## What To Watch
 

--- a/docs/work/2026-07-09-v0.11.1-release-body.md
+++ b/docs/work/2026-07-09-v0.11.1-release-body.md
@@ -1,0 +1,11 @@
+# v0.11.1 Release Body (draft)
+
+Status: active — shipped wording lives in `.goreleaser.yml`; archive this file after the release.
+
+## Bug Fixes
+
+- `ha-nova update` and `ha-nova setup claude` no longer fail with "plugin not found after sync" when run from a shell that redirects Claude Code's config (`CLAUDE_CONFIG_DIR` — for example a terminal inside a Claude Code session). ha-nova now reads and writes the same Claude profile as the `claude` CLI it drives, and tells you when a sync targeted a non-default profile.
+
+## What To Watch
+
+- No NOVA Relay App update needed for this release — it stays on 0.2.6.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -53,14 +53,13 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
-  it("keeps v0.11.0 release-facing wording user-centric", () => {
+  it("keeps v0.11.1 release-facing wording user-centric", () => {
     // Shipped release-note bodies are archived (docs/archive/work/) and
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
-    expect(goreleaser).toContain("New **Energy** skill");
-    expect(goreleaser).toContain("New **Maintenance** skill");
-    expect(goreleaser).toContain("what did the dryer cost last month?");
-    expect(goreleaser).toContain("typed confirmation before anything destructive");
+    expect(goreleaser).toContain("no longer fail with \"plugin not found after sync\"");
+    expect(goreleaser).toContain("`CLAUDE_CONFIG_DIR`");
+    expect(goreleaser).toContain("reads and writes the same Claude profile as the `claude` CLI it drives");
     expect(goreleaser).toContain("No NOVA Relay App update needed for this release — it stays on 0.2.6");
     expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");
   });

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.11.0",
+  "skill_version": "0.11.1",
   "min_relay_version": "0.2.5"
 }


### PR DESCRIPTION
Release-prep for **v0.11.1** (CLI-fix-only; Relay stays 0.2.6): ships #271 — `ha-nova update`/`setup claude` now resolve the Claude profile via `CLAUDE_CONFIG_DIR` like the `claude` CLI itself, fixing the 'plugin not found after sync' abort from redirected shells.

- Version bump 0.11.0 → 0.11.1 in the four synced files
- GoReleaser stable-notes: Bug Fixes body; release-contract pins updated
- `npm run verify` + full sweep green

After merge: strict audit → `v0.11.1-rc1` rehearsal → public-install verify → final tag → env-clean live update test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhefhWnMEyVLyYpU6LF4kf