### PR TITLE
feat(relay): envelope v2 (window mode + in-envelope subscriptions) and binary responses

### DIFF
--- a/cli/relay.go
+++ b/cli/relay.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -35,14 +36,15 @@ func newRelayHTTPClient(connectTimeoutSeconds, maxTimeSeconds float64) *http.Cli
 }
 
 type relayRequestOptions struct {
-	InlineJSON   string
-	JSONFile     string
-	JQFilter     string
-	JQFile       string
-	OutputFile   string
-	Method       string
-	Path         string
-	StrictStatus bool
+	InlineJSON    string
+	JSONFile      string
+	JQFilter      string
+	JQFile        string
+	OutputFile    string
+	BinaryOutFile string
+	Method        string
+	Path          string
+	StrictStatus  bool
 }
 
 func runRelayCommand(paths runtimePaths, args []string) int {
@@ -86,6 +88,7 @@ func parseRelayFlags(command string, args []string) (relayRequestOptions, error)
 		fs.StringVar(&opts.InlineJSON, "d", "", "inline JSON body")
 		fs.StringVar(&opts.JSONFile, "body-file", "", "path to JSON body file")
 		fs.BoolVar(&opts.StrictStatus, "strict-status", false, "exit nonzero for any upstream HTTP error status")
+		fs.StringVar(&opts.BinaryOutFile, "out-binary", "", "decode a base64 upstream body and write the raw bytes to this file")
 	default:
 		return opts, fmt.Errorf("unsupported relay command: %s", command)
 	}
@@ -99,6 +102,14 @@ func parseRelayFlags(command string, args []string) (relayRequestOptions, error)
 	if command == "core" {
 		if opts.Method == "" || opts.Path == "" {
 			return opts, errors.New("--method and --path are required for relay core")
+		}
+	}
+	if opts.BinaryOutFile != "" {
+		if opts.JQFilter != "" || opts.JQFile != "" {
+			return opts, errors.New("--out-binary cannot be combined with --jq/--jq-file: the binary body is decoded from the raw envelope")
+		}
+		if opts.OutputFile != "" {
+			return opts, errors.New("use either --out or --out-binary, not both")
 		}
 	}
 	return opts, nil
@@ -233,7 +244,12 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 		bodyBytes = []byte(res.output)
 	}
 
-	if opts.OutputFile != "" {
+	if opts.BinaryOutFile != "" {
+		if err := writeRelayBinaryBody(bodyBytes, opts.BinaryOutFile); err != nil {
+			printErr("%s", err)
+			return 1
+		}
+	} else if opts.OutputFile != "" {
 		if err := os.MkdirAll(filepath.Dir(opts.OutputFile), 0o755); err != nil {
 			printErr("%s", err)
 			return 1
@@ -256,6 +272,44 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 		return upstreamExitStatus
 	}
 	return 0
+}
+
+// writeRelayBinaryBody decodes a base64 upstream body (camera frames and other
+// binary responses, marked by the relay with body_encoding: "base64") and
+// writes the raw bytes. A missing marker is an error, not a silent text write:
+// that would hand the caller a file full of JSON instead of an image.
+func writeRelayBinaryBody(envelope []byte, path string) error {
+	// body is RawMessage on purpose: a text/JSON body is not a string, and
+	// decoding must fail with the actionable "use --out" message instead of an
+	// unmarshal error about the field type.
+	var parsed struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Body         json.RawMessage `json:"body"`
+			BodyEncoding string          `json:"body_encoding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(envelope, &parsed); err != nil {
+		return fmt.Errorf("cannot read the relay response as JSON: %w", err)
+	}
+	if !parsed.OK {
+		return errors.New("relay returned an error envelope; run the request without --out-binary to see it")
+	}
+	if parsed.Data.BodyEncoding != "base64" {
+		return errors.New("upstream body is not binary (no base64 marker) — use --out instead of --out-binary")
+	}
+	var encoded string
+	if err := json.Unmarshal(parsed.Data.Body, &encoded); err != nil {
+		return fmt.Errorf("binary body is marked base64 but is not a string: %w", err)
+	}
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return fmt.Errorf("cannot decode the binary body: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, raw, 0o644)
 }
 
 func relayCoreUpstreamExitStatus(body []byte, strict bool) int {

--- a/cli/relay_test.go
+++ b/cli/relay_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -313,5 +315,54 @@ func TestRelayProxyWarnsOnOutdatedRelayVersionHeader(t *testing.T) {
 	}
 	if strings.Contains(output, "Relay outdated") {
 		t.Fatalf("expected throttled second call without warning, got: %q", output)
+	}
+}
+
+// --out-binary decodes the base64 body the relay marks with
+// body_encoding: "base64" (camera frames). A missing marker must fail loudly:
+// silently writing the JSON envelope would hand the caller a "JPEG" full of
+// JSON.
+func TestWriteRelayBinaryBodyDecodesMarkedBase64(t *testing.T) {
+	jpeg := []byte{0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10}
+	envelope := []byte(`{"ok":true,"data":{"status":200,"body":"` +
+		base64.StdEncoding.EncodeToString(jpeg) +
+		`","body_encoding":"base64","content_type":"image/jpeg"}}`)
+
+	out := filepath.Join(t.TempDir(), "nested", "frame.jpg")
+	if err := writeRelayBinaryBody(envelope, out); err != nil {
+		t.Fatalf("writeRelayBinaryBody() error: %v", err)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read decoded file: %v", err)
+	}
+	if !bytes.Equal(got, jpeg) {
+		t.Fatalf("decoded bytes = %x, want %x", got, jpeg)
+	}
+}
+
+func TestWriteRelayBinaryBodyRejectsUnmarkedBody(t *testing.T) {
+	envelope := []byte(`{"ok":true,"data":{"status":200,"body":{"state":"on"}}}`)
+	err := writeRelayBinaryBody(envelope, filepath.Join(t.TempDir(), "x.bin"))
+	if err == nil {
+		t.Fatal("expected an error for a non-binary body")
+	}
+	if !strings.Contains(err.Error(), "--out") {
+		t.Fatalf("error should point at --out, got: %v", err)
+	}
+}
+
+func TestParseRelayFlagsRejectsBinaryOutWithFilters(t *testing.T) {
+	if _, err := parseRelayFlags("core", []string{
+		"--method", "GET", "--path", "/api/camera_proxy/camera.front",
+		"--out-binary", "f.jpg", "--jq", ".data",
+	}); err == nil {
+		t.Fatal("expected --out-binary + --jq to be rejected")
+	}
+	if _, err := parseRelayFlags("core", []string{
+		"--method", "GET", "--path", "/api/camera_proxy/camera.front",
+		"--out-binary", "f.jpg", "--out", "f.json",
+	}); err == nil {
+		t.Fatal("expected --out-binary + --out to be rejected")
 	}
 }

--- a/docs/reference/bridge-architecture.md
+++ b/docs/reference/bridge-architecture.md
@@ -98,13 +98,28 @@ collection with an explicit envelope:
   "collect_events": {
     "until_type": "finish",
     "max_events": 100,
-    "timeout_ms": 10000
+    "timeout_ms": 10000,
+    "on_limit": "error"
   }
 }
 ```
 
 The Relay forwards `message`, collects events until `until_type`, and returns
 them as `data.events`. It does not inspect command semantics or event payloads.
+
+`on_limit` (relay 0.3.0) decides what happens when `max_events` or `timeout_ms`
+is reached before the finish event:
+
+- `"error"` (default): fail with `502 UPSTREAM_WS_ERROR` / `UPSTREAM_WS_TIMEOUT` — the original strict semantics.
+- `"return"` (window mode): resolve with the events collected so far and set `data.truncated: true`. This is what makes bounded *sniffing* possible for streams that never emit a finish event (MQTT topics, event buses).
+
+**Subscription commands are allowed INSIDE a `collect_events` envelope** (relay
+0.3.0). The two reasons for the general ban do not apply there: the collection
+unsubscribes in its `finally` block, and its lifetime is bounded by
+`max_events`/`timeout_ms`, so no upstream subscription can leak or accumulate.
+A *bare* subscription (no envelope) is still rejected with
+`400 UNSUPPORTED_WS_TYPE`, because the relay could neither deliver its events
+nor bound its lifetime.
 
 Optional: Batch mode
 ```json

--- a/nova/CHANGELOG.md
+++ b/nova/CHANGELOG.md
@@ -9,6 +9,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/) and [Semantic
 Recent changes are tracked in [GitHub releases](https://github.com/markusleben/ha-nova/releases)
 and merged PRs. This changelog will be updated with the next tagged relay version.
 
+## [Relay 0.3.0] - 2026-07-11
+
+### Added
+- `collect_events.on_limit: "return"` (window mode): the relay resolves with the events collected so far and marks the response `truncated: true` instead of failing when `max_events`/`timeout_ms` is reached. Enables bounded sniffing of streams that never emit a finish event (MQTT topics, event buses).
+- Subscription WS commands are allowed inside a `collect_events` envelope. The collection unsubscribes in its `finally` block and its lifetime is bounded, so nothing leaks; bare subscriptions stay rejected.
+- Binary responses on `/core`: non-text/non-JSON upstream bodies (camera frames) are returned base64-encoded with `body_encoding: "base64"` and `content_type`, capped at 8 MiB. They were previously UTF-8 decoded, which silently corrupted every non-ASCII byte.
+
+### Compatibility
+- Default behavior is unchanged: without `on_limit` the strict semantics apply, and JSON/text bodies (including the plain-text `/api/error_log`) keep their exact shape.
+
 ## [Relay 0.2.6] - 2026-07-08
 
 ### Fixed

--- a/nova/config.yaml
+++ b/nova/config.yaml
@@ -1,5 +1,5 @@
 name: NOVA Relay
-version: "0.2.6"
+version: "0.3.0"
 slug: ha_nova_relay
 description: Thin Home Assistant relay for WS proxy and skill workflows
 url: https://github.com/markusleben/ha-nova

--- a/nova/src/ha/rest-client.ts
+++ b/nova/src/ha/rest-client.ts
@@ -27,6 +27,11 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 // Mirrors the WS payload ceiling (nova/src/ha/socket.ts) so both proxy paths
 // share one bound instead of the REST path buffering unbounded HA responses.
 const DEFAULT_MAX_RESPONSE_BYTES = 256 * 1024 * 1024;
+// Binary bodies (camera snapshots, downloads) are returned base64-encoded,
+// which inflates them by ~33% and has to be held as a JS string. They get a
+// much smaller ceiling than the text/JSON path: a single frame is far below
+// this, and anything larger is a streaming use case the relay does not serve.
+const DEFAULT_MAX_BINARY_RESPONSE_BYTES = 8 * 1024 * 1024;
 
 export function createHaRestClient(options: HaRestClientOptions): HaRestClient {
   const baseUrl = options.baseUrl.endsWith("/") ? options.baseUrl.slice(0, -1) : options.baseUrl;
@@ -55,7 +60,7 @@ export function createHaRestClient(options: HaRestClientOptions): HaRestClient {
 
             return {
               status: response.status,
-              body: await parseResponseBody(response, maxResponseBytes)
+              ...(await parseResponseBody(response, maxResponseBytes))
             };
           })(),
           requestTimeoutMs,
@@ -90,24 +95,56 @@ function buildHeaders(token: string, method: CoreProxyRequest["method"]): Header
   return headers;
 }
 
-async function parseResponseBody(response: Response, maxBytes: number): Promise<unknown> {
-  const contentType = response.headers.get("content-type") ?? "";
-  const text = await readBodyWithLimit(response, maxBytes);
+type ParsedBody = Pick<CoreProxyResponse, "body" | "body_encoding" | "content_type">;
 
-  if (contentType.toLowerCase().includes("application/json")) {
+async function parseResponseBody(response: Response, maxBytes: number): Promise<ParsedBody> {
+  const contentType = response.headers.get("content-type") ?? "";
+  const normalizedType = contentType.toLowerCase();
+
+  if (isBinaryContentType(normalizedType)) {
+    // Dumb transport: a binary body is forwarded as honest bytes. Decoding it
+    // as UTF-8 (the old path) silently corrupted every camera frame.
+    const buffer = await readBodyBytesWithLimit(response, DEFAULT_MAX_BINARY_RESPONSE_BYTES);
+    if (buffer.byteLength === 0) {
+      return { body: null };
+    }
+    return {
+      body: buffer.toString("base64"),
+      body_encoding: "base64",
+      content_type: contentType
+    };
+  }
+
+  const text = (await readBodyBytesWithLimit(response, maxBytes)).toString("utf8");
+
+  if (normalizedType.includes("application/json")) {
     try {
-      return JSON.parse(text) as unknown;
+      return { body: JSON.parse(text) as unknown };
     } catch {
-      return null;
+      return { body: null };
     }
   }
 
-  return text.length > 0 ? text : null;
+  return { body: text.length > 0 ? text : null };
 }
 
-async function readBodyWithLimit(response: Response, maxBytes: number): Promise<string> {
+// JSON and text stay on the text path (that includes HA's plain-text
+// /api/error_log and every JSON API); everything else is treated as bytes.
+function isBinaryContentType(normalizedContentType: string): boolean {
+  if (normalizedContentType === "") {
+    return false;
+  }
+  return !(
+    normalizedContentType.includes("json") ||
+    normalizedContentType.startsWith("text/") ||
+    normalizedContentType.includes("xml") ||
+    normalizedContentType.includes("x-www-form-urlencoded")
+  );
+}
+
+async function readBodyBytesWithLimit(response: Response, maxBytes: number): Promise<Buffer> {
   if (!response.body) {
-    return "";
+    return Buffer.alloc(0);
   }
 
   const chunks: Uint8Array[] = [];
@@ -135,5 +172,5 @@ async function readBodyWithLimit(response: Response, maxBytes: number): Promise<
     reader.releaseLock();
   }
 
-  return Buffer.concat(chunks).toString("utf8");
+  return Buffer.concat(chunks);
 }

--- a/nova/src/ha/ws-client.ts
+++ b/nova/src/ha/ws-client.ts
@@ -30,6 +30,13 @@ export interface HaWsClient {
   isConnected(): boolean;
 }
 
+// Window mode budgets the ack separately from the collection window: the WS
+// connection is already open, so an ack lands in milliseconds. If it does not
+// land within this grace period the outer timeout fires and the call fails
+// honestly, instead of reporting an empty window for a subscription that never
+// existed.
+const SUBSCRIPTION_ACK_GRACE_MS = 2_000;
+
 export interface HaWsEventCollectionOptions {
   finishEventType?: string;
   maxEvents?: number;
@@ -148,14 +155,6 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
               }
             };
 
-            if (returnOnLimit) {
-              // Window mode: the stream may never emit a finish event, so the
-              // timeout is a normal end condition, not a failure.
-              windowTimer = setTimeout(() => {
-                settleResolve({ events: [...events], truncated: true });
-              }, timeoutMs);
-            }
-
             subscribeMessage(
               (event: unknown) => {
                 if (settled) {
@@ -188,13 +187,25 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
                 unsubscribe = cancel;
                 if (unsubscribeOnAck) {
                   void Promise.resolve(cancel()).catch(() => undefined);
+                  return;
+                }
+                if (returnOnLimit && !settled) {
+                  // Window mode: the stream may never emit a finish event, so
+                  // the window timeout is a normal end condition. It starts
+                  // only AFTER the subscription is acknowledged — otherwise a
+                  // subscription that never establishes would resolve as an
+                  // empty-but-successful sniff window instead of failing.
+                  windowTimer = setTimeout(() => {
+                    settleResolve({ events: [...events], truncated: true });
+                  }, timeoutMs);
                 }
               })
               .catch(settleReject);
           }),
-          // In window mode the internal timer is the real deadline; withTimeout
-          // only backstops a subscription that never even acks.
-          returnOnLimit ? timeoutMs + 1_000 : timeoutMs
+          // In window mode the post-ack timer is the real deadline; withTimeout
+          // backstops a subscription that never acks, which then surfaces as an
+          // honest UPSTREAM_WS_TIMEOUT instead of a fake empty window.
+          returnOnLimit ? timeoutMs + SUBSCRIPTION_ACK_GRACE_MS : timeoutMs
         );
       } catch (error) {
         const commandError = describeUpstreamCommandError(error);

--- a/nova/src/ha/ws-client.ts
+++ b/nova/src/ha/ws-client.ts
@@ -23,7 +23,10 @@ export interface HaWsConnection {
 
 export interface HaWsClient {
   sendMessage<T>(message: HaWsRequest): Promise<T>;
-  collectMessageEvents<T>(message: HaWsRequest, options?: HaWsEventCollectionOptions): Promise<T[]>;
+  collectMessageEvents<T>(
+    message: HaWsRequest,
+    options?: HaWsEventCollectionOptions
+  ): Promise<HaWsEventCollection<T>>;
   isConnected(): boolean;
 }
 
@@ -31,6 +34,19 @@ export interface HaWsEventCollectionOptions {
   finishEventType?: string;
   maxEvents?: number;
   timeoutMs?: number;
+  /**
+   * What to do when max_events or the timeout is reached before the finish
+   * event arrives. "error" (default) preserves the original strict semantics;
+   * "return" resolves with the events collected so far and marks the result
+   * truncated — that is what turns a bounded collection into a sniff window
+   * for streams that never emit a finish event (e.g. mqtt/subscribe).
+   */
+  onLimit?: "error" | "return";
+}
+
+export interface HaWsEventCollection<T> {
+  events: T[];
+  truncated: boolean;
 }
 
 export interface HaWsClientOptions {
@@ -96,7 +112,7 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
     async collectMessageEvents<T>(
       message: HaWsRequest,
       collectionOptions: HaWsEventCollectionOptions = {}
-    ): Promise<T[]> {
+    ): Promise<HaWsEventCollection<T>> {
       const upstream = await getOrCreateConnection();
       const subscribeMessage = upstream.subscribeMessage;
       if (!subscribeMessage) {
@@ -109,15 +125,17 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
       const finishEventType = collectionOptions.finishEventType ?? "finish";
       const maxEvents = collectionOptions.maxEvents ?? 100;
       const timeoutMs = collectionOptions.timeoutMs ?? requestTimeoutMs;
+      const returnOnLimit = collectionOptions.onLimit === "return";
       const events: T[] = [];
       let unsubscribe: (() => void | Promise<void>) | undefined;
       let unsubscribeOnAck = false;
+      let windowTimer: ReturnType<typeof setTimeout> | undefined;
 
       try {
         return await withTimeout(
-          new Promise<T[]>((resolve, reject) => {
+          new Promise<HaWsEventCollection<T>>((resolve, reject) => {
             let settled = false;
-            const settleResolve = (value: T[]) => {
+            const settleResolve = (value: HaWsEventCollection<T>) => {
               if (!settled) {
                 settled = true;
                 resolve(value);
@@ -130,6 +148,14 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
               }
             };
 
+            if (returnOnLimit) {
+              // Window mode: the stream may never emit a finish event, so the
+              // timeout is a normal end condition, not a failure.
+              windowTimer = setTimeout(() => {
+                settleResolve({ events: [...events], truncated: true });
+              }, timeoutMs);
+            }
+
             subscribeMessage(
               (event: unknown) => {
                 if (settled) {
@@ -138,11 +164,15 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
 
                 events.push(event as T);
                 if (isEventType(event, finishEventType)) {
-                  settleResolve([...events]);
+                  settleResolve({ events: [...events], truncated: false });
                   return;
                 }
 
                 if (events.length >= maxEvents) {
+                  if (returnOnLimit) {
+                    settleResolve({ events: [...events], truncated: true });
+                    return;
+                  }
                   settleReject(
                     new HaWsClientError(
                       "UPSTREAM_WS_ERROR",
@@ -162,7 +192,9 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
               })
               .catch(settleReject);
           }),
-          timeoutMs
+          // In window mode the internal timer is the real deadline; withTimeout
+          // only backstops a subscription that never even acks.
+          returnOnLimit ? timeoutMs + 1_000 : timeoutMs
         );
       } catch (error) {
         const commandError = describeUpstreamCommandError(error);
@@ -191,6 +223,9 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
 
         throw new HaWsClientError("UPSTREAM_WS_ERROR", describeTransportError(error), error);
       } finally {
+        if (windowTimer) {
+          clearTimeout(windowTimer);
+        }
         if (unsubscribe) {
           await unsubscribe();
         } else {

--- a/nova/src/http/handlers/ws-proxy.ts
+++ b/nova/src/http/handlers/ws-proxy.ts
@@ -1,4 +1,9 @@
-import { HaWsClientError, type HaWsEventCollectionOptions, type HaWsRequest } from "../../ha/ws-client.js";
+import {
+  HaWsClientError,
+  type HaWsEventCollection,
+  type HaWsEventCollectionOptions,
+  type HaWsRequest,
+} from "../../ha/ws-client.js";
 import { HttpError } from "../errors.js";
 import type { RouteContext, RouteHandler } from "../router.js";
 
@@ -8,7 +13,7 @@ export interface WsProxyHandlerOptions {
     collectMessageEvents?(
       message: HaWsRequest,
       options?: HaWsEventCollectionOptions
-    ): Promise<unknown[]>;
+    ): Promise<HaWsEventCollection<unknown>>;
   };
 }
 
@@ -26,12 +31,16 @@ export function createWsProxyHandler(options: WsProxyHandlerOptions): RouteHandl
 
     try {
       if (request.collectEvents) {
-        const events = await collectFiniteEvents(
+        const collection = await collectFiniteEvents(
           options.wsClient,
           request.message,
           request.collectEvents
         );
-        return { events };
+        // `truncated` is emitted only when it is true: an unset flag keeps the
+        // response shape identical for every caller that does not use window mode.
+        return collection.truncated
+          ? { events: collection.events, truncated: true }
+          : { events: collection.events };
       }
 
       return await options.wsClient.sendMessage(request.message);
@@ -77,12 +86,19 @@ function isWsMessageLike(value: unknown): boolean {
 
 function parseEnvelopeRequest(body: Record<string, unknown>): ParsedWsProxyRequest {
   const message = parseHaWsMessage(body.message);
-  rejectUnsupportedWsType(message.type);
 
   if (!("collect_events" in body)) {
+    // No envelope options: this is a bare request/response call in envelope
+    // clothing, so the subscription ban still applies.
+    rejectUnsupportedWsType(message.type);
     return { message };
   }
 
+  // Subscription commands ARE allowed inside a collect_events envelope: the
+  // two reasons for the ban do not apply here. The collection unsubscribes in
+  // its finally block, and its lifetime is bounded by max_events/timeout_ms,
+  // so no upstream subscription can leak or accumulate. Bare subscriptions
+  // (above) stay rejected exactly as before.
   return {
     message,
     collectEvents: parseCollectEventsOptions(body.collect_events),
@@ -160,6 +176,18 @@ function parseCollectEventsOptions(value: unknown): HaWsEventCollectionOptions {
     options.maxEvents = maxEvents;
   }
 
+  if ("on_limit" in raw) {
+    const onLimit = raw.on_limit;
+    if (onLimit !== "error" && onLimit !== "return") {
+      throw new HttpError(
+        400,
+        "VALIDATION_ERROR",
+        "collect_events.on_limit must be 'error' or 'return'"
+      );
+    }
+    options.onLimit = onLimit;
+  }
+
   if ("timeout_ms" in raw) {
     const timeoutMs = raw.timeout_ms;
     if (
@@ -184,7 +212,7 @@ async function collectFiniteEvents(
   wsClient: WsProxyHandlerOptions["wsClient"],
   request: HaWsRequest,
   collectionOptions: HaWsEventCollectionOptions
-): Promise<unknown[]> {
+): Promise<HaWsEventCollection<unknown>> {
   if (!wsClient.collectMessageEvents) {
     throw new HttpError(
       502,

--- a/nova/src/index.ts
+++ b/nova/src/index.ts
@@ -1,7 +1,11 @@
 import type { Server } from "node:http";
 
 import type { CoreProxyRequest, CoreProxyResponse } from "./types/api.js";
-import type { HaWsRequest } from "./ha/ws-client.js";
+import type {
+  HaWsEventCollection,
+  HaWsEventCollectionOptions,
+  HaWsRequest,
+} from "./ha/ws-client.js";
 import { createCoreProxyHandler } from "./http/handlers/core-proxy.js";
 import { createHealthHandler } from "./http/handlers/health.js";
 import { createWsProxyHandler } from "./http/handlers/ws-proxy.js";
@@ -14,7 +18,10 @@ export interface AppOptions {
   wsClient: {
     isConnected(): boolean;
     sendMessage(message: HaWsRequest): Promise<unknown>;
-    collectMessageEvents(message: HaWsRequest): Promise<unknown[]>;
+    collectMessageEvents(
+      message: HaWsRequest,
+      options?: HaWsEventCollectionOptions
+    ): Promise<HaWsEventCollection<unknown>>;
   };
   coreClient: {
     request(input: CoreProxyRequest): Promise<CoreProxyResponse>;

--- a/nova/src/types/api.ts
+++ b/nova/src/types/api.ts
@@ -24,4 +24,10 @@ export interface CoreProxyRequest {
 export interface CoreProxyResponse {
   status: number;
   body: unknown;
+  /**
+   * Set to "base64" when the upstream body is binary (e.g. a camera JPEG).
+   * Absent for JSON and text bodies, so every existing consumer is unaffected.
+   */
+  body_encoding?: "base64";
+  content_type?: string;
 }

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -8,6 +8,38 @@ Transport, auth headers, and the base URL are handled internally by the `ha-nova
 
 Underlying HTTP contract (reference only, not for direct use): `Authorization: Bearer <relay token>` and `Content-Type: application/json` against the relay base URL.
 
+## Bounded Event Collection (envelope)
+
+Window mode (`on_limit`) and binary responses require **Relay 0.3.0 or newer**. An older relay silently ignores `on_limit` and falls back to strict mode (a timeout then fails the call instead of returning partial events). Check the running version with `ha-nova relay health` before relying on either feature, and tell the user to update the NOVA Relay App if it is older.
+
+
+Some WS commands answer with events instead of a single response. Wrap them:
+
+```json
+{
+  "message": { "type": "system_health/info" },
+  "collect_events": { "until_type": "finish", "max_events": 100, "timeout_ms": 10000 }
+}
+```
+
+The events come back as `.data.events`.
+
+`on_limit` controls what happens when `max_events` or `timeout_ms` is hit first:
+- omit it (or `"error"`): the call fails — use this when a finish event is expected.
+- `"on_limit": "return"`: window mode — the relay returns what it saw and sets `.data.truncated: true`. Use this to sniff a stream that never finishes (for example `mqtt/subscribe`).
+
+Subscription commands are permitted **only inside this envelope** (the relay unsubscribes and bounds the window). A bare subscription without the envelope is rejected with `UNSUPPORTED_WS_TYPE`.
+
+## Binary Responses
+
+`/core` returns binary upstream bodies (camera frames, downloads) base64-encoded with a marker:
+
+```json
+{ "ok": true, "data": { "status": 200, "body": "<base64>", "body_encoding": "base64", "content_type": "image/jpeg" } }
+```
+
+Write the raw bytes with `ha-nova relay core --method GET --path <path> --out-binary <file>` — it decodes the marker for you and refuses a body that is not marked binary (use `--out` for those). Binary bodies have a smaller ceiling (8 MiB) than text/JSON responses. JSON and text (including `/api/error_log`) keep their existing shape.
+
 ## Endpoints
 
 - `GET /health`

--- a/tests/ha/rest-client.test.ts
+++ b/tests/ha/rest-client.test.ts
@@ -215,4 +215,47 @@ describe("ha rest client", () => {
 
     await expectation;
   });
+
+  // Binary bodies (camera frames) used to be UTF-8 decoded, which silently
+  // corrupted every byte outside ASCII. They now travel as base64 with an
+  // explicit marker — dumb, honest transport.
+  it("returns binary bodies as base64 with an encoding marker", async () => {
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]);
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(jpeg, {
+          status: 200,
+          headers: { "content-type": "image/jpeg" }
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createHaRestClient({ baseUrl: "http://ha.local", token: "upstream-token" });
+    const response = await client.request({
+      method: "GET",
+      path: "/api/camera_proxy/camera.front"
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body_encoding).toBe("base64");
+    expect(response.content_type).toBe("image/jpeg");
+    expect(Buffer.from(response.body as string, "base64").equals(jpeg)).toBe(true);
+  });
+
+  it("keeps plain-text bodies on the text path without markers", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("2026-07-11 ERROR (MainThread) boom", {
+          status: 200,
+          headers: { "content-type": "text/plain; charset=utf-8" }
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createHaRestClient({ baseUrl: "http://ha.local", token: "upstream-token" });
+    const response = await client.request({ method: "GET", path: "/api/error_log" });
+
+    expect(response.body).toBe("2026-07-11 ERROR (MainThread) boom");
+    expect(response.body_encoding).toBeUndefined();
+  });
 });

--- a/tests/ha/ws-client.test.ts
+++ b/tests/ha/ws-client.test.ts
@@ -246,6 +246,25 @@ describe("ha ws client", () => {
     expect(unsubscribed).toBe(true);
   });
 
+  // A subscription that never acks must FAIL in window mode, not resolve as an
+  // empty-but-successful sniff window — otherwise "nothing seen" is
+  // indistinguishable from "never subscribed".
+  it("fails in window mode when the subscription is never acknowledged", async () => {
+    const client = createHaWsClient({
+      createConnection: async () => ({
+        sendMessagePromise: async () => ({ ok: true }),
+        subscribeMessage: () => new Promise(() => undefined)
+      })
+    });
+
+    await expect(
+      client.collectMessageEvents(
+        { type: "mqtt/subscribe", topic: "zigbee2mqtt/#" },
+        { timeoutMs: 50, onLimit: "return" }
+      )
+    ).rejects.toThrow(/timed out/i);
+  });
+
   it("still errors at max_events in the default strict mode", async () => {
     const client = createHaWsClient({
       createConnection: async () => ({

--- a/tests/ha/ws-client.test.ts
+++ b/tests/ha/ws-client.test.ts
@@ -179,11 +179,88 @@ describe("ha ws client", () => {
       })
     });
 
-    await expect(client.collectMessageEvents({ type: "system_health/info" })).resolves.toEqual([
-      { type: "initial", data: { source: "system_health/info" } },
-      { type: "finish" },
-    ]);
+    await expect(client.collectMessageEvents({ type: "system_health/info" })).resolves.toEqual({
+      events: [
+        { type: "initial", data: { source: "system_health/info" } },
+        { type: "finish" },
+      ],
+      truncated: false,
+    });
     expect(unsubscribed).toBe(true);
+  });
+
+  // Envelope v2 window mode: a stream that never emits a finish event (mqtt
+  // topics, event buses) must end at max_events / timeout with the events seen
+  // so far, marked truncated — instead of the strict mode's hard error.
+  it("returns partial events at max_events in window mode", async () => {
+    let unsubscribed = false;
+    const client = createHaWsClient({
+      createConnection: async () => ({
+        sendMessagePromise: async () => ({ ok: true }),
+        subscribeMessage: async (callback) => {
+          callback({ type: "one" });
+          callback({ type: "two" });
+          callback({ type: "three" });
+          return () => {
+            unsubscribed = true;
+          };
+        }
+      })
+    });
+
+    await expect(
+      client.collectMessageEvents(
+        { type: "mqtt/subscribe", topic: "zigbee2mqtt/#" },
+        { maxEvents: 2, onLimit: "return" }
+      )
+    ).resolves.toEqual({
+      events: [{ type: "one" }, { type: "two" }],
+      truncated: true,
+    });
+    expect(unsubscribed).toBe(true);
+  });
+
+  it("returns what it saw when the window times out in window mode", async () => {
+    let unsubscribed = false;
+    const client = createHaWsClient({
+      createConnection: async () => ({
+        sendMessagePromise: async () => ({ ok: true }),
+        subscribeMessage: async (callback) => {
+          callback({ type: "only" });
+          return () => {
+            unsubscribed = true;
+          };
+        }
+      })
+    });
+
+    await expect(
+      client.collectMessageEvents(
+        { type: "mqtt/subscribe", topic: "zigbee2mqtt/#" },
+        { timeoutMs: 30, onLimit: "return" }
+      )
+    ).resolves.toEqual({
+      events: [{ type: "only" }],
+      truncated: true,
+    });
+    expect(unsubscribed).toBe(true);
+  });
+
+  it("still errors at max_events in the default strict mode", async () => {
+    const client = createHaWsClient({
+      createConnection: async () => ({
+        sendMessagePromise: async () => ({ ok: true }),
+        subscribeMessage: async (callback) => {
+          callback({ type: "one" });
+          callback({ type: "two" });
+          return () => undefined;
+        }
+      })
+    });
+
+    await expect(
+      client.collectMessageEvents({ type: "system_health/info" }, { maxEvents: 1 })
+    ).rejects.toThrow(/exceeded 1 events/);
   });
 
   it("unsubscribes when event collection times out before subscription ack", async () => {

--- a/tests/http/ws-proxy.test.ts
+++ b/tests/http/ws-proxy.test.ts
@@ -148,10 +148,13 @@ describe("ws proxy endpoint", () => {
           collectMessageEvents: async (message, options) => {
             sentType = message.type;
             collectOptions = options;
-            return [
-              { type: "initial", data: { homeassistant: { info: { version: "2026.6.4" } } } },
-              { type: "finish" },
-            ];
+            return {
+              events: [
+                { type: "initial", data: { homeassistant: { info: { version: "2026.6.4" } } } },
+                { type: "finish" },
+              ],
+              truncated: false,
+            };
           }
         }
       })
@@ -314,21 +317,25 @@ describe("ws proxy endpoint", () => {
     }
   });
 
-  it("rejects subscription ws types inside event collection envelope", async () => {
+  // Envelope v2: a subscription is safe INSIDE collect_events — the collection
+  // unsubscribes in its finally block and its lifetime is bounded by
+  // max_events/timeout_ms, so nothing can leak or accumulate upstream.
+  it("allows subscription ws types inside an event collection envelope", async () => {
     const router = createRouter();
-    let forwarded = false;
+    let collectedType = "";
+    let collectOptions: unknown;
     router.register(
       "POST",
       "/ws",
       createWsProxyHandler({
         wsClient: {
           sendMessage: async () => {
-            forwarded = true;
-            return { ok: true };
+            throw new Error("should collect events instead");
           },
-          collectMessageEvents: async () => {
-            forwarded = true;
-            return [];
+          collectMessageEvents: async (message, options) => {
+            collectedType = message.type;
+            collectOptions = options;
+            return { events: [{ topic: "zigbee2mqtt/bridge/state" }], truncated: true };
           },
         },
       })
@@ -342,15 +349,86 @@ describe("ws proxy endpoint", () => {
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        message: { type: "subscribe_events" },
-        collect_events: { until_type: "finish" },
+        message: { type: "mqtt/subscribe", topic: "zigbee2mqtt/#" },
+        collect_events: { max_events: 5, timeout_ms: 2000, on_limit: "return" },
       }),
+    });
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      ok: boolean;
+      data: { events: unknown[]; truncated?: boolean };
+    };
+    expect(json.ok).toBe(true);
+    expect(json.data.events).toEqual([{ topic: "zigbee2mqtt/bridge/state" }]);
+    expect(json.data.truncated).toBe(true);
+    expect(collectedType).toBe("mqtt/subscribe");
+    expect(collectOptions).toEqual({ maxEvents: 5, timeoutMs: 2000, onLimit: "return" });
+  });
+
+  // A BARE subscription (no envelope) stays rejected: the relay cannot deliver
+  // its events and the upstream subscription would accumulate.
+  it("still rejects bare subscription ws types", async () => {
+    const router = createRouter();
+    let forwarded = false;
+    router.register(
+      "POST",
+      "/ws",
+      createWsProxyHandler({
+        wsClient: {
+          sendMessage: async () => {
+            forwarded = true;
+            return { ok: true };
+          },
+        },
+      })
+    );
+
+    const { baseUrl } = await startServer(servers, router);
+    const response = await fetch(`${baseUrl}/ws`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ type: "subscribe_events" }),
     });
 
     expect(response.status).toBe(400);
     const json = (await response.json()) as { error: { code: string } };
     expect(json.error.code).toBe("UNSUPPORTED_WS_TYPE");
     expect(forwarded).toBe(false);
+  });
+
+  it("rejects an invalid on_limit value", async () => {
+    const router = createRouter();
+    router.register(
+      "POST",
+      "/ws",
+      createWsProxyHandler({
+        wsClient: {
+          sendMessage: async () => ({ ok: true }),
+          collectMessageEvents: async () => ({ events: [], truncated: false }),
+        },
+      })
+    );
+
+    const { baseUrl } = await startServer(servers, router);
+    const response = await fetch(`${baseUrl}/ws`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        message: { type: "mqtt/subscribe", topic: "x" },
+        collect_events: { on_limit: "sometimes" },
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const json = (await response.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("VALIDATION_ERROR");
   });
 
   it("returns 400 for missing message type", async () => {


### PR DESCRIPTION
## Summary
**Relay 0.3.0.** Two generic transport capabilities — no HA-domain logic, both are the enablers the coverage roadmap needs (`mqtt`, `camera`).

**Envelope v2**
- `collect_events.on_limit: "return"` (**window mode**): resolves with the events collected so far and marks the response `truncated: true`, instead of failing at `max_events`/`timeout_ms`. That is what makes bounded *sniffing* possible for streams that never emit a finish event (MQTT topics, event buses). Default stays `"error"` → existing callers see byte-identical behavior, and `truncated` is emitted **only when true**, so the response shape is unchanged for them.
- **Subscriptions are now allowed INSIDE a `collect_events` envelope.** The two reasons for the ban do not apply there: the collection unsubscribes in its `finally` block and its lifetime is bounded by `max_events`/`timeout_ms`, so no upstream subscription can leak or accumulate. **Bare** subscriptions stay rejected exactly as before (new test pins both halves).
- `collectMessageEvents` now returns `{events, truncated}` so truncation is carried honestly instead of inferred.

**Binary responses on `/core`**
- Non-text/non-JSON bodies (camera frames) were `Buffer.concat(...).toString("utf8")` — silently corrupting every non-ASCII byte. They now travel as base64 with `body_encoding` + `content_type` markers, under their own **8 MiB** ceiling (base64 inflates ~33%; a single frame is far below it).
- JSON and text keep their exact shape — including HA's plain-text `/api/error_log`, which `diagnose` depends on.
- CLI: `relay core --out-binary <file>` decodes the marker and writes raw bytes. It **refuses an unmarked body** (silently writing the JSON envelope as a "JPEG" would be worse than failing) and rejects `--jq`/`--out` combinations.

## Verification
- `tsc -p nova/tsconfig.json` clean; full suite 70 files / 649 tests green (7 new relay tests: window mode at max_events, window mode at timeout, strict mode still errors, in-envelope subscription allowed, bare subscription still rejected, invalid `on_limit` → 400, binary base64 round-trip, text path unmarked).
- Full `go test ./...` green (3 new CLI tests: base64 round-trip through nested dirs, unmarked-body refusal points at `--out`, flag-combination guards).

## Risks / notes
- `version.json:min_relay_version` deliberately **stays 0.2.5**: no shipped skill uses these features yet. The skills that will (`mqtt`, `camera`) raise it — that keeps the floor honest instead of forcing an App update for nothing.
- `relay-api.md` states plainly that an older relay **silently ignores** `on_limit` and falls back to strict mode, so a skill must check `relay health` before relying on window mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UABh9QxzyCg8JhostzVUF