### PR TITLE
feat(cli): bounded update-revert stack — last 5 targets revertible

### DIFF
--- a/cli/snapshot.go
+++ b/cli/snapshot.go
@@ -295,6 +295,7 @@ func selectUndoSnapshot(paths runtimePaths, target, domain string) (undoSnapshot
 		}
 		return stack.Snapshots[0], nil
 	}
+	var matches []undoSnapshot
 	for _, snap := range stack.Snapshots {
 		if snap.TargetID != target {
 			continue
@@ -302,9 +303,18 @@ func selectUndoSnapshot(paths runtimePaths, target, domain string) (undoSnapshot
 		if domain != "" && snap.Domain != domain {
 			continue
 		}
-		return snap, nil
+		matches = append(matches, snap)
 	}
-	return undoSnapshot{}, fmt.Errorf("no undo snapshot for target %s", target)
+	switch len(matches) {
+	case 0:
+		return undoSnapshot{}, fmt.Errorf("no undo snapshot for target %s", target)
+	case 1:
+		return matches[0], nil
+	default:
+		// Same target_id in more than one domain (save keys on domain+target,
+		// so this is legal): never guess which config to restore.
+		return undoSnapshot{}, fmt.Errorf("target %s is ambiguous across domains; pass --domain", target)
+	}
 }
 
 func validateUndoSnapshot(snap undoSnapshot) error {

--- a/cli/snapshot.go
+++ b/cli/snapshot.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 )
 
-// undoSnapshot is the client-side, single-slot record of the most recent
-// revertible write. It stores the pre-write config (to restore) and the
-// post-write verified read-back (to detect external drift before restoring).
+// undoSnapshot is one client-side record of a revertible write. It stores the
+// pre-write config (to restore) and the post-write verified read-back (to
+// detect external drift before restoring).
 //
 // The store performs NO Home Assistant calls. The skill orchestrates the
 // actual restore through `ha-nova relay` and the apply-agent, so the single
@@ -29,12 +29,30 @@ type undoSnapshot struct {
 
 const undoSnapshotSchemaVersion = 1
 
+// undoSnapshotStack keeps the most recent revertible updates, newest first —
+// one entry per domain+target (a re-update of the same target replaces its
+// entry; reverting an update always restores that target's LAST before-state).
+// Bounded so a multi-target logical change stays fully revertible without the
+// store growing forever (issue #282; previously a single slot).
+type undoSnapshotStack struct {
+	SchemaVersion int            `json:"schema_version"`
+	Snapshots     []undoSnapshot `json:"snapshots"`
+}
+
+const undoSnapshotStackSchemaVersion = 2
+const undoSnapshotStackLimit = 5
+
 // Exit codes for `snapshot verify`: 0 = live matches the post-write state,
 // snapshotExitDrift = live drifted (external edit), 1 = operational error.
 const snapshotExitDrift = 2
 
+// undoSnapshotPath is the legacy single-slot store; still read for migration.
 func undoSnapshotPath(paths runtimePaths) string {
 	return filepath.Join(paths.ConfigDir, "undo-snapshot.json")
+}
+
+func undoSnapshotStackPath(paths runtimePaths) string {
+	return filepath.Join(paths.ConfigDir, "undo-snapshots.json")
 }
 
 func runSnapshotCommand(paths runtimePaths, args []string) int {
@@ -46,7 +64,7 @@ func runSnapshotCommand(paths runtimePaths, args []string) int {
 	case "save":
 		return runSnapshotSave(paths, args[1:])
 	case "show":
-		return runSnapshotShow(paths)
+		return runSnapshotShow(paths, args[1:])
 	case "verify":
 		return runSnapshotVerify(paths, args[1:])
 	default:
@@ -97,8 +115,42 @@ func runSnapshotSave(paths runtimePaths, args []string) int {
 	return 0
 }
 
-func runSnapshotShow(paths runtimePaths) int {
-	snap, err := loadUndoSnapshot(paths)
+func runSnapshotShow(paths runtimePaths, args []string) int {
+	fs := flag.NewFlagSet("snapshot show", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var target, domain string
+	var list bool
+	fs.StringVar(&target, "target", "", "select the snapshot for this target_id (default: newest)")
+	fs.StringVar(&domain, "domain", "", "optional domain filter when selecting by target")
+	fs.BoolVar(&list, "list", false, "list the stored snapshots (op/domain/target_id, newest first)")
+	if err := fs.Parse(args); err != nil {
+		printErr("%s", err)
+		return 1
+	}
+	if list {
+		stack, err := loadUndoSnapshotStack(paths)
+		if err != nil {
+			printErr("%s", err)
+			return 1
+		}
+		type entry struct {
+			Op       string `json:"op"`
+			Domain   string `json:"domain"`
+			TargetID string `json:"target_id"`
+		}
+		entries := make([]entry, 0, len(stack.Snapshots))
+		for _, s := range stack.Snapshots {
+			entries = append(entries, entry{Op: s.Op, Domain: s.Domain, TargetID: s.TargetID})
+		}
+		out, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			printErr("cannot render snapshot list: %s", err)
+			return 1
+		}
+		fmt.Fprintln(os.Stdout, string(out))
+		return 0
+	}
+	snap, err := selectUndoSnapshot(paths, target, domain)
 	if err != nil {
 		printErr("%s", err)
 		return 1
@@ -115,8 +167,10 @@ func runSnapshotShow(paths runtimePaths) int {
 func runSnapshotVerify(paths runtimePaths, args []string) int {
 	fs := flag.NewFlagSet("snapshot verify", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	var against string
+	var against, target, domain string
 	fs.StringVar(&against, "against", "", "path to the current live config JSON")
+	fs.StringVar(&target, "target", "", "select the snapshot for this target_id (default: newest)")
+	fs.StringVar(&domain, "domain", "", "optional domain filter when selecting by target")
 	if err := fs.Parse(args); err != nil {
 		printErr("%s", err)
 		return 1
@@ -125,7 +179,7 @@ func runSnapshotVerify(paths runtimePaths, args []string) int {
 		printErr("--against <live.json> is required")
 		return 1
 	}
-	snap, err := loadUndoSnapshot(paths)
+	snap, err := selectUndoSnapshot(paths, target, domain)
 	if err != nil {
 		printErr("%s", err)
 		return 1
@@ -148,12 +202,12 @@ func runSnapshotVerify(paths runtimePaths, args []string) int {
 	return snapshotExitDrift
 }
 
-// saveUndoSnapshotBytes parses, validates and atomically writes the snapshot.
-// N=1: it overwrites any prior snapshot — only the last write is revertible.
-// The store assumes single-flight writes: the skill's single write path
-// (apply-agent) serialises operations, so concurrent saves don't race on the one
-// slot. The write itself is atomic (temp file + rename), so a reader never sees a
-// torn file even if that assumption is violated.
+// saveUndoSnapshotBytes parses, validates and atomically writes the snapshot
+// onto the bounded stack: newest first, one entry per domain+target (same
+// target replaces its entry), oldest evicted beyond the limit. The store
+// assumes single-flight writes: the skill's single write path (apply-agent)
+// serialises operations. The write itself is atomic (temp file + rename), so a
+// reader never sees a torn file even if that assumption is violated.
 func saveUndoSnapshotBytes(paths runtimePaths, data []byte) error {
 	var snap undoSnapshot
 	if err := json.Unmarshal(data, &snap); err != nil {
@@ -163,10 +217,94 @@ func saveUndoSnapshotBytes(paths runtimePaths, data []byte) error {
 		return err
 	}
 	snap.SchemaVersion = undoSnapshotSchemaVersion
-	if err := writeJSONFile(undoSnapshotPath(paths), snap, 0o600); err != nil {
+	stack, err := loadUndoSnapshotStack(paths)
+	if err != nil {
+		return err
+	}
+	kept := make([]undoSnapshot, 0, len(stack.Snapshots)+1)
+	kept = append(kept, snap)
+	for _, existing := range stack.Snapshots {
+		if existing.Domain == snap.Domain && existing.TargetID == snap.TargetID {
+			continue
+		}
+		kept = append(kept, existing)
+	}
+	if len(kept) > undoSnapshotStackLimit {
+		kept = kept[:undoSnapshotStackLimit]
+	}
+	stack = undoSnapshotStack{SchemaVersion: undoSnapshotStackSchemaVersion, Snapshots: kept}
+	if err := writeJSONFile(undoSnapshotStackPath(paths), stack, 0o600); err != nil {
 		return fmt.Errorf("cannot write snapshot: %s", err)
 	}
+	// The legacy single-slot file is folded into the stack above; drop it so
+	// the two stores can never disagree. Best effort — a leftover legacy file
+	// only re-migrates as the oldest entry.
+	if err := os.Remove(undoSnapshotPath(paths)); err != nil && !isNotExist(err) {
+		printHumanWarn("legacy undo-snapshot cleanup skipped: %s", err)
+	}
 	return nil
+}
+
+// loadUndoSnapshotStack reads the stack store; a pre-stack single-slot file
+// migrates as a one-element stack so an update written by an older CLI stays
+// revertible after upgrading.
+func loadUndoSnapshotStack(paths runtimePaths) (undoSnapshotStack, error) {
+	data, err := os.ReadFile(undoSnapshotStackPath(paths))
+	if err == nil {
+		var stack undoSnapshotStack
+		if err := json.Unmarshal(data, &stack); err != nil {
+			return undoSnapshotStack{}, fmt.Errorf("undo snapshot store is corrupt: %s", err)
+		}
+		return stack, nil
+	}
+	if !isNotExist(err) {
+		return undoSnapshotStack{}, err
+	}
+	legacy, err := os.ReadFile(undoSnapshotPath(paths))
+	if err != nil {
+		if isNotExist(err) {
+			return undoSnapshotStack{SchemaVersion: undoSnapshotStackSchemaVersion}, nil
+		}
+		return undoSnapshotStack{}, err
+	}
+	var snap undoSnapshot
+	if err := json.Unmarshal(legacy, &snap); err != nil {
+		return undoSnapshotStack{}, fmt.Errorf("undo snapshot is corrupt: %s", err)
+	}
+	return undoSnapshotStack{
+		SchemaVersion: undoSnapshotStackSchemaVersion,
+		Snapshots:     []undoSnapshot{snap},
+	}, nil
+}
+
+// selectUndoSnapshot picks the newest snapshot, or the one for an explicit
+// target (optionally narrowed by domain).
+func selectUndoSnapshot(paths runtimePaths, target, domain string) (undoSnapshot, error) {
+	stack, err := loadUndoSnapshotStack(paths)
+	if err != nil {
+		return undoSnapshot{}, err
+	}
+	if len(stack.Snapshots) == 0 {
+		return undoSnapshot{}, fmt.Errorf("no undo snapshot available")
+	}
+	target = strings.TrimSpace(target)
+	domain = strings.TrimSpace(domain)
+	if target == "" {
+		if domain != "" {
+			return undoSnapshot{}, fmt.Errorf("--domain requires --target")
+		}
+		return stack.Snapshots[0], nil
+	}
+	for _, snap := range stack.Snapshots {
+		if snap.TargetID != target {
+			continue
+		}
+		if domain != "" && snap.Domain != domain {
+			continue
+		}
+		return snap, nil
+	}
+	return undoSnapshot{}, fmt.Errorf("no undo snapshot for target %s", target)
 }
 
 func validateUndoSnapshot(snap undoSnapshot) error {
@@ -202,19 +340,10 @@ func hasJSONContent(raw json.RawMessage) bool {
 	return trimmed != "" && trimmed != "null"
 }
 
+// loadUndoSnapshot returns the newest stored snapshot (legacy call sites and
+// tests; selection lives in selectUndoSnapshot).
 func loadUndoSnapshot(paths runtimePaths) (undoSnapshot, error) {
-	data, err := os.ReadFile(undoSnapshotPath(paths))
-	if err != nil {
-		if isNotExist(err) {
-			return undoSnapshot{}, fmt.Errorf("no undo snapshot available")
-		}
-		return undoSnapshot{}, err
-	}
-	var snap undoSnapshot
-	if err := json.Unmarshal(data, &snap); err != nil {
-		return undoSnapshot{}, fmt.Errorf("undo snapshot is corrupt: %s", err)
-	}
-	return snap, nil
+	return selectUndoSnapshot(paths, "", "")
 }
 
 // snapshotMatchesLive reports whether the live config still matches the stored

--- a/cli/snapshot_test.go
+++ b/cli/snapshot_test.go
@@ -43,12 +43,100 @@ func TestSnapshotSaveShowRoundTrip(t *testing.T) {
 	}
 
 	// File is written with owner-only permissions (contains config detail).
-	info, err := os.Stat(undoSnapshotPath(paths))
+	info, err := os.Stat(undoSnapshotStackPath(paths))
 	if err != nil {
 		t.Fatalf("stat failed: %v", err)
 	}
 	if perm := info.Mode().Perm(); perm != 0o600 {
 		t.Fatalf("expected 0600 permissions, got %o", perm)
+	}
+}
+
+func TestSnapshotStackKeepsMultipleTargetsAndReplacesSameTarget(t *testing.T) {
+	paths := testSnapshotPaths(t)
+	record := func(target, before string) string {
+		return `{"op":"update","domain":"automation","target_id":"` + target + `","before_config":{"alias":"` + before + `"},"expected_after":{"alias":"after"}}`
+	}
+	// Three targets, then a re-update of the second: 3 entries, second replaced + moved to top.
+	for _, r := range []string{record("t1", "b1"), record("t2", "b2"), record("t3", "b3"), record("t2", "b2-new")} {
+		if err := saveUndoSnapshotBytes(paths, []byte(r)); err != nil {
+			t.Fatalf("save failed: %v", err)
+		}
+	}
+	stack, err := loadUndoSnapshotStack(paths)
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+	if len(stack.Snapshots) != 3 {
+		t.Fatalf("expected 3 entries (same target replaced), got %d", len(stack.Snapshots))
+	}
+	if stack.Snapshots[0].TargetID != "t2" || stack.Snapshots[1].TargetID != "t3" || stack.Snapshots[2].TargetID != "t1" {
+		t.Fatalf("unexpected order: %s, %s, %s", stack.Snapshots[0].TargetID, stack.Snapshots[1].TargetID, stack.Snapshots[2].TargetID)
+	}
+	// Per-target selection returns the replaced record, newest-default returns t2.
+	snap, err := selectUndoSnapshot(paths, "t1", "")
+	if err != nil {
+		t.Fatalf("select t1: %v", err)
+	}
+	if string(snap.BeforeConfig) == "" || snap.TargetID != "t1" {
+		t.Fatalf("select t1 returned wrong record: %+v", snap)
+	}
+	if _, err := selectUndoSnapshot(paths, "missing", ""); err == nil {
+		t.Fatal("expected error for unknown target")
+	}
+	if _, err := selectUndoSnapshot(paths, "", "automation"); err == nil {
+		t.Fatal("expected error for --domain without --target")
+	}
+}
+
+func TestSnapshotStackEvictsOldestBeyondLimit(t *testing.T) {
+	paths := testSnapshotPaths(t)
+	for i := 0; i < undoSnapshotStackLimit+2; i++ {
+		r := `{"op":"update","domain":"automation","target_id":"t` + string(rune('a'+i)) + `","before_config":{"a":1},"expected_after":{"a":2}}`
+		if err := saveUndoSnapshotBytes(paths, []byte(r)); err != nil {
+			t.Fatalf("save %d failed: %v", i, err)
+		}
+	}
+	stack, err := loadUndoSnapshotStack(paths)
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+	if len(stack.Snapshots) != undoSnapshotStackLimit {
+		t.Fatalf("expected stack capped at %d, got %d", undoSnapshotStackLimit, len(stack.Snapshots))
+	}
+	if _, err := selectUndoSnapshot(paths, "ta", ""); err == nil {
+		t.Fatal("oldest entry should have been evicted")
+	}
+}
+
+func TestSnapshotLegacySingleFileMigratesIntoStack(t *testing.T) {
+	paths := testSnapshotPaths(t)
+	legacy := `{"schema_version":1,"op":"update","domain":"automation","target_id":"old","before_config":{"a":1},"expected_after":{"a":2}}`
+	if err := os.WriteFile(undoSnapshotPath(paths), []byte(legacy), 0o600); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+	// Read path: the legacy record is visible as the newest snapshot.
+	snap, err := loadUndoSnapshot(paths)
+	if err != nil {
+		t.Fatalf("load legacy: %v", err)
+	}
+	if snap.TargetID != "old" {
+		t.Fatalf("legacy record not surfaced: %+v", snap)
+	}
+	// Write path: a new save folds the legacy record in and removes the file.
+	next := `{"op":"update","domain":"automation","target_id":"new","before_config":{"b":1},"expected_after":{"b":2}}`
+	if err := saveUndoSnapshotBytes(paths, []byte(next)); err != nil {
+		t.Fatalf("save after legacy: %v", err)
+	}
+	stack, err := loadUndoSnapshotStack(paths)
+	if err != nil {
+		t.Fatalf("load stack: %v", err)
+	}
+	if len(stack.Snapshots) != 2 || stack.Snapshots[0].TargetID != "new" || stack.Snapshots[1].TargetID != "old" {
+		t.Fatalf("legacy migration produced wrong stack: %+v", stack.Snapshots)
+	}
+	if _, err := os.Stat(undoSnapshotPath(paths)); !os.IsNotExist(err) {
+		t.Fatal("legacy file should be removed after a stack save")
 	}
 }
 

--- a/cli/snapshot_test.go
+++ b/cli/snapshot_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -83,6 +84,17 @@ func TestSnapshotStackKeepsMultipleTargetsAndReplacesSameTarget(t *testing.T) {
 	}
 	if _, err := selectUndoSnapshot(paths, "missing", ""); err == nil {
 		t.Fatal("expected error for unknown target")
+	}
+	// Same target_id in a second domain: target-only selection must refuse
+	// to guess, and --domain must disambiguate.
+	if err := saveUndoSnapshotBytes(paths, []byte(`{"op":"update","domain":"script","target_id":"t1","before_config":{"a":1},"expected_after":{"a":2}}`)); err != nil {
+		t.Fatalf("save script t1: %v", err)
+	}
+	if _, err := selectUndoSnapshot(paths, "t1", ""); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguity error for cross-domain target, got %v", err)
+	}
+	if snap, err := selectUndoSnapshot(paths, "t1", "automation"); err != nil || snap.Domain != "automation" {
+		t.Fatalf("domain disambiguation failed: %+v, %v", snap, err)
 	}
 	if _, err := selectUndoSnapshot(paths, "", "automation"); err == nil {
 		t.Fatal("expected error for --domain without --target")

--- a/cli/uninstall_paths.go
+++ b/cli/uninstall_paths.go
@@ -37,6 +37,7 @@ func managedConfigArtifactPaths(paths runtimePaths, purge bool) []string {
 		filepath.Join(paths.ConfigDir, "doctor-cache.env"),
 		filepath.Join(paths.ConfigDir, "claude-marketplace"),
 		filepath.Join(paths.ConfigDir, "undo-snapshot.json"),
+		filepath.Join(paths.ConfigDir, "undo-snapshots.json"),
 	}
 	if purge {
 		pathsList = append(pathsList, paths.ConfigFile)

--- a/cli/uninstall_test.go
+++ b/cli/uninstall_test.go
@@ -32,6 +32,9 @@ func TestUninstallManagedArtifactsIncludeWriteSafetyState(t *testing.T) {
 	if got := managedConfigArtifactPaths(paths, true); !contains(got, filepath.Join("/cfg", "undo-snapshot.json")) {
 		t.Errorf("config artifacts missing undo-snapshot.json: %v", got)
 	}
+	if got := managedConfigArtifactPaths(paths, true); !contains(got, filepath.Join("/cfg", "undo-snapshots.json")) {
+		t.Errorf("config artifacts missing undo-snapshots.json (revert stack store): %v", got)
+	}
 	if got := managedCacheArtifactPaths(paths); !contains(got, filepath.Join("/cache", "automation-bp-snapshot.json")) {
 		t.Errorf("cache artifacts missing automation-bp-snapshot.json: %v", got)
 	}

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -243,11 +243,15 @@ rollback option in the same breath — never a bare "undo":
    snapshot show --list` lists what is still revertible (newest first).
 2. Re-read the current live config of `target_id` (same read-back path as
    Phase 4) into a file.
-3. Drift check (same `--target`/`--domain` selection as step 1):
+3. Drift check — MUST carry the same `--target`/`--domain` selection as
+   step 1 (a bare `verify` compares against the NEWEST snapshot and would
+   drift-check an earlier target against the wrong `expected_after`):
 
    ```text
-   ha-nova snapshot verify --against <live-file>
+   ha-nova snapshot verify --target <target_id> --against <live-file>
    ```
+
+   Only when reverting the newest update may the `--target` flag be omitted.
 
    - `match` (exit 0) → the config is still exactly as written; safe to restore.
    - `drift` (exit 2) → it changed since the write (e.g. an external UI edit).

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -165,14 +165,16 @@ previews alone hide the whole picture. Before the FIRST per-target preview:
 
 1. Present the change plan: every target, what changes in each, the intended
    combined behavior, and the apply order (dependencies first).
-2. State revert coverage honestly BEFORE starting: update-revert keeps only
-   the most recent update (N=1) — after target two, target one is no longer
-   auto-revertible (only updates evict the snapshot; creates do not). For a broad or hard-to-reconstruct change, offer a safety
-   backup via `ha-nova:backup` first (proportionality rules apply).
+2. State revert coverage honestly BEFORE starting: update-revert keeps the
+   last 5 updated targets (one snapshot per target) — a logical change with
+   more update targets than that loses auto-revert for the oldest ones; say
+   so. For a broad or hard-to-reconstruct change, offer a safety backup via
+   `ha-nova:backup` first (proportionality rules apply).
 3. Get plan-level consent, then run the normal per-target flow (each target
    still gets its own preview + confirmation — the plan does not replace them).
-4. Close with a combined summary: all targets applied, the one still-revertible
-   target named, and the verification-honesty wording for the whole change.
+4. Close with a combined summary: all targets applied, the still-revertible
+   targets named (`ha-nova snapshot show --list`), and the
+   verification-honesty wording for the whole change.
 
 If a mid-sequence target fails or is cancelled, stop and show which targets
 are already applied — never continue silently into a half-applied state.
@@ -189,8 +191,9 @@ Home Assistant Backup, or recreating the item. Point the user to HA Backups
 
 ### 1. Capture the snapshot (after a verified update)
 
-After Phase-4 verification of an update succeeds, store exactly one snapshot.
-N=1: only the most recent update is revertible.
+After Phase-4 verification of an update succeeds, store the snapshot. The
+store keeps the last 5 updates, one per domain+target — a re-update of the
+same target replaces its entry; beyond 5 targets the oldest entry is evicted.
 
 - `before_config` = the pre-write read-back captured during resolve
   (`CURRENT_CONFIG`). It is HA's own normalized form, so re-writing it
@@ -233,10 +236,14 @@ rollback option in the same breath — never a bare "undo":
 ### 3. Execute `revert`
 
 1. Run `ha-nova snapshot show` — the **only** source of `before_config`. Never
-   reconstruct the previous config from memory or context.
+   reconstruct the previous config from memory or context. The bare command
+   returns the newest update; for an earlier target in a multi-target change,
+   select it: `ha-nova snapshot show --target <target_id>` (add
+   `--domain <domain>` if the same id exists in both domains). `ha-nova
+   snapshot show --list` lists what is still revertible (newest first).
 2. Re-read the current live config of `target_id` (same read-back path as
    Phase 4) into a file.
-3. Drift check:
+3. Drift check (same `--target`/`--domain` selection as step 1):
 
    ```text
    ha-nova snapshot verify --against <live-file>
@@ -263,7 +270,9 @@ Use `ha-nova snapshot show` to read the stored record (including
 
 ### Honesty
 
-- The store holds only the last update; the next write overwrites it.
+- The store holds the last 5 updated targets; older entries are gone, and a
+  re-update of a target replaces that target's snapshot (one step back per
+  target, never two).
 - `revert` restores the captured config through the normal write path; it does
   not replay HA's exact byte-for-byte formatting. For a guaranteed point-in-time
   restore, Home Assistant Backups is the source of truth.
@@ -279,8 +288,8 @@ expensive. Never suggest a backup for routine small edits.
 
 | Skill / family | Pre-write diff | Update-revert | Fallback recovery path |
 |---|---|---|---|
-| `write` (automation/script) | yes (`ha-nova diff`) | yes (verified updates, N=1) | HA Backups |
-| `helper` storage family | yes | yes (verified updates, N=1) | HA Backups |
+| `write` (automation/script) | yes (`ha-nova diff`) | yes (verified updates, last 5 targets) | HA Backups |
+| `helper` storage family | yes | yes (verified updates, last 5 targets) | HA Backups |
 | `helper` config-entry family | diff only | no (multi-step options flow) | HA Backups |
 | `dashboard` | preview + read-back verify | no | HA Backups |
 | `scene` | preview + read-back verify | no | HA Backups |

--- a/tests/skills/write-delete-safety-contract.test.ts
+++ b/tests/skills/write-delete-safety-contract.test.ts
@@ -44,7 +44,11 @@ describe("write delete safety contract", () => {
     expect(writeSafety).toContain("it may actuate real devices; never run it unrequested");
     // One logical change over several targets: plan first, honest revert scope.
     expect(writeSafety).toContain("## Multi-Target Changes (one logical change, several items)");
-    expect(writeSafety).toContain("after target two, target one is no longer");
+    expect(writeSafety).toContain("update-revert keeps the");
+    expect(writeSafety).toContain("last 5 updated targets");
+    expect(writeSafety).toContain("one step back per");
+    expect(writeSafety).toContain("snapshot show --target <target_id>");
+    expect(writeSafety).toContain("snapshot show --list");
     expect(writeSafety).toContain("never continue silently into a half-applied state");
     expect(writeSkill).toContain("Multi-target logical changes: present the plan first");
   });


### PR DESCRIPTION
Closes #282 (follow-up from #274 problem 8; spec: `docs/archive/work/2026-07-10-issue-274-preview-quality-spec.md`).

The undo store grows from one slot to a newest-first **stack of 5, one entry per domain+target**: re-updating a target replaces its entry (one step back per target, never two), older targets evict beyond the limit — a typical multi-target logical change stays fully revertible.

- `snapshot show`/`verify` unchanged by default (newest entry) — the shipped v0.12.0 skill texts keep working against a new CLI; `--target <id>` (+ optional `--domain`) selects an earlier target, `show --list` enumerates what is still revertible.
- Legacy single-slot file migrates on read and folds into the stack on the next save (then removed) — an update written by an older CLI stays revertible after upgrading.
- write-safety updated: capture/execute/multi-target/honesty sections + availability table now state the 5-target scope; multi-target step 2 warns only beyond 5 update targets.

## Verification
- New tests: multi-target keep + same-target replace + selection errors, eviction beyond the limit, legacy migration (read and save paths); Go suite green (147 s)
- Full vitest sweep 69/626 green (write-delete-safety pins updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhefhWnMEyVLyYpU6LF4kf