### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.11.1"
+    "version": "0.12.0"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,9 +83,16 @@ release:
     ```
 
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
-    {{ else }}## Bug Fixes
+    {{ else }}## New Features
 
-    - `ha-nova update` and `ha-nova setup claude` no longer fail with "plugin not found after sync" when run from a shell that redirects Claude Code's config (`CLAUDE_CONFIG_DIR` — for example a terminal inside a Claude Code session). ha-nova now reads and writes the same Claude profile as the `claude` CLI it drives, and tells you when a sync targeted a non-default profile.
+    - **Previews you can actually judge**: change previews now show WHICH triggers/actions were added, removed, or nested — not just an item count — plus a plain-language sentence about what the change does to behavior. Post-write results name exactly what was checked instead of a bare "verified", and offer an optional real test run.
+    - **Smarter reviews**: three new checks catch silent logic traps — presence conditions that miss named zones (a person at "work" is not `not_home`), fixed delays standing in for real completion, and startup automations reading sensors before they are ready.
+    - Changes that span several automations/scripts now start with a full plan and an honest note about what stays undoable.
+
+    ## Bug Fixes
+
+    - Claude Code attach checks now ask the `claude` CLI directly when state files disagree — robust against Claude Code state-format changes (and a disabled plugin no longer counts as attached).
+    - Windows: Credential Manager errors in SSH sessions now explain the fix (use a local console or RDP session) instead of printing a raw OS error.
 
     ## What To Watch
 

--- a/docs/work/2026-07-10-v0.12.0-release-body.md
+++ b/docs/work/2026-07-10-v0.12.0-release-body.md
@@ -1,0 +1,18 @@
+# v0.12.0 Release Body (draft)
+
+Status: active — shipped wording lives in `.goreleaser.yml`; archive this file after the release.
+
+## New Features
+
+- **Previews you can actually judge**: change previews now show WHICH triggers/actions were added, removed, or nested — not just an item count — plus a plain-language sentence about what the change does to behavior. Post-write results name exactly what was checked instead of a bare "verified", and offer an optional real test run.
+- **Smarter reviews**: three new checks catch silent logic traps — presence conditions that miss named zones (a person at "work" is not `not_home`), fixed delays standing in for real completion, and startup automations reading sensors before they are ready.
+- Changes that span several automations/scripts now start with a full plan and an honest note about what stays undoable.
+
+## Bug Fixes
+
+- Claude Code attach checks now ask the `claude` CLI directly when state files disagree — robust against Claude Code state-format changes (and a disabled plugin no longer counts as attached).
+- Windows: Credential Manager errors in SSH sessions now explain the fix (use a local console or RDP session) instead of printing a raw OS error.
+
+## What To Watch
+
+- No NOVA Relay App update needed for this release — it stays on 0.2.6.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -53,13 +53,16 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
-  it("keeps v0.11.1 release-facing wording user-centric", () => {
+  it("keeps v0.12.0 release-facing wording user-centric", () => {
     // Shipped release-note bodies are archived (docs/archive/work/) and
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
-    expect(goreleaser).toContain("no longer fail with \"plugin not found after sync\"");
-    expect(goreleaser).toContain("`CLAUDE_CONFIG_DIR`");
-    expect(goreleaser).toContain("reads and writes the same Claude profile as the `claude` CLI it drives");
+    expect(goreleaser).toContain("Previews you can actually judge");
+    expect(goreleaser).toContain("not just an item count");
+    expect(goreleaser).toContain('instead of a bare "verified"');
+    expect(goreleaser).toContain('a person at "work" is not `not_home`');
+    expect(goreleaser).toContain("robust against Claude Code state-format changes");
+    expect(goreleaser).toContain("use a local console or RDP session");
     expect(goreleaser).toContain("No NOVA Relay App update needed for this release — it stays on 0.2.6");
     expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");
   });

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.11.1",
+  "skill_version": "0.12.0",
   "min_relay_version": "0.2.5"
 }


### PR DESCRIPTION
Release-prep for **v0.12.0** (Relay stays 0.2.6): ships #275 (Claude attach CLI confirmation), #276 (Windows keyring classification, closes the last of both open issues), #277 + #278 (issue #274: aligned diff rendering, behavior narrative, verification honesty, multi-target flow, checks R-26..R-28).

- Version bump 0.11.1 → 0.12.0 in the four synced files
- GoReleaser stable notes: user-centric New Features + Bug Fixes; release-contract pins updated
- No README changes needed (no inventory/claims drift)
- `npm run verify` + full sweep green

After merge: strict audit → `v0.12.0-rc1` rehearsal → public-install verify → final tag → live update test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhefhWnMEyVLyYpU6LF4kf