### PR TITLE
feat(write-review): behavior narrative, verification honesty, semantic checks, multi-target flow (#274, part B)

### DIFF
--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -261,7 +261,7 @@ Rules:
 ## Review Architecture
 
 `ha-nova:review` is a self-contained read-only reviewer:
-- Config quality: safety (S-01..S-03), reliability (R-01..R-25), performance (P-01..P-05), style (M-01..M-05; M-04 retired, moved to R-20), script-specific (F-01..F-08), helper-specific (H-01..H-10)
+- Config quality: safety (S-01..S-03), reliability (R-01..R-28), performance (P-01..P-05), style (M-01..M-05; M-04 retired, moved to R-20), script-specific (F-01..F-08), helper-specific (H-01..H-10)
 - `R-25` is pasted-YAML only (legacy template platform syntax, removed in HA 2026.6); `M-05` is a modernize advisory for pre-2024.10 automation keys
 - Collision scan: `search/related` on top 3 target entities
 - Conflict analysis: 3-step test (polarity → temporal → guard conditions)
@@ -402,7 +402,7 @@ After any mutation (automation, script, or helper):
    - **Findings**: 🔴🟠🟡 findings with short descriptive titles plus `Why` / `Fix` — only when there are real issues.
    - **Collision check**: only when related items exist (list them + the conflict verdict).
    - **Advisory**: 🟠🟡 findings — only when non-empty.
-   - Omit any section with nothing to report — never print an empty "none" bucket. When all are empty, collapse to one localized confirmation line (e.g. "Verified — no issues or conflicts").
+   - Omit any section with nothing to report — never print an empty "none" bucket. When all are empty, collapse to one scope-honest confirmation line (write-safety → Verification Honesty; never a bare "verified").
    - Do not emit `Questions to consider`, `Suggestions`, or `Instant help` in post-write mode.
 
 ## Adding a New Skill — Checklist

--- a/skills/ha-nova/output-rules.md
+++ b/skills/ha-nova/output-rules.md
@@ -45,5 +45,5 @@ Apply these rules to every user-facing HA NOVA response, including direct sub-sk
 
 - Standalone and bulk review keep their full shape because the user explicitly asked for review; a clear "no issues found" result is useful.
 - Post-write review is different: the user asked to write, not to review. Show only sections that carry substance.
-- Do not print empty "none" buckets in post-write review. If every post-write check is clean, collapse to one localized confirmation line.
+- Do not print empty "none" buckets in post-write review. If every post-write check is clean, collapse to one localized confirmation line — scope-honest per `skills/ha-nova/write-safety.md` → Verification Honesty, never a bare "verified".
 - In review output, put uncertainty in `Questions to consider`; put only confident recommendations in `Suggestions`.

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -1,9 +1,13 @@
 # HA NOVA Write Safety
 
-Shared mechanics for two write-time safety features, owned here and referenced by
-`ha-nova:write` and `ha-nova:helper` (do not duplicate them):
+Shared mechanics for the write-time safety features, owned here and referenced
+by `ha-nova:write` and `ha-nova:helper` (do not duplicate them):
 
 - **Pre-Write Diff** — show exactly what a change alters before it is applied.
+- **Behavior narrative** — say what the change does, not only which fields move.
+- **Verification Honesty** — post-write wording names the proven scope.
+- **Multi-Target Changes** — plan-first flow for one logical change over
+  several items.
 - **Update-Revert** — durably undo the most recent update.
 
 Skill source stays English. Localize headings and labels at runtime per
@@ -55,6 +59,24 @@ summary of what the new item does.
 
 **delete**: no `## Changes` (the consumer-check result already covers it).
 
+### Behavior narrative (required with every update preview)
+
+The diff states WHAT fields change; the preview-summary sentence must state
+what the change DOES — the behavioral effect in plain language ("the three
+light actions now only run when someone is home", "the wait now has a 2-minute
+timeout"). This narrative is your interpretation, clearly outside the Changes
+slot — the diff lines stay verbatim CLI output, the two never mix. The diff is
+what will be saved: if your narrative and the diff disagree, fix the draft or
+the narrative before showing the preview — never show both and let the user
+guess.
+
+Confirmation quality depends on it: a user who cannot tell what the payload
+changes cannot meaningfully confirm it. If the diff still contains a
+count-only or `… and N more` line for something the user's request touched,
+the summary MUST name what was added, removed, or nested there. If you cannot
+explain the behavioral effect of your own draft, stop and re-derive it —
+never ask for confirmation of a change you cannot describe.
+
 ### User-authored notification copy
 
 Notification text is user-authored copy, not disposable implementation detail.
@@ -81,7 +103,8 @@ when an existing notification title, message, or notification payload changed.
 Render a terminal-friendly preview in this exact order, nothing extra — users
 should learn one shape and always recognize it:
 
-1. Preview-summary slot: target name and one plain-language sentence.
+1. Preview-summary slot: target name and one to three plain-language sentences
+   (the behavior narrative lives here).
 2. Changes slot: the `ha-nova diff` file/stdout lines, verbatim.
 3. Pre-write-check/impact slot: one or two short lines.
 4. Save-status slot: explicitly say that nothing has been saved yet.
@@ -115,6 +138,44 @@ semantic placeholders; localize them before showing the user:
 2. show yaml — show the full proposed config.
 3. cancel — do not save anything.
 ```
+
+## Verification Honesty (post-write wording)
+
+Post-write checks prove persistence, not behavior. What they establish: the
+write was accepted, the read-back matches, the domain reloaded, the runtime
+entity exists. What they do NOT establish: that conditions carry the intended
+meaning, that every branch is reachable, that timing assumptions hold, or that
+the physical action succeeds.
+
+Wording rules for the result and the collapsed no-findings line:
+
+- Never a bare "verified"/"works now". Name the proven scope instead — the
+  localized equivalent of: "Saved and checked: config persisted, reload OK,
+  entity live. Runtime behavior was not exercised."
+- Where a real run is meaningful, offer it as an explicit optional step: a
+  manual trigger via `ha-nova:service-call` (its own preview + confirmation —
+  it may actuate real devices; never run it unrequested). If the user
+  declines, the uncertainty stays in the final wording — do not let the
+  closing sentence sound more conclusive than the checks were.
+
+## Multi-Target Changes (one logical change, several items)
+
+When one logical change spans multiple automations/scripts/helpers, per-target
+previews alone hide the whole picture. Before the FIRST per-target preview:
+
+1. Present the change plan: every target, what changes in each, the intended
+   combined behavior, and the apply order (dependencies first).
+2. State revert coverage honestly BEFORE starting: update-revert keeps only
+   the most recent update (N=1) — after target two, target one is no longer
+   auto-revertible (only updates evict the snapshot; creates do not). For a broad or hard-to-reconstruct change, offer a safety
+   backup via `ha-nova:backup` first (proportionality rules apply).
+3. Get plan-level consent, then run the normal per-target flow (each target
+   still gets its own preview + confirmation — the plan does not replace them).
+4. Close with a combined summary: all targets applied, the one still-revertible
+   target named, and the verification-honesty wording for the whole change.
+
+If a mid-sequence target fails or is cancelled, stop and show which targets
+are already applied — never continue silently into a half-applied state.
 
 ## Update-Revert (durable, identity-preserving)
 

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -415,7 +415,7 @@ Instead, run the minimal config-entry post-write contract:
    - say that storage-helper H-01..H-10 checks do not apply to this family
    - config-entry updates are not auto-revertible (options-flow writes are multi-step); for undo, point the user to Home Assistant Backups
 
-Report only what has substance (same rule as the write flow — see `skills/write/SKILL.md` Phase 4): keep **Verification** (and the editable snapshot when present), but omit an empty **Collision check** or **Advisory** — never an empty "none" bucket. When the write is clean, the verification plus a single localized confirmation line suffices.
+Report only what has substance (same rule as the write flow — see `skills/write/SKILL.md` Phase 4): keep **Verification** (and the editable snapshot when present), but omit an empty **Collision check** or **Advisory** — never an empty "none" bucket. When the write is clean, the verification plus a single scope-honest confirmation line suffices (`skills/ha-nova/write-safety.md` → Verification Honesty). Multi-target logical changes: plan first per write-safety → Multi-Target Changes.
 
 ## Output Format
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -223,7 +223,7 @@ Traverse all `variables:` mappings in the config, not just the top-level block. 
 - Codes are internal only; NEVER show them in any user-facing message (reports, chat replies, follow-up questions) — describe findings in plain language instead
 
 **Apply these families by domain:**
-- Automation: S-01..S-03, R-01..R-25, P-01..P-05, M-01..M-05
+- Automation: S-01..S-03, R-01..R-28, P-01..P-05, M-01..M-05
 - Script: automation families plus F-01..F-08
 - Helper (storage-based family): H-01..H-10
 - Helper (config-entry family): minimal config-entry review

--- a/skills/review/checks.md
+++ b/skills/review/checks.md
@@ -53,6 +53,10 @@ Load this catalog from `skills/review/SKILL.md` Step 1 before evaluating finding
 - R-24 [LOW]: Capacity-like variable reads `available_energy` — a variable named like `capacity`, `capacity_kwh`, `maximum_energy`, or similar reads an entity containing `available_energy`. Available charge may not be nominal or maximum battery capacity, so calculated targets can be wrong. Advisory only: verify whether a maximum, nominal, or capacity entity is the intended source. Do not hard-code integration-specific replacements or automatically rewrite entity IDs.
 - R-25 [HIGH]: Legacy template platform syntax (removed in HA 2026.6) — pasted/draft YAML defines template entities under a domain platform key (`sensor:`, `binary_sensor:`, `cover:`, `fan:`, `light:`, `lock:`, `switch:`, `vacuum:`, `weather:`, or `alarm_control_panel:` containing `- platform: template`), or as a bare top-level `- platform: template` list (pasted contents of an `!include` file such as `sensors.yaml`; entity-shaped items only, see the Evidence Boundary). Home Assistant 2026.6 removed this syntax entirely: the entities silently stop being created — no error banner, automations depending on them stop firing. It was deprecated in 2025.12 and still current before that — always phrase per the version split in the R-25 Evidence Boundary. Fix: migrate to the modern top-level `template:` syntax (`value_template` → `state`, `friendly_name` → `name`, per-entity maps → list items). Applies only when reviewing pasted or draft YAML (see R-25 Evidence Boundary).
 
+- R-26 [MEDIUM → HIGH]: Exact-state equality narrower than the stated intent — a condition/trigger pins one literal state (classic: `== 'not_home'`) on a domain whose runtime states exceed a simple pair (person/device_tracker report named zones as states; media_player, vacuum, climate carry multi-state enums), while the user's stated intent is the broader category ("nobody home", "the TV is off" — which `standby`/`idle` also satisfy). The config is valid, saves, reloads, and read-back matches — it just never matches legitimate runtime states (a person at zone `work` has state `work`, not `not_home`). Fix: express the category (`!= 'home'` for away-semantics, `zone.home` person count for nobody-home, negations over enumerations). Default MEDIUM; escalate to HIGH when the narrow comparison gates the automation's core purpose. See R-26 Evidence Boundary.
+- R-27 [MEDIUM]: Fixed `delay:` standing in for asynchronous completion — an action starts an asynchronous operation (non-blocking `script.turn_on`, a device command that takes variable time) and a following fixed `delay:` is the only thing "guaranteeing" completion before dependent actions run. The delay documents a hope, not a fact. Fix: `wait_template`/`wait_for_trigger` on the actual completion signal, with `timeout:` (R-04) and a defined timeout path. Do not flag delays that are themselves the intent (light on for 5 minutes).
+- R-28 [MEDIUM]: Startup race — a `trigger: homeassistant` / `event: start` path immediately reads integration-backed entity states in conditions or actions. Right after startup those states can be `unknown`, `unavailable`, or stale-restored before their integration first updates. Fix: guard with an availability wait (`wait_template` on `has_value(...)` with timeout) or accept-and-document the race. Helpers restore their own state and rarely need the guard; template sensors inherit the race from their integration-backed dependencies.
+
 ## R-02 Evidence Boundary
 
 Without `to:`, a `trigger: state` fires on every attribute change of the entity. The footgun is real but its blast radius depends entirely on the automation's mode:
@@ -202,6 +206,23 @@ Self-trigger / feedback loop = the automation triggers on an entity that it also
         - name: "My Sensor"
           state: "{{ ... }}"
   ```
+
+## R-26 Evidence Boundary
+
+- Flag only when the stated or obvious intent is a CATEGORY and the comparison
+  pins one literal that under-covers it. `== 'work'` for "when Markus is at
+  work" is exactly right — never flag intent-matching literals.
+- The criterion is under-coverage of the intent, not open vs closed state
+  sets: two-state domains (binary_sensor on/off) and comparisons that cover
+  the intended category exactly are fine.
+- The classic instance: person/device_tracker away-semantics via
+  `== 'not_home'` — any named zone (work, school, gym) silently fails the
+  comparison although the person is away. Home-semantics via `== 'home'` is
+  normally correct — only a user-defined zone placed inside the home radius
+  can shadow it; do not flag it by default.
+- This is a static check: it cannot prove which zones exist. Phrase it as "this
+  comparison misses valid states like named zones" and show the category-safe
+  form; never claim the automation is currently broken.
 
 ## Performance (Medium)
 

--- a/skills/write/SKILL.md
+++ b/skills/write/SKILL.md
@@ -24,6 +24,8 @@ If this fails, run onboarding: `ha-nova setup`.
 
 ## Flow
 
+Multi-target logical changes: present the plan first per `skills/ha-nova/write-safety.md` → Multi-Target Changes.
+
 ### Phase 1: Resolve (Agent)
 
 1. Read `skills/ha-nova/agents/resolve-agent.md`.
@@ -54,7 +56,7 @@ If this fails, run onboarding: `ha-nova setup`.
      Track findings by check type for dedup in Phase 4, except R-18.
    - **3c) Pre-Write Impact (update only)**: run `skills/review/SKILL.md` Step 2 (Collision Scan) `search/related`; show affected automations/scripts as advisory. Skip `create`/`delete`.
 4. Preview (see `skills/ha-nova/write-safety.md` for the fixed shape):
-   - update: **run** `ha-nova diff` (prefer `--out <diff-file>`), print the diff output **verbatim** in the Changes slot — never write it yourself. create: summary. Create/update previews show `apply`, `show yaml`, and `cancel` options.
+   - update: **run** `ha-nova diff` (prefer `--out <diff-file>`), print the diff output **verbatim** in the Changes slot — never write it yourself; state the behavioral effect in the summary sentence (write-safety → Behavior narrative). create: summary. Create/update previews show `apply`, `show yaml`, and `cancel` options.
    - Delete preview MUST include the consumer-check result before confirmation: either the affected consumers or an explicit no-consumer result.
    - Delete previews do not show `apply`, `show yaml`, `cancel`, or any menu; ask only for the exact `confirm:<token>` or cancellation.
 5. Confirmation: create/update=natural, delete=tokenized `confirm:<token>`. Active Preview Confirmation is required; delete is the typed token, never a menu. Pre-preview consent is draft-only; payload/diff changes need preview.
@@ -94,7 +96,7 @@ Do NOT invoke `ha-nova:review` separately.
 3. Collision scan: `{"type":"search/related","item_type":"entity","item_id":"<entity_id>"}` via `ha-nova relay ws --data-file <payload-file>`; read max 3 related configs.
 4. Post-Write Review output (localized; see `skills/ha-nova/output-rules.md`) — report only what has substance; scans still run, only empty output is suppressed:
    - **Findings**: real issues only. **Collision check**: only when related items exist (list them + the verdict). **Advisory**: only when non-empty. Omit any section with nothing to report — never print an empty "none" bucket.
-   - If nothing is worth reporting, collapse to one localized confirmation line (e.g. "Verified — no issues or conflicts").
+   - If nothing is worth reporting, collapse to one scope-honest confirmation line (write-safety → Verification Honesty).
    - Never emit `Questions to consider`, `Suggestions`, or `Instant help` post-write; never repeat an item across **Findings** and **Advisory**.
 5. Update-Revert: updates only → **run `ha-nova snapshot save`** and offer `revert` (see `skills/ha-nova/write-safety.md`). Creates → cleanup via normal HA NOVA delete flow with preview, `confirm:<token>`, and absence verification. Deletes → Home Assistant Backups.
 

--- a/tests/skills/ha-cross-skill-integration.test.ts
+++ b/tests/skills/ha-cross-skill-integration.test.ts
@@ -102,7 +102,7 @@ describe("ha cross-skill integration", () => {
     expect(writeSkill).toContain("Collision check");
     expect(writeSkill).toContain("Advisory");
     expect(writeSkill).toContain('never print an empty "none" bucket');
-    expect(writeSkill).toContain("collapse to one localized confirmation line");
+    expect(writeSkill).toContain("collapse to one scope-honest confirmation line");
     expect(writeSkill).toContain("Never emit `Questions to consider`, `Suggestions`, or `Instant help` post-write");
     expect(writeSkill).toContain("never repeat an item across **Findings** and **Advisory**");
     expect(writeSkill).toContain("skills/ha-nova/output-rules.md");

--- a/tests/skills/review-contract.test.ts
+++ b/tests/skills/review-contract.test.ts
@@ -114,8 +114,8 @@ describe("review contract", () => {
     expect(reviewChecks).toContain("R-16 [HIGH]");
     expect(reviewChecks).toContain("Templated event name");
     expect(reviewChecks).toContain("`event_type:` does not evaluate templates");
-    expect(reviewSkill).toContain("R-01..R-25");
-    expect(architectureDoc).toContain("R-01..R-25");
+    expect(reviewSkill).toContain("R-01..R-28");
+    expect(architectureDoc).toContain("R-01..R-28");
     expect(templateGuidelines).toContain("Event trigger names must be literal strings");
     expect(templateGuidelines).toContain("do not template `event_type:`");
   });
@@ -150,6 +150,22 @@ describe("review contract", () => {
     expect(templateGuidelines).toContain("self-contained template with internal `{% set %}`");
     expect(templateGuidelines).toContain("ordered `variables` actions");
     expect(architectureDoc).toContain("`R-18` is same-mapping only");
+  });
+
+  it("documents the issue-274 semantic and timing checks (R-26..R-28)", () => {
+    // Valid config, clean save, matching read-back — and still never matches
+    // legitimate runtime states: the silent regression class from issue #274.
+    expect(reviewChecks).toContain("R-26 [MEDIUM → HIGH]: Exact-state equality narrower than the stated intent");
+    expect(reviewChecks).toContain("a person at zone `work` has state `work`, not `not_home`");
+    expect(reviewChecks).toContain("## R-26 Evidence Boundary");
+    expect(reviewChecks).toContain("never flag intent-matching literals");
+    expect(reviewChecks).toContain("never claim the automation is currently broken");
+    // A fixed delay documents a hope, not completion.
+    expect(reviewChecks).toContain("R-27 [MEDIUM]: Fixed `delay:` standing in for asynchronous completion");
+    expect(reviewChecks).toContain("Do not flag delays that are themselves the intent");
+    // Startup paths read states before integrations report them.
+    expect(reviewChecks).toContain("R-28 [MEDIUM]: Startup race");
+    expect(reviewChecks).toContain("`unknown`, `unavailable`, or stale-restored");
   });
 
   it("documents boolean-string template comparisons as R-23", () => {
@@ -263,9 +279,9 @@ describe("review contract", () => {
     expect(outputRules).toContain("findings, summaries, clean states, pre-write verdicts");
     // Post-write review omits empty sections instead of printing "none" buckets.
     expect(architectureDoc).toContain('never print an empty "none" bucket');
-    expect(architectureDoc).toContain("collapse to one localized confirmation line");
+    expect(architectureDoc).toContain("collapse to one scope-honest confirmation line");
     expect(writeSkill).toContain('never print an empty "none" bucket');
-    expect(writeSkill).toContain("collapse to one localized confirmation line");
+    expect(writeSkill).toContain("collapse to one scope-honest confirmation line");
     // Standalone review still states a clean result (it answers an explicit request).
     expect(outputRules).toContain('"no issues found" result is useful');
   });

--- a/tests/skills/write-delete-safety-contract.test.ts
+++ b/tests/skills/write-delete-safety-contract.test.ts
@@ -30,6 +30,25 @@ describe("write delete safety contract", () => {
     expect(writeSkill).toContain("cancel");
   });
 
+  it("requires an understandable preview and honest verification wording (issue #274)", () => {
+    // The diff states WHAT changes; the summary must state what it DOES —
+    // confirmation of an incomprehensible preview is not informed consent.
+    expect(writeSafety).toContain("### Behavior narrative (required with every update preview)");
+    expect(writeSafety).toContain("never ask for confirmation of a change you cannot describe");
+    expect(writeSafety).toContain("the summary MUST name what was added, removed, or nested there");
+    expect(writeSkill).toContain("state the behavioral effect in the summary sentence");
+    // Post-write checks prove persistence, not behavior — wording must say so.
+    expect(writeSafety).toContain("## Verification Honesty (post-write wording)");
+    expect(writeSafety).toContain('Never a bare "verified"');
+    expect(writeSafety).toContain("Runtime behavior was not exercised");
+    expect(writeSafety).toContain("it may actuate real devices; never run it unrequested");
+    // One logical change over several targets: plan first, honest revert scope.
+    expect(writeSafety).toContain("## Multi-Target Changes (one logical change, several items)");
+    expect(writeSafety).toContain("after target two, target one is no longer");
+    expect(writeSafety).toContain("never continue silently into a half-applied state");
+    expect(writeSkill).toContain("Multi-target logical changes: present the plan first");
+  });
+
   it("defines diff + durable update-revert in the shared owner doc", () => {
     expect(writeSafety).toContain("## Changes");
     expect(writeSafety).toContain("Update-Revert");


### PR DESCRIPTION
Part B of #274 (spec: `docs/work/2026-07-10-issue-274-preview-quality-spec.md`, merged with PR A #277). **Fixes #274.**

- **Behavior narrative** (write-safety, required per update preview): the summary states what the change DOES; count-only/`… and N more` remainders the request touched must be named; the verbatim diff stays the sole Changes-slot content and is authoritative — 'never ask for confirmation of a change you cannot describe'. (Problems 2, 3, 12)
- **Verification Honesty**: post-write wording names the proven scope and states behavior was not exercised; bare 'verified' banned across write/helper/output-rules/architecture; optional consent-gated behavior test via `ha-nova:service-call` ('may actuate real devices; never run it unrequested'). (Problems 5, 9)
- **Multi-Target Changes**: plan-first (all targets, combined behavior, apply order), honest N=1 revert scope up front + proportional backup offer, per-target previews stay mandatory, loud stop on mid-sequence failure. (Problems 7, 8-honesty, 12)
- **New review checks**: R-26 exact-state narrower than intent (the person-at-zone-`work`-is-not-`not_home` class, with evidence boundary incl. zone-shadowing nuance), R-27 fixed delay standing in for async completion, R-28 startup races. Ranges bumped to R-01..R-28. (Problems 4, 6, 10, 11)

Red-team round (subagent) applied before this PR: 2 P1 + 8 P2, incl. correcting a factually wrong zone claim and an internal R-26 contradiction. Closure map for all 12 problems is in the review report; problem 8's full fix (N>1 revert stack) is documented as a CLI follow-up in the spec.

## Verification
- Full vitest sweep 626 green (incl. new pins for narrative/honesty/multi-target and R-26..R-28); `npm run verify` fully green
- write/SKILL.md at 1145/1150 words; all new text English-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhefhWnMEyVLyYpU6LF4kf