### PR TITLE
fix(cli): classify Windows network-logon Credential Manager errors

### DIFF
--- a/cli/keyring_service.go
+++ b/cli/keyring_service.go
@@ -291,6 +291,9 @@ func relayAuthTokenProblemMessage(err error) string {
 	if isMissingRelayAuthTokenError(err) {
 		return "relay auth token missing; run: ha-nova setup"
 	}
+	if isWindowsNetworkLogonSessionError(err) {
+		return "secure storage unavailable in this Windows session (network logon, for example SSH); run HA NOVA from a local interactive session (console or RDP) on this machine, and then run: ha-nova setup"
+	}
 	if isDesktopKeyringSessionUnavailableError(err) {
 		return "secure storage unavailable in this Linux session; run HA NOVA from a terminal inside the Linux desktop session on this machine, and then run: ha-nova setup"
 	}
@@ -310,6 +313,19 @@ func relayAuthTokenProblemMessage(err error) string {
 		return fmt.Sprintf("service token file is not usable: %s", err)
 	}
 	return fmt.Sprintf("relay auth token unavailable: %s", err)
+}
+
+// isWindowsNetworkLogonSessionError matches the Credential Manager failure
+// in Windows network logon sessions (for example PowerShell over OpenSSH):
+// there is no interactive logon session to hold the credential store. Local
+// console, Windows Terminal, and RDP sessions are unaffected. String-matched
+// here (not build-tagged) so every platform classifies forwarded errors and
+// tests run everywhere.
+func isWindowsNetworkLogonSessionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "a specified logon session does not exist")
 }
 
 func isDesktopKeyringUnavailableError(err error) bool {
@@ -406,6 +422,9 @@ func relayAuthTokenSetupReadError(err error) error {
 }
 
 func relayAuthTokenSetupOperationError(action string, err error) error {
+	if isWindowsNetworkLogonSessionError(err) {
+		return fmt.Errorf("cannot %s: secure storage unavailable in this Windows session (network logon, for example SSH). Run HA NOVA from a local interactive session (console or RDP) on this machine, and rerun `ha-nova setup`", action)
+	}
 	if isDesktopKeyringSessionUnavailableError(err) {
 		return fmt.Errorf("cannot %s: secure storage unavailable in this Linux session. Run HA NOVA from a terminal inside the Linux desktop session on this machine, and rerun `ha-nova setup`", action)
 	}

--- a/cli/keyring_service_test.go
+++ b/cli/keyring_service_test.go
@@ -48,6 +48,11 @@ func TestRelayAuthTokenProblemMessageDifferentiatesMissingAndUnavailable(t *test
 	if got := relayAuthTokenProblemMessage(errors.New("dbus: couldn't determine address of session bus")); got != "secure storage unavailable in this Linux session; run HA NOVA from a terminal inside the Linux desktop session on this machine, and then run: ha-nova setup" {
 		t.Fatalf("secret-service-session-unavailable message = %q", got)
 	}
+	// Windows network logon sessions (issue #213): the raw Credential
+	// Manager text must classify with local-session guidance.
+	if got := relayAuthTokenProblemMessage(errors.New("cannot save relay token: A specified logon session does not exist. It may already have been terminated.")); got != "secure storage unavailable in this Windows session (network logon, for example SSH); run HA NOVA from a local interactive session (console or RDP) on this machine, and then run: ha-nova setup" {
+		t.Fatalf("windows-network-logon message = %q", got)
+	}
 	if got := relayAuthTokenProblemMessage(errors.New("exec: \"dbus-launch\": executable file not found in $PATH")); got != "secure storage unavailable in this Linux session; run HA NOVA from a terminal inside the Linux desktop session on this machine, and then run: ha-nova setup" {
 		t.Fatalf("secret-service-dbus-launch-missing message = %q", got)
 	}
@@ -94,6 +99,16 @@ func TestRelayAuthTokenSetupPreflightSkipsPlatformCheckForInsecureTestOverride(t
 
 	if err := relayAuthTokenSetupPreflight(); err != nil {
 		t.Fatalf("relayAuthTokenSetupPreflight() error = %v", err)
+	}
+}
+
+func TestRelayAuthTokenSetupSaveErrorExplainsWindowsNetworkLogonSession(t *testing.T) {
+	// Issue #213: Credential Manager writes fail in network logon sessions
+	// (PowerShell over OpenSSH) with this raw OS text.
+	err := relayAuthTokenSetupSaveError(errors.New("A specified logon session does not exist. It may already have been terminated."))
+	want := "cannot save relay token: secure storage unavailable in this Windows session (network logon, for example SSH). Run HA NOVA from a local interactive session (console or RDP) on this machine, and rerun `ha-nova setup`"
+	if err == nil || err.Error() != want {
+		t.Fatalf("relayAuthTokenSetupSaveError() = %v, want %q", err, want)
 	}
 }
 


### PR DESCRIPTION
Closes #213.

In Windows network logon sessions (PowerShell over OpenSSH) Credential Manager access fails with the raw OS text `A specified logon session does not exist...`. This now classifies like the Linux keyring classes, with actionable guidance (local interactive session — console or RDP), in both classification sites: `relayAuthTokenProblemMessage` (doctor/status) and `relayAuthTokenSetupOperationError` (setup save/read).

String-matched in shared, un-tagged code so forwarded errors classify on every platform and the unit tests run everywhere (per the issue: guidance is the right scope — there is deliberately no service token-file mode on native Windows).

## Verification
- Full Go suite green (150 s) incl. new tests for both sites with the exact raw OS text
- `GOOS=windows go build` clean
- Real-Windows validation rides the existing gold-test lane (SSH path is not a documented public path; not release-blocking per the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhefhWnMEyVLyYpU6LF4kf