### PR TITLE
feat(skills): token diet — self-contained checks catalog, lazy references, revert split

### DIFF
--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -432,7 +432,7 @@ Unified spec for post-write review. Both `write` and `helper` skills reference t
 
 After any mutation (automation, script, or helper):
 1. Re-read written config via relay
-2. Enter via `skills/review/SKILL.md` Step 1 and load the detailed checks from `skills/review/checks.md`:
+2. Apply `skills/review/checks.md` → Application (family matrix + evidence boundaries):
    - **Automations:** S + R + P + M checks. If actions reference helpers, also H checks on those helpers.
    - **Scripts:** S + R + P + M + F checks. If actions reference helpers, also H checks.
    - **Helpers:**
@@ -469,9 +469,9 @@ When creating a new skill under `skills/{name}/SKILL.md`:
 
 ## Review Check Single Source of Truth
 
-`skills/review/SKILL.md` is the stable review entrypoint.
-`skills/review/checks.md` is the authoritative source for the detailed review catalog (S/R/P/M/F/H).
-There is deliberately no review agent template: `write` and `helper` run their post-write review inline against `skills/review/SKILL.md` and `skills/review/checks.md` instead of duplicating checks in a separate template.
+`skills/review/SKILL.md` is the stable review entrypoint for standalone reviews (workflow, output shape, collision/conflict analysis).
+`skills/review/checks.md` is the authoritative, self-contained source for the detailed review catalog (S/R/P/M/F/H) plus its `## Application` section (family matrix, evidence boundaries, live-helper evidence).
+There is deliberately no review agent template: `write` and `helper` run their post-write review inline against `skills/review/checks.md` only — they no longer load the standalone review workflow.
 When adding or modifying checks, update `skills/review/checks.md` first and keep `skills/review/SKILL.md` aligned as the facade/workflow file.
 
 ## Review Check Taxonomy

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -2,11 +2,11 @@
 
 Single source of truth for Relay calls used by HA NOVA skills.
 
-## Auth
+## Auth & Transport
 
-- Header: `Authorization: Bearer $RELAY_AUTH_TOKEN`
-- Header: `Content-Type: application/json`
-- Base URL: `RELAY_BASE_URL`
+Transport, auth headers, and the base URL are handled internally by the `ha-nova relay` CLI wrapper — the relay token lives in the OS credential store. Never set, request, export, or ask the user for `RELAY_AUTH_TOKEN` or `RELAY_BASE_URL`. If a relay call fails, run `ha-nova relay health`; if that fails, have the user run `ha-nova setup`.
+
+Underlying HTTP contract (reference only, not for direct use): `Authorization: Bearer <relay token>` and `Content-Type: application/json` against the relay base URL.
 
 ## Endpoints
 

--- a/skills/ha-nova/update-revert.md
+++ b/skills/ha-nova/update-revert.md
@@ -1,6 +1,7 @@
 # HA NOVA Update-Revert Execution
 
-Load this file only when the user actually asks to `revert` an update.
+Load this file whenever the user asks to revert, undo, or restore a verified
+update — any of those intents, not only the literal word `revert`.
 Snapshot capture and the revert offer live in `skills/ha-nova/write-safety.md`
 → Update-Revert; this file owns the execution.
 

--- a/skills/ha-nova/update-revert.md
+++ b/skills/ha-nova/update-revert.md
@@ -1,0 +1,53 @@
+# HA NOVA Update-Revert Execution
+
+Load this file only when the user actually asks to `revert` an update.
+Snapshot capture and the revert offer live in `skills/ha-nova/write-safety.md`
+→ Update-Revert; this file owns the execution.
+
+## Execute `revert`
+
+1. Run `ha-nova snapshot show` — the **only** source of `before_config`. Never
+   reconstruct the previous config from memory or context. The bare command
+   returns the newest update; for an earlier target in a multi-target change,
+   select it: `ha-nova snapshot show --target <target_id>` (add
+   `--domain <domain>` if the same id exists in both domains). `ha-nova
+   snapshot show --list` lists what is still revertible (newest first).
+2. Re-read the current live config of `target_id` (same read-back path as
+   Phase 4) into a file.
+3. Drift check — MUST carry the same `--target`/`--domain` selection as
+   step 1 (a bare `verify` compares against the NEWEST snapshot and would
+   drift-check an earlier target against the wrong `expected_after`):
+
+   ```text
+   ha-nova snapshot verify --target <target_id> --against <live-file>
+   ```
+
+   Only when reverting the newest update may the `--target` flag be omitted.
+
+   - `match` (exit 0) → the config is still exactly as written; safe to restore.
+   - `drift` (exit 2) → it changed since the write (e.g. an external UI edit).
+     Do NOT overwrite blindly. Show what differs and ask the user how to proceed.
+4. On `match`, restore the `before_config` from step 1 through the skill's own
+   write path, then verify it like any other write:
+   - `ha-nova:write` (automation/script): run the apply phase with
+     `OPERATION=update`, `TARGET_ID=<target_id>`, `PAYLOAD=before_config`.
+   - `ha-nova:helper` storage family: rebuild a schema-valid `{type}/update`
+     payload from `before_config` — set `{type}_id` from its stored `id` and
+     include only writable update fields (drop read-only `id`/`entity_id`; see
+     `skills/ha-nova/helper-schemas.md` → Common Rules). Sending the raw
+     `before_config` list item fails: it lacks the required `{type}_id`. Re-issue
+     that `{type}/update` WS call, then re-read the list item to confirm.
+   - `ha-nova:helper` config-entry family: no auto-revert (options-flow writes
+     are multi-step) — point to HA Backups.
+
+Use `ha-nova snapshot show` to read the stored record (including
+`before_config`) back when you need it.
+
+## Honesty
+
+- The store holds the last 5 updated targets; older entries are gone, and a
+  re-update of a target replaces that target's snapshot (one step back per
+  target, never two).
+- `revert` restores the captured config through the normal write path; it does
+  not replay HA's exact byte-for-byte formatting. For a guaranteed point-in-time
+  restore, Home Assistant Backups is the source of truth.

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -235,51 +235,11 @@ rollback option in the same breath — never a bare "undo":
 
 ### 3. Execute `revert`
 
-1. Run `ha-nova snapshot show` — the **only** source of `before_config`. Never
-   reconstruct the previous config from memory or context. The bare command
-   returns the newest update; for an earlier target in a multi-target change,
-   select it: `ha-nova snapshot show --target <target_id>` (add
-   `--domain <domain>` if the same id exists in both domains). `ha-nova
-   snapshot show --list` lists what is still revertible (newest first).
-2. Re-read the current live config of `target_id` (same read-back path as
-   Phase 4) into a file.
-3. Drift check — MUST carry the same `--target`/`--domain` selection as
-   step 1 (a bare `verify` compares against the NEWEST snapshot and would
-   drift-check an earlier target against the wrong `expected_after`):
-
-   ```text
-   ha-nova snapshot verify --target <target_id> --against <live-file>
-   ```
-
-   Only when reverting the newest update may the `--target` flag be omitted.
-
-   - `match` (exit 0) → the config is still exactly as written; safe to restore.
-   - `drift` (exit 2) → it changed since the write (e.g. an external UI edit).
-     Do NOT overwrite blindly. Show what differs and ask the user how to proceed.
-4. On `match`, restore the `before_config` from step 1 through the skill's own
-   write path, then verify it like any other write:
-   - `ha-nova:write` (automation/script): run the apply phase with
-     `OPERATION=update`, `TARGET_ID=<target_id>`, `PAYLOAD=before_config`.
-   - `ha-nova:helper` storage family: rebuild a schema-valid `{type}/update`
-     payload from `before_config` — set `{type}_id` from its stored `id` and
-     include only writable update fields (drop read-only `id`/`entity_id`; see
-     `skills/ha-nova/helper-schemas.md` → Common Rules). Sending the raw
-     `before_config` list item fails: it lacks the required `{type}_id`. Re-issue
-     that `{type}/update` WS call, then re-read the list item to confirm.
-   - `ha-nova:helper` config-entry family: no auto-revert (options-flow writes
-     are multi-step) — point to HA Backups.
-
-Use `ha-nova snapshot show` to read the stored record (including
-`before_config`) back when you need it.
-
-### Honesty
-
-- The store holds the last 5 updated targets; older entries are gone, and a
-  re-update of a target replaces that target's snapshot (one step back per
-  target, never two).
-- `revert` restores the captured config through the normal write path; it does
-  not replay HA's exact byte-for-byte formatting. For a guaranteed point-in-time
-  restore, Home Assistant Backups is the source of truth.
+Execution — `snapshot show` as the only `before_config` source, the
+`--target`/`--domain`-bound drift check, and the restore through the skill's
+own write path — lives in `skills/ha-nova/update-revert.md`. Load that file
+only when the user actually says `revert`; it also carries the honesty limits
+(5-target stack, one step back per target, no byte-exact formatting).
 
 ## Safety-Mechanism Availability by Skill
 

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -238,7 +238,8 @@ rollback option in the same breath — never a bare "undo":
 Execution — `snapshot show` as the only `before_config` source, the
 `--target`/`--domain`-bound drift check, and the restore through the skill's
 own write path — lives in `skills/ha-nova/update-revert.md`. Load that file
-only when the user actually says `revert`; it also carries the honesty limits
+whenever the user asks to revert, undo, or restore a verified update (any of
+those intents — not only the literal word `revert`); it also carries the honesty limits
 (5-target stack, one step back per target, no byte-exact formatting).
 
 ## Safety-Mechanism Availability by Skill

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -124,7 +124,7 @@ If 0 results: try synonyms or shorter stems. Never dump entire domains.
 
 1. Resolve target from `{type}/list` by `name` or internal `id`.
 2. Extract `id` from the list response (this is the `{type}_id` for the update command).
-3. Preview current vs proposed in the Changes slot with `ha-nova diff` (see `skills/ha-nova/write-safety.md` → Pre-Write Diff). Then run a pre-write impact check — `search/related` on this helper entity (see `skills/review/SKILL.md` Step 2, Collision Scan) — and surface affected automations/scripts as an advisory. Advisory only; never block. Include an explicit not-saved-yet line and Options block (`apply`, `show yaml`, `cancel`).
+3. Preview current vs proposed in the Changes slot with `ha-nova diff` (see `skills/ha-nova/write-safety.md` → Pre-Write Diff). Then run a pre-write impact check — `search/related` on this helper entity (max 3 related configs) — and surface affected automations/scripts as an advisory. Advisory only; never block. Include an explicit not-saved-yet line and Options block (`apply`, `show yaml`, `cancel`).
 4. Ask for natural confirmation bound to this exact preview (see context skill → Active Preview Confirmation).
 5. Execute:
    ```text
@@ -389,7 +389,7 @@ Do NOT report results to user until complete.
 
 #### Storage-based family
 
-1. Enter via `skills/review/SKILL.md` Step 1.
+1. Apply `skills/review/checks.md` → Application (storage family: H-01..H-10).
 2. Apply H-01..H-08 directly to the written helper config.
 3. Only evaluate H-09/H-10 if the collision scan finds a referencing automation/script with a direct helper-backed threshold and you also read live helper state per `skills/review/checks.md`.
 4. Collision scan: `search/related` for the helper entity, max 3 related automations/scripts.
@@ -491,4 +491,5 @@ Never show raw JSON to the user.
 - Relay API: `skills/ha-nova/relay-api.md`
 - Storage helper schemas: `skills/ha-nova/helper-schemas.md`
 - Config-entry helper schemas: `skills/ha-nova/helper-flow-schemas.md`
-- Review Checks: `skills/review/SKILL.md` (entrypoint) + `skills/review/checks.md` (storage helper catalog)
+- Review Checks: `skills/review/checks.md` (self-contained catalog + Application)
+- On demand: `skills/ha-nova/update-revert.md` — only when the user actually says `revert`

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -492,4 +492,4 @@ Never show raw JSON to the user.
 - Storage helper schemas: `skills/ha-nova/helper-schemas.md`
 - Config-entry helper schemas: `skills/ha-nova/helper-flow-schemas.md`
 - Review Checks: `skills/review/checks.md` (self-contained catalog + Application)
-- On demand: `skills/ha-nova/update-revert.md` — only when the user actually says `revert`
+- On demand: `skills/ha-nova/update-revert.md` — when the user asks to revert, undo, or restore a verified update

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -219,40 +219,9 @@ Traverse all `variables:` mappings in the config, not just the top-level block. 
 - Load `skills/review/checks.md` before evaluating findings.
 - `skills/review/SKILL.md` is the stable review entrypoint; `skills/review/checks.md` is the full rule catalog.
 
-**Check Taxonomy (internal only):**
-- Format: `{CATEGORY}-{NN}` (example: `H-09`)
-- Category letter = family
-- Severity is separate from the code
-- Codes are internal only; NEVER show them in any user-facing message (reports, chat replies, follow-up questions) — describe findings in plain language instead
-
-**Apply these families by domain:**
-- Automation: S-01..S-03, R-01..R-28, P-01..P-05, M-01..M-05
-- Script: automation families plus F-01..F-08
-- Helper (storage-based family): H-01..H-10
-- Helper (config-entry family): minimal config-entry review
-  - do not apply H-01..H-10
-  - confirm config-entry metadata is present
-  - inspect linked entities when available
-  - in Step 2, derive collision candidates from `linked_entities[]`, not from config actions
-  - run `search/related` on up to 3 linked entities
-  - say explicitly that config-entry helper review does not use the storage-helper H rules
-  - for the `template` domain, also read the linked entity's rendered state (`unavailable`/`unknown` is inconclusive, not proof of breakage — source state or an intentional sentinel); to apply the template-level reliability checks, open the options flow for the entry first (non-persisting readback — the canonical metadata item does not carry the `state` template)
-- If an automation or script references helpers in actions or direct thresholds, also apply H-01..H-10 to those helpers
-- R-17 is an intra-config branch comparison only. Never emit it from collision scan or cross-automation conflict analysis.
-- R-18 applies only to sibling-variable references within one `variables:` mapping. Never emit it for cross-action or cross-scope references, script `fields`, HA builtins, or `{% set %}` locals inside the same template.
-- For R-18 output, include the block context plus at least one concrete variable pair. For pasted YAML or draft configs, describe it as future write fragility. For HA read-back or post-write review, describe it as a persisted runtime risk.
-- R-19 applies only to Jinja2 chains with `if` plus at least one `elif`, entity-state-style branch guards, and a terminal bare `else` that contains a direct `trigger.id` comparison. Skip single `if` / `else`, `trigger.id` in `elif`, non-entity-state selector trees, `else` blocks with extra explicit guards, and `choose` + `condition: trigger`.
-- For R-19 output, state: final else branch is only reached when the earlier entity-state branches are false. Move the `trigger.id` check into an explicit `elif`. Or refactor to `choose` + `condition: trigger`.
-- R-23 applies only to boolean-like templates compared to string boolean literals (`'True'`, `'true'`, `'False'`, `'false'`) in either comparison direction. Do not flag bare boolean checks such as `is true` or `== true`.
-- R-24 is advisory only and applies only when a capacity-like variable reads an `available_energy` source. Do not hard-code integration-specific replacement entities.
-- R-25 applies only to pasted or draft YAML containing `platform: template` entity definitions (domain-level blocks or bare `!include`-file lists); configs read back from HA never carry this syntax. When it fires, fetch the HA version via `/api/config` on demand and phrase the finding version-sensitively (removed as of HA 2026.6; deprecated 2025.12–2026.5; still current earlier — see the R-25 Evidence Boundary in `skills/review/checks.md`).
-- M-05 is a modernize advisory for legacy automation keys (`platform:` in triggers, singular `trigger:`/`condition:`/`action:` blocks). Mention once, never as an error, never rewrite just to modernize.
-
-**Live helper evidence for H-09/H-10:**
-- See `skills/review/checks.md` → Helper Threshold Evidence
-- Read `/api/states/<helper_entity_id>` only when the threshold reference is direct
-- If `state`, `attributes.min`, `attributes.max`, or `attributes.step` are missing or non-numeric, skip H-09/H-10
-- Do not emit unrelated findings just because an H-09/H-10 signal matched
+**Apply the catalog:**
+- Load `skills/review/checks.md` and follow its `## Application` section — the family-by-domain matrix, the per-check evidence boundaries (R-17..R-25, M-05), and the live-helper evidence rules live there.
+- Codes stay internal (checks.md → Output Guardrail): never show them in user-facing output — describe findings in plain language instead.
 
 ### Step 2: Collision Scan
 

--- a/skills/review/checks.md
+++ b/skills/review/checks.md
@@ -2,7 +2,7 @@
 
 Canonical path: `skills/review/checks.md`
 
-Load this catalog from `skills/review/SKILL.md` Step 1 before evaluating findings.
+Self-contained catalog: load this file before evaluating findings — from `skills/review/SKILL.md` for standalone reviews, or directly from `skills/write/SKILL.md` / `skills/helper/SKILL.md` post-write phases.
 
 ## Output Guardrail (Critical)
 
@@ -18,6 +18,37 @@ Load this catalog from `skills/review/SKILL.md` Step 1 before evaluating finding
 - Number = running rule number within that family
 - Severity is separate from the code
 - Code visibility is governed by the Output Guardrail above
+
+## Application (family matrix + evidence boundaries)
+
+**Apply these families by domain:**
+- Automation: S-01..S-03, R-01..R-28, P-01..P-05, M-01..M-05
+- Script: automation families plus F-01..F-08
+- Helper (storage-based family): H-01..H-10
+- Helper (config-entry family): minimal config-entry review
+  - do not apply H-01..H-10
+  - confirm config-entry metadata is present
+  - inspect linked entities when available
+  - in Step 2, derive collision candidates from `linked_entities[]`, not from config actions
+  - run `search/related` on up to 3 linked entities
+  - say explicitly that config-entry helper review does not use the storage-helper H rules
+  - for the `template` domain, also read the linked entity's rendered state (`unavailable`/`unknown` is inconclusive, not proof of breakage — source state or an intentional sentinel); to apply the template-level reliability checks, open the options flow for the entry first (non-persisting readback — the canonical metadata item does not carry the `state` template)
+- If an automation or script references helpers in actions or direct thresholds, also apply H-01..H-10 to those helpers
+- R-17 is an intra-config branch comparison only. Never emit it from collision scan or cross-automation conflict analysis.
+- R-18 applies only to sibling-variable references within one `variables:` mapping. Never emit it for cross-action or cross-scope references, script `fields`, HA builtins, or `{% set %}` locals inside the same template.
+- For R-18 output, include the block context plus at least one concrete variable pair. For pasted YAML or draft configs, describe it as future write fragility. For HA read-back or post-write review, describe it as a persisted runtime risk.
+- R-19 applies only to Jinja2 chains with `if` plus at least one `elif`, entity-state-style branch guards, and a terminal bare `else` that contains a direct `trigger.id` comparison. Skip single `if` / `else`, `trigger.id` in `elif`, non-entity-state selector trees, `else` blocks with extra explicit guards, and `choose` + `condition: trigger`.
+- For R-19 output, state: final else branch is only reached when the earlier entity-state branches are false. Move the `trigger.id` check into an explicit `elif`. Or refactor to `choose` + `condition: trigger`.
+- R-23 applies only to boolean-like templates compared to string boolean literals (`'True'`, `'true'`, `'False'`, `'false'`) in either comparison direction. Do not flag bare boolean checks such as `is true` or `== true`.
+- R-24 is advisory only and applies only when a capacity-like variable reads an `available_energy` source. Do not hard-code integration-specific replacement entities.
+- R-25 applies only to pasted or draft YAML containing `platform: template` entity definitions (domain-level blocks or bare `!include`-file lists); configs read back from HA never carry this syntax. When it fires, fetch the HA version via `/api/config` on demand and phrase the finding version-sensitively (removed as of HA 2026.6; deprecated 2025.12–2026.5; still current earlier — see the R-25 Evidence Boundary in `skills/review/checks.md`).
+- M-05 is a modernize advisory for legacy automation keys (`platform:` in triggers, singular `trigger:`/`condition:`/`action:` blocks). Mention once, never as an error, never rewrite just to modernize.
+
+**Live helper evidence for H-09/H-10:**
+- See `skills/review/checks.md` → Helper Threshold Evidence
+- Read `/api/states/<helper_entity_id>` only when the threshold reference is direct
+- If `state`, `attributes.min`, `attributes.max`, or `attributes.step` are missing or non-numeric, skip H-09/H-10
+- Do not emit unrelated findings just because an H-09/H-10 signal matched
 
 ## Safety (Critical)
 

--- a/skills/write/SKILL.md
+++ b/skills/write/SKILL.md
@@ -140,4 +140,4 @@ On demand — read only when the trigger applies:
 - `skills/ha-nova/automation-patterns.md` — drafting new branching, timing, or flow-control logic
 - `skills/ha-nova/template-guidelines.md` — the draft contains Jinja templates
 - `skills/ha-nova/safe-refactoring.md` — rename, migrate, or orphan-cleanup tasks
-- `skills/ha-nova/update-revert.md` — the user actually says `revert`
+- `skills/ha-nova/update-revert.md` — the user asks to revert, undo, or restore a verified update (create cleanup and delete recovery stay out — see write-safety)

--- a/skills/write/SKILL.md
+++ b/skills/write/SKILL.md
@@ -47,7 +47,7 @@ Multi-target logical changes: present the plan first per `skills/ha-nova/write-s
 2. BP gate (`skills/ha-nova/write-safety.md`): fresh/stale+simple->continue, stale+complex->block.
 3. Suggestions + Pre-Write Checks (skip for `delete`):
    - **3a) Suggestions**: Show `suggested_enhancements` (max 4, numbered/menu). User accepts numbers or "skip" → merge accepted into config BEFORE preview. Skip when `SUGGESTED_ENHANCEMENTS: none`.
-   - **3b) Static Checks**: Use `skills/review/SKILL.md` Step 1 (Config Quality Review) plus `skills/review/checks.md`. Run S/R/P/M checks analytically on the draft YAML — no relay calls (scripts: F-01..F-08; helper refs: H-01..H-08. Defer H-09/H-10 to Phase 4).
+   - **3b) Static Checks**: Use `skills/review/checks.md` → Application (family matrix + evidence boundaries). Run S/R/P/M checks analytically on the draft YAML — no relay calls (scripts: F-01..F-08; helper refs: H-01..H-08. Defer H-09/H-10 to Phase 4).
      One pre-write verdict line before apply:
      - clean draft → localized equivalent of "Pre-write check: no issues worth flagging before save."
      - any flagged draft → localized equivalent of "Pre-write check: this draft may not behave as intended."
@@ -58,7 +58,7 @@ Multi-target logical changes: present the plan first per `skills/ha-nova/write-s
      - If R-23 matches: boolean-like template values are compared to string `"True"`/`"False"`; use the boolean directly or direct negation.
      - If R-24 matches: `available_energy` may be current charge, not capacity; ask user to verify maximum/nominal source. Never auto-rewrite integration-specific entity IDs.
      Track findings by check type for dedup in Phase 4, except R-18.
-   - **3c) Pre-Write Impact (update only)**: run `skills/review/SKILL.md` Step 2 (Collision Scan) `search/related`; show affected automations/scripts as advisory. Skip `create`/`delete`.
+   - **3c) Pre-Write Impact (update only)**: run `search/related` on the top target entities (max 3 related configs); show affected automations/scripts as advisory. Skip `create`/`delete`.
 4. Preview (see `skills/ha-nova/write-safety.md` for the fixed shape):
    - update: **run** `ha-nova diff` (prefer `--out <diff-file>`), print the diff output **verbatim** in the Changes slot — never write it yourself; state the behavioral effect in the summary sentence (write-safety → Behavior narrative). create: summary. Create/update previews show `apply`, `show yaml`, and `cancel` options.
    - Delete preview MUST include the consumer-check result before confirmation: either the affected consumers or an explicit no-consumer result.
@@ -91,7 +91,7 @@ Do NOT invoke `ha-nova:review` separately.
 2. S/R/P/M/F checks (narrowed):
    - Compare read-back vs draft as normalized objects, not raw JSON strings; key order is irrelevant. Ignore metadata (`id`,`unique_id`,`created_at`,`modified_at`,`editor`,`enabled`).
    - HA may normalize keys during write (`trigger`→`triggers`, `action`→`actions`, `condition`→`conditions`). Account for plural aliasing when comparing — these are not real diffs.
-   - Core fields differ beyond aliasing → full checks from `skills/review/SKILL.md` Step 1. If they match, skip covered checks but re-run storage-sensitive R-18 subset.
+   - Core fields differ beyond aliasing → full checks per `skills/review/checks.md` → Application. If they match, skip covered checks but re-run storage-sensitive R-18 subset.
    - **Dedup**: findings from Phase 2 Step 3b that the user saw MUST NOT repeat. Track by check type.
     - Exception: if R-18 still matches on persisted read-back config, report it again as a persisted runtime risk.
     - `R-19` follows normal dedup; R-23/R-24 do too. If already shown pre-write, do not repeat unless it becomes a new category.
@@ -131,6 +131,13 @@ See `skills/ha-nova/SKILL.md` → Response Format.
 
 ## References
 
-- Refs: `skills/ha-nova/relay-api.md`, `skills/ha-nova/payload-schemas.md`, `skills/ha-nova/best-practices.md`, `skills/ha-nova/automation-patterns.md`, `skills/ha-nova/template-guidelines.md`, `skills/ha-nova/safe-refactoring.md`, `skills/ha-nova/write-safety.md`
-- Agent refs: `skills/ha-nova/agents/resolve-agent.md`, `skills/ha-nova/agents/apply-agent.md`
-- Review refs: `skills/review/SKILL.md`, `skills/review/checks.md`, `docs/reference/skill-architecture.md`
+Always load:
+- `skills/ha-nova/relay-api.md`, `skills/ha-nova/payload-schemas.md`, `skills/ha-nova/best-practices.md`, `skills/ha-nova/write-safety.md`
+- Agent templates: `skills/ha-nova/agents/resolve-agent.md`, `skills/ha-nova/agents/apply-agent.md`
+- Review checks: `skills/review/checks.md` (self-contained catalog + Application)
+
+On demand — read only when the trigger applies:
+- `skills/ha-nova/automation-patterns.md` — drafting new branching, timing, or flow-control logic
+- `skills/ha-nova/template-guidelines.md` — the draft contains Jinja templates
+- `skills/ha-nova/safe-refactoring.md` — rename, migrate, or orphan-cleanup tasks
+- `skills/ha-nova/update-revert.md` — the user actually says `revert`

--- a/tests/skills/best-practice-patterns-contract.test.ts
+++ b/tests/skills/best-practice-patterns-contract.test.ts
@@ -320,12 +320,14 @@ describe("best-practice patterns contract", () => {
       expect(checks).toContain("Zigbee Button Patterns");
     });
 
-    it("review SKILL.md references P-01..P-05 range", () => {
-      const reviewSkill = readFileSync(
-        "skills/review/SKILL.md",
+    it("checks.md Application references P-01..P-05 range", () => {
+      // M1: the family matrix moved from review Step 1 into the
+      // self-contained checks.md -> Application section.
+      const checksCatalog = readFileSync(
+        "skills/review/checks.md",
         "utf8",
       );
-      expect(reviewSkill).toContain("P-01..P-05");
+      expect(checksCatalog).toContain("P-01..P-05");
     });
 
     it("skill-architecture.md references P-01..P-05 range", () => {

--- a/tests/skills/ha-cross-skill-integration.test.ts
+++ b/tests/skills/ha-cross-skill-integration.test.ts
@@ -10,7 +10,10 @@ describe("ha cross-skill integration", () => {
     expect(writeSkill).toContain("Phase 2: Preview + Confirm (Main Thread)");
     expect(writeSkill).toContain("Phase 3: Apply + Verify (Agent)");
     expect(writeSkill).toContain("Phase 4: Post-Write Review");
-    expect(writeSkill).toContain("skills/review/SKILL.md");
+    // M1: write's post-write review loads only the self-contained checks
+    // catalog, no longer the standalone review workflow.
+    expect(writeSkill).toContain("skills/review/checks.md");
+    expect(writeSkill).not.toContain("skills/review/SKILL.md");
     expect(writeSkill).toContain("full-replacement merge (base=current, overlay=user changes)");
     expect(writeSkill).toContain("confirm:<token>");
     expect(writeSkill).toContain("Changes slot");
@@ -26,7 +29,7 @@ describe("ha cross-skill integration", () => {
     expect(writeSkill).toContain("skills/ha-nova/best-practices.md");
     expect(writeSkill).toContain("skills/ha-nova/agents/resolve-agent.md");
     expect(writeSkill).toContain("skills/ha-nova/agents/apply-agent.md");
-    expect(writeSkill).toContain("skills/review/SKILL.md");
+    expect(writeSkill).toContain("skills/review/checks.md");
     expect(writeSkill).toContain("config/entity_registry/get");
     expect(writeSkill).toContain("list_for_display` only for search/disambiguation");
   });

--- a/tests/skills/review-contract.test.ts
+++ b/tests/skills/review-contract.test.ts
@@ -68,7 +68,7 @@ describe("review contract", () => {
   it("keeps shared references aligned to H-01..H-10", () => {
     expect(writeSkill).toContain("H-01..H-10");
     expect(helperSkill).toContain("H-01..H-10");
-    expect(reviewSkill).toContain("Helper (storage-based family): H-01..H-10");
+    expect(reviewChecks).toContain("Helper (storage-based family): H-01..H-10");
     expect(architectureDoc).toContain("H-01..H-10");
   });
 
@@ -80,8 +80,8 @@ describe("review contract", () => {
     expect(helperSkill).toContain("direct helper-backed threshold");
     expect(helperSkill).toContain("Do not pretend H-01..H-10 apply here");
     expect(helperSkill).toContain("minimal config-entry post-write contract");
-    expect(reviewSkill).toContain("Helper (config-entry family): minimal config-entry review");
-    expect(reviewSkill).toContain("do not apply H-01..H-10");
+    expect(reviewChecks).toContain("Helper (config-entry family): minimal config-entry review");
+    expect(reviewChecks).toContain("do not apply H-01..H-10");
   });
 
   it("documents config-entry helper target resolution before minimal review", () => {
@@ -95,7 +95,7 @@ describe("review contract", () => {
     expect(reviewSkill).toContain("For standalone config-entry helper review, skip this step entirely.");
     expect(reviewSkill).toContain("If the target already in context is a config-entry helper metadata item: skip Target Resolution entirely and go straight to the config-entry helper review lane in Step 1.");
     expect(reviewSkill).toContain("Do not attempt primary-controlled-entity state reads or Quick-Fix detection from that path.");
-    expect(reviewSkill).toContain("in Step 2, derive collision candidates from `linked_entities[]`, not from config actions");
+    expect(reviewChecks).toContain("in Step 2, derive collision candidates from `linked_entities[]`, not from config actions");
     expect(reviewSkill).toContain("config-entry helper metadata item: use `linked_entities[]` from the canonical metadata item; do not attempt action extraction");
     expect(reviewSkill).toContain("helper (config-entry family): use up to 3 `linked_entities[]` from the canonical metadata item");
   });
@@ -114,7 +114,7 @@ describe("review contract", () => {
     expect(reviewChecks).toContain("R-16 [HIGH]");
     expect(reviewChecks).toContain("Templated event name");
     expect(reviewChecks).toContain("`event_type:` does not evaluate templates");
-    expect(reviewSkill).toContain("R-01..R-28");
+    expect(reviewChecks).toContain("R-01..R-28");
     expect(architectureDoc).toContain("R-01..R-28");
     expect(templateGuidelines).toContain("Event trigger names must be literal strings");
     expect(templateGuidelines).toContain("do not template `event_type:`");
@@ -127,7 +127,7 @@ describe("review contract", () => {
     expect(reviewChecks).toContain("`live/incremental`");
     expect(reviewChecks).toContain("`recompute/reset`");
     expect(reviewChecks).toContain("fixed preset branches");
-    expect(reviewSkill).toContain("R-17 is an intra-config branch comparison only");
+    expect(reviewChecks).toContain("R-17 is an intra-config branch comparison only");
     expect(architectureDoc).toContain("R-17` is intra-config only");
   });
 
@@ -143,9 +143,9 @@ describe("review contract", () => {
     expect(reviewChecks).toContain("self-contained template");
     expect(reviewChecks).toContain("ordered `variables` actions");
     expect(reviewSkill).toContain("Traverse all `variables:` mappings");
-    expect(reviewSkill).toContain("future write fragility");
-    expect(reviewSkill).toContain("persisted runtime risk");
-    expect(reviewSkill).toContain("concrete variable pair");
+    expect(reviewChecks).toContain("future write fragility");
+    expect(reviewChecks).toContain("persisted runtime risk");
+    expect(reviewChecks).toContain("concrete variable pair");
     expect(templateGuidelines).toContain("Do not rely on sibling-variable order inside one `variables:` mapping");
     expect(templateGuidelines).toContain("self-contained template with internal `{% set %}`");
     expect(templateGuidelines).toContain("ordered `variables` actions");
@@ -175,7 +175,7 @@ describe("review contract", () => {
     expect(reviewChecks).toContain("`'True' == avg_valid`");
     expect(reviewChecks).toContain("Do not flag bare boolean comparisons");
     expect(reviewChecks).toContain("`is sameas true`");
-    expect(reviewSkill).toContain("R-23 applies only to boolean-like templates");
+    expect(reviewChecks).toContain("R-23 applies only to boolean-like templates");
     expect(writeSkill).toContain("If R-23 matches");
     expect(architectureDoc).toContain("`R-23` catches boolean-like templates");
   });
@@ -190,8 +190,8 @@ describe("review contract", () => {
     // Version fetch is on-demand only, never a routine per-review call.
     expect(reviewChecks).toContain("only when this check actually fires");
     expect(reviewChecks).toContain("`value_template` → `state`");
-    expect(reviewSkill).toContain("R-25 applies only to pasted or draft YAML");
-    expect(reviewSkill).toContain("phrase the finding version-sensitively");
+    expect(reviewChecks).toContain("R-25 applies only to pasted or draft YAML");
+    expect(reviewChecks).toContain("phrase the finding version-sensitively");
   });
 
   it("documents the legacy automation key modernize advisory as M-05", () => {
@@ -200,7 +200,7 @@ describe("review contract", () => {
     expect(reviewChecks).toContain("renamed to `trigger:` in HA 2024.10");
     // Advisory only — both forms still work; never an error, never a rewrite trigger.
     expect(reviewChecks).toContain("never as an error, and never rewrite a config just to modernize");
-    expect(reviewSkill).toContain("M-05 is a modernize advisory");
+    expect(reviewChecks).toContain("M-05 is a modernize advisory");
   });
 
   it("documents capacity-like available_energy advisories as R-24", () => {
@@ -208,7 +208,7 @@ describe("review contract", () => {
     expect(reviewChecks).toContain("Capacity-like variable reads `available_energy`");
     expect(reviewChecks).toContain("Available charge may not be nominal or maximum battery capacity");
     expect(reviewChecks).toContain("Do not assume a specific integration");
-    expect(reviewSkill).toContain("R-24 is advisory only");
+    expect(reviewChecks).toContain("R-24 is advisory only");
     expect(writeSkill).toContain("If R-24 matches");
     expect(architectureDoc).toContain("`R-24` is a low-severity capacity-source advisory");
   });
@@ -228,8 +228,8 @@ describe("review contract", () => {
     expect(reviewChecks).toContain("terminal bare `else`");
     expect(reviewChecks).toContain("move the `trigger.id` check into an explicit `elif`");
     expect(reviewChecks).toContain("refactor to `choose` + `condition: trigger`");
-    expect(reviewSkill).toContain("R-19 applies only to Jinja2 chains with `if` plus at least one `elif`");
-    expect(reviewSkill).toContain("final else branch is only reached when the earlier entity-state branches are false");
+    expect(reviewChecks).toContain("R-19 applies only to Jinja2 chains with `if` plus at least one `elif`");
+    expect(reviewChecks).toContain("final else branch is only reached when the earlier entity-state branches are false");
     expect(architectureDoc).toContain("`R-19` is branch-structure reachability only");
     expect(templateGuidelines).toContain("Direct `trigger.id` check in a terminal bare `else`");
   });
@@ -293,7 +293,7 @@ describe("review contract", () => {
   });
   it("keeps standalone config-entry helper review aligned to the 9 helper-owned domains", () => {
     expect(reviewSkill).toContain("supported config-entry family: domain is one of `utility_meter`, `derivative`, `integration`, `min_max`, `threshold`, `tod`, `statistics`, `group`, `history_stats`, `template`");
-    expect(reviewSkill).toContain("Helper (config-entry family): minimal config-entry review");
+    expect(reviewChecks).toContain("Helper (config-entry family): minimal config-entry review");
   });
 
   it("keeps standalone bulk review separate from post-write output", () => {

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -106,7 +106,7 @@ const WORD_BUDGETS: Record<string, number> = {
   maintenance: 1200,
   fallback: 2050,
   helper: 3600,
-  review: 4800,
+  review: 4300,
 };
 const DEFAULT_WORD_BUDGET = 1150;
 

--- a/tests/skills/write-delete-safety-contract.test.ts
+++ b/tests/skills/write-delete-safety-contract.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 const writeSkill = readFileSync("skills/write/SKILL.md", "utf8");
 const refactorGuide = readFileSync("skills/ha-nova/safe-refactoring.md", "utf8");
 const writeSafety = readFileSync("skills/ha-nova/write-safety.md", "utf8");
+  const updateRevert = readFileSync("skills/ha-nova/update-revert.md", "utf8");
 const applyAgent = readFileSync("skills/ha-nova/agents/apply-agent.md", "utf8");
 const resolveAgent = readFileSync("skills/ha-nova/agents/resolve-agent.md", "utf8");
 
@@ -47,7 +48,7 @@ describe("write delete safety contract", () => {
     expect(writeSafety).toContain("update-revert keeps the");
     expect(writeSafety).toContain("last 5 updated targets");
     expect(writeSafety).toContain("one step back per");
-    expect(writeSafety).toContain("snapshot show --target <target_id>");
+    expect(updateRevert).toContain("snapshot show --target <target_id>");
     expect(writeSafety).toContain("snapshot show --list");
     expect(writeSafety).toContain("never continue silently into a half-applied state");
     expect(writeSkill).toContain("Multi-target logical changes: present the plan first");
@@ -65,7 +66,7 @@ describe("write delete safety contract", () => {
     expect(writeSafety).toContain("**not** reduce it to core fields");
     expect(writeSafety).toContain("ha-nova snapshot verify");
     // Restore goes through the normal write path; create/delete fall back to backups.
-    expect(writeSafety).toContain("Home Assistant Backups");
+    expect(updateRevert).toContain("Home Assistant Backups");
   });
 
   it("documents safety-mechanism availability per skill and backup pointers where revert is absent", () => {
@@ -148,8 +149,8 @@ describe("write delete safety contract", () => {
     expect(writeSafety).toContain("paste the ha-nova diff file/stdout");
     // Snapshot save is an explicit command; revert reads before_config only from it.
     expect(writeSkill).toContain("**run `ha-nova snapshot save`**");
-    expect(writeSafety).toContain("only** source of `before_config`");
-    expect(writeSafety).toContain("reconstruct the previous config from memory");
+    expect(updateRevert).toContain("only** source of `before_config`");
+    expect(updateRevert).toContain("reconstruct the previous config from memory");
   });
 
   it("keeps delete a typed token even under menu pressure", () => {


### PR DESCRIPTION
## Summary
Masterplan A5 (wave 2). The transitive write path pulled ~25k words / ~33-46k tokens; the biggest single item was the 4.6k-word standalone review workflow loaded only for its Step 1 preamble.

- **M1 — checks.md becomes self-contained**: the family-by-domain matrix, taxonomy application, R-17..R-25/M-05 evidence boundaries, and live-helper evidence rules move verbatim from review Step 1 into a new `## Application` section of `skills/review/checks.md`. write/helper post-write phases load **only checks.md** (a negative test pin now enforces that write never loads `review/SKILL.md` again); collision recipes are inlined (`search/related`, max 3 related configs). The standalone review workflow stays the entrypoint for standalone reviews.
- **M2 — lazy References**: write/helper References split into "Always load" and "On demand" with explicit triggers (automation-patterns → new branching/timing logic; template-guidelines → Jinja drafts; safe-refactoring → rename/migrate/orphan; update-revert → the user says `revert`).
- **M3 — revert execution split**: `snapshot show` as the only `before_config` source, the target-bound drift check, restore paths, and honesty limits move to new `skills/ha-nova/update-revert.md` (398 words), loaded only on an actual `revert`; write-safety keeps snapshot capture + offer hot.
- **M4 — relay-api auth rewrite**: opens with "transport/auth handled internally by `ha-nova relay` — never set/request `RELAY_AUTH_TOKEN`/`RELAY_BASE_URL`" instead of presenting raw env-var auth 30 lines before the wrapper clarification (the audit's fresh-agent confusion finding).

**Effect**: standard write path −~6.8k words (~9k tokens) — review/SKILL.md (4.2k) out entirely, three reference docs lazy, revert execution lazy. review/SKILL.md itself 4,727 → 4,213 words (ratchet lowered 4800 → 4300).

## Verification
- Full suite 70 files / 638 tests green; `tsc --noEmit` clean; pre-push suite green.
- Test pins migrated WITH the content, not weakened: review-contract family-matrix/boundary pins → checks.md (11 assertions, audited one by one), write-delete-safety revert pins → update-revert.md, cross-skill write wiring → checks.md + negative pin.
- Content moves are verbatim (python string surgery with asserts); no rule wording changed except the review catalog pointer gaining the plain-language sentence its pin protects.

## Risks
- If a nuance of review Step 1 was silently load-bearing for post-write review quality beyond the moved preamble, quality could dip — the moved block IS the complete family matrix + boundaries, and the masterplan schedules a live e2e smoke (`npm run e2e:skill:codex:promoted:smoke`) before the final release as the behavioral gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UABh9QxzyCg8JhostzVUF