### PR TITLE
chore(release): prepare v0.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,14 +85,7 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## New Features
 
-    - **Previews you can actually judge**: change previews now show WHICH triggers/actions were added, removed, or nested — not just an item count — plus a plain-language sentence about what the change does to behavior. Post-write results name exactly what was checked instead of a bare "verified", and offer an optional real test run.
-    - **Smarter reviews**: three new checks catch silent logic traps — presence conditions that miss named zones (a person at "work" is not `not_home`), fixed delays standing in for real completion, and startup automations reading sensors before they are ready.
-    - Changes that span several automations/scripts now start with a full plan and an honest note about what stays undoable.
-
-    ## Bug Fixes
-
-    - Claude Code attach checks now ask the `claude` CLI directly when state files disagree — robust against Claude Code state-format changes (and a disabled plugin no longer counts as attached).
-    - Windows: Credential Manager errors in SSH sessions now explain the fix (use a local console or RDP session) instead of printing a raw OS error.
+    - **Undo now covers multi-item changes**: the last 5 updated automations, scripts, or helpers each keep their own one-step revert (previously only the most recent update). When one change touches several items, every one of them stays individually undoable — and the assistant tells you upfront what is still revertible.
 
     ## What To Watch
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,7 +85,7 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## New Features
 
-    - **Undo now covers multi-item changes**: the last 5 updated automations, scripts, or helpers each keep their own one-step revert (previously only the most recent update) — and the assistant tells you upfront what is still revertible, including when a change is too broad for full coverage.
+    - **Undo now covers multi-item changes**: the last 5 updated automations, scripts, or standard helpers each keep their own one-step revert (previously only the most recent update; a few multi-step helper types still recover via Backups) — and the assistant tells you upfront what is still revertible, including when a change is too broad for full coverage.
 
     ## What To Watch
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,7 +85,7 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## New Features
 
-    - **Undo now covers multi-item changes**: the last 5 updated automations, scripts, or helpers each keep their own one-step revert (previously only the most recent update). When one change touches several items, every one of them stays individually undoable — and the assistant tells you upfront what is still revertible.
+    - **Undo now covers multi-item changes**: the last 5 updated automations, scripts, or helpers each keep their own one-step revert (previously only the most recent update) — and the assistant tells you upfront what is still revertible, including when a change is too broad for full coverage.
 
     ## What To Watch
 

--- a/docs/work/2026-07-10-v0.13.0-release-body.md
+++ b/docs/work/2026-07-10-v0.13.0-release-body.md
@@ -4,7 +4,7 @@ Status: active — shipped wording lives in `.goreleaser.yml`; archive this file
 
 ## New Features
 
-- **Undo now covers multi-item changes**: the last 5 updated automations, scripts, or helpers each keep their own one-step revert (previously only the most recent update) — and the assistant tells you upfront what is still revertible, including when a change is too broad for full coverage.
+- **Undo now covers multi-item changes**: the last 5 updated automations, scripts, or standard helpers each keep their own one-step revert (previously only the most recent update; a few multi-step helper types still recover via Backups) — and the assistant tells you upfront what is still revertible, including when a change is too broad for full coverage.
 
 ## What To Watch
 

--- a/docs/work/2026-07-10-v0.13.0-release-body.md
+++ b/docs/work/2026-07-10-v0.13.0-release-body.md
@@ -4,7 +4,7 @@ Status: active — shipped wording lives in `.goreleaser.yml`; archive this file
 
 ## New Features
 
-- **Undo now covers multi-item changes**: the last 5 updated automations, scripts, or helpers each keep their own one-step revert (previously only the most recent update). When one change touches several items, every one of them stays individually undoable — and the assistant tells you upfront what is still revertible.
+- **Undo now covers multi-item changes**: the last 5 updated automations, scripts, or helpers each keep their own one-step revert (previously only the most recent update) — and the assistant tells you upfront what is still revertible, including when a change is too broad for full coverage.
 
 ## What To Watch
 

--- a/docs/work/2026-07-10-v0.13.0-release-body.md
+++ b/docs/work/2026-07-10-v0.13.0-release-body.md
@@ -1,0 +1,11 @@
+# v0.13.0 Release Body (draft)
+
+Status: active — shipped wording lives in `.goreleaser.yml`; archive this file after the release.
+
+## New Features
+
+- **Undo now covers multi-item changes**: the last 5 updated automations, scripts, or helpers each keep their own one-step revert (previously only the most recent update). When one change touches several items, every one of them stays individually undoable — and the assistant tells you upfront what is still revertible.
+
+## What To Watch
+
+- No NOVA Relay App update needed for this release — it stays on 0.2.6.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "home-assistant-js-websocket": "^9.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -53,16 +53,13 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
-  it("keeps v0.12.0 release-facing wording user-centric", () => {
+  it("keeps v0.13.0 release-facing wording user-centric", () => {
     // Shipped release-note bodies are archived (docs/archive/work/) and
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
-    expect(goreleaser).toContain("Previews you can actually judge");
-    expect(goreleaser).toContain("not just an item count");
-    expect(goreleaser).toContain('instead of a bare "verified"');
-    expect(goreleaser).toContain('a person at "work" is not `not_home`');
-    expect(goreleaser).toContain("robust against Claude Code state-format changes");
-    expect(goreleaser).toContain("use a local console or RDP session");
+    expect(goreleaser).toContain("Undo now covers multi-item changes");
+    expect(goreleaser).toContain("last 5 updated automations, scripts, or helpers");
+    expect(goreleaser).toContain("previously only the most recent update");
     expect(goreleaser).toContain("No NOVA Relay App update needed for this release — it stays on 0.2.6");
     expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");
   });

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -58,7 +58,8 @@ describe("release contract", () => {
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
     expect(goreleaser).toContain("Undo now covers multi-item changes");
-    expect(goreleaser).toContain("last 5 updated automations, scripts, or helpers");
+    expect(goreleaser).toContain("last 5 updated automations, scripts, or standard helpers");
+    expect(goreleaser).toContain("a few multi-step helper types still recover via Backups");
     expect(goreleaser).toContain("previously only the most recent update");
     expect(goreleaser).toContain("No NOVA Relay App update needed for this release — it stays on 0.2.6");
     expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.12.0",
+  "skill_version": "0.13.0",
   "min_relay_version": "0.2.5"
 }


### PR DESCRIPTION
Release-prep for **v0.13.0** (Relay stays 0.2.6): ships #284 (bounded update-revert stack — last 5 targets individually revertible, incl. the write-safety texts that teach `--target`/`--list` selection), #283 (dead axios dependency removed), vitest 4.1.10 + tsx 4.23.0.

- Version bump 0.12.0 → 0.13.0 in the four synced files
- GoReleaser stable notes: one user-centric New-Features bullet (internal dep/toolchain changes deliberately omitted per release-notes policy); release-contract pins updated
- No README changes needed
- `npm run verify` + full sweep green

After merge: strict audit → `v0.13.0-rc1` rehearsal → public-install verify → final tag → env-clean live update test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhefhWnMEyVLyYpU6LF4kf