### PR TITLE
feat(skills): bootstrap-independent Safety Core in every sub-skill

### DIFF
--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -401,6 +401,29 @@ Scope → Bootstrap (once per session) → Relay Contract → [domain] → Flow 
 
 **The context skill (`ha-nova/SKILL.md`) is exempt** from the sub-skill template: it is a router, not an operation skill. Its required anchors stay pinned by `tests/skills/ha-nova-contract.test.ts`.
 
+### Safety Core (canonical text)
+
+Every mutation-capable sub-skill opens its `## Safety` section with this block, byte-identical (linter-enforced; the linter extracts this fenced block as the SSOT). It carries the bootstrap-independent guarantees — preview binding, delete tokenization, and the fallback write gate — so a bare agent that never auto-loads the context skill still gets them:
+
+```text
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+```
+
+Read-only sub-skills open `## Safety` with this block instead:
+
+```text
+- Read-only skill: never issue mutating relay or service calls.
+- For write intent, hand off to the owning skill; unfamiliar writes go through `ha-nova:fallback` first.
+```
+
+Skill-specific safety bullets follow the core block; bullets that merely restate a core line are removed, domain nuances (confirmation tiering, no-revert notes, session-cleanup rules) stay.
+
 ## Post-Write Review Standard
 
 Unified spec for post-write review. Both `write` and `helper` skills reference this.

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -424,6 +424,8 @@ Read-only sub-skills open `## Safety` with this block instead:
 
 Skill-specific safety bullets follow the core block; bullets that merely restate a core line are removed, domain nuances (confirmation tiering, no-revert notes, session-cleanup rules) stay.
 
+A skill may declare an explicit, named exception to a single core bullet directly below the core block — it must reference the core rule it narrows ("Declared exception to the core ... rule above") so a bare agent never sees two contradicting instructions. Current declared exceptions: `todo` item removes (`todo.remove_item`, `todo.remove_completed_items`) stay at natural preview confirmation; list deletion keeps the typed token.
+
 ## Post-Write Review Standard
 
 Unified spec for post-write review. Both `write` and `helper` skills reference this.

--- a/skills/backup/SKILL.md
+++ b/skills/backup/SKILL.md
@@ -83,6 +83,14 @@ Use stable localized slot labels in this order; omit empty slots. Dates are ISO 
 
 ## Safety
 
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 - Create uses natural confirmation; delete uses exact token confirmation only.
 - Restore is never executed here — it reboots the system; always route to the HA UI.
 - A backup is only real once it appears completed in Status — initiation is not success.

--- a/skills/calendar/SKILL.md
+++ b/skills/calendar/SKILL.md
@@ -65,6 +65,9 @@ For multiple calendars, group by calendar and keep each group short.
 
 ## Safety
 
+- Read-only skill: never issue mutating relay or service calls.
+- For write intent, hand off to the owning skill; unfamiliar writes go through `ha-nova:fallback` first.
+
 - Read-only skill. No event writes.
 - Always use bounded windows.
 - Never guess a calendar id from a partial name when multiple matches exist.

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -146,8 +146,15 @@ Do not dump the full dashboard JSON/YAML by default.
 
 ## Safety
 
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 - No guessed `url_path` or `dashboard_id` values.
-- Create/update uses natural confirmation after preview, bound to the exact displayed payload/diff (see context skill → Active Preview Confirmation).
 - Dashboard/resource/card delete uses exact token confirmation only, even for items created earlier in the same session. Dashboard writes have no `revert`; the recovery path is Home Assistant Backups.
 - If the change needs a broad re-layout instead of a targeted edit, say so before writing.
 

--- a/skills/energy/SKILL.md
+++ b/skills/energy/SKILL.md
@@ -80,6 +80,14 @@ Use stable localized slot labels in this order; omit empty slots. Rankings as co
 
 ## Safety
 
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 - Config writes: preview + confirmation per save (natural for single edits; typed token for empty/wholesale-replace saves — step 5); verify by read-back + validate.
 - No update-revert — recovery is a corrective save or HA Backups (see `skills/ha-nova/write-safety.md`).
 - Analysis flows are strictly read-only; never call `save_prefs` while answering an analysis question.

--- a/skills/entity-discovery/SKILL.md
+++ b/skills/entity-discovery/SKILL.md
@@ -141,6 +141,9 @@ Return the Step 4 shortlist shape; never dump raw `get_states` output.
 
 ## Safety
 
+- Read-only skill: never issue mutating relay or service calls.
+- For write intent, hand off to the owning skill; unfamiliar writes go through `ha-nova:fallback` first.
+
 - Read-only — this skill never modifies Home Assistant state or config.
 - No `POST`, `PUT`, `PATCH`, or `DELETE` relay writes.
 - All communication with Home Assistant goes through `ha-nova relay` exclusively.

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -245,6 +245,14 @@ Every experimental call result names the tier (Relay-Ready / Roadmap / External)
 
 ## Safety
 
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 Premise handling:
 - Correct invalid Home Assistant premises explicitly.
 - Do not silently compensate for a wrong premise.
@@ -252,7 +260,6 @@ Premise handling:
 
 Rules for all experimental relay calls in this skill:
 
-- Always preview the full payload before execution
 - Read before write: fetch current state first for any destructive operation
 - **Full-document overwrites** (e.g., `lovelace/config/save`): MUST read full config, merge changes in memory, preview merged result, then write. There is no partial update endpoint — the entire config is replaced. After the write, read the document back and verify both the intended change and the survival of unrelated content (views, cards, sources) before reporting success.
 - **Field-level list replacements** (e.g., `energy/save_prefs`): omitted top-level keys are preserved, but each provided key replaces its entire list. To add one item, read the existing list first, append, then save back the full list. After the write, read the prefs back and verify the pre-existing list items survived alongside the new one.
@@ -260,9 +267,6 @@ Rules for all experimental relay calls in this skill:
 - Every experimental call must show: "EXPERIMENTAL: No dedicated subskill schema guardrails. Proceed with caution."
 - **No diff or auto-undo here**: these writes have no `## Changes` preview or `revert`. When a write may be hard to reverse, say so plainly and point to Home Assistant Backups (Settings > System > Backups) as the safety net before confirming.
 - One resource at a time (no batch writes)
-- Delete requires tokenized confirmation (`confirm:<token>`)
-- Broad pre-preview approval is never write confirmation; changed payloads require a fresh preview and confirmation.
-- Never guess IDs: resolve via list/search first
 - Experimental results may be unexpected — verify data-target match before presenting conclusions (see `skills/ha-nova/SKILL.md` → Claim-Evidence Binding)
 
 ### Write Safety by Endpoint Type

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -118,6 +118,9 @@ Choose one safe `Next step`:
 
 ## Safety
 
+- Read-only skill: never issue mutating relay or service calls.
+- For write intent, hand off to the owning skill; unfamiliar writes go through `ha-nova:fallback` first.
+
 - Read-only skill. No writes.
 - Never call repair/fix/ignore/delete issue commands.
 - Never restart/reload Home Assistant from this skill.

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -465,12 +465,17 @@ Never show raw JSON to the user.
 
 ## Safety
 
-- Preview before every write
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 - No guessing entity IDs, linked entities, or config entry IDs; resolve or ask
 - `entry_id` is the canonical write identity for the config-entry family
-- Delete requires tokenized confirmation
 - Destructive cleanup still requires `confirm:<token>`, even for helpers created earlier in the same session.
-- All HA communication through `ha-nova relay` only
 - Every write MUST end with the Post-Write Review slot; use terminal-friendly labels where Markdown headings add noise.
 
 ## Guardrails

--- a/skills/history/SKILL.md
+++ b/skills/history/SKILL.md
@@ -87,6 +87,9 @@ Keep default output compact. Raw payload dumps are opt-in only.
 
 ## Safety
 
+- Read-only skill: never issue mutating relay or service calls.
+- For write intent, hand off to the owning skill; unfamiliar writes go through `ha-nova:fallback` first.
+
 - Read-only skill. No writes.
 - No guessed entity ids.
 - If more than one entity could match, ask one blocking question.

--- a/skills/maintenance/SKILL.md
+++ b/skills/maintenance/SKILL.md
@@ -76,6 +76,14 @@ Use stable localized slot labels in this order; omit empty slots. Grouped counts
 
 ## Safety
 
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 - Every write: preview → confirmation → per-item verification. Clear/purge/registry remove take the typed token; the reversible spike adjustment and unit relabel take payload-bound natural confirmation — offer the spike rollback.
 - Backup gate: before clearing statistics in bulk, purging with low keep_days, repack, or bulk registry removal, check for a recent backup via `ha-nova:backup` (proportional — never for a single small fix).
 - Never remove an entity that is merely offline; when in doubt, report instead of removing.

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -49,6 +49,9 @@ On success, keep the response to the status line only. Do not dump raw relay out
 
 ## Safety
 
+- Read-only skill: never issue mutating relay or service calls.
+- For write intent, hand off to the owning skill; unfamiliar writes go through `ha-nova:fallback` first.
+
 - Diagnostics only — this skill never modifies Home Assistant state, config, or relay settings.
 - Never ask the user to paste tokens or secrets in chat.
 - All communication with Home Assistant goes through `ha-nova relay` exclusively.

--- a/skills/organize/SKILL.md
+++ b/skills/organize/SKILL.md
@@ -114,8 +114,14 @@ Default to a compact field summary, not raw registry JSON.
 
 ## Safety
 
-- Never guess ids.
-- Create/update uses natural confirmation after preview, bound to the exact displayed payload (see context skill → Active Preview Confirmation).
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 - Delete uses token confirmation only, even for cleanup of items created earlier in the same session.
 - If the user asks for entity removal, stop and hand off to `ha-nova:maintenance` (dead registry entries only — for live entities offer disable here instead). For device category assignment or config-entry detachment, hand off to `ha-nova:fallback`.
 

--- a/skills/read/SKILL.md
+++ b/skills/read/SKILL.md
@@ -214,5 +214,8 @@ Manual relay path:
 
 ## Safety
 
+- Read-only skill: never issue mutating relay or service calls.
+- For write intent, hand off to the owning skill; unfamiliar writes go through `ha-nova:fallback` first.
+
 - never guess ids
 - if multiple close matches, ask one selection question

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -490,9 +490,16 @@ For resolved targets `> 1`, return exactly these 6 sections:
 
 ## Safety
 
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 - Read-only analysis: no config writes through the relay (see Scope for the single Quick-Fix exception).
 - The Quick-Fix service call requires confirmation bound to its exact preview; bulk mode disables it entirely.
-- Never guess entity or config IDs; resolve or ask.
 
 ## Guardrails
 

--- a/skills/scene/SKILL.md
+++ b/skills/scene/SKILL.md
@@ -118,8 +118,15 @@ Use stable localized slot labels in this order; omit empty slots.
 
 ## Safety
 
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 - Create/update use natural confirmation after preview; delete uses exact token confirmation only, even for scenes created earlier in the same session.
 - Scene writes have no `revert`; the recovery path is Home Assistant Backups — say so before destructive operations.
-- Never guess ids or entity_ids; resolve via registry first.
 - One scene per mutation; verify read-back, not just the save response.
 - Activation hands off to `ha-nova:service-call` — `scene.turn_on` supports `transition` (lights only); `scene.apply` applies a one-off state set without storing a scene.

--- a/skills/service-call/SKILL.md
+++ b/skills/service-call/SKILL.md
@@ -124,8 +124,14 @@ Report the executed service, its target, and the verified state change (or the d
 
 ## Safety
 
-- Preview every service call before execution.
-- Never guess entity IDs; resolve or ask.
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 - No token confirmation needed for ordinary service calls; confirmation is still bound to the active preview.
 - For potentially disruptive services (e.g., `homeassistant.restart`), warn and ask for explicit post-preview confirmation.
 

--- a/skills/todo/SKILL.md
+++ b/skills/todo/SKILL.md
@@ -114,6 +114,14 @@ Use stable localized slot labels in this order; omit empty slots. Present items 
 
 ## Safety
 
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 - Item writes use natural confirmation after a compact preview; list deletion uses exact token confirmation only. Item removes are re-addable data edits, deliberately below the destructive token tier.
 - Item operations have no `revert`; removed items are gone — bulk removals list what will be removed in the preview.
 - Never guess uids or entry_ids; resolve via Read items / registry first.

--- a/skills/todo/SKILL.md
+++ b/skills/todo/SKILL.md
@@ -122,7 +122,7 @@ Use stable localized slot labels in this order; omit empty slots. Present items 
 - Home Assistant is reached exclusively through `ha-nova relay`.
 - For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
 
-- Item writes use natural confirmation after a compact preview; list deletion uses exact token confirmation only. Item removes are re-addable data edits, deliberately below the destructive token tier.
+- Declared exception to the core delete rule above: item removes (`todo.remove_item`, `todo.remove_completed_items`) are re-addable data edits, deliberately below the destructive token tier — they use natural confirmation bound to the compact preview. List deletion stays at the typed token.
 - Item operations have no `revert`; removed items are gone — bulk removals list what will be removed in the preview.
 - Never guess uids or entry_ids; resolve via Read items / registry first.
 - One list per mutation; verify by reading back, not by service success alone.

--- a/skills/updates/SKILL.md
+++ b/skills/updates/SKILL.md
@@ -91,6 +91,14 @@ Use stable localized slot labels in this order; omit empty slots. Group counts +
 
 ## Safety
 
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 - Installs: natural confirmation per update after preview; batches need an explicitly confirmed plan.
 - Updates are effectively irreversible — for core/OS name the safety-backup offer before, not after.
 - Never install anything the user did not ask about or confirm; `auto_update: true` items update themselves — say so instead of installing them unprompted; an explicit, confirmed user request may still install.

--- a/skills/write/SKILL.md
+++ b/skills/write/SKILL.md
@@ -112,9 +112,14 @@ See `skills/ha-nova/SKILL.md` → Response Format.
 
 ## Safety
 
-- Preview before every write
-- No guessing entity_ids; resolve or ask
-- Delete requires tokenized confirmation
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
 - Destructive cleanup still requires `confirm:<token>`, even for items created earlier in the same session.
 - Agents must use Relay only; no MCP, no direct HA API
 - Every write MUST end with the Post-Write Review slot; use terminal-friendly labels where Markdown headings add noise.

--- a/tests/skills/ha-safety-contract.test.ts
+++ b/tests/skills/ha-safety-contract.test.ts
@@ -11,7 +11,9 @@ describe("ha safety contract", () => {
     expect(router).toContain("create`/`update`: natural confirmation");
     expect(router).toContain("token confirmation `confirm:<token>`");
     expect(writeSkill).toContain("Confirmation: create/update=natural, delete=tokenized `confirm:<token>`");
-    expect(writeSkill).toContain("No guessing entity_ids; resolve or ask");
+    // Safety Core wording (A3): the no-guessing rule now arrives via the
+    // byte-identical core block in every mutation-capable skill.
+    expect(writeSkill).toContain("Never guess entity, service, or config IDs — resolve them or ask.");
   });
 
   it("rejects pre-preview blanket approval for live writes", () => {
@@ -43,7 +45,13 @@ describe("ha safety contract", () => {
       "skills/write/SKILL.md",
       "skills/helper/SKILL.md",
       "skills/dashboard/SKILL.md",
+      "skills/scene/SKILL.md",
       "skills/organize/SKILL.md",
+      "skills/todo/SKILL.md",
+      "skills/backup/SKILL.md",
+      "skills/updates/SKILL.md",
+      "skills/energy/SKILL.md",
+      "skills/maintenance/SKILL.md",
       "skills/service-call/SKILL.md",
       "skills/review/SKILL.md",
       "skills/fallback/SKILL.md",

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -59,19 +59,56 @@ const FORBIDDEN_HEADINGS = [
   "Agent Flow",
 ];
 
-// Word budgets: default 1000. Documented ratchets for content-dense skills;
-// write and review drop again after the masterplan A5 token diet (References
-// split / checks.md self-containment).
+const MUTATION_SKILLS = new Set([
+  "write",
+  "helper",
+  "dashboard",
+  "scene",
+  "organize",
+  "todo",
+  "backup",
+  "updates",
+  "energy",
+  "maintenance",
+  "service-call",
+  "fallback",
+  "review",
+]);
+const READ_ONLY_SKILLS = new Set([
+  "read",
+  "entity-discovery",
+  "history",
+  "health",
+  "calendar",
+  "onboarding",
+]);
+
+// SSOT: the fenced blocks in skill-architecture.md → "Safety Core (canonical text)".
+const SAFETY_CORE_BLOCKS = ((): { mutation: string; readOnly: string } => {
+  const doc = readFileSync("docs/reference/skill-architecture.md", "utf8");
+  const section = doc.split("### Safety Core (canonical text)")[1] ?? "";
+  const fenced = [...section.matchAll(/```text\n([\s\S]*?)```/g)].map((m) =>
+    (m[1] ?? "").trimEnd(),
+  );
+  return { mutation: fenced[0] ?? "", readOnly: fenced[1] ?? "" };
+})();
+
+// Word budgets: default 1150 (every sub-skill carries the mandatory ~100-word
+// Safety Core plus the output-rules pointer). Documented ratchets for
+// content-dense skills; write and review drop again after the masterplan A5
+// token diet (References split / checks.md self-containment).
 const WORD_BUDGETS: Record<string, number> = {
-  write: 1200,
-  scene: 1250,
-  "service-call": 1100,
-  health: 1150,
+  write: 1350,
+  scene: 1350,
+  "service-call": 1200,
+  todo: 1200,
+  updates: 1200,
+  maintenance: 1200,
   fallback: 2050,
   helper: 3600,
   review: 4800,
 };
-const DEFAULT_WORD_BUDGET = 1000;
+const DEFAULT_WORD_BUDGET = 1150;
 
 // Internal review-check codes (S-01, R-18, H-09, ...) may flow only between
 // the reviewer/mutation files that implement the dedup logic; user-flow
@@ -224,6 +261,43 @@ describe("skill template v2 contract", () => {
         bootstrapVariants,
         `${name}: Bootstrap heading must be exactly '## ${expected}'`,
       ).toEqual([expected]);
+    }
+  });
+
+  it("covers every sub-skill by exactly one safety class", () => {
+    for (const name of SUBSKILLS) {
+      expect(
+        MUTATION_SKILLS.has(name) !== READ_ONLY_SKILLS.has(name),
+        `${name}: must be in exactly one of MUTATION_SKILLS / READ_ONLY_SKILLS`,
+      ).toBe(true);
+    }
+  });
+
+  it("opens every mutation-capable Safety section with the canonical Safety Core", () => {
+    expect(SAFETY_CORE_BLOCKS.mutation, "SSOT block missing in skill-architecture.md").toContain(
+      "Preview before write",
+    );
+    for (const name of SUBSKILLS) {
+      if (!MUTATION_SKILLS.has(name)) continue;
+      const body = sectionBody(readFileSync(subskillPath(name), "utf8"), "Safety");
+      expect(
+        body.trimStart().startsWith(SAFETY_CORE_BLOCKS.mutation),
+        `${name}: ## Safety must open with the byte-identical Safety Core (SSOT: skill-architecture.md)`,
+      ).toBe(true);
+    }
+  });
+
+  it("opens every read-only Safety section with the canonical read-only core", () => {
+    expect(SAFETY_CORE_BLOCKS.readOnly, "SSOT block missing in skill-architecture.md").toContain(
+      "Read-only skill",
+    );
+    for (const name of SUBSKILLS) {
+      if (!READ_ONLY_SKILLS.has(name)) continue;
+      const body = sectionBody(readFileSync(subskillPath(name), "utf8"), "Safety");
+      expect(
+        body.trimStart().startsWith(SAFETY_CORE_BLOCKS.readOnly),
+        `${name}: ## Safety must open with the byte-identical read-only core (SSOT: skill-architecture.md)`,
+      ).toBe(true);
     }
   });
 


### PR DESCRIPTION
## Summary
Masterplan A3 (wave 2). The mandatory Write Routing Gate, active-preview confirmation binding, and delete tokenization lived ONLY in the auto-loaded context skill — a bare agent that discovers a sub-skill directly (Codex/OpenCode/Antigravity flat installs, Hermes) silently lost all three guarantees.

- **Safety Core**: every mutation-capable sub-skill (13) opens `## Safety` with a canonical 7-bullet block, byte-identical: preview-before-write, confirmation binding + expiry (carries the "Active Preview Confirmation" pointer), pre-preview phrases = drafting only, typed `confirm:<token>` verbatim, never guess IDs, relay-only access, **STOP → `ha-nova:fallback` before any uncovered write**.
- **Read-only core**: the 6 read-only skills open `## Safety` with a 2-line block (never mutate; write intent hands off via owning skill/fallback).
- **SSOT**: fenced blocks in `skill-architecture.md` → "Safety Core (canonical text)"; the linter extracts them at test time and asserts byte-identical containment — future wording changes are one mechanical PR, drift is impossible.
- **Dedupe**: per-skill bullets that merely restated a core line removed (write/helper/dashboard/scene/organize/service-call/fallback/review); domain nuances kept (todo's deliberate below-token item-remove tier, backup/updates/energy/maintenance confirmation tiering, no-revert notes, session-cleanup rules).
- `ha-safety-contract.test.ts`: mutationDocs extended 7 → 13 (scene/todo/backup/updates/energy/maintenance now also pinned to "Active Preview Confirmation"); write's no-guessing pin moved to the core wording.
- Word budgets recalibrated: default 1000 → 1150 (every skill now carries the mandatory ~100-word core); dense-skill ratchets documented; write/review drop again after the A5 token diet.

## Verification
- Linter extended by 3 tests (class partition completeness, mutation core verbatim, read-only core verbatim): 14/14 green.
- All 20 skill test files / 253 tests green; `tsc --noEmit` clean; full pre-push suite green.
- Installer portability was verified in the masterplan audit: both skill rewriters (`cli/client_antigravity.go` rewriteFlatMarkdown, `scripts/onboarding/install-local-skills.sh`) transform embedded text (backticked refs, `ha-nova:` names) correctly on flat installs.

## Risks
- +~100 words per skill loaded — accepted; A5 (References split, checks.md self-containment) recovers far more on the heavy paths.
- Safety Core wording changes now touch 13 files + SSOT — deliberate: the linter makes it one mechanical PR instead of silent drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UABh9QxzyCg8JhostzVUF