### PR TITLE
docs: archive the merged issue-274 preview-quality spec

### DIFF
--- a/docs/archive/work/2026-07-10-issue-274-preview-quality-spec.md
+++ b/docs/archive/work/2026-07-10-issue-274-preview-quality-spec.md
@@ -1,6 +1,6 @@
 # Issue #274 — Write/Review Preview & Verification Quality
 
-Status: active
+Status: merged (#277 + #278)
 Issue: #274 (12 observed problems). Delivered as two PRs — different subsystems, one logical topic:
 
 ## PR A — `ha-nova diff`: aligned per-item rendering (problems 1–3 root cause)


### PR DESCRIPTION
Post-merge bookkeeping per the work-doc rules: #277 + #278 landed, the spec moves to `docs/archive/work/` with status merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhefhWnMEyVLyYpU6LF4kf