### PR TITLE
feat(cli): surface update nudges through relay traffic for all clients

### DIFF
--- a/cli/claude_paths_test.go
+++ b/cli/claude_paths_test.go
@@ -18,6 +18,12 @@ import (
 // behavior prepend their own mock in front of it.
 func TestMain(m *testing.M) {
 	os.Unsetenv("CLAUDE_CONFIG_DIR")
+	// Same protection class for the update-nudge background refresh: under
+	// `go test`, os.Executable() is the generated test binary, so the real
+	// spawn would detach a recursive test-suite run whenever any test walks a
+	// relay command into a cache miss. Nudge tests that assert spawn behavior
+	// install their own recorder on top of this no-op.
+	spawnDetachedUpdateRefresh = func() {}
 	stubDir, err := os.MkdirTemp("", "claude-stub")
 	if err == nil {
 		script := "#!/usr/bin/env bash\necho \"Error: not found\" >&2\nexit 1\n"

--- a/cli/relay.go
+++ b/cli/relay.go
@@ -207,6 +207,7 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 			printHumanNotice(notice)
 		}
 	}
+	maybeNudgeSkillUpdate(paths, true)
 
 	bodyBytes, err := readAllLimited(resp.Body, maxRelayResponseBytes)
 	if err != nil {
@@ -342,9 +343,10 @@ func runHealth(paths runtimePaths, args []string) int {
 		return 1
 	}
 
-	if notice := checkForUpdate(paths, true); !notice.empty() {
-		printHumanNotice(notice)
-	}
+	// Cache-only nudge instead of the previous inline checkForUpdate: that one
+	// hit GitHub on a stale cache with the default 15s client, silently
+	// unbounding a probe whose whole contract is caller-bounded timeouts.
+	maybeNudgeSkillUpdate(paths, false)
 
 	_, _ = os.Stdout.Write(bodyBytes)
 	if len(bodyBytes) > 0 && bodyBytes[len(bodyBytes)-1] != '\n' {

--- a/cli/update_nudge.go
+++ b/cli/update_nudge.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	updateNudgeOptOutEnv    = "HA_NOVA_NO_UPDATE_NUDGE"
+	updateNudgeMarkerName   = "update-nudge-shown"
+	updateRefreshMarkerName = "update-refresh-spawned"
+	updateNudgeInterval     = 24 * time.Hour
+)
+
+// spawnDetachedUpdateRefresh fires the same cache-refresh contract the Claude
+// session hook uses (`check-update --quiet --json`), detached so the hot path
+// never waits on GitHub. Overridable for tests.
+var spawnDetachedUpdateRefresh = func() {
+	self, err := os.Executable()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(self, "check-update", "--quiet", "--json")
+	// Stdout/Stderr stay nil on purpose: exec connects nil descriptors to
+	// /dev/null, so the child's JSON can never interleave with the relay JSON
+	// on the parent's stdout that skills parse.
+	if err := cmd.Start(); err != nil {
+		return
+	}
+	_ = cmd.Process.Release()
+}
+
+// maybeNudgeSkillUpdate surfaces a skill/CLI update notice during normal relay
+// traffic so every client learns about updates through commands skills already
+// run — not only Claude's session hook.
+func maybeNudgeSkillUpdate(paths runtimePaths, throttled bool) {
+	printHumanNotice(skillUpdateNudgeNotice(paths, throttled))
+}
+
+// skillUpdateNudgeNotice decides whether relay traffic should surface an
+// update notice. Hot-path contract: the version compare is cache-only (never a
+// network call); a non-fresh cache is refreshed by a detached background
+// check. `throttled` keeps skill traffic (ws/core) at one notice per 24h;
+// `relay health` passes false and stays unthrottled as the explicit
+// diagnostic path, mirroring the relay-outdated warning split.
+func skillUpdateNudgeNotice(paths runtimePaths, throttled bool) humanNotice {
+	if strings.TrimSpace(os.Getenv(updateNudgeOptOutEnv)) == "1" {
+		return humanNotice{}
+	}
+	current := localVersion(paths)
+	// Same dev short-circuit as buildUpdateCheckResult: a dev-synced tree must
+	// never be nudged to overwrite itself.
+	if current == "dev" || BuildChannel == "dev" {
+		return humanNotice{}
+	}
+
+	cached, cacheStatus := inspectCachedRelease(paths)
+	if cacheStatus != "fresh" && passesNudgeThrottle(paths, updateRefreshMarkerName) {
+		spawnDetachedUpdateRefresh()
+	}
+	if cacheStatus == "miss" {
+		return humanNotice{}
+	}
+
+	cmp, err := compareReleaseVersions(current, cached.Version)
+	if err != nil {
+		return humanNotice{}
+	}
+	returnToStable := isStableTargetFromRC(current, cached.Version)
+	if cmp >= 0 && !returnToStable {
+		return humanNotice{}
+	}
+	if throttled && !passesNudgeThrottle(paths, updateNudgeMarkerName) {
+		return humanNotice{}
+	}
+
+	lead := "HA NOVA update available"
+	if returnToStable {
+		lead = "HA NOVA return to stable"
+	}
+	return humanNotice{
+		level:   humanNoticeWarning,
+		kind:    humanNoticeKindUpdateAvailable,
+		message: fmt.Sprintf("%s: v%s -> v%s. Inform the user: run 'ha-nova update', then start a new session.", lead, current, cached.Version),
+	}
+}
+
+// passesNudgeThrottle reports whether the marker is older than the nudge
+// interval and stamps it when it passes — the same marker-file pattern as
+// shouldWarnRelayOutdated. Failures degrade to "allow" so a broken cache dir
+// never suppresses notices.
+func passesNudgeThrottle(paths runtimePaths, markerName string) bool {
+	marker := filepath.Join(paths.CacheDir, markerName)
+	if info, err := os.Stat(marker); err == nil && time.Since(info.ModTime()) < updateNudgeInterval {
+		return false
+	}
+	if err := os.MkdirAll(paths.CacheDir, 0o755); err != nil {
+		return true
+	}
+	if err := os.WriteFile(marker, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o644); err != nil {
+		return true
+	}
+	return true
+}

--- a/cli/update_nudge.go
+++ b/cli/update_nudge.go
@@ -14,6 +14,11 @@ const (
 	updateNudgeMarkerName   = "update-nudge-shown"
 	updateRefreshMarkerName = "update-refresh-spawned"
 	updateNudgeInterval     = 24 * time.Hour
+	// updateRefreshInterval matches the release-cache TTL: a stale cache may
+	// spawn a background refresh as soon as the cache can turn fresh again.
+	// Tying refreshes to the 24h notice interval instead would hide a same-day
+	// release from relay-only clients for up to a day.
+	updateRefreshInterval = time.Duration(updateCacheTTLSeconds) * time.Second
 )
 
 // spawnDetachedUpdateRefresh fires the same cache-refresh contract the Claude
@@ -59,7 +64,7 @@ func skillUpdateNudgeNotice(paths runtimePaths, throttled bool) humanNotice {
 	}
 
 	cached, cacheStatus := inspectCachedRelease(paths)
-	if cacheStatus != "fresh" && passesNudgeThrottle(paths, updateRefreshMarkerName) {
+	if cacheStatus != "fresh" && passesNudgeThrottle(paths, updateRefreshMarkerName, updateRefreshInterval) {
 		spawnDetachedUpdateRefresh()
 	}
 	if cacheStatus == "miss" {
@@ -74,7 +79,7 @@ func skillUpdateNudgeNotice(paths runtimePaths, throttled bool) humanNotice {
 	if cmp >= 0 && !returnToStable {
 		return humanNotice{}
 	}
-	if throttled && !passesNudgeThrottle(paths, updateNudgeMarkerName) {
+	if throttled && !passesNudgeThrottle(paths, updateNudgeMarkerName, updateNudgeInterval) {
 		return humanNotice{}
 	}
 
@@ -98,13 +103,13 @@ func skillUpdateNudgeMessage(lead, current, latest, installSource string) string
 	return fmt.Sprintf("%s: v%s -> v%s. Inform the user: %s (new session required after update).", lead, current, latest, updateGuidanceForInstallSource(installSource))
 }
 
-// passesNudgeThrottle reports whether the marker is older than the nudge
+// passesNudgeThrottle reports whether the marker is older than the given
 // interval and stamps it when it passes — the same marker-file pattern as
 // shouldWarnRelayOutdated. Failures degrade to "allow" so a broken cache dir
 // never suppresses notices.
-func passesNudgeThrottle(paths runtimePaths, markerName string) bool {
+func passesNudgeThrottle(paths runtimePaths, markerName string, interval time.Duration) bool {
 	marker := filepath.Join(paths.CacheDir, markerName)
-	if info, err := os.Stat(marker); err == nil && time.Since(info.ModTime()) < updateNudgeInterval {
+	if info, err := os.Stat(marker); err == nil && time.Since(info.ModTime()) < interval {
 		return false
 	}
 	if err := os.MkdirAll(paths.CacheDir, 0o755); err != nil {

--- a/cli/update_nudge.go
+++ b/cli/update_nudge.go
@@ -82,11 +82,20 @@ func skillUpdateNudgeNotice(paths runtimePaths, throttled bool) humanNotice {
 	if returnToStable {
 		lead = "HA NOVA return to stable"
 	}
+	source := detectInstallSource(paths, loadStateOrDefault(paths))
 	return humanNotice{
 		level:   humanNoticeWarning,
 		kind:    humanNoticeKindUpdateAvailable,
-		message: fmt.Sprintf("%s: v%s -> v%s. Inform the user: run 'ha-nova update', then start a new session.", lead, current, cached.Version),
+		message: skillUpdateNudgeMessage(lead, current, cached.Version, source),
 	}
+}
+
+// skillUpdateNudgeMessage keeps the surfaced action aligned with what the
+// detected install source actually supports: legacy Windows package installs
+// reject `ha-nova update`, so they get the same uninstall/reinstall guidance
+// the explicit check-update path uses.
+func skillUpdateNudgeMessage(lead, current, latest, installSource string) string {
+	return fmt.Sprintf("%s: v%s -> v%s. Inform the user: %s (new session required after update).", lead, current, latest, updateGuidanceForInstallSource(installSource))
 }
 
 // passesNudgeThrottle reports whether the marker is older than the nudge

--- a/cli/update_nudge_test.go
+++ b/cli/update_nudge_test.go
@@ -174,6 +174,45 @@ func TestSkillUpdateNudgeNoticeUpToDateStaysSilent(t *testing.T) {
 	}
 }
 
+func TestSkillUpdateNudgeRefreshThrottleFollowsCacheTTLNotNoticeInterval(t *testing.T) {
+	paths, spawnCount := nudgeTestEnv(t, "0.2.0")
+	// Up to date but stale cache: silent, yet a refresh is spawned.
+	writeFreshReleaseCache(t, paths, "0.2.0")
+	stale := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(paths.UpdateCacheFile, stale, stale); err != nil {
+		t.Fatalf("age cache: %v", err)
+	}
+	if notice := skillUpdateNudgeNotice(paths, true); !notice.empty() {
+		t.Fatalf("up to date: expected empty notice, got %q", notice.message)
+	}
+	if *spawnCount != 1 {
+		t.Fatalf("spawnCount = %d, want 1", *spawnCount)
+	}
+
+	// Within the cache TTL: no second spawn.
+	if notice := skillUpdateNudgeNotice(paths, true); !notice.empty() {
+		t.Fatalf("repeat: expected empty notice, got %q", notice.message)
+	}
+	if *spawnCount != 1 {
+		t.Fatalf("repeat: spawnCount = %d, want 1", *spawnCount)
+	}
+
+	// Once the refresh marker is older than the cache TTL — but far under the
+	// 24h notice interval — a still-stale cache must refresh again, or a
+	// same-day release stays hidden from relay-only clients for up to a day.
+	marker := filepath.Join(paths.CacheDir, updateRefreshMarkerName)
+	agedMarker := time.Now().Add(-updateRefreshInterval - time.Minute)
+	if err := os.Chtimes(marker, agedMarker, agedMarker); err != nil {
+		t.Fatalf("age refresh marker: %v", err)
+	}
+	if notice := skillUpdateNudgeNotice(paths, true); !notice.empty() {
+		t.Fatalf("after marker expiry: expected empty notice, got %q", notice.message)
+	}
+	if *spawnCount != 2 {
+		t.Fatalf("after marker expiry: spawnCount = %d, want 2", *spawnCount)
+	}
+}
+
 func TestSkillUpdateNudgeMessageMatchesInstallSourceGuidance(t *testing.T) {
 	normal := skillUpdateNudgeMessage("HA NOVA update available", "0.1.0", "0.2.0", installSourceBundle)
 	if !strings.Contains(normal, "Run: ha-nova update") {

--- a/cli/update_nudge_test.go
+++ b/cli/update_nudge_test.go
@@ -174,6 +174,22 @@ func TestSkillUpdateNudgeNoticeUpToDateStaysSilent(t *testing.T) {
 	}
 }
 
+func TestSkillUpdateNudgeMessageMatchesInstallSourceGuidance(t *testing.T) {
+	normal := skillUpdateNudgeMessage("HA NOVA update available", "0.1.0", "0.2.0", installSourceBundle)
+	if !strings.Contains(normal, "Run: ha-nova update") {
+		t.Fatalf("bundle install must advise ha-nova update: %q", normal)
+	}
+	// Legacy Windows package installs reject `ha-nova update` in runUpdate, so
+	// the passive nudge must never advertise a known-failing command.
+	legacy := skillUpdateNudgeMessage("HA NOVA update available", "0.1.0", "0.2.0", installSourceLegacyWindowsPackage)
+	if strings.Contains(legacy, "Run: ha-nova update") {
+		t.Fatalf("legacy Windows package installs must not be told to run ha-nova update: %q", legacy)
+	}
+	if !strings.Contains(legacy, "install.ps1") {
+		t.Fatalf("legacy guidance must point at the supported reinstall path: %q", legacy)
+	}
+}
+
 func TestSkillUpdateNudgeNoticeReturnToStableFromRC(t *testing.T) {
 	paths, _ := nudgeTestEnv(t, "0.2.0-rc1")
 	writeFreshReleaseCache(t, paths, "0.2.0")

--- a/cli/update_nudge_test.go
+++ b/cli/update_nudge_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// nudgeTestEnv prepares an isolated HOME with a release-build identity at the
+// given local version, intercepts the detached refresh spawn, and returns the
+// paths plus a counter of spawn attempts.
+func nudgeTestEnv(t *testing.T, localVersionValue string) (runtimePaths, *int) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(updateNudgeOptOutEnv, "")
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.VersionFile), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	versionJSONBody := `{"skill_version":"` + localVersionValue + `","min_relay_version":"0.1.0"}`
+	if err := os.WriteFile(paths.VersionFile, []byte(versionJSONBody), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	origChannel := BuildChannel
+	BuildChannel = ""
+	t.Cleanup(func() { BuildChannel = origChannel })
+
+	spawnCount := 0
+	origSpawn := spawnDetachedUpdateRefresh
+	spawnDetachedUpdateRefresh = func() { spawnCount++ }
+	t.Cleanup(func() { spawnDetachedUpdateRefresh = origSpawn })
+
+	return paths, &spawnCount
+}
+
+func writeFreshReleaseCache(t *testing.T, paths runtimePaths, version string) {
+	t.Helper()
+	if err := writeJSONFile(paths.UpdateCacheFile, releaseInfo{Version: version}, 0o644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+}
+
+func TestSkillUpdateNudgeNoticeThrottlesTo24h(t *testing.T) {
+	paths, spawnCount := nudgeTestEnv(t, "0.1.0")
+	writeFreshReleaseCache(t, paths, "0.2.0")
+
+	notice := skillUpdateNudgeNotice(paths, true)
+	if notice.empty() {
+		t.Fatal("first throttled call: expected an update notice")
+	}
+	if notice.kind != humanNoticeKindUpdateAvailable {
+		t.Fatalf("kind = %q, want %q", notice.kind, humanNoticeKindUpdateAvailable)
+	}
+	if !strings.Contains(notice.message, "v0.1.0 -> v0.2.0") {
+		t.Fatalf("message missing versions: %q", notice.message)
+	}
+	if !strings.Contains(notice.message, "ha-nova update") {
+		t.Fatalf("message missing update guidance: %q", notice.message)
+	}
+
+	if got := skillUpdateNudgeNotice(paths, true); !got.empty() {
+		t.Fatalf("second throttled call within 24h: expected empty, got %q", got.message)
+	}
+
+	// The explicit diagnostic path (relay health) stays unthrottled.
+	if got := skillUpdateNudgeNotice(paths, false); got.empty() {
+		t.Fatal("unthrottled call: expected an update notice despite marker")
+	}
+
+	// Fresh cache: no background refresh may be spawned.
+	if *spawnCount != 0 {
+		t.Fatalf("spawnCount = %d, want 0 for a fresh cache", *spawnCount)
+	}
+}
+
+func TestSkillUpdateNudgeNoticeExpiredMarkerNudgesAgain(t *testing.T) {
+	paths, _ := nudgeTestEnv(t, "0.1.0")
+	writeFreshReleaseCache(t, paths, "0.2.0")
+
+	if notice := skillUpdateNudgeNotice(paths, true); notice.empty() {
+		t.Fatal("first call: expected an update notice")
+	}
+	marker := filepath.Join(paths.CacheDir, updateNudgeMarkerName)
+	old := time.Now().Add(-25 * time.Hour)
+	if err := os.Chtimes(marker, old, old); err != nil {
+		t.Fatalf("age marker: %v", err)
+	}
+	if notice := skillUpdateNudgeNotice(paths, true); notice.empty() {
+		t.Fatal("call after marker expiry: expected an update notice")
+	}
+}
+
+func TestSkillUpdateNudgeNoticeOptOutEnv(t *testing.T) {
+	paths, spawnCount := nudgeTestEnv(t, "0.1.0")
+	writeFreshReleaseCache(t, paths, "0.2.0")
+	t.Setenv(updateNudgeOptOutEnv, "1")
+
+	if notice := skillUpdateNudgeNotice(paths, true); !notice.empty() {
+		t.Fatalf("opted out: expected empty notice, got %q", notice.message)
+	}
+	if *spawnCount != 0 {
+		t.Fatalf("opted out: spawnCount = %d, want 0", *spawnCount)
+	}
+}
+
+func TestSkillUpdateNudgeNoticeDevBuildSuppressed(t *testing.T) {
+	paths, spawnCount := nudgeTestEnv(t, "0.1.0")
+	writeFreshReleaseCache(t, paths, "0.2.0")
+	BuildChannel = "dev"
+
+	if notice := skillUpdateNudgeNotice(paths, true); !notice.empty() {
+		t.Fatalf("dev build: expected empty notice, got %q", notice.message)
+	}
+	if *spawnCount != 0 {
+		t.Fatalf("dev build: spawnCount = %d, want 0", *spawnCount)
+	}
+}
+
+func TestSkillUpdateNudgeNoticeCacheMissSpawnsRefreshOnce(t *testing.T) {
+	paths, spawnCount := nudgeTestEnv(t, "0.1.0")
+
+	if notice := skillUpdateNudgeNotice(paths, true); !notice.empty() {
+		t.Fatalf("cache miss: expected empty notice, got %q", notice.message)
+	}
+	if *spawnCount != 1 {
+		t.Fatalf("cache miss: spawnCount = %d, want 1", *spawnCount)
+	}
+
+	// Second call within the refresh window must not spawn again.
+	if notice := skillUpdateNudgeNotice(paths, true); !notice.empty() {
+		t.Fatalf("cache miss repeat: expected empty notice, got %q", notice.message)
+	}
+	if *spawnCount != 1 {
+		t.Fatalf("cache miss repeat: spawnCount = %d, want 1", *spawnCount)
+	}
+}
+
+func TestSkillUpdateNudgeNoticeStaleCacheStillNudgesAndRefreshes(t *testing.T) {
+	paths, spawnCount := nudgeTestEnv(t, "0.1.0")
+	writeFreshReleaseCache(t, paths, "0.2.0")
+	stale := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(paths.UpdateCacheFile, stale, stale); err != nil {
+		t.Fatalf("age cache: %v", err)
+	}
+
+	notice := skillUpdateNudgeNotice(paths, true)
+	if notice.empty() {
+		t.Fatal("stale cache: expected an update notice from stale data")
+	}
+	if *spawnCount != 1 {
+		t.Fatalf("stale cache: spawnCount = %d, want 1", *spawnCount)
+	}
+}
+
+func TestSkillUpdateNudgeNoticeUpToDateStaysSilent(t *testing.T) {
+	paths, _ := nudgeTestEnv(t, "0.2.0")
+	writeFreshReleaseCache(t, paths, "0.2.0")
+
+	if notice := skillUpdateNudgeNotice(paths, false); !notice.empty() {
+		t.Fatalf("up to date: expected empty notice, got %q", notice.message)
+	}
+	// No nudge marker may be stamped on silent runs, or the first real update
+	// after a quiet day would be swallowed by a stale throttle.
+	if _, err := os.Stat(filepath.Join(paths.CacheDir, updateNudgeMarkerName)); !os.IsNotExist(err) {
+		t.Fatal("up to date: nudge marker must not be written")
+	}
+}
+
+func TestSkillUpdateNudgeNoticeReturnToStableFromRC(t *testing.T) {
+	paths, _ := nudgeTestEnv(t, "0.2.0-rc1")
+	writeFreshReleaseCache(t, paths, "0.2.0")
+
+	notice := skillUpdateNudgeNotice(paths, false)
+	if notice.empty() {
+		t.Fatal("rc build with stable release: expected a return-to-stable notice")
+	}
+	if !strings.Contains(notice.message, "return to stable") {
+		t.Fatalf("message missing return-to-stable lead: %q", notice.message)
+	}
+	if !strings.Contains(notice.message, "v0.2.0-rc1 -> v0.2.0") {
+		t.Fatalf("message missing versions: %q", notice.message)
+	}
+}

--- a/docs/reference/update-guide.md
+++ b/docs/reference/update-guide.md
@@ -62,13 +62,14 @@ On native Windows, post-update client sync uses the installed HA NOVA runtime di
 
 ## Automatic Checks
 
-Two checks run automatically:
+Three checks run automatically:
 
 1. **Skill update check** — `ha-nova check-update` compares the installed version against the latest GitHub release. The result is cached briefly, then revalidated against GitHub with a conditional request, so a newly published release is detected promptly instead of being hidden until a long cache expires. Claude Code SessionStart reads the same shared release cache and can trigger a background CLI refresh when the cache is stale. Other clients should run the quiet check once on the first HA NOVA skill use in a session.
 2. **Relay compat check** — `ha-nova relay health` compares Relay version against `min_relay_version`. Claude Code SessionStart context can surface the same warning independently.
+3. **Relay-traffic update nudge** — every `ha-nova relay ws|core` call surfaces a cached "update available" notice on stderr at most once per 24h; `ha-nova relay health` surfaces it unthrottled as the explicit diagnostic path. The compare is cache-only (never a network call in the hot path); a non-fresh cache is refreshed by a detached background `check-update --quiet --json`. Opt out with `HA_NOVA_NO_UPDATE_NUDGE=1`.
 
-The `doctor` command runs both checks synchronously and also refreshes the update cache.
-Other clients use the same shared CLI updater path (`ha-nova check-update`, `ha-nova doctor`, `ha-nova update`), but do not currently inject the same automatic SessionStart banner.
+The `doctor` command runs the first two checks synchronously and also refreshes the update cache.
+Other clients use the same shared CLI updater path (`ha-nova check-update`, `ha-nova doctor`, `ha-nova update`) and do not inject the same automatic SessionStart banner; the relay-traffic nudge reaches them during normal skill use instead.
 Installed Claude uses the tested HA NOVA release payload on disk; update discovery stays automatic where HA NOVA already provides it.
 
 ## Agent-Driven Updates

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -35,6 +35,7 @@ Before the first HA task in a session:
 2. Otherwise run: `ha-nova check-update --quiet`
 3. If the output contains `UPDATE AVAILABLE`, inform the user and offer to update.
 4. If the output is empty, continue silently.
+5. If any `ha-nova relay` command later prints an `[ha-nova]` update notice on stderr, surface it to the user once and continue the current task.
 
 When an update is available:
 1. Run: `ha-nova update`


### PR DESCRIPTION
## Summary
Implements masterplan-2026 workstream C2 (release 0.14 "Lifecycle & parity").

- **New `cli/update_nudge.go`**: `maybeNudgeSkillUpdate` surfaces a cached "update available" notice during normal relay traffic, so Codex/OpenCode/Antigravity/Hermes users learn about updates without Claude's SessionStart hook.
- `ha-nova relay ws|core`: nudge throttled to one per 24h (marker-file pattern shared with the relay-outdated warning). `ha-nova relay health`: unthrottled, as the explicit diagnostic path.
- **Hot-path contract**: version compare is cache-only (`inspectCachedRelease` + `compareReleaseVersions`), never a network call. A non-fresh cache is refreshed by a detached `check-update --quiet --json` whose stdio stays on /dev/null (nil `exec.Cmd` descriptors), so child JSON can never interleave with skill-parsed relay stdout. Notices print on stderr only.
- Opt-out via `HA_NOVA_NO_UPDATE_NUDGE=1`; dev builds never nudged (same short-circuit as `buildUpdateCheckResult`); RC builds get a "return to stable" lead.
- **Fixes a latent stall**: `runHealth` previously called `checkForUpdate` inline, hitting GitHub with the default 15s client on a stale cache — although `relay health` exists precisely to honor caller-bounded timeouts (session hooks pass `--max-time 2`). Now cache-only.
- Docs: `docs/reference/update-guide.md` "Automatic Checks" gains the third check; context skill Self-Update gains one line telling agents to surface the notice once.

## Verification
- `go vet ./...` clean; full `go test ./...` green (includes 8 new tests in `cli/update_nudge_test.go`: 24h throttle + marker expiry, unthrottled health path, opt-out env, dev-build suppression, cache-miss single background spawn, stale-cache nudge+refresh, up-to-date stays silent without stamping the marker, RC→stable lead).
- `npm run test:safe -- tests/skills/ha-nova-contract.test.ts` green (31/31 — existing Self-Update pins only extended).
- Full pre-push suite (typecheck, 626 tests, build, docs fact-check) green.

## Risks
- Behavior change: `relay health` no longer performs a network update check; `check-update` and `doctor` remain the explicit network paths, and the Claude session hook already reads the shared cache file directly (unaffected).
- Worst case on notice spam is bounded: one stderr line per 24h per machine for ws/core, plus per-health-call when an update is genuinely pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UABh9QxzyCg8JhostzVUF