### PR TITLE
fix(diff): aligned per-item rendering instead of count-only array lines (#274, part A)

### DIFF
--- a/cli/diff.go
+++ b/cli/diff.go
@@ -152,8 +152,16 @@ func renderConfigChanges(before, after map[string]interface{}) []string {
 		return changes[i].path < changes[j].path
 	})
 	lines := make([]string, 0, len(changes))
-	for _, c := range changes {
+	var prev configChange
+	for i, c := range changes {
+		// The aligned-item pairing and the notification-copy pass can surface
+		// the same field change twice; identical entries are adjacent after
+		// the stable sort.
+		if i > 0 && c.path == prev.path && c.text == prev.text {
+			continue
+		}
 		lines = append(lines, "- "+c.text)
+		prev = c
 	}
 	return lines
 }
@@ -227,18 +235,92 @@ func isEmptyValue(v interface{}) bool {
 
 func diffArrays(segs []segment, before, after []interface{}, changes *[]configChange) {
 	if len(before) != len(after) {
-		// Structural change: report the count, do not flood with per-element diffs.
+		// Structural change: the count line stays as the group header, followed
+		// by aligned per-item lines so the user can see WHAT was added/removed —
+		// a bare count can actively misrepresent a change (nesting actions into
+		// one if-block reduces the count without removing behavior).
 		*changes = append(*changes, configChange{
 			order: topOrder(segs),
 			path:  pathString(segs),
 			text:  fmt.Sprintf("%s: %d → %d items", humanizeLabel(segs), len(before), len(after)),
 		})
+		diffAlignedItems(segs, before, after, changes)
 		diffNotificationCopyInCommonItems(segs, before, after, changes)
 		return
 	}
 	for i := range before {
 		diffValues(appendSegment(segs, segment{index: i, isIndex: true}), before[i], after[i], changes)
 	}
+}
+
+// maxAlignedItemsPerSide bounds the per-item lines rendered for one array's
+// length change; the remainder is summarized honestly, never dropped silently.
+const maxAlignedItemsPerSide = 8
+
+// diffAlignedItems renders which items changed when an array's length differs:
+// items equal at the head and tail (common prefix/suffix) are skipped; the
+// middle windows are paired positionally as long as both sides hold the same
+// KIND of item (same service call, trigger platform, block type …) — those
+// pairs get a normal field-level diff. From the first dissimilar pair on, the
+// remainders are rendered as per-item removed/added summary lines. A pure move
+// shows as symmetric removed+added lines — deliberate: deterministic and
+// readable beats clever matching here.
+func diffAlignedItems(segs []segment, before, after []interface{}, changes *[]configChange) {
+	prefix := 0
+	for prefix < len(before) && prefix < len(after) && valuesEqual(before[prefix], after[prefix]) {
+		prefix++
+	}
+	suffix := 0
+	for suffix < len(before)-prefix && suffix < len(after)-prefix &&
+		valuesEqual(before[len(before)-1-suffix], after[len(after)-1-suffix]) {
+		suffix++
+	}
+	bMid := before[prefix : len(before)-suffix]
+	aMid := after[prefix : len(after)-suffix]
+	paired := 0
+	for paired < len(bMid) && paired < len(aMid) && alignedPairable(bMid[paired], aMid[paired]) {
+		diffValues(appendSegment(segs, segment{index: prefix + paired, isIndex: true}), bMid[paired], aMid[paired], changes)
+		paired++
+	}
+	renderAlignedSide(segs, bMid[paired:], prefix+paired, "removed (was %s)", changes)
+	renderAlignedSide(segs, aMid[paired:], prefix+paired, "added (%s)", changes)
+}
+
+// alignedPairable reports whether two items are the same kind of step, so a
+// positional field-level diff reads as an edit of one item rather than noise
+// between two unrelated items.
+func alignedPairable(before, after interface{}) bool {
+	kind := configItemKind(before)
+	return kind != "" && kind == configItemKind(after)
+}
+
+func renderAlignedSide(segs []segment, items []interface{}, offset int, verbFormat string, changes *[]configChange) {
+	rendered := len(items)
+	if rendered > maxAlignedItemsPerSide {
+		rendered = maxAlignedItemsPerSide
+	}
+	for i := 0; i < rendered; i++ {
+		itemSegs := appendSegment(segs, segment{index: offset + i, isIndex: true})
+		*changes = append(*changes, configChange{
+			order: topOrder(segs),
+			path:  pathString(itemSegs),
+			text:  fmt.Sprintf("%s: %s", humanizeLabel(itemSegs), fmt.Sprintf(verbFormat, summarizeConfigItem(items[i]))),
+		})
+	}
+	if len(items) > rendered {
+		*changes = append(*changes, configChange{
+			order: topOrder(segs),
+			path:  pathString(appendSegment(segs, segment{index: offset + rendered, isIndex: true})),
+			text:  fmt.Sprintf("%s: … and %d more %s", humanizeLabel(segs), len(items)-rendered, alignedVerbWord(verbFormat)),
+		})
+	}
+}
+
+func alignedVerbWord(verbFormat string) string {
+	if strings.HasPrefix(verbFormat, "removed") {
+		return "removed"
+	}
+	return "added"
 }
 
 func appendSegment(segs []segment, s segment) []segment {
@@ -290,7 +372,9 @@ func pathString(segs []segment) string {
 	var sb strings.Builder
 	for _, s := range segs {
 		if s.isIndex {
-			fmt.Fprintf(&sb, "[%d]", s.index)
+			// Zero-padded so lexicographic path sorting equals numeric index
+			// order ("[0002]" < "[0010]"); paths are sort keys, never shown.
+			fmt.Fprintf(&sb, "[%04d]", s.index)
 		} else {
 			if sb.Len() > 0 {
 				sb.WriteByte('.')

--- a/cli/diff_format.go
+++ b/cli/diff_format.go
@@ -147,6 +147,116 @@ func formatDuration(m map[string]interface{}) string {
 	return strings.Join(parts, " ")
 }
 
+// summarizeConfigItem renders one trigger/condition/action/step as a short,
+// recognizable phrase for the aligned per-item diff lines. Preference order:
+// the user's own alias, then the semantic head of the item (service call,
+// trigger platform, condition type, delay/wait, block type with nested
+// counts), then the compact-JSON fallback.
+func summarizeConfigItem(v interface{}) string {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return formatValue(v)
+	}
+	if alias, _ := m["alias"].(string); alias != "" {
+		return truncate(fmt.Sprintf("%q", escapeInline(alias)))
+	}
+	if action, _ := m["action"].(string); action != "" {
+		return truncate("action " + escapeInline(action))
+	}
+	if service, _ := m["service"].(string); service != "" {
+		return truncate("action " + escapeInline(service))
+	}
+	if platform, _ := m["platform"].(string); platform != "" {
+		return truncate("trigger " + escapeInline(platform))
+	}
+	if trigger, _ := m["trigger"].(string); trigger != "" {
+		return truncate("trigger " + escapeInline(trigger))
+	}
+	if condition, _ := m["condition"].(string); condition != "" {
+		return truncate("condition " + escapeInline(condition))
+	}
+	if delay, ok := m["delay"]; ok {
+		return truncate("delay " + formatValue(delay))
+	}
+	if _, ok := m["wait_template"]; ok {
+		return "wait_template"
+	}
+	if _, ok := m["wait_for_trigger"]; ok {
+		return "wait_for_trigger"
+	}
+	if blockSummary := summarizeBlockItem(m); blockSummary != "" {
+		return blockSummary
+	}
+	return truncate(compactJSON(m))
+}
+
+// configItemKind identifies what KIND of step an item is (which service call,
+// which trigger platform, which block type) for the aligned-pairing decision.
+// Empty string = unrecognized shape, never pairable.
+func configItemKind(v interface{}) string {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	if s, _ := m["action"].(string); s != "" {
+		return "action:" + s
+	}
+	if s, _ := m["service"].(string); s != "" {
+		return "action:" + s
+	}
+	if s, _ := m["platform"].(string); s != "" {
+		return "trigger:" + s
+	}
+	if s, _ := m["trigger"].(string); s != "" {
+		return "trigger:" + s
+	}
+	if s, _ := m["condition"].(string); s != "" {
+		return "condition:" + s
+	}
+	for _, key := range []string{"delay", "wait_template", "wait_for_trigger", "if", "choose", "repeat", "parallel", "stop"} {
+		if _, ok := m[key]; ok {
+			return key
+		}
+	}
+	return ""
+}
+
+// summarizeBlockItem names structural blocks with their nested sizes so
+// "3 actions wrapped into one if-block" is visible as exactly that.
+func summarizeBlockItem(m map[string]interface{}) string {
+	if _, ok := m["if"]; ok {
+		summary := fmt.Sprintf("if/then block (%s", countItems(m["then"], "action"))
+		if _, hasElse := m["else"]; hasElse {
+			summary += ", " + countItems(m["else"], "else action")
+		}
+		return summary + ")"
+	}
+	if _, ok := m["choose"]; ok {
+		return fmt.Sprintf("choose block (%s)", countItems(m["choose"], "option"))
+	}
+	if _, ok := m["repeat"]; ok {
+		return "repeat block"
+	}
+	if _, ok := m["parallel"]; ok {
+		return fmt.Sprintf("parallel block (%s)", countItems(m["parallel"], "branch"))
+	}
+	if _, ok := m["stop"]; ok {
+		return "stop"
+	}
+	return ""
+}
+
+func countItems(v interface{}, noun string) string {
+	items, ok := v.([]interface{})
+	if !ok {
+		return "1 " + noun
+	}
+	if len(items) == 1 {
+		return "1 " + noun
+	}
+	return fmt.Sprintf("%d %ss", len(items), noun)
+}
+
 func compactJSON(v interface{}) string {
 	out, err := json.Marshal(v)
 	if err != nil {

--- a/cli/diff_test.go
+++ b/cli/diff_test.go
@@ -146,7 +146,53 @@ func TestDiffModeAndDelayInStableOrder(t *testing.T) {
 
 func TestDiffArrayLengthChange(t *testing.T) {
 	got := diffLines(t, `{"triggers":[{"a":1}]}`, `{"triggers":[{"a":1},{"b":2}]}`)
-	assertLines(t, got, []string{"- Triggers: 1 → 2 items"})
+	assertLines(t, got, []string{
+		"- Triggers: 1 → 2 items",
+		`- Trigger 2: added ({"b":2})`,
+	})
+}
+
+func TestDiffNestingActionsIntoIfBlockShowsWhatMoved(t *testing.T) {
+	// Issue #274 problem 1: wrapping actions into one if-block REDUCES the
+	// count — the diff must show what was removed and what block appeared,
+	// or the count line actively misrepresents the change.
+	before := `{"actions":[{"action":"script.a"},{"action":"script.b"},{"action":"script.c"},{"action":"script.d"},{"action":"script.e"}]}`
+	after := `{"actions":[{"action":"script.a"},{"if":[{"condition":"state"}],"then":[{"action":"script.b"},{"action":"script.c"},{"action":"script.d"}]},{"action":"script.e"}]}`
+	got := diffLines(t, before, after)
+	assertLines(t, got, []string{
+		"- Actions: 5 → 3 items",
+		"- Action 2: removed (was action script.b)",
+		"- Action 2: added (if/then block (3 actions))",
+		"- Action 3: removed (was action script.c)",
+		"- Action 4: removed (was action script.d)",
+	})
+}
+
+func TestDiffAlignedItemsCapIsHonest(t *testing.T) {
+	afterItems := make([]string, 0, 12)
+	for _, id := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"} {
+		afterItems = append(afterItems, `{"action":"script.`+id+`"}`)
+	}
+	got := diffLines(t, `{"actions":[]}`, `{"actions":[`+strings.Join(afterItems, ",")+`]}`)
+	if len(got) != 1+maxAlignedItemsPerSide+1 {
+		t.Fatalf("expected header + %d items + honesty line, got %d lines: %#v", maxAlignedItemsPerSide, len(got), got)
+	}
+	if got[len(got)-1] != "- Actions: … and 4 more added" {
+		t.Fatalf("expected honest remainder line, got %q", got[len(got)-1])
+	}
+}
+
+func TestDiffAlignedPairingKeepsFieldDiffForSameKind(t *testing.T) {
+	// An edited item followed by an insertion pairs positionally with its
+	// same-kind counterpart: field-level diff, not removed+added noise.
+	before := `{"actions":[{"action":"light.turn_on","data":{"brightness":100}}]}`
+	after := `{"actions":[{"action":"light.turn_on","data":{"brightness":50}},{"action":"script.extra"}]}`
+	got := diffLines(t, before, after)
+	assertLines(t, got, []string{
+		"- Actions: 1 → 2 items",
+		"- Action 1 (data › brightness): 100 → 50",
+		"- Action 2: added (action script.extra)",
+	})
 }
 
 func TestDiffShowsNotificationCopyChangeEvenWhenActionsLengthChanges(t *testing.T) {
@@ -156,6 +202,7 @@ func TestDiffShowsNotificationCopyChangeEvenWhenActionsLengthChanges(t *testing.
 	assertLines(t, got, []string{
 		"- Actions: 1 → 2 items",
 		"- Action 1 (data › message): Plan erstellt → Plan ist bereit",
+		"- Action 2: added (action input_boolean.turn_on)",
 	})
 }
 
@@ -165,6 +212,9 @@ func TestDiffShowsMovedNotificationCopyChangeWhenActionsLengthChanges(t *testing
 	got := diffLines(t, before, after)
 	assertLines(t, got, []string{
 		"- Actions: 1 → 2 items",
+		"- Action 1: removed (was action notify.mobile_app_phone)",
+		"- Action 1: added (action input_boolean.turn_on)",
+		"- Action 2: added (action notify.mobile_app_phone)",
 		"- Action 2 (data › message): Plan erstellt → Plan ist bereit",
 	})
 }

--- a/docs/work/2026-07-10-issue-274-preview-quality-spec.md
+++ b/docs/work/2026-07-10-issue-274-preview-quality-spec.md
@@ -1,0 +1,60 @@
+# Issue #274 — Write/Review Preview & Verification Quality
+
+Status: active
+Issue: #274 (12 observed problems). Delivered as two PRs — different subsystems, one logical topic:
+
+## PR A — `ha-nova diff`: aligned per-item rendering (problems 1–3 root cause)
+
+Today `diffArrays` collapses any length change to `Actions: N → M items` ("do not
+flood"). That single line can misrepresent a change (nesting actions into one
+`if` block *reduces* the count) and makes the confirmed preview incomprehensible.
+
+Change (deterministic, no LLM involvement — the diff stays a stable artifact):
+- Keep the count line as the group header.
+- Align common prefix/suffix (via `valuesEqual`), render the middle window as
+  per-item `added (…)` / `removed (was …)` lines using a compact one-line item
+  summary (`alias` > `action`/`service` > trigger `platform`/`trigger` >
+  `condition` > `delay`/`wait_*` > block types `if`/`choose`/`repeat`/`parallel`
+  with nested action counts > compact JSON fallback).
+- Cap at 8 rendered items per side, then one honest `… and N more` line —
+  no silent truncation.
+- Notification-copy recursion (`diff_notification.go`) unchanged.
+- Pure reorders show as symmetric removed+added summaries — accepted (KISS; no
+  LCS matching).
+
+## PR B — skill texts: narrative, honesty, semantic checks (problems 2–12)
+
+1. **Behavior narrative (write-safety Pre-Write Diff):** the preview-summary
+   sentence must state the behavioral effect in plain language; when the diff
+   still contains a count-only/`… and N more` line, the summary MUST name what
+   was added/removed/nested. The narrative is agent-authored interpretation and
+   lives in the summary slot — the Changes slot stays verbatim CLI output
+   (resolves the problem-3 tension without giving up determinism).
+2. **Verification honesty (write SKILL Phase 4 + write-safety):** ban the bare
+   word "verified"; the post-write result names what was proven (saved,
+   read-back matched, reloaded, entity present) and states that behavior was
+   not exercised; offer an optional consent-gated behavior test (manual
+   trigger via `ha-nova:service-call`) where meaningful. Covers problems 5, 9.
+3. **Semantic-narrowness review check (review/checks.md):** exact-state
+   equality against open state sets (person/device_tracker zone states,
+   media_player, vacuum, climate…) that is narrower than the stated intent —
+   e.g. `state == "home"` vs "when nobody is home" (`!= "home"` matches zone
+   states too). New check, also referenced by write pre-check. Covers 4, 6.
+4. **Timing advisory:** fixed `delay` standing in for completion of an
+   asynchronous operation (child script start, device action) → advise
+   `wait_for_trigger`/`wait_template`. Covers 10.
+5. **Startup advisory:** `homeassistant` start trigger + immediate state
+   checks on integration entities → advise availability guard. Covers 11.
+6. **Multi-target logical changes (write SKILL/write-safety):** when one
+   logical change spans multiple automations/scripts: present a change plan
+   (all targets, combined behavior, apply order) BEFORE the first per-target
+   preview; state revert coverage honestly (N=1 — only the last update stays
+   auto-revertible) and offer a safety backup proportionally; per-target flow
+   after plan confirmation; combined final summary. Covers 7, 8 (honesty), 12.
+
+## Out of scope (documented follow-ups)
+
+- Multi-snapshot revert stack (N>1) — CLI storage change; would fully close
+  problem 8. Candidate follow-up issue.
+- Automated behavioral testing — actuates physical devices; stays a
+  consent-gated manual offer.


### PR DESCRIPTION
Part A of #274 (spec: `docs/work/2026-07-10-issue-274-preview-quality-spec.md`) — the root cause of problems 1–3: `ha-nova diff` collapsed any array-length change to a count-only line that can actively misrepresent the change (nesting actions into one `if` block *reduces* the count) and makes the confirmed preview incomprehensible.

**Now:** the count line heads a group of aligned per-item lines — common prefix/suffix skipped; positional pairs of the same KIND (same service call, trigger platform, block type) get a normal field-level diff; the remainder renders as `added (…)`/`removed (was …)` with compact summaries (alias > service > trigger platform > condition > delay/wait > block types with nested action counts). Capped at 8 per side with an honest `… and N more` line. Deterministic — no LLM involvement; the diff stays a stable verbatim artifact.

Example (the issue's reproduction — wrap 3 actions into an if-block):
```
- Actions: 5 → 3 items
- Action 2: removed (was action script.b)
- Action 2: added (if/then block (3 actions))
- Action 3: removed (was action script.c)
- Action 4: removed (was action script.d)
```

Notification-copy special handling unchanged; duplicate lines from pairing+notification pass dedup; sort paths zero-padded (sort keys only, never displayed).

Part B (skill texts: behavior narrative, verification honesty, semantic checks, multi-target flow) follows as its own PR and closes #274.

## Verification
- New tests: if-block nesting scenario, same-kind pairing, honest cap, updated pins for the three existing length-change tests
- Full Go suite green (153 s); `npm run verify` + full vitest sweep (624) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhefhWnMEyVLyYpU6LF4kf