### PR TITLE
feat(cli): guided server-side teardown in uninstall + unconditional HA checklist

### DIFF
--- a/cli/command_uninstall.go
+++ b/cli/command_uninstall.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"io"
@@ -25,6 +26,7 @@ func runInternalUninstall(_ runtimePaths, args []string) int {
 	parentPID := fs.Int("parent-pid", 0, "parent pid")
 	selfPath := fs.String("self-path", "", "temp helper path")
 	purge := fs.Bool("purge", false, "remove config and token")
+	teardownDone := fs.Bool("teardown-done", false, "server-side teardown already completed by the parent")
 	if err := fs.Parse(args); err != nil {
 		printHumanErr("%s", err)
 		return 1
@@ -49,7 +51,13 @@ func runInternalUninstall(_ runtimePaths, args []string) int {
 		printHumanErr("%s", err)
 		return 1
 	}
-	applyUninstallPreflightNotes(report, preflight)
+	if *teardownDone {
+		for _, note := range teardownCompletedNoteLines(uninstallModeFromFlag(*purge)) {
+			report.addNote(note)
+		}
+	} else {
+		applyUninstallPreflightNotes(report, preflight)
+	}
 	if report.print() {
 		printHumanInfo("HA NOVA removed")
 	}
@@ -102,9 +110,29 @@ func runUninstall(paths runtimePaths, args []string) int {
 	}
 
 	preflight := collectUninstallPreflight(paths)
+	teardown := teardownNotOffered
+	if !*yes && !recoveryMode && isInteractiveTTY() {
+		outcome, err := maybeOfferGuidedTeardown(bufio.NewReader(os.Stdin), os.Stdout, preflight, defaultTeardownDeps())
+		if err != nil {
+			printHumanErr("%s", err)
+			return 1
+		}
+		if outcome == teardownCancelled {
+			printHumanInfo("Uninstall cancelled — nothing was removed.")
+			return 0
+		}
+		teardown = outcome
+		if teardown == teardownCompleted {
+			preflight.relayStillRunning = false
+		}
+	}
 	if runtime.GOOS == "windows" && source == installSourceBundle {
-		printUninstallPreflightNotes(os.Stdout, preflight)
-		if err := launchWindowsUninstall(paths, mode); err != nil {
+		if teardown == teardownCompleted {
+			printTeardownCompletedNotes(os.Stdout, mode)
+		} else {
+			printUninstallPreflightNotes(os.Stdout, preflight)
+		}
+		if err := launchWindowsUninstall(paths, mode, teardown == teardownCompleted); err != nil {
 			printHumanErr("cannot finish Windows uninstall: %s", err)
 			return 1
 		}
@@ -133,14 +161,20 @@ func runUninstall(paths runtimePaths, args []string) int {
 		}
 	}
 
-	applyUninstallPreflightNotes(report, preflight)
+	if teardown == teardownCompleted {
+		for _, note := range teardownCompletedNoteLines(mode) {
+			report.addNote(note)
+		}
+	} else {
+		applyUninstallPreflightNotes(report, preflight)
+	}
 	if report.print() {
 		printHumanInfo("HA NOVA removed")
 	}
 	return 0
 }
 
-func launchWindowsUninstall(paths runtimePaths, mode uninstallMode) error {
+func launchWindowsUninstall(paths runtimePaths, mode uninstallMode, teardownDone bool) error {
 	tempHelper := filepath.Join(os.TempDir(), "ha-nova-uninstall-"+strconv.Itoa(os.Getpid())+".exe")
 	if err := copyFile(filepath.Join(paths.InstallRoot, publicBinaryName()), tempHelper); err != nil {
 		return err
@@ -149,6 +183,9 @@ func launchWindowsUninstall(paths runtimePaths, mode uninstallMode) error {
 	args := []string{"internal-uninstall", "--parent-pid", strconv.Itoa(os.Getpid()), "--self-path", tempHelper}
 	if mode == uninstallModePurge {
 		args = append(args, "--purge")
+	}
+	if teardownDone {
+		args = append(args, "--teardown-done")
 	}
 	return launchWindowsDetachedHelperWithEnv(tempHelper, paths.UninstallStatusFile, statusTicks, helperInstallRootEnv(paths.InstallRoot), args...)
 }

--- a/cli/setup_urls.go
+++ b/cli/setup_urls.go
@@ -26,6 +26,14 @@ func haProfileSecurityURL(haURL string) string {
 	return haURL + "/profile/security"
 }
 
+// haAppStoreURL links to the app store through the instance's own my-redirect
+// endpoint (same version-resolution rationale as haRelayAppPageURL).
+// Repository removal has no dedicated my-link; it lives in the store's
+// three-dot menu > Repositories dialog.
+func haAppStoreURL(haURL string) string {
+	return haURL + "/_my_redirect/supervisor_store"
+}
+
 func openBrowserShowingURL(out io.Writer, target string) {
 	renderSetupLink(out, "Opening in your browser:", target)
 	if err := openBrowserForSetup(target); err != nil {

--- a/cli/uninstall_preflight.go
+++ b/cli/uninstall_preflight.go
@@ -5,11 +5,15 @@ import (
 	"io"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 type uninstallPreflight struct {
 	relayStillRunning bool
 	tokenUnavailable  string
+	haURL             string
+	relayToken        string
+	config            runtimeConfig
 }
 
 func renderUninstallPreflight(out io.Writer, paths runtimePaths, source string) {
@@ -56,11 +60,19 @@ func uninstallWindowsBundleNote() string {
 	return "Windows bundle note: a short-lived helper finishes the uninstall after the running ha-nova.exe exits. Please wait a moment for the final removal to complete."
 }
 
+// collectUninstallPreflight reads the raw config (loadJSONConfig, not
+// loadConfig: partial setups must still yield the HA URL for the server-side
+// checklist) and probes whether the relay still answers.
 func collectUninstallPreflight(paths runtimePaths) uninstallPreflight {
 	preflight := uninstallPreflight{}
 
-	cfg, err := loadConfig(paths)
-	if err != nil || cfg.RelayBaseURL == "" {
+	cfg, err := loadJSONConfig(paths.ConfigFile)
+	if err != nil {
+		return preflight
+	}
+	preflight.config = cfg
+	preflight.haURL = strings.TrimSpace(cfg.HAURL)
+	if cfg.RelayBaseURL == "" {
 		return preflight
 	}
 
@@ -74,6 +86,7 @@ func collectUninstallPreflight(paths runtimePaths) uninstallPreflight {
 	if token == "" {
 		return preflight
 	}
+	preflight.relayToken = token
 
 	if _, err := fetchRelayHealth(cfg.RelayBaseURL, token); err == nil {
 		preflight.relayStillRunning = true
@@ -97,16 +110,29 @@ func printUninstallPreflightNotes(out io.Writer, preflight uninstallPreflight) {
 	}
 }
 
+// preflightNoteLines always returns the full server-side cleanup checklist.
+// The CLI cannot remove the app, the repository, or the LLAT itself, and a
+// currently unreachable relay is no evidence the server side is gone — the
+// old reachability-gated single note left users with a running app and a
+// valid token they were never told about.
 func preflightNoteLines(preflight uninstallPreflight) []string {
-	if !preflight.relayStillRunning {
-		if preflight.tokenUnavailable == "" {
-			return nil
-		}
-		return []string{preflight.tokenUnavailable}
+	lead := "Home Assistant side (if still installed, finish these to fully remove HA NOVA):"
+	if preflight.relayStillRunning {
+		lead = "The NOVA Relay app is still running in Home Assistant. To fully remove HA NOVA:"
 	}
-	notes := []string{
-		"Note: The NOVA Relay app is still running in Home Assistant.",
-		"To remove it: Settings > Apps > NOVA Relay > Uninstall (older Home Assistant: Settings > Add-ons)",
+	notes := []string{lead}
+	if preflight.haURL != "" {
+		notes = append(notes,
+			"1. Remove the NOVA Relay app: "+haRelayAppPageURL(preflight.haURL),
+			"2. Remove the repository: "+haAppStoreURL(preflight.haURL)+" > three-dot menu > Repositories > remove "+haNovaRepositoryURL,
+			"3. Revoke the \"NOVA\" access token: "+haProfileSecurityURL(preflight.haURL),
+		)
+	} else {
+		notes = append(notes,
+			"1. Remove the NOVA Relay app: Settings > Apps > NOVA Relay > Uninstall (older Home Assistant: Settings > Add-ons)",
+			"2. Remove the repository: Settings > Apps > App Store > three-dot menu > Repositories > remove "+haNovaRepositoryURL,
+			"3. Revoke the \"NOVA\" access token: Profile > Security > Long-lived access tokens",
+		)
 	}
 	if preflight.tokenUnavailable != "" {
 		notes = append(notes, preflight.tokenUnavailable)

--- a/cli/uninstall_teardown.go
+++ b/cli/uninstall_teardown.go
@@ -14,6 +14,10 @@ const (
 	teardownDeclined
 	teardownCancelled
 	teardownCompleted
+	// teardownCompletedUnverified: the user walked all steps, but the relay
+	// still answered the post-removal probes — the final report must keep the
+	// full HA checklist instead of claiming the server side is gone.
+	teardownCompletedUnverified
 )
 
 // teardownDeps isolates the guided teardown's side effects so tests can
@@ -57,6 +61,10 @@ func maybeOfferGuidedTeardown(reader *bufio.Reader, out io.Writer, preflight uni
 	}
 
 	stage := teardownStageOffer
+	// Trust-the-user default: only a probe that POSITIVELY shows the relay
+	// still answering downgrades the outcome — repo removal and LLAT
+	// revocation are unverifiable by design.
+	relayVerifiedGone := true
 	for {
 		switch stage {
 		case teardownStageOffer:
@@ -106,7 +114,7 @@ func maybeOfferGuidedTeardown(reader *bufio.Reader, out io.Writer, preflight uni
 			if err != nil {
 				return teardownNotOffered, err
 			}
-			verifyRelayGone(out, preflight, deps)
+			relayVerifiedGone = verifyRelayGone(out, preflight, deps)
 			stage = teardownStageRepo
 
 		case teardownStageRepo:
@@ -174,6 +182,9 @@ func maybeOfferGuidedTeardown(reader *bufio.Reader, out io.Writer, preflight uni
 			if err != nil {
 				return teardownNotOffered, err
 			}
+			if !relayVerifiedGone {
+				return teardownCompletedUnverified, nil
+			}
 			return teardownCompleted, nil
 		}
 	}
@@ -182,11 +193,14 @@ func maybeOfferGuidedTeardown(reader *bufio.Reader, out io.Writer, preflight uni
 // verifyRelayGone is the one verifiable teardown step: after the app is
 // removed, the relay must stop answering. A still-answering relay only warns
 // and never blocks — the user may legitimately run a second instance, and the
-// CLI cannot tell the difference. The token revocation step stays deliberately
-// unverifiable: the CLI never held the LLAT.
-func verifyRelayGone(out io.Writer, preflight uninstallPreflight, deps teardownDeps) {
+// CLI cannot tell the difference. It returns false only in that
+// still-answering case so the final report keeps the full checklist instead
+// of claiming the server side is gone; with nothing to probe (no base URL or
+// token) it stays trust-the-user, like the repo and LLAT steps. The token
+// revocation step stays deliberately unverifiable: the CLI never held the LLAT.
+func verifyRelayGone(out io.Writer, preflight uninstallPreflight, deps teardownDeps) bool {
 	if preflight.config.RelayBaseURL == "" || preflight.relayToken == "" {
-		return
+		return true
 	}
 	session := resolveStatusUISession(out)
 	for attempt := 0; attempt < 3; attempt++ {
@@ -195,10 +209,11 @@ func verifyRelayGone(out io.Writer, preflight uninstallPreflight, deps teardownD
 		}
 		if _, err := deps.relayHealth(preflight.config.RelayBaseURL, preflight.relayToken); err != nil {
 			fmt.Fprintf(out, "  %s Relay no longer answers — app removed.\n", session.style("success", session.successMarker()))
-			return
+			return true
 		}
 	}
 	fmt.Fprintf(out, "  %s The relay still answers at %s. If you run more than one instance this is expected; otherwise finish the app removal in Home Assistant.\n", session.style("warning", session.warningMarker()), preflight.config.RelayBaseURL)
+	return false
 }
 
 // teardownCompletedNoteLines replaces the server-side checklist after a

--- a/cli/uninstall_teardown.go
+++ b/cli/uninstall_teardown.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"time"
+)
+
+type teardownOutcome int
+
+const (
+	teardownNotOffered teardownOutcome = iota
+	teardownDeclined
+	teardownCancelled
+	teardownCompleted
+)
+
+// teardownDeps isolates the guided teardown's side effects so tests can
+// script the whole flow with a reader and a buffer.
+type teardownDeps struct {
+	openURL     func(io.Writer, string)
+	relayHealth func(relayBaseURL, token string) ([]byte, error)
+	probeHA     func(url string) error
+	sleep       func(time.Duration)
+}
+
+func defaultTeardownDeps() teardownDeps {
+	return teardownDeps{
+		openURL:     openAnnouncedBrowserURL,
+		relayHealth: fetchRelayHealth,
+		probeHA:     probeHTTP,
+		sleep:       time.Sleep,
+	}
+}
+
+const (
+	teardownStageOffer = iota
+	teardownStageApp
+	teardownStageRepo
+	teardownStageLLAT
+)
+
+// maybeOfferGuidedTeardown walks the server-side removal (NOVA Relay app,
+// HA NOVA repository, "NOVA" access token) before any local file is touched.
+// It mirrors the setup wizard: announce a link, open the browser, guide the
+// clicks, continue on Enter. `back` returns to the previous step, `exit`
+// cancels the entire uninstall — both are always safe because this flow
+// deletes nothing locally.
+func maybeOfferGuidedTeardown(reader *bufio.Reader, out io.Writer, preflight uninstallPreflight, deps teardownDeps) (teardownOutcome, error) {
+	if preflight.haURL == "" {
+		return teardownNotOffered, nil
+	}
+	if err := deps.probeHA(preflight.haURL); err != nil {
+		renderSetupParagraphTight(out, "Home Assistant is not reachable right now — the server-side cleanup checklist is included at the end for when it is back online.")
+		return teardownNotOffered, nil
+	}
+
+	stage := teardownStageOffer
+	for {
+		switch stage {
+		case teardownStageOffer:
+			renderSetupParagraph(out, "Home Assistant still hosts the server side: the NOVA Relay app, the HA NOVA repository, and the \"NOVA\" access token.")
+			confirmed, err := promptWizardYesNoFromReader(reader, out, "Remove them now with a guided walkthrough?", true)
+			if err == errSetupBack {
+				return teardownDeclined, nil
+			}
+			if err == errSetupExit {
+				return teardownCancelled, nil
+			}
+			if err != nil {
+				return teardownNotOffered, err
+			}
+			if !confirmed {
+				return teardownDeclined, nil
+			}
+			stage = teardownStageApp
+
+		case teardownStageApp:
+			renderSetupStep(out, 1, 3, "Uninstall the NOVA Relay app")
+			renderSetupLink(out, "This will open:", haRelayAppPageURL(preflight.haURL))
+			_, err := promptWizardLineFromReader(reader, out, "Press Enter to open your browser", "")
+			if err == errSetupBack {
+				stage = teardownStageOffer
+				continue
+			}
+			if err == errSetupExit {
+				return teardownCancelled, nil
+			}
+			if err != nil {
+				return teardownNotOffered, err
+			}
+			deps.openURL(out, haRelayAppPageURL(preflight.haURL))
+			renderSetupIndentedBlock(out, "On the NOVA Relay page:", "    ",
+				"1. Click Stop if the app is running",
+				"2. Click Uninstall and confirm",
+			)
+			_, err = promptWizardLineFromReader(reader, out, "Press Enter when the app is removed", "")
+			if err == errSetupBack {
+				stage = teardownStageOffer
+				continue
+			}
+			if err == errSetupExit {
+				return teardownCancelled, nil
+			}
+			if err != nil {
+				return teardownNotOffered, err
+			}
+			verifyRelayGone(out, preflight, deps)
+			stage = teardownStageRepo
+
+		case teardownStageRepo:
+			renderSetupStep(out, 2, 3, "Remove the HA NOVA repository")
+			renderSetupLink(out, "This will open:", haAppStoreURL(preflight.haURL))
+			_, err := promptWizardLineFromReader(reader, out, "Press Enter to open your browser", "")
+			if err == errSetupBack {
+				stage = teardownStageApp
+				continue
+			}
+			if err == errSetupExit {
+				return teardownCancelled, nil
+			}
+			if err != nil {
+				return teardownNotOffered, err
+			}
+			deps.openURL(out, haAppStoreURL(preflight.haURL))
+			renderSetupIndentedBlock(out, "In the app store:", "    ",
+				"1. Open the three-dot menu in the top-right corner",
+				"2. Choose \"Repositories\"",
+				"3. Remove "+haNovaRepositoryURL,
+			)
+			renderSetupParagraphTight(out, "Home Assistant only allows removing the repository after the app itself is uninstalled.")
+			_, err = promptWizardLineFromReader(reader, out, "Press Enter when the repository is removed", "")
+			if err == errSetupBack {
+				stage = teardownStageApp
+				continue
+			}
+			if err == errSetupExit {
+				return teardownCancelled, nil
+			}
+			if err != nil {
+				return teardownNotOffered, err
+			}
+			stage = teardownStageLLAT
+
+		case teardownStageLLAT:
+			renderSetupStep(out, 3, 3, "Revoke the Home Assistant access token")
+			renderSetupLink(out, "This will open:", haProfileSecurityURL(preflight.haURL))
+			_, err := promptWizardLineFromReader(reader, out, "Press Enter to open your browser", "")
+			if err == errSetupBack {
+				stage = teardownStageRepo
+				continue
+			}
+			if err == errSetupExit {
+				return teardownCancelled, nil
+			}
+			if err != nil {
+				return teardownNotOffered, err
+			}
+			deps.openURL(out, haProfileSecurityURL(preflight.haURL))
+			renderSetupIndentedBlock(out, "On your profile's Security tab:", "    ",
+				"1. Scroll to \"Long-lived access tokens\"",
+				"2. Find the token named \"NOVA\"",
+				"3. Delete it",
+			)
+			_, err = promptWizardLineFromReader(reader, out, "Press Enter when the token is revoked", "")
+			if err == errSetupBack {
+				stage = teardownStageRepo
+				continue
+			}
+			if err == errSetupExit {
+				return teardownCancelled, nil
+			}
+			if err != nil {
+				return teardownNotOffered, err
+			}
+			return teardownCompleted, nil
+		}
+	}
+}
+
+// verifyRelayGone is the one verifiable teardown step: after the app is
+// removed, the relay must stop answering. A still-answering relay only warns
+// and never blocks — the user may legitimately run a second instance, and the
+// CLI cannot tell the difference. The token revocation step stays deliberately
+// unverifiable: the CLI never held the LLAT.
+func verifyRelayGone(out io.Writer, preflight uninstallPreflight, deps teardownDeps) {
+	if preflight.config.RelayBaseURL == "" || preflight.relayToken == "" {
+		return
+	}
+	session := resolveStatusUISession(out)
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			deps.sleep(2 * time.Second)
+		}
+		if _, err := deps.relayHealth(preflight.config.RelayBaseURL, preflight.relayToken); err != nil {
+			fmt.Fprintf(out, "  %s Relay no longer answers — app removed.\n", session.style("success", session.successMarker()))
+			return
+		}
+	}
+	fmt.Fprintf(out, "  %s The relay still answers at %s. If you run more than one instance this is expected; otherwise finish the app removal in Home Assistant.\n", session.style("warning", session.warningMarker()), preflight.config.RelayBaseURL)
+}
+
+// teardownCompletedNoteLines replaces the server-side checklist after a
+// completed guided teardown. Standard mode keeps the connection config on
+// purpose, so it gets the pointing-at-nothing hint.
+func teardownCompletedNoteLines(mode uninstallMode) []string {
+	notes := []string{"Server side removed in Home Assistant (app, repository, access token)."}
+	if mode != uninstallModePurge {
+		notes = append(notes, "The kept connection config now points at nothing. Run 'ha-nova uninstall --purge' to clear it, or keep it for a reinstall.")
+	}
+	return notes
+}
+
+func printTeardownCompletedNotes(out io.Writer, mode uninstallMode) {
+	session := resolveStatusUISession(out)
+	for _, note := range teardownCompletedNoteLines(mode) {
+		fmt.Fprintf(out, "  %s %s\n", session.style("success", session.successMarker()), note)
+	}
+}

--- a/cli/uninstall_teardown_test.go
+++ b/cli/uninstall_teardown_test.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func teardownTestPreflight() uninstallPreflight {
+	return uninstallPreflight{
+		haURL:      "http://192.168.1.5:8123",
+		relayToken: "test-relay-token",
+		config: runtimeConfig{
+			HAURL:        "http://192.168.1.5:8123",
+			RelayBaseURL: "http://192.168.1.5:8791",
+		},
+	}
+}
+
+type teardownRecorder struct {
+	opened       []string
+	relayGone    bool
+	healthProbes int
+}
+
+func (r *teardownRecorder) deps() teardownDeps {
+	return teardownDeps{
+		openURL: func(_ io.Writer, target string) { r.opened = append(r.opened, target) },
+		relayHealth: func(_, _ string) ([]byte, error) {
+			r.healthProbes++
+			if r.relayGone {
+				return nil, errors.New("connection refused")
+			}
+			return []byte(`{"ok":true}`), nil
+		},
+		probeHA: func(string) error { return nil },
+		sleep:   func(time.Duration) {},
+	}
+}
+
+func runTeardownWithInput(t *testing.T, input string, preflight uninstallPreflight, rec *teardownRecorder) (teardownOutcome, string) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	outcome, err := maybeOfferGuidedTeardown(bufio.NewReader(strings.NewReader(input)), out, preflight, rec.deps())
+	if err != nil {
+		t.Fatalf("maybeOfferGuidedTeardown() error: %v\noutput:\n%s", err, out.String())
+	}
+	return outcome, out.String()
+}
+
+func TestGuidedTeardownHappyPathOpensAllThreePages(t *testing.T) {
+	rec := &teardownRecorder{relayGone: true}
+	// offer yes, then Enter through: open app page, app removed, open store,
+	// repo removed, open profile, token revoked.
+	outcome, output := runTeardownWithInput(t, "y\n\n\n\n\n\n\n", teardownTestPreflight(), rec)
+
+	if outcome != teardownCompleted {
+		t.Fatalf("outcome = %v, want teardownCompleted\noutput:\n%s", outcome, output)
+	}
+	wantOpened := []string{
+		haRelayAppPageURL("http://192.168.1.5:8123"),
+		haAppStoreURL("http://192.168.1.5:8123"),
+		haProfileSecurityURL("http://192.168.1.5:8123"),
+	}
+	if len(rec.opened) != len(wantOpened) {
+		t.Fatalf("opened %d URLs (%v), want %d", len(rec.opened), rec.opened, len(wantOpened))
+	}
+	for i, want := range wantOpened {
+		if rec.opened[i] != want {
+			t.Fatalf("opened[%d] = %q, want %q", i, rec.opened[i], want)
+		}
+	}
+	for _, want := range []string{
+		"Step 1 of 3",
+		"Step 2 of 3",
+		"Step 3 of 3",
+		"Relay no longer answers",
+		"Long-lived access tokens",
+		haNovaRepositoryURL,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected teardown output %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestGuidedTeardownDeclinedLeavesEverythingAlone(t *testing.T) {
+	rec := &teardownRecorder{}
+	outcome, _ := runTeardownWithInput(t, "n\n", teardownTestPreflight(), rec)
+	if outcome != teardownDeclined {
+		t.Fatalf("outcome = %v, want teardownDeclined", outcome)
+	}
+	if len(rec.opened) != 0 {
+		t.Fatalf("declined teardown must not open URLs, opened %v", rec.opened)
+	}
+}
+
+func TestGuidedTeardownExitCancelsWholeUninstall(t *testing.T) {
+	rec := &teardownRecorder{}
+	outcome, _ := runTeardownWithInput(t, "y\nexit\n", teardownTestPreflight(), rec)
+	if outcome != teardownCancelled {
+		t.Fatalf("outcome = %v, want teardownCancelled", outcome)
+	}
+}
+
+func TestGuidedTeardownBackReturnsToPreviousStep(t *testing.T) {
+	rec := &teardownRecorder{relayGone: true}
+	// offer yes → app step (Enter, Enter) → repo step: back → app step again
+	// (Enter, Enter) → repo (Enter, Enter) → llat (Enter, Enter).
+	outcome, output := runTeardownWithInput(t, "y\n\n\nback\n\n\n\n\n\n\n", teardownTestPreflight(), rec)
+	if outcome != teardownCompleted {
+		t.Fatalf("outcome = %v, want teardownCompleted\noutput:\n%s", outcome, output)
+	}
+	if got := strings.Count(output, "Step 1 of 3"); got != 2 {
+		t.Fatalf("expected the app step to render twice after back-navigation, got %d\noutput:\n%s", got, output)
+	}
+}
+
+func TestGuidedTeardownNotOfferedWithoutHAURL(t *testing.T) {
+	rec := &teardownRecorder{}
+	outcome, output := runTeardownWithInput(t, "", uninstallPreflight{}, rec)
+	if outcome != teardownNotOffered {
+		t.Fatalf("outcome = %v, want teardownNotOffered", outcome)
+	}
+	if output != "" {
+		t.Fatalf("expected silent skip without HA URL, got:\n%s", output)
+	}
+}
+
+func TestGuidedTeardownNotOfferedWhenHAUnreachable(t *testing.T) {
+	rec := &teardownRecorder{}
+	deps := rec.deps()
+	deps.probeHA = func(string) error { return errors.New("dial tcp: timeout") }
+
+	out := &bytes.Buffer{}
+	outcome, err := maybeOfferGuidedTeardown(bufio.NewReader(strings.NewReader("")), out, teardownTestPreflight(), deps)
+	if err != nil {
+		t.Fatalf("maybeOfferGuidedTeardown() error: %v", err)
+	}
+	if outcome != teardownNotOffered {
+		t.Fatalf("outcome = %v, want teardownNotOffered", outcome)
+	}
+	if !strings.Contains(out.String(), "not reachable right now") {
+		t.Fatalf("expected unreachable notice, got:\n%s", out.String())
+	}
+}
+
+func TestGuidedTeardownWarnsWhenRelayStillAnswers(t *testing.T) {
+	rec := &teardownRecorder{relayGone: false}
+	outcome, output := runTeardownWithInput(t, "y\n\n\n\n\n\n\n", teardownTestPreflight(), rec)
+	if outcome != teardownCompleted {
+		t.Fatalf("outcome = %v, want teardownCompleted\noutput:\n%s", outcome, output)
+	}
+	if !strings.Contains(output, "still answers") {
+		t.Fatalf("expected still-answering warning:\n%s", output)
+	}
+	if rec.healthProbes != 3 {
+		t.Fatalf("healthProbes = %d, want 3 (retry loop)", rec.healthProbes)
+	}
+}
+
+func TestGuidedTeardownVerifySkippedWithoutToken(t *testing.T) {
+	rec := &teardownRecorder{}
+	preflight := teardownTestPreflight()
+	preflight.relayToken = ""
+	outcome, output := runTeardownWithInput(t, "y\n\n\n\n\n\n\n", preflight, rec)
+	if outcome != teardownCompleted {
+		t.Fatalf("outcome = %v, want teardownCompleted\noutput:\n%s", outcome, output)
+	}
+	if rec.healthProbes != 0 {
+		t.Fatalf("healthProbes = %d, want 0 without a stored token", rec.healthProbes)
+	}
+}
+
+func TestTeardownCompletedNoteLinesByMode(t *testing.T) {
+	standard := teardownCompletedNoteLines(uninstallModeStandard)
+	if len(standard) != 2 || !strings.Contains(standard[1], "--purge") {
+		t.Fatalf("standard mode must hint at the kept config: %#v", standard)
+	}
+	purge := teardownCompletedNoteLines(uninstallModePurge)
+	if len(purge) != 1 {
+		t.Fatalf("purge mode needs no kept-config hint: %#v", purge)
+	}
+}
+
+func TestPreflightNoteLinesAlwaysListServerSideCleanup(t *testing.T) {
+	// With a known HA URL the checklist carries deep links.
+	withURL := preflightNoteLines(uninstallPreflight{haURL: "http://ha.local:8123"})
+	joined := strings.Join(withURL, "\n")
+	for _, want := range []string{
+		haRelayAppPageURL("http://ha.local:8123"),
+		haAppStoreURL("http://ha.local:8123"),
+		haProfileSecurityURL("http://ha.local:8123"),
+		haNovaRepositoryURL,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected checklist to contain %q:\n%s", want, joined)
+		}
+	}
+
+	// Without any config the checklist still prints with generic panel paths —
+	// an unreachable relay is no evidence the server side is gone.
+	generic := strings.Join(preflightNoteLines(uninstallPreflight{}), "\n")
+	for _, want := range []string{
+		"Settings > Apps > NOVA Relay > Uninstall",
+		"Repositories",
+		"Long-lived access tokens",
+	} {
+		if !strings.Contains(generic, want) {
+			t.Fatalf("expected generic checklist to contain %q:\n%s", want, generic)
+		}
+	}
+}

--- a/cli/uninstall_teardown_test.go
+++ b/cli/uninstall_teardown_test.go
@@ -149,11 +149,14 @@ func TestGuidedTeardownNotOfferedWhenHAUnreachable(t *testing.T) {
 	}
 }
 
-func TestGuidedTeardownWarnsWhenRelayStillAnswers(t *testing.T) {
+func TestGuidedTeardownStillAnsweringRelayDowngradesToUnverified(t *testing.T) {
 	rec := &teardownRecorder{relayGone: false}
 	outcome, output := runTeardownWithInput(t, "y\n\n\n\n\n\n\n", teardownTestPreflight(), rec)
-	if outcome != teardownCompleted {
-		t.Fatalf("outcome = %v, want teardownCompleted\noutput:\n%s", outcome, output)
+	// A relay that positively still answers must not produce the verified
+	// outcome — runUninstall would otherwise replace the HA checklist with a
+	// "server side removed" claim.
+	if outcome != teardownCompletedUnverified {
+		t.Fatalf("outcome = %v, want teardownCompletedUnverified\noutput:\n%s", outcome, output)
 	}
 	if !strings.Contains(output, "still answers") {
 		t.Fatalf("expected still-answering warning:\n%s", output)

--- a/cli/uninstall_test.go
+++ b/cli/uninstall_test.go
@@ -281,8 +281,10 @@ func TestRunUninstallShowsPreflightAndRelayStillRunningNote(t *testing.T) {
 		"Full purge also removes:",
 		"Home Assistant connection config",
 		uninstallTokenLineLabel(),
-		"Note: The NOVA Relay app is still running in Home Assistant.",
-		"To remove it: Settings > Apps > NOVA Relay > Uninstall",
+		"The NOVA Relay app is still running in Home Assistant. To fully remove HA NOVA:",
+		"1. Remove the NOVA Relay app: " + haRelayAppPageURL("http://192.168.1.5:8123"),
+		"2. Remove the repository: " + haAppStoreURL("http://192.168.1.5:8123"),
+		"3. Revoke the \"NOVA\" access token: http://192.168.1.5:8123/profile/security",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected uninstall output %q:\n%s", want, output)
@@ -299,8 +301,8 @@ func TestUninstallWindowsBundleNoteMentionsWait(t *testing.T) {
 
 func TestPreflightNoteLinesIncludeSecureStoreWarningWhenTokenLookupFails(t *testing.T) {
 	notes := preflightNoteLines(uninstallPreflight{tokenUnavailable: "relay auth token unavailable: keychain locked"})
-	if len(notes) != 1 || notes[0] != "relay auth token unavailable: keychain locked" {
-		t.Fatalf("unexpected preflight notes: %#v", notes)
+	if len(notes) == 0 || notes[len(notes)-1] != "relay auth token unavailable: keychain locked" {
+		t.Fatalf("expected the secure-store warning as the last preflight note: %#v", notes)
 	}
 }
 


### PR DESCRIPTION
## Summary
Implements masterplan-2026 workstream C1 (release 0.14 "Lifecycle & parity"). Closes the audit finding that uninstall was server-side blind: the relay app, the added repository, and the "NOVA" LLAT survived every uninstall; the only hint printed exclusively while the relay was still reachable; LLAT revocation was never mentioned anywhere in the product.

- **New `cli/uninstall_teardown.go`**: interactive uninstalls now offer a guided server-side teardown before any local file is touched, mirroring the setup wizard (announce link → open browser → guided clicks → Enter): 1/3 uninstall the app (verifies the relay stops answering via 3 health probes — warn-only, never blocks), 2/3 remove the repository (new `haAppStoreURL` = `_my_redirect/supervisor_store`; notes HA only allows this after app removal), 3/3 revoke the "NOVA" token (deliberately unverifiable: the CLI never held the LLAT). `back` walks steps, `exit` cancels the entire uninstall — safe because teardown deletes nothing locally.
- **Unconditional checklist**: `preflightNoteLines` now always returns the full 3-step HA cleanup checklist (deep links when the HA URL is known from the raw config via `loadJSONConfig` — works for partial setups; generic panel paths otherwise). An unreachable relay is no evidence the server side is gone.
- After a completed teardown the checklist is replaced by a completion note; standard mode adds the kept-config hint ("points at nothing; `--purge` or keep for reinstall").
- Windows detached helper gets `--teardown-done` so its report matches the parent's teardown state.

## Verification
- `go vet ./...` clean; full `go test ./...` green. 10 new tests in `cli/uninstall_teardown_test.go` (scripted-reader pattern): happy path opens exactly the 3 pages in order, decline, exit-cancels, back-navigation re-renders step 1, silent skip without HA URL, unreachable-HA notice, still-answering warning after 3 probes, verify skipped without token, completed-note modes, checklist contents with/without URLs.
- Existing uninstall tests updated to the new checklist contract (incl. asserting the LLAT revocation line — the line that previously never existed).

## Risks
- Prompt flow adds one yes/no question to interactive uninstalls (default Yes); `--yes`/non-TTY/recovery paths are unchanged except for the now-always-printed checklist.
- Ordering: teardown runs before local removal so purge cannot delete the HA URL/token the deep links and verify probe need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UABh9QxzyCg8JhostzVUF