### PR TITLE
feat(skills): skill template v2 + structural linter + normalization

### DIFF
--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -360,25 +360,46 @@ The end-user installer contract is:
 - `ha-nova setup` owns product setup, migration, and client attachment
 - bundled Claude installs attach to a versioned local release snapshot under `~/.config/ha-nova/claude-marketplace/releases/vX.Y.Z`; the flat `~/.config/ha-nova/claude-marketplace` root stays repo/dev-only
 
-## Skill Section Template
+## Skill Section Template (v2)
 
-Standard sections for all sub-skills. Follow this when creating or auditing skills.
+Canonical structure for all sub-skills, enforced by `tests/skills/skill-template-contract.test.ts`. Follow this when creating or auditing skills.
 
-**Required for ALL skills:**
+**Canonical H2 order** (domain-specific sections may appear in the `[domain]` slots; the canonical sections must appear in this relative order):
+
+```
+Scope → Bootstrap (once per session) → Relay Contract → [domain] → Flow → [domain]
+  → Error Handling (optional, always directly before Output Format)
+  → Output Format → Safety → Guardrails (optional) → References (optional)
+```
+
+**Required for ALL sub-skills:**
 - **Scope** — what this skill does + inverse scope (what it does NOT do, which skill to use instead)
-- **Bootstrap** — relay CLI verification + onboarding fallback
+- **Bootstrap (once per session)** — exact heading; relay CLI verification + onboarding fallback
+- **Relay Contract** — the file-based `ha-nova relay` command contract this skill uses
 - **Flow** — step-by-step operations with relay commands
-- **Output Format** — what the user receives (structure, content)
+- **Output Format** — first line starts with ``Apply `skills/ha-nova/output-rules.md` `` ; then what the user receives
 - **Safety** — risk mitigations, confirmation rules, relay-only constraint
-- **Guardrails** — limits, constraints, "never use raw `get_states`"
 
-**Required for MUTATION skills** (write, helper):
-- **Post-Write Review** — mandatory inline review after every create/update/delete
+**Required for config-persisting skills** (write, helper):
+- **Post-Write Review** — mandatory inline review phase after every create/update/delete (a Flow phase, not a separate H2)
 - **References** — links to schema docs, relay API, review checks
 
 **Optional:**
-- **Error Handling** — error classification + remediation (recommended for external calls)
+- **Error Handling** — error classification + remediation (recommended for external calls); when present it sits directly before Output Format
+- **Guardrails** — hard limits and constraints (e.g. "never use raw `get_states`")
 - **Latency Policy** — when to optimize for speed
+
+**Declared deviations** (the only allowed ones):
+- `onboarding` — heading `## Bootstrap` (it repairs the relay; "once per session" would be wrong) and no `Relay Contract` section (the diagnostics skill's whole body is remediation commands)
+- `fallback` — heading `## Bootstrap (only before Relay-Ready calls)`
+
+**Forbidden heading variants** (normalized in 2026-07, must not return): `## Output Rules`, `## Safety Baseline` (sub-skills; the context skill keeps its own), `## Safety Guardrails`, `## Agent Flow`.
+
+**Terminology rule:** prose says "App(s)"; `add-on` / `addon` may appear only inside inline code or fenced blocks as literal API identifiers (`include_all_addons`, `failed_addons`, `<addon_slug>`, ...) or as backticked search-query strings.
+
+**Portability rule:** if a referenced shared file is unavailable in an install, do not guess its content — ask the user to re-run `ha-nova setup`. Exception: the existing `config-body-filter.jq` "recreate exactly" blocks (a one-line filter, self-recreation is strictly better).
+
+**The context skill (`ha-nova/SKILL.md`) is exempt** from the sub-skill template: it is a router, not an operation skill. Its required anchors stay pinned by `tests/skills/ha-nova-contract.test.ts`.
 
 ## Post-Write Review Standard
 

--- a/docs/work/masterplan-2026.md
+++ b/docs/work/masterplan-2026.md
@@ -137,16 +137,19 @@ Dispatch sharpness at 28 skills: `diagnose` = root-cause a concrete failure, `he
 
 ## Release sequencing
 
-| Release | Theme | Contents |
-|---------|-------|----------|
-| **0.14** | Lifecycle & parity | C1 guided teardown + C2 update nudge (multiplies reach of every later release) |
-| **0.15** | Coverage wave 1 | `diagnose` + `media` + `notify` + fallback catalog (B11); workstream A lands silently (linter = internal, no release claim) |
-| **0.16** | Runs everywhere | Docker relay + wizard branch + disposable-HA e2e (shared infra) + README platform update; skills.sh/forum/awesome-ha push |
-| **0.17** | Trust & compare | `docs/safety.md` + dated eval report + `docs/comparison.md` + Relay 0.3.0 (envelope v2 + binary) + `camera`/`mqtt` |
-| **0.18+** | Rest by demand | `assist`, `admin`, Relay 0.4.0 (`/files`) + `yaml-config`, `external-sources`, weather row |
-| **1.0 gate** | | (a) all 4 HA install types validated; (b) lifecycle symmetric + parity everywhere; (c) safety.md fully evidence-linked with green scheduled run; (d) top domains shipped (media/notify/camera/logs); (e) Windows gold test (open breadcrumb); (f) no known false-success write path; (g) comparison page live |
+**Maintainer decision (2026-07-11): all phases land on `main` first; ONE release ships at the very end.** The former 0.14–0.17 staging becomes internal waves — same content, same order, no intermediate tags. `main` may run ahead of the stable tag for the duration of the program; the README stays stable-truth the whole time (release-bound claims collect in the release-body draft per the README gate).
 
-Every release follows repo rules: one topic one branch, PR merge checklist, Codex review cycle, release rehearsal gate.
+| Wave | Theme | Contents | Status |
+|------|-------|----------|--------|
+| **1** | Lifecycle & parity | C1 guided teardown + C2 update nudge | shipped to main (#288, #289) |
+| **2** | Template & portability | Workstream A: template v2 + linter + normalization, Safety Core, Execution Mode, token diet, frontmatter alignment | in progress |
+| **3** | Coverage wave 1 | `diagnose` + `media` + `notify` + fallback catalog (B11) | open |
+| **4** | Runs everywhere | Docker relay + wizard branch + disposable-HA e2e + platform claims (release-body draft) | open |
+| **5** | Trust & compare | `docs/safety.md` + dated eval report + `docs/comparison.md` + Relay 0.3.0 (envelope v2 + binary) + `camera`/`mqtt` | open |
+| **6** | Coverage wave 2 | `assist`, `admin`, Relay 0.4.0 (`/files`) + `yaml-config`, `external-sources`, weather row | open |
+| **Final release gate** | | (a) all 4 HA install types validated; (b) lifecycle symmetric + parity everywhere; (c) safety.md fully evidence-linked with green scheduled run; (d) top domains shipped (media/notify/camera/logs); (e) Windows gold test (open breadcrumb); (f) no known false-success write path; (g) comparison page live; (h) release-prep PR (version bump + notes + README updates) followed immediately by the RC/final tag flow | open |
+
+Every wave follows repo rules: one topic one branch, PR merge checklist, Codex review cycle; the single release at the end follows the full release rehearsal gate.
 
 ## Opinionated defaults (documented instead of asked)
 - Teardown in standard mode: config kept with a hint note ("points at nothing; `--purge` or keep for reinstall") — no auto-purge.

--- a/skills/backup/SKILL.md
+++ b/skills/backup/SKILL.md
@@ -31,7 +31,7 @@ WS response body: `.data` (`skills/ha-nova/relay-api.md` → Standard Envelope).
 
 ### Status
 `{"type":"backup/info"}` → report from `.data`:
-- `backups` (count, newest `date`, sizes via `agents`), `state` (`idle` or in progress). Distinguish full backups (`homeassistant_included`) from partial add-on backups and automatic (`with_automatic_settings`) from manual; when the newest backup is partial, also report the newest FULL backup
+- `backups` (count, newest `date`, sizes via `agents`), `state` (`idle` or in progress). Distinguish full backups (`homeassistant_included`) from partial App backups and automatic (`with_automatic_settings`) from manual; when the newest backup is partial, also report the newest FULL backup
 - `last_completed_automatic_backup`, `next_automatic_backup` — say plainly when automatic backups are NOT configured (`next` is null)
 - surface `agent_errors` when non-empty (a failing backup location is silent data-loss risk)
 
@@ -41,9 +41,9 @@ WS response body: `.data` (`skills/ha-nova/relay-api.md` → Standard Envelope).
 3. Primary path — the user's own settings (encryption, locations, scope): `{"type":"backup/generate_with_automatic_settings"}`.
 4. Fallback when that fails because automatic settings are not configured: `{"type":"backup/generate","name":"<name>","agent_ids":["<local-agent>"],"include_homeassistant":true,"include_database":true}`:
    - discover the local agent via `{"type":"backup/agents/info"}`: Supervised installs register `hassio.local`, Core installs `backup.local` — never hardcode
-   - add `"include_all_addons":true` ONLY for `hassio.local` (Core rejects add-on options)
+   - add `"include_all_addons":true` ONLY for `hassio.local` (Core rejects App options)
    - if `backup/config/info` shows an encryption password configured, pass it as `password`; never invent one
-5. Both generate commands return when the job is INITIATED, not when it finishes. Poll `backup/info` every ~10 s until `state` returns to `idle` and a new backup appears in `backups`; then check the new backup's `failed_agent_ids`, `failed_addons`, and `failed_folders`: if any is non-empty, report partial success — the backup exists but is missing those locations, add-ons, or folders — never plain success. Otherwise report name, date, size, and locations. If still running after ~5 minutes, say the backup continues in the background and how to check later.
+5. Both generate commands return when the job is INITIATED, not when it finishes. Poll `backup/info` every ~10 s until `state` returns to `idle` and a new backup appears in `backups`; then check the new backup's `failed_agent_ids`, `failed_addons`, and `failed_folders`: if any is non-empty, report partial success — the backup exists but is missing those locations, Apps, or folders — never plain success. Otherwise report name, date, size, and locations. If still running after ~5 minutes, say the backup continues in the background and how to check later.
 6. If Status afterwards shows the attempt failed (`last_action_event`/no new backup), report the failure — never claim success from initiation alone.
 
 ### Safety backup before risky changes
@@ -53,7 +53,7 @@ Other skills name HA Backups as the recovery path (see `skills/ha-nova/write-saf
 - Create a fresh one only when the user asks or accepts, or the last full backup is stale relative to what the change touches; then proceed with the risky change only after the backup completed.
 
 ### Inspect
-`{"type":"backup/details","backup_id":"<id>"}` → what is included (Home Assistant, database, add-ons, folders), which locations hold it, protected (encrypted) or not.
+`{"type":"backup/details","backup_id":"<id>"}` → what is included (Home Assistant, database, Apps, folders), which locations hold it, protected (encrypted) or not.
 
 ### Delete
 1. Require `state: idle` first (one backup operation at a time). Resolve the exact `backup_id` from Status; show name, date, and locations in the preview — deletion removes it from ALL listed locations, irreversibly.

--- a/skills/entity-discovery/SKILL.md
+++ b/skills/entity-discovery/SKILL.md
@@ -23,10 +23,6 @@ Read-only behavior.
 Verify relay CLI: `ha-nova relay health`
 If this fails: `ha-nova setup`
 
-## Output Rules
-
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
-
 ## Relay Contract
 
 Use file-based relay requests by default:
@@ -136,6 +132,12 @@ This is more reliable than keyword search or assuming `.ai` is populated for roo
 - keyword match on entity_id + name second
 
 If ambiguity remains: present top candidates (max 10), ask one selection question.
+
+## Output Format
+
+Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+
+Return the Step 4 shortlist shape; never dump raw `get_states` output.
 
 ## Safety
 

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -14,17 +14,7 @@ Mandatory fallback for HA features without a dedicated skill. Three tiers:
 - **Roadmap**: Planned for future Relay phases -- explain timeline + workaround.
 - **External**: Outside HA NOVA scope -- web search + HA UI pointer.
 
-All relay calls in this skill are experimental -- always follow Safety Guardrails below.
-
-## Safety Baseline
-
-- Correct invalid Home Assistant premises explicitly.
-- Do not silently compensate for a wrong premise.
-- Keep corrections brief and technical, not preachy.
-
-## Output Rules
-
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+All relay calls in this skill are experimental -- always follow the Safety section below.
 
 ## Bootstrap (only before Relay-Ready calls)
 
@@ -78,7 +68,7 @@ For every Relay-Ready call in this skill:
 | HACS | External | -- |
 | Zigbee / Z-Wave Config | External | -- |
 
-## Agent Flow
+## Flow
 
 ```
 1. Check Capability Map for user's request
@@ -239,7 +229,26 @@ Device pairing is hardware-specific, requires direct coordinator access (ZHA, Z2
 
 **Alternative:** HA UI: Settings > Devices & Services > [Zigbee/Z-Wave integration].
 
-## Safety Guardrails
+## Error Handling
+
+Experimental calls may fail with unfamiliar errors. Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` → Error Handling. Fallback-specific rules:
+
+- `400/VALIDATION_ERROR`: payload schema wrong -- search web for current WS type schema
+- `404/NOT_FOUND`: endpoint may not exist in this HA version -- check HA release notes
+- `502/UPSTREAM_*` transport errors: verify state/config first (see `relay-api.md` → Timeout and Retry Guidance); retry once only when verification shows no change, then route to `ha-nova:onboarding`
+
+## Output Format
+
+Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+
+Every experimental call result names the tier (Relay-Ready / Roadmap / External), carries the EXPERIMENTAL marker where required, and summarizes verified outcomes only.
+
+## Safety
+
+Premise handling:
+- Correct invalid Home Assistant premises explicitly.
+- Do not silently compensate for a wrong premise.
+- Keep corrections brief and technical, not preachy.
 
 Rules for all experimental relay calls in this skill:
 
@@ -274,11 +283,3 @@ No HA WS endpoint has optimistic locking (no ETags, no version numbers). Last wr
 - Probing write endpoints to "see what happens" — read the Relay-Ready section first
 - Skipping this skill and going straight to `ha-nova relay ws`/`ha-nova relay core` for unfamiliar operations
 - Using trial-and-error to discover payload schemas — search web for the WS type schema instead
-
-## Error Handling
-
-Experimental calls may fail with unfamiliar errors. Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` → Error Handling. Fallback-specific rules:
-
-- `400/VALIDATION_ERROR`: payload schema wrong -- search web for current WS type schema
-- `404/NOT_FOUND`: endpoint may not exist in this HA version -- check HA release notes
-- `502/UPSTREAM_*` transport errors: verify state/config first (see `relay-api.md` → Timeout and Retry Guidance); retry once only when verification shows no change, then route to `ha-nova:onboarding`

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -26,14 +26,17 @@ Read-only analysis. Exception: after explicit user confirmation, one Quick-Fix s
 
 ## Bootstrap (once per session)
 
+Preflight: `ha-nova relay health` (once per session, skip if already verified). If this fails: `ha-nova setup`.
+
+## Relay Contract
+
 Relay CLI: `ha-nova relay`
-- Preflight: `ha-nova relay health` (once per session, skip if already verified)
 - `ha-nova relay ws --data-file <payload-file>` — canonical WebSocket path
 - `ha-nova relay core --method <METHOD> --path <PATH> --body-file <payload-file>` — canonical REST path
 - `ha-nova relay ... --jq-file <filter-file>` — canonical complex filter path
 - `ha-nova relay ... --out <result-file>` — canonical large-output path
 
-### Target Resolution
+## Target Resolution
 
 If user provides an exact automation/script `entity_id` (e.g., `automation.main_lights`), skip search and go directly to config read.
 
@@ -155,7 +158,7 @@ If config is already in the thread context (e.g., user pasted YAML):
 
 Do NOT invoke `ha-nova:entity-discovery` or `ha-nova:read` as separate skills — handle everything within this review flow.
 
-### Bulk Mode Gate
+## Bulk Mode Gate
 
 After target resolution:
 
@@ -484,6 +487,12 @@ For resolved targets `> 1`, return exactly these 6 sections:
 - group conflicts by shared controlled entity or linked helper
 - separate true conflicts from safe/redundant clusters
 - if clean: localized "no conflicts"
+
+## Safety
+
+- Read-only analysis: no config writes through the relay (see Scope for the single Quick-Fix exception).
+- The Quick-Fix service call requires confirmation bound to its exact preview; bulk mode disables it entirely.
+- Never guess entity or config IDs; resolve or ask.
 
 ## Guardrails
 

--- a/skills/scene/SKILL.md
+++ b/skills/scene/SKILL.md
@@ -94,7 +94,7 @@ Persistence routing per `skills/ha-nova/best-practices.md` → Persistence Model
 4. `ha-nova relay core --method DELETE --path /api/config/scene/config/<id>`
 5. Verify absence: config GET returns status 404 and the entity is gone.
 
-## Error Handling & State Semantics
+## Error Handling
 
 - A scene entity's state is the timestamp of its last activation; `unknown` means "never activated" — not an error.
 - Config GET 404 on a `homeassistant`-platform scene: the scene was deleted outside this session — re-list instead of retrying.

--- a/skills/service-call/SKILL.md
+++ b/skills/service-call/SKILL.md
@@ -20,10 +20,6 @@ No config mutations (use `ha-nova:write` for automation/script changes).
 Verify relay CLI: `ha-nova relay health`
 If this fails: `ha-nova setup`
 
-## Output Rules
-
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
-
 ## Relay Contract
 
 Use file-based payloads for service writes:
@@ -111,13 +107,6 @@ Rules:
 - Ask for confirmation bound to that exact runtime-call preview before execution.
 - After execution, verify only the target automation/script state and any user-approved helper/state assertions; do not infer device safety from a successful service response alone.
 
-## Safety
-
-- Preview every service call before execution.
-- Never guess entity IDs; resolve or ask.
-- No token confirmation needed for ordinary service calls; confirmation is still bound to the active preview.
-- For potentially disruptive services (e.g., `homeassistant.restart`), warn and ask for explicit post-preview confirmation.
-
 ## Error Handling
 
 Full relay/upstream error taxonomy (codes, HTTP-status split, retry rules): `skills/ha-nova/relay-api.md` → Error Handling.
@@ -126,6 +115,19 @@ Service-call specifics:
 - `404/NOT_FOUND` or upstream `.data.status` 404: entity or service does not exist — re-resolve before retrying
 - `502/UPSTREAM_*` transport errors: HA may already have accepted the action — verify entity state first (see `relay-api.md` → Timeout and Retry Guidance); retry once only when verification shows no state change, otherwise report the result
 - State verification failure (state didn't change): report discrepancy, do not retry automatically
+
+## Output Format
+
+Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+
+Report the executed service, its target, and the verified state change (or the discrepancy); summarize response-service data instead of dumping it.
+
+## Safety
+
+- Preview every service call before execution.
+- Never guess entity IDs; resolve or ask.
+- No token confirmation needed for ordinary service calls; confirmation is still bound to the active preview.
+- For potentially disruptive services (e.g., `homeassistant.restart`), warn and ask for explicit post-preview confirmation.
 
 ## Guardrails
 

--- a/skills/write/SKILL.md
+++ b/skills/write/SKILL.md
@@ -22,6 +22,10 @@ ha-nova relay health
 
 If this fails, run onboarding: `ha-nova setup`.
 
+## Relay Contract
+
+File-based relay requests only: `ha-nova relay core --method <METHOD> --path <PATH> --body-file <payload-file>` for config writes, `ha-nova relay ws --data-file <payload-file>` for reads/reloads, `--jq-file` / `--out` for filters and large reads.
+
 ## Flow
 
 Multi-target logical changes: present the plan first per `skills/ha-nova/write-safety.md` → Multi-Target Changes.

--- a/tests/skills/ha-nova-contract.test.ts
+++ b/tests/skills/ha-nova-contract.test.ts
@@ -405,41 +405,6 @@ describe("ha-nova contract", () => {
     expect(apply).toContain("`write`, `read-back`, `reload`, or `runtime-verify`");
   });
 
-  it("keeps all operational subskills concise", () => {
-    const skills = [
-      "skills/dashboard/SKILL.md",
-      "skills/scene/SKILL.md",
-      "skills/todo/SKILL.md",
-      "skills/backup/SKILL.md",
-      "skills/updates/SKILL.md",
-      "skills/energy/SKILL.md",
-      "skills/maintenance/SKILL.md",
-      "skills/organize/SKILL.md",
-      "skills/history/SKILL.md",
-      "skills/write/SKILL.md",
-      "skills/read/SKILL.md",
-      "skills/entity-discovery/SKILL.md",
-      "skills/onboarding/SKILL.md",
-    ];
-    // Default budget is 1000 words. write/ carries the most safety machinery —
-    // the four-phase flow plus pre-write diff, pre-write impact, and durable
-    // update-revert wiring — so it gets a slightly larger, documented budget.
-    // scene/ carries the editability guard, upsert-overwrite protection,
-    // deliberate attribute-capture rules, and error/state semantics — that
-    // resilience content is the skill's value, so it gets a documented budget
-    // too. Everything else stays under 1000; recalibration, not removal.
-    const wordLimits: Record<string, number> = {
-      "skills/write/SKILL.md": 1150,
-      "skills/scene/SKILL.md": 1200,
-    };
-    for (const file of skills) {
-      const content = readFileSync(file, "utf8");
-      const wordCount = content.trim().split(/\s+/).length;
-      const limit = wordLimits[file] ?? 1000;
-      expect(wordCount, `${file} has ${wordCount} words (limit ${limit})`).toBeLessThan(limit);
-    }
-  });
-
   it("keeps the history skill read-only, bounded, and stats-aware", () => {
     const history = readFileSync("skills/history/SKILL.md", "utf8");
 
@@ -486,72 +451,6 @@ describe("ha-nova contract", () => {
       const content = readFileSync(file, "utf8");
       expect(content).not.toContain("__HA_NOVA_REPO_ROOT__");
       expect(content).not.toContain("ha-nova-managed-install");
-    }
-  });
-
-  it("enforces English-only content across all skill files", () => {
-    const allSkillFiles = [
-      "skills/ha-nova/SKILL.md",
-      "skills/dashboard/SKILL.md",
-      "skills/scene/SKILL.md",
-      "skills/todo/SKILL.md",
-      "skills/backup/SKILL.md",
-      "skills/updates/SKILL.md",
-      "skills/organize/SKILL.md",
-      "skills/history/SKILL.md",
-      "skills/write/SKILL.md",
-      "skills/read/SKILL.md",
-      "skills/helper/SKILL.md",
-      "skills/entity-discovery/SKILL.md",
-      "skills/onboarding/SKILL.md",
-      "skills/service-call/SKILL.md",
-      "skills/review/SKILL.md",
-      "skills/review/checks.md",
-      "skills/energy/SKILL.md",
-      "skills/energy/energy-reference.md",
-      "skills/maintenance/SKILL.md",
-      "skills/maintenance/maintenance-reference.md",
-      "skills/fallback/SKILL.md",
-      "skills/ha-nova/relay-api.md",
-      "skills/ha-nova/best-practices.md",
-      "skills/ha-nova/bulk-patterns.md",
-      "skills/ha-nova/payload-schemas.md",
-      "skills/ha-nova/automation-patterns.md",
-      "skills/ha-nova/template-guidelines.md",
-      "skills/ha-nova/safe-refactoring.md",
-      "skills/ha-nova/helper-schemas.md",
-      "skills/ha-nova/helper-flow-schemas.md",
-      "skills/ha-nova/agents/resolve-agent.md",
-      "skills/ha-nova/agents/apply-agent.md",
-    ];
-
-    // German words/phrases that should never appear in skill files
-    const germanPatterns = [
-      /\bAnalysiere\b/,
-      /\bZeige\b/,
-      /\bErstelle\b/,
-      /\bÄndere\b/,
-      /\bSpeichere\b/,
-      /\bImportiere\b/,
-      /\bmeine\b/,
-      /\bfehlt\b/,
-      /\blöschen\b/,
-      /\bBitte\b/,
-      /\bBedingung\b/,
-      /\bWohnzimmer\b/,
-      /\bfunktioniert\b/,
-      /\bgeht nicht\b/,
-      /\bist falsch\b/,
-    ];
-
-    for (const file of allSkillFiles) {
-      const content = readFileSync(file, "utf8");
-      for (const pattern of germanPatterns) {
-        expect(
-          pattern.test(content),
-          `${file} contains German text matching ${pattern}`,
-        ).toBe(false);
-      }
     }
   });
 

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -1,0 +1,287 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// Skill Section Template v2 linter — enforces docs/reference/skill-architecture.md
+// → "Skill Section Template (v2)". One behavior, one place: the English-only and
+// word-budget checks moved here from ha-nova-contract.test.ts with dynamic
+// globbing (hardcoded file lists silently exempt new skills).
+
+const SKILLS_ROOT = "skills";
+
+const SUBSKILLS = readdirSync(SKILLS_ROOT).filter(
+  (d) => d !== "ha-nova" && statSync(join(SKILLS_ROOT, d)).isDirectory(),
+);
+
+const ALL_SKILL_MD_FILES = ((): string[] => {
+  const files: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const p = join(dir, entry);
+      if (statSync(p).isDirectory()) walk(p);
+      else if (entry.endsWith(".md")) files.push(p);
+    }
+  };
+  walk(SKILLS_ROOT);
+  return files;
+})();
+
+// Canonical H2 relative order; "Bootstrap" matches all declared variants.
+const CANON = [
+  "Scope",
+  "Bootstrap",
+  "Relay Contract",
+  "Flow",
+  "Error Handling",
+  "Output Format",
+  "Safety",
+  "Guardrails",
+  "References",
+];
+
+const BOOTSTRAP_HEADINGS: Record<string, string> = {
+  onboarding: "Bootstrap",
+  fallback: "Bootstrap (only before Relay-Ready calls)",
+};
+const DEFAULT_BOOTSTRAP = "Bootstrap (once per session)";
+
+// The diagnostics skill's whole body is remediation commands — declared
+// exception, see skill-architecture.md → Declared deviations.
+const RELAY_CONTRACT_EXEMPT = new Set(["onboarding"]);
+
+const REFERENCES_REQUIRED = new Set(["write", "helper"]);
+
+const FORBIDDEN_HEADINGS = [
+  "Output Rules",
+  "Safety Baseline",
+  "Safety Guardrails",
+  "Agent Flow",
+];
+
+// Word budgets: default 1000. Documented ratchets for content-dense skills;
+// write and review drop again after the masterplan A5 token diet (References
+// split / checks.md self-containment).
+const WORD_BUDGETS: Record<string, number> = {
+  write: 1200,
+  scene: 1250,
+  "service-call": 1100,
+  health: 1150,
+  fallback: 2050,
+  helper: 3600,
+  review: 4800,
+};
+const DEFAULT_WORD_BUDGET = 1000;
+
+// Internal review-check codes (S-01, R-18, H-09, ...) may flow only between
+// the reviewer/mutation files that implement the dedup logic; user-flow
+// skills must never carry them (output-rules.md forbids surfacing them).
+const CHECK_CODE_ALLOWLIST = new Set([
+  "skills/review/checks.md",
+  "skills/review/SKILL.md",
+  "skills/write/SKILL.md",
+  "skills/helper/SKILL.md",
+  "skills/ha-nova/output-rules.md",
+  "skills/ha-nova/write-safety.md",
+  "skills/ha-nova/automation-patterns.md",
+  "skills/ha-nova/payload-schemas.md",
+  "skills/ha-nova/safe-refactoring.md",
+  "skills/ha-nova/template-guidelines.md",
+  "skills/ha-nova/best-practices.md",
+]);
+
+const GERMAN_PATTERNS = [
+  /\bAnalysiere\b/,
+  /\bZeige\b/,
+  /\bErstelle\b/,
+  /\bÄndere\b/,
+  /\bSpeichere\b/,
+  /\bImportiere\b/,
+  /\bmeine\b/,
+  /\bfehlt\b/,
+  /\blöschen\b/,
+  /\bBitte\b/,
+  /\bBedingung\b/,
+  /\bWohnzimmer\b/,
+  /\bfunktioniert\b/,
+  /\bgeht nicht\b/,
+  /\bist falsch\b/,
+];
+
+function stripFences(md: string): string {
+  return md.replace(/```[\s\S]*?```/g, "");
+}
+
+function stripInlineCode(md: string): string {
+  return md.replace(/`[^`\n]*`/g, "");
+}
+
+function parseFrontmatter(md: string): Record<string, string> {
+  const match = md.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const fm: Record<string, string> = {};
+  for (const line of (match[1] ?? "").split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx > 0) fm[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+  }
+  return fm;
+}
+
+function h2s(md: string): string[] {
+  return [...stripFences(md).matchAll(/^## (.+)$/gm)].map((m) => (m[1] ?? "").trim());
+}
+
+function sectionBody(md: string, heading: string): string {
+  const stripped = stripFences(md);
+  const re = new RegExp(`^## ${heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "m");
+  const start = stripped.search(re);
+  if (start < 0) return "";
+  const rest = stripped.slice(start).split("\n").slice(1);
+  const end = rest.findIndex((l) => l.startsWith("## "));
+  return (end < 0 ? rest : rest.slice(0, end)).join("\n");
+}
+
+function subskillPath(name: string): string {
+  return join(SKILLS_ROOT, name, "SKILL.md");
+}
+
+describe("skill template v2 contract", () => {
+  it("keeps every sub-skill frontmatter spec-compliant", () => {
+    for (const name of SUBSKILLS) {
+      const fm = parseFrontmatter(readFileSync(subskillPath(name), "utf8"));
+      const fmName = fm.name ?? "";
+      const fmDescription = fm.description ?? "";
+      expect(fmName, `${name}: frontmatter name must equal directory name`).toBe(name);
+      expect(fmName, `${name}: lowercase-hyphen name`).toMatch(/^[a-z][a-z0-9-]*$/);
+      // 'ha-nova-' namespacing on flat installs must stay under the spec's 64.
+      expect(fmName.length, `${name}: name too long for namespaced installs`).toBeLessThanOrEqual(56);
+      expect(fmDescription, `${name}: description required`).toBeTruthy();
+      expect(fmDescription.length, `${name}: description over spec limit`).toBeLessThanOrEqual(1024);
+      const allowed = new Set(["name", "description", "license", "compatibility"]);
+      for (const key of Object.keys(fm)) {
+        expect(allowed.has(key), `${name}: frontmatter key '${key}' not allowed`).toBe(true);
+      }
+    }
+  });
+
+  it("pins the fallback discovery-time write gate in its description", () => {
+    const fm = parseFrontmatter(readFileSync(subskillPath("fallback"), "utf8"));
+    expect(fm.description).toContain(
+      "Must be invoked before any raw relay write operation",
+    );
+  });
+
+  it("keeps required sections present per skill class", () => {
+    for (const name of SUBSKILLS) {
+      const headings = h2s(readFileSync(subskillPath(name), "utf8"));
+      const bootstrap = BOOTSTRAP_HEADINGS[name] ?? DEFAULT_BOOTSTRAP;
+      const required = ["Scope", bootstrap, "Flow", "Output Format", "Safety"];
+      if (!RELAY_CONTRACT_EXEMPT.has(name)) required.push("Relay Contract");
+      if (REFERENCES_REQUIRED.has(name)) required.push("References");
+      for (const section of required) {
+        expect(headings, `${name}: missing required section '## ${section}'`).toContain(section);
+      }
+    }
+  });
+
+  it("keeps canonical sections in canonical order", () => {
+    for (const name of SUBSKILLS) {
+      const headings = h2s(readFileSync(subskillPath(name), "utf8"));
+      const canonical = headings
+        .map((h) => (h.startsWith("Bootstrap") ? "Bootstrap" : h))
+        .filter((h) => CANON.includes(h));
+      const indexes = canonical.map((h) => CANON.indexOf(h));
+      for (let i = 1; i < indexes.length; i++) {
+        expect(
+          indexes[i] ?? -1,
+          `${name}: '## ${canonical[i]}' must come after '## ${canonical[i - 1]}'`,
+        ).toBeGreaterThan(indexes[i - 1] ?? -1);
+      }
+    }
+  });
+
+  it("keeps Error Handling directly before Output Format when present", () => {
+    for (const name of SUBSKILLS) {
+      const headings = h2s(readFileSync(subskillPath(name), "utf8"));
+      const idx = headings.indexOf("Error Handling");
+      if (idx < 0) continue;
+      expect(
+        headings[idx + 1],
+        `${name}: the H2 after '## Error Handling' must be '## Output Format'`,
+      ).toBe("Output Format");
+    }
+  });
+
+  it("rejects forbidden heading variants in sub-skills", () => {
+    for (const name of SUBSKILLS) {
+      const headings = h2s(readFileSync(subskillPath(name), "utf8"));
+      for (const bad of FORBIDDEN_HEADINGS) {
+        expect(headings, `${name}: use the canonical heading, not '## ${bad}'`).not.toContain(bad);
+      }
+      const bootstrapVariants = headings.filter((h) => h.startsWith("Bootstrap"));
+      const expected = BOOTSTRAP_HEADINGS[name] ?? DEFAULT_BOOTSTRAP;
+      expect(
+        bootstrapVariants,
+        `${name}: Bootstrap heading must be exactly '## ${expected}'`,
+      ).toEqual([expected]);
+    }
+  });
+
+  it("starts every Output Format section with the shared output-rules pointer", () => {
+    for (const name of SUBSKILLS) {
+      const body = sectionBody(readFileSync(subskillPath(name), "utf8"), "Output Format");
+      const firstLine = body.split("\n").find((l) => l.trim() !== "") ?? "";
+      expect(
+        firstLine.trimStart().startsWith("Apply `skills/ha-nova/output-rules.md`"),
+        `${name}: Output Format must start with the output-rules pointer, got: ${firstLine}`,
+      ).toBe(true);
+    }
+  });
+
+  it("uses App terminology in prose across all skill files", () => {
+    for (const file of ALL_SKILL_MD_FILES) {
+      const prose = stripInlineCode(stripFences(readFileSync(file, "utf8")));
+      const match = prose.match(/\badd-?ons?\b/i);
+      expect(
+        match,
+        `${file}: prose says 'App(s)'; 'add-on' is allowed only as a code literal (found '${match?.[0]}')`,
+      ).toBeNull();
+    }
+  });
+
+  it("keeps internal review-check codes out of user-flow skills", () => {
+    for (const file of ALL_SKILL_MD_FILES) {
+      if (CHECK_CODE_ALLOWLIST.has(file.split("\\").join("/"))) continue;
+      const content = readFileSync(file, "utf8");
+      const match = content.match(/\b[SRPMFH]-\d{2}\b/);
+      expect(
+        match,
+        `${file}: internal check code '${match?.[0]}' outside the reviewer allowlist`,
+      ).toBeNull();
+    }
+  });
+
+  it("enforces English-only content across all skill files", () => {
+    for (const file of ALL_SKILL_MD_FILES) {
+      const content = readFileSync(file, "utf8");
+      for (const pattern of GERMAN_PATTERNS) {
+        expect(
+          pattern.test(content),
+          `${file} contains German text matching ${pattern}`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("keeps every sub-skill within its word budget", () => {
+    for (const name of SUBSKILLS) {
+      const content = readFileSync(subskillPath(name), "utf8");
+      const wordCount = content.trim().split(/\s+/).length;
+      const limit = WORD_BUDGETS[name] ?? DEFAULT_WORD_BUDGET;
+      expect(
+        wordCount,
+        `skills/${name}/SKILL.md has ${wordCount} words (limit ${limit})`,
+      ).toBeLessThan(limit);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Masterplan workstream A1/A2 (wave 2 of the single-release program; sequencing update included). The documented skill section template existed in `skill-architecture.md` but was never enforced — 6 of 19 sub-skills had structurally drifted.

- **Template v2** (`docs/reference/skill-architecture.md`): canonical H2 order (`Scope → Bootstrap (once per session) → Relay Contract → [domain] → Flow → [domain] → Error Handling → Output Format → Safety → Guardrails? → References?`), exactly two declared Bootstrap deviations (onboarding, fallback), `Relay Contract` required in 18 of 19 (onboarding exempt as the diagnostics skill), `Guardrails` officially optional (reality: 9/19), forbidden legacy headings, App-terminology prose rule, bounded portability rule.
- **New linter** `tests/skills/skill-template-contract.test.ts` (11 tests): frontmatter spec (name=dirname, lowercase-hyphen, ≤56 chars for `ha-nova-` namespacing headroom, description ≤1024, allowed-keys whitelist), section presence per class, canonical relative order, Error-Handling-before-Output-Format, forbidden heading variants, output-rules pointer as Output Format's first line, App terminology (fences/inline code stripped), check-code leak allowlist, fallback discovery-time write-gate description pin. Absorbs the English-only and word-budget tests from `ha-nova-contract.test.ts` with **dynamic globbing** (hardcoded lists silently exempted new skills). Word budgets recalibrated with documented ratchets (write/review drop again after the A5 token diet).
- **Normalization** (content preserved, headings/positions canonicalized): `entity-discovery`/`service-call`/`fallback` (Output Rules → Output Format at canonical position), `fallback` (Safety Baseline + Safety Guardrails → one `## Safety`, Agent Flow → Flow, Error Handling repositioned), `scene` (exact heading), `write` (+compact Relay Contract), `review` (Relay Contract split out of Bootstrap; Target Resolution + Bulk Mode Gate promoted to H2; minimal `## Safety` added — it had none), `backup` (4 prose add-on → App; code literals untouched).
- **Masterplan sequencing** updated to the maintainer decision (2026-07-11): all waves land on main, ONE release at the very end.

## Verification
- New linter green on first full run after normalization (11/11) — no KNOWN_DRIFT map needed.
- Full suite: 70 files / 635 tests green (was 69/626: −2 migrated, +11 new). `tsc --noEmit` clean under `noUncheckedIndexedAccess`.
- No stale cross-references to renamed sections (repo-wide grep for the forbidden variants).

## Risks
- Pure structure/docs/tests — no runtime code. Skill CONTENT moves but does not change semantically; the one addition is review's minimal Safety section.
- Existing positive content pins (e.g. backup's `include_all_addons` code literal, fallback's "Settings > Apps") verified untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UABh9QxzyCg8JhostzVUF