### PR TITLE
feat(skills): explicit execution modes for resolve/apply agent templates

### DIFF
--- a/skills/ha-nova/agents/apply-agent.md
+++ b/skills/ha-nova/agents/apply-agent.md
@@ -2,6 +2,15 @@
 
 Purpose: autonomous apply + verify phase after user confirmation.
 
+## Execution Mode
+
+This template runs in one of two modes:
+
+- **Dispatched**: you are a sub-agent. The sections under "Output Format (Structured Text)" are your literal return contract to the main thread.
+- **INLINE** (no sub-agent dispatch available): the caller executes the Execution Steps directly. `{PLACEHOLDER}` values are the values already confirmed in the conversation; "Output Format (Structured Text)" is an internal completeness checklist, never user-facing output. In INLINE mode "the main thread" is you: proceed only if you yourself showed the exact preview and received the user's confirmation for this operation, target, and payload.
+
+Hard Scope binds identically in both modes.
+
 ## Runtime Inputs
 
 - `{DOMAIN}`: `automation` or `script`

--- a/skills/ha-nova/agents/resolve-agent.md
+++ b/skills/ha-nova/agents/resolve-agent.md
@@ -2,6 +2,15 @@
 
 Purpose: autonomous resolve phase for HA NOVA writes.
 
+## Execution Mode
+
+This template runs in one of two modes:
+
+- **Dispatched**: you are a sub-agent. The sections under "Output Format (Structured Text)" are your literal return contract to the main thread.
+- **INLINE** (no sub-agent dispatch available): the caller executes the Execution Steps directly. `{PLACEHOLDER}` values are the values already resolved in the conversation; "Output Format (Structured Text)" is an internal completeness checklist, never user-facing output.
+
+Hard Scope binds identically in both modes.
+
 ## Runtime Inputs
 
 - `{DOMAIN}`: `automation` or `script`


### PR DESCRIPTION
## Summary
Masterplan A4 (wave 2). The write skill's agent templates assume an orchestration model: `{PLACEHOLDER}` fill-ins and fixed structured-text return contracts (`RESOLVED_ENTITIES:`, `VERIFICATION:` ...). write says "if agent dispatch unavailable, execute inline", but the templates read as if a second agent always exists — a single-threaded client (Codex/OpenCode/Antigravity/Hermes) could misread the return contract as literal user-facing output.

Both templates now open with an `## Execution Mode` section directly after Purpose:
- **Dispatched**: structured sections are the literal return contract to the main thread.
- **INLINE**: the caller executes the steps itself; placeholders are the already-resolved values; the structured sections are an internal completeness checklist, never user-facing output. apply-agent additionally clarifies that in INLINE mode "the main thread" is the caller, which must have shown the exact preview and received the user's confirmation itself.
- Hard Scope binds identically in both modes.

## Verification
- All 19 skill contract test files green; full pre-push suite (typecheck, 635 tests, build, docs fact-check) green.

## Risks
- Additive only (2 files, +18 lines); no flow, scope, or safety semantics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UABh9QxzyCg8JhostzVUF