### PR TITLE
feat(docs): safety guarantees, comparison page, and a live disposable-HA e2e

### DIFF
--- a/.github/workflows/e2e-disposable-ha.yml
+++ b/.github/workflows/e2e-disposable-ha.yml
@@ -1,0 +1,31 @@
+name: E2E (disposable Home Assistant)
+
+# Boots a real Home Assistant, runs the standalone relay against it, and asserts
+# the guarantees only a live system can prove (see docs/reference/safety.md).
+# Non-blocking by design: it is evidence, not a merge gate — a Home Assistant
+# release or a Docker Hub hiccup must not block unrelated PRs.
+
+on:
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  disposable-ha:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install the websocket client used to mint the token
+        run: pip install --quiet websockets
+
+      - name: Run the live end-to-end verification
+        run: bash scripts/e2e/disposable-ha/run.sh

--- a/docs/reference/comparison.md
+++ b/docs/reference/comparison.md
@@ -1,0 +1,63 @@
+# Why skills instead of tools
+
+HA NOVA is deliberately **not** an MCP server. This page explains that choice honestly, including where the alternatives are ahead.
+
+Everything below reflects the state on **2026-07-11**. The main alternative — [ha-mcp](https://github.com/homeassistant-ai/ha-mcp), "The Unofficial and Awesome Home Assistant MCP Server" (MIT, ~87 tools) — is a good, actively maintained project, and HA NOVA is not trying to pretend otherwise. Their approach is different, and the differences are real in both directions.
+
+## The three approaches
+
+| | **Home Assistant's official MCP server** | **ha-mcp** (community MCP server) | **HA NOVA** |
+|---|---|---|---|
+| What the AI gets | The Assist API (exposed entities) | ~87 MCP tools | 24 markdown skills + 3 generic relay endpoints |
+| Can it edit automations, dashboards, the registry? | No | Yes | Yes |
+| Where the domain knowledge lives | In Home Assistant | In the server's Python code | In markdown you can read and edit |
+| Protocol dependency | MCP | MCP | none — skills are plain text |
+
+## What "skills instead of tools" actually buys you
+
+**Context cost.** An MCP client loads every tool definition into the model's context at the start of a session, whether you use them or not. At ~87 tools, that is real weight — enough that ha-mcp built a BM25 search mode to hide tools from smaller models. HA NOVA loads a skill only when the task needs it: a light-switching request never sees the dashboard rules.
+
+**You can read and change the behavior.** When HA NOVA gets something wrong, the fix is a markdown edit you can make yourself. When a tool-based server gets something wrong, the fix is a Python change, a release, and an update. Every safety rule on this page is a sentence in a file you can open.
+
+**It does not depend on a protocol.** MCP is a good standard and it is not going away — but skills are just text. The same skills work in Claude Code, Codex, OpenCode, Antigravity, and Hermes today, and they will work in whatever comes next, because there is nothing to port. (Agent Skills is now an open standard under the Linux Foundation's Agentic AI Foundation, which makes this bet less lonely than it was.)
+
+**The server stays dumb on purpose.** HA NOVA's relay is ~1,800 lines that forward requests and nothing more — no domain handlers, no caching, no interpretation. A build-time check fails if that ever stops being true. The consequence: the relay cannot silently reinterpret your request, because it does not know what a light is.
+
+## Safety, side by side
+
+This is where the projects differ most, and it is the reason HA NOVA exists.
+
+| | ha-mcp | HA NOVA |
+|---|---|---|
+| Preview before a write | Per-tool `confirm` parameters and approval rules you configure | Enforced for every mutation skill, in a block that is byte-identical across all of them and asserted by a test |
+| Confirmation binding | Parameter-level | Bound to the exact preview shown; expires if the payload, target, or scope changes |
+| Deletes | `destructiveHint` / confirm parameter | A typed token (`confirm:del-…`); "yes" is rejected, and a click-menu is never offered instead |
+| Verification after a write | Per-tool | The config is read back and compared; "it saved" is never reported as "it works" |
+| Undo | Full-system backups | Per-config revert of the last 5 changed targets — plus an honest statement wherever revert does *not* exist |
+| Unknown APIs | The tool set is the boundary | An AI may not trial-and-error an unfamiliar Home Assistant API: it must go through the fallback skill first |
+| Token storage | Long-lived token in client config (or in-process, with the HACS component) | Home Assistant token stays on the server; the relay token lives in your OS keychain |
+| Process isolation | The recommended install runs inside Home Assistant | Separate process (App or container): a relay crash cannot take Home Assistant down |
+
+Every HA NOVA row is backed by a file and a test in **[safety.md](safety.md)** — read that page instead of trusting this one.
+
+## Where ha-mcp is ahead (as of 2026-07-11)
+
+Being honest about this is the point of the page:
+
+- **YAML and filesystem editing.** ha-mcp can edit `configuration.yaml` and read/write files (beta, with automatic backups). HA NOVA cannot yet — it is on the roadmap behind an opt-in relay capability, because file access is the largest thing you can hand an AI and we want the write flow (diff → confirm → `check_config` → reload → verify → rollback) built before the door opens.
+- **Add-on and HACS management.** ha-mcp can install and manage those. HA NOVA points you at the Home Assistant UI.
+- **Dashboard screenshots** and **ZHA device inspection**: ha-mcp has them, HA NOVA does not.
+- **Maturity of reach.** ha-mcp has more stars, more contributors, and more integrations wired up. HA NOVA is younger.
+
+## Where HA NOVA is ahead (as of 2026-07-11)
+
+- **Media, notifications, and MQTT** have dedicated skills with real domain rules — feature-bit gating before a media call, the iOS/Android payload split for notifications, retained-vs-live distinction when listening to MQTT. ha-mcp does not cover these.
+- **Root-cause diagnosis** as a workflow (traces → logs → bounded history → template probe), not just raw log access.
+- **The safety model above**, which is enforced structurally rather than per tool.
+- **Runs on every Home Assistant install** — App for HA OS/Supervised, container for Container/Core — from one codebase.
+
+## Which should you use?
+
+If you want the broadest tool coverage today and are comfortable with MCP, ha-mcp is a solid choice and we would rather you use it than nothing.
+
+Use HA NOVA if you want an AI that shows you what it will change before it changes it, verifies afterwards, tells you when it cannot undo something, and whose behavior you can read in plain text and edit yourself.

--- a/docs/reference/safety.md
+++ b/docs/reference/safety.md
@@ -1,0 +1,69 @@
+# Safety guarantees
+
+What HA NOVA promises, what enforces it, and what proves it. Every row names a file you can read and a test you can run — no adjectives.
+
+Last verified: 2026-07-11 — `npm run verify` (70 test files / 650 tests), `go test ./...`, and the live end-to-end run against a real, disposable Home Assistant (`bash scripts/e2e/disposable-ha/run.sh`), all green.
+
+## Writes
+
+| Guarantee | Enforced by | Verified by |
+|---|---|---|
+| Nothing is written before you see a preview of exactly what will change | Safety Core, first bullet in every mutation skill (`docs/reference/skill-architecture.md` → Safety Core) | `tests/skills/skill-template-contract.test.ts` asserts the byte-identical block in all 13 mutation skills; `tests/skills/ha-safety-contract.test.ts` |
+| Your confirmation binds to the shown preview and expires if the target, payload, endpoint, or scope changes | Safety Core bullet 2; context skill → Active Preview Confirmation | `tests/skills/ha-safety-contract.test.ts` (13 mutation skills pinned) |
+| "Go ahead" said *before* a preview authorizes drafting only — never the write | Safety Core bullet 3 | `tests/skills/ha-safety-contract.test.ts` (all five pre-preview phrases pinned) |
+| Deletes require a typed `confirm:<token>`; "yes" is not accepted, and a menu is never offered instead | Safety Core bullet 4; context skill → Confirmation Tiers | `tests/skills/write-delete-safety-contract.test.ts` ("keeps delete a typed token even under menu pressure") |
+| Every write is verified by reading the config back, not by trusting the response | `skills/write/SKILL.md` Phase 3; `skills/ha-nova/write-safety.md` → Verification Honesty | `tests/skills/ha-cross-skill-integration.test.ts`; `tests/skills/write-delete-safety-contract.test.ts` |
+| A verified update can be reverted — the last 5 changed targets, one step back each | `skills/ha-nova/write-safety.md` → Update-Revert; `skills/ha-nova/update-revert.md`; `cli/snapshot.go` | `cli/snapshot_test.go`; `tests/skills/write-delete-safety-contract.test.ts` |
+| Where there is no revert (deletes, dashboards, scenes, registry ops), the skill says so *before* the write instead of implying safety | `skills/ha-nova/write-safety.md` → Safety-Mechanism Availability by Skill | `tests/skills/write-delete-safety-contract.test.ts` |
+| An AI never writes to an unfamiliar Home Assistant API by trial and error | Safety Core bullet 7 (STOP → `ha-nova:fallback`); `skills/fallback/SKILL.md` → Anti-Patterns | `tests/skills/ha-safety-contract.test.ts` ("enforces fallback skill as mandatory for raw relay writes") |
+| IDs are never guessed — they are resolved or you are asked | Safety Core bullet 5 | `tests/skills/skill-template-contract.test.ts` (Safety Core verbatim) |
+
+## Tokens and privacy
+
+| Guarantee | Enforced by | Verified by |
+|---|---|---|
+| Your Home Assistant token stays on the server. The AI client never receives it | The relay resolves it from its own environment (`nova/src/security/token-resolver.ts`); no code path sends it downstream | `nova` relay tests (`tests/security/token-resolver.test.ts`); `scripts/check-docs.sh` |
+| The relay token is stored in your OS credential store (Keychain / Credential Manager / Secret Service), not in a config file | `cli/keyring_*.go` (service `ha-nova.relay-auth-token`); the plaintext file path exists only for headless `--service` installs | `cli/keyring_*_test.go`; `scripts/check-docs.sh` ("macOS Keychain integration") |
+| No telemetry, no analytics, no phone-home | There is none to disable | `scripts/check-docs.sh` check [11] fails the build if telemetry patterns appear in `nova/src` |
+| No cloud relay: your data goes from your machine to your Home Assistant, and nowhere else | The relay only talks to `HA_URL` (`nova/src/ha/*`); it cannot proxy other hosts | Relay tests; `docs/reference/bridge-architecture.md` |
+| Camera frames stay in client-private scratch storage and are never sent onward | `skills/camera/SKILL.md` → Safety | `tests/skills/skill-template-contract.test.ts` |
+
+## The relay itself
+
+| Guarantee | Enforced by | Verified by |
+|---|---|---|
+| Every endpoint requires authentication — there is no unauthenticated surface, not even `/health` | `nova/src/http/server.ts` (auth runs before routing) | `tests/security/auth.test.ts`; `tests/http/*`; the container smoke test asserts a 401 |
+| Token comparison is constant-time | `nova/src/security/auth.ts` (`timingSafeEqual`) | `tests/security/auth.test.ts` |
+| Path traversal into non-`/api/` paths is rejected, including multi-round percent-encoding | `nova/src/http/handlers/core-proxy.ts` → `normalizeCorePath` | `tests/http/core-proxy.test.ts` (traversal vector suite) |
+| Requests and responses are bounded (1 MiB in, 256 MiB out, 8 MiB for binary) | `nova/src/http/server.ts`; `nova/src/ha/rest-client.ts` | `tests/http/*`; `tests/ha/rest-client.test.ts` |
+| The relay holds no long-lived subscriptions: event collection is bounded and always unsubscribes | `nova/src/ha/ws-client.ts` (`finally` unsubscribe, `max_events`/`timeout_ms`); bare subscriptions are rejected | `tests/ha/ws-client.test.ts`; `tests/http/ws-proxy.test.ts` |
+| A subscription that never establishes fails loudly instead of looking like an empty result | `nova/src/ha/ws-client.ts` (window timer starts only after the ack) | `tests/ha/ws-client.test.ts` ("fails in window mode when the subscription is never acknowledged") |
+| The relay contains no Home Assistant business logic — it cannot silently reinterpret your request | `nova/src/**` is transport only | `scripts/check-docs.sh` checks [3], [4], [5] fail the build on domain handlers, tool definitions, or new endpoint families |
+| A health check never opens a connection to Home Assistant — but once real traffic has, `/health` says so honestly | `nova/src/ha/ws-client.ts` (event-driven `ready`/`disconnected` tracking, no probe-triggered connect) | `scripts/e2e/disposable-ha/run.sh` asserts both halves against a live Home Assistant |
+| One relay codebase for both distributions (App and container) — no second implementation to drift | `nova/Dockerfile.standalone` builds from `nova/src` | `scripts/check-docs.sh` check [2b] |
+
+## Honesty rules
+
+These are guarantees about what HA NOVA *says*, which matter as much as what it does:
+
+| Guarantee | Enforced by | Verified by |
+|---|---|---|
+| A successful write is never reported as verified behavior — persistence is not the same as "it works" | `skills/ha-nova/write-safety.md` → Verification Honesty ("never a bare 'verified'") | `tests/skills/write-delete-safety-contract.test.ts` |
+| Conclusions are bound to evidence; without it, hypotheses are labelled as such | Context skill → Claim-Evidence Binding; `skills/diagnose/SKILL.md` | `tests/skills/ha-nova-contract.test.ts` |
+| A notification that Home Assistant accepted is not claimed as delivered to your phone | `skills/notify/SKILL.md` | `tests/skills/skill-template-contract.test.ts` |
+| An empty MQTT window means "nothing was published", and retained broker replays are never counted as live device traffic | `skills/mqtt/SKILL.md` | `tests/skills/skill-template-contract.test.ts` |
+| Internal review codes (R-18, H-09, …) never reach you — findings are described in plain language | `skills/ha-nova/output-rules.md`; `skills/review/checks.md` → Output Guardrail | `tests/skills/skill-template-contract.test.ts` (check-code leak allowlist) |
+
+## Reproduce it
+
+```bash
+npm run verify                            # typecheck + full test suite + build + documentation fact-check
+cd cli && go test ./...                   # CLI: keyring, snapshot/revert, uninstall teardown, update nudges
+bash scripts/e2e/disposable-ha/run.sh     # boots a REAL Home Assistant and verifies the relay against it
+```
+
+The last one is the honest one: it boots Home Assistant in a container, completes its onboarding, mints a token, starts the relay against it, and asserts the guarantees that only a live system can prove — authentication is enforced, the version the CLI compares against is real, proxied calls return actual Home Assistant data, a bare subscription is rejected while a bounded window is served, and the health endpoint neither opens a connection nor lies about one. It runs weekly in CI (non-blocking: it is evidence, not a merge gate) and can be run by anyone in about three minutes.
+
+Everything is torn down afterwards; nothing touches your own Home Assistant.
+
+The documentation fact-check (`scripts/check-docs.sh`) is deliberately hostile to its own README: it fails the build if the relay grows domain logic, endpoint families, telemetry, or a second implementation.

--- a/scripts/e2e/disposable-ha/docker-compose.yml
+++ b/scripts/e2e/disposable-ha/docker-compose.yml
@@ -1,0 +1,43 @@
+# Disposable Home Assistant + NOVA Relay, for end-to-end verification.
+#
+# This is throwaway infrastructure: it boots a real Home Assistant, starts the
+# relay against it (as the standalone container, which validates that
+# distribution at the same time), and is destroyed afterwards. Nothing here is
+# meant to survive a run.
+
+services:
+  homeassistant:
+    image: homeassistant/home-assistant:stable
+    container_name: nova-e2e-ha
+    volumes:
+      - ./config:/config
+    environment:
+      TZ: UTC
+    ports:
+      - "8123:8123"
+    healthcheck:
+      # HA answers 200 on / once the frontend is up.
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:8123/ || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+      start_period: 20s
+
+  relay:
+    build:
+      context: ../../../nova
+      dockerfile: Dockerfile.standalone
+      args:
+        RELAY_VERSION: "${RELAY_VERSION:-e2e}"
+    container_name: nova-e2e-relay
+    depends_on:
+      homeassistant:
+        condition: service_healthy
+    environment:
+      # Both are validated by the relay itself at startup; compose must not
+      # gate on them, or the Home Assistant service could not start first.
+      RELAY_AUTH_TOKEN: "${RELAY_AUTH_TOKEN:-}"
+      HA_LLAT: "${HA_LLAT:-}"
+      HA_URL: "http://homeassistant:8123"
+    ports:
+      - "8791:8791"

--- a/scripts/e2e/disposable-ha/mint-llat.py
+++ b/scripts/e2e/disposable-ha/mint-llat.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Mint a long-lived access token on a disposable Home Assistant.
+
+Home Assistant only offers this over the WebSocket API (auth/long_lived_access_token),
+not over REST — the same path the user's browser takes in Profile > Security.
+Used by run.sh; not part of the shipped product.
+"""
+
+import json
+import sys
+from urllib.parse import urlparse
+
+try:
+    from websockets.sync.client import connect
+except ImportError:  # pragma: no cover - developer environment hint
+    print(
+        "missing dependency: pip install websockets  (needed only for the disposable-HA e2e)",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+def main() -> int:
+    ha_url, access_token = sys.argv[1], sys.argv[2]
+    parsed = urlparse(ha_url)
+    ws_url = f"ws://{parsed.netloc}/api/websocket"
+
+    with connect(ws_url) as ws:
+        # auth_required -> auth -> auth_ok
+        json.loads(ws.recv())
+        ws.send(json.dumps({"type": "auth", "access_token": access_token}))
+        auth_result = json.loads(ws.recv())
+        if auth_result.get("type") != "auth_ok":
+            print(f"authentication failed: {auth_result}", file=sys.stderr)
+            return 1
+
+        ws.send(
+            json.dumps(
+                {
+                    "id": 1,
+                    "type": "auth/long_lived_access_token",
+                    "client_name": "HA NOVA E2E",
+                    "lifespan": 1,
+                }
+            )
+        )
+        result = json.loads(ws.recv())
+
+    if not result.get("success"):
+        print(f"could not mint a long-lived token: {result}", file=sys.stderr)
+        return 1
+
+    print(result["result"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e/disposable-ha/run.sh
+++ b/scripts/e2e/disposable-ha/run.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# End-to-end verification against a REAL, disposable Home Assistant.
+#
+# Boots Home Assistant, completes its onboarding through the API, mints a
+# long-lived access token, starts the standalone relay container against it,
+# and asserts the guarantees that only a live system can prove:
+#   - authentication is enforced (401 without a token)
+#   - the relay reports its baked-in version, so the CLI's compatibility check works
+#   - a health probe does NOT open the upstream WebSocket (no lazy-connect)...
+#   - ...but /health honestly reports the connection once real traffic opened it
+#   - REST and WS proxy calls return real Home Assistant data
+#   - a bare subscription is rejected, but a bounded window is served
+#
+# Everything is destroyed afterwards. Run: bash scripts/e2e/disposable-ha/run.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HA_URL="http://127.0.0.1:8123"
+RELAY_URL="http://127.0.0.1:8791"
+export RELAY_AUTH_TOKEN="e2e-relay-token-$RANDOM"
+export RELAY_VERSION="$(grep -E '^version:' "$HERE/../../../nova/config.yaml" | head -1 | sed -E 's/^version:[[:space:]]*"?([^"]+)"?/\1/')"
+
+pass() { echo "  ok: $*"; }
+fail() { echo "  FAIL: $*" >&2; FAILED=1; }
+FAILED=0
+
+cleanup() {
+  echo "--- tearing down"
+  ( cd "$HERE" && docker compose down -v --remove-orphans > /dev/null 2>&1 || true )
+  rm -rf "$HERE/config"
+}
+trap cleanup EXIT
+
+echo "--- booting a disposable Home Assistant (relay version: $RELAY_VERSION)"
+rm -rf "$HERE/config"
+mkdir -p "$HERE/config"
+( cd "$HERE" && docker compose up -d homeassistant )
+
+echo "--- waiting for Home Assistant"
+for i in $(seq 1 90); do
+  if curl -sf "$HA_URL/" > /dev/null 2>&1; then break; fi
+  if [[ "$i" == "90" ]]; then echo "Home Assistant did not start" >&2; exit 1; fi
+  sleep 2
+done
+pass "Home Assistant is up"
+
+echo "--- onboarding + minting a long-lived token"
+# A fresh HA exposes an onboarding API exactly once; this is the supported way
+# to create the owner user without touching the UI.
+auth_code="$(curl -sf -X POST "$HA_URL/api/onboarding/users" \
+  -H 'Content-Type: application/json' \
+  -d '{"client_id":"http://127.0.0.1:8123/","name":"E2E","username":"e2e","password":"e2e-password-1234","language":"en"}' \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["auth_code"])')"
+
+access_token="$(curl -sf -X POST "$HA_URL/auth/token" \
+  -d "client_id=http://127.0.0.1:8123/&grant_type=authorization_code&code=${auth_code}" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')"
+
+# Finish onboarding so the core config exists and integrations can load.
+for step in core_config analytics integration; do
+  curl -sf -X POST "$HA_URL/api/onboarding/$step" \
+    -H "Authorization: Bearer ${access_token}" \
+    -H 'Content-Type: application/json' \
+    -d '{"client_id":"http://127.0.0.1:8123/"}' > /dev/null 2>&1 || true
+done
+
+HA_LLAT="$(python3 "$HERE/mint-llat.py" "$HA_URL" "$access_token")"
+export HA_LLAT
+pass "long-lived token minted"
+
+echo "--- starting the standalone relay container against it"
+( cd "$HERE" && docker compose up -d --build relay )
+for i in $(seq 1 30); do
+  code="$(curl -s -o /dev/null -w '%{http_code}' "$RELAY_URL/health" || true)"
+  if [[ "$code" == "401" ]]; then break; fi
+  if [[ "$i" == "30" ]]; then echo "relay did not start (last: ${code:-none})" >&2; ( cd "$HERE" && docker compose logs relay ); exit 1; fi
+  sleep 2
+done
+pass "relay rejects unauthenticated requests (401)"
+
+echo "--- asserting the live guarantees"
+health="$(curl -sf -H "Authorization: Bearer $RELAY_AUTH_TOKEN" "$RELAY_URL/health")"
+echo "      $health"
+
+python3 - "$health" "$RELAY_VERSION" <<'PY' || FAILED=1
+import json, sys
+health = json.loads(sys.argv[1])["data"]
+expected_version = sys.argv[2]
+ok = True
+if health.get("version") != expected_version:
+    print(f"  FAIL: relay reports version {health.get('version')!r}, expected {expected_version!r} (the baked-in version is what the CLI compatibility check reads)", file=sys.stderr)
+    ok = False
+else:
+    print(f"  ok: relay reports its baked-in version ({expected_version})")
+
+# A health probe must NOT open the upstream WebSocket — the connection is
+# established lazily by real traffic (docs/choices.md: no lazy-connect through
+# health probes, no added latency). So ha_ws_connected is expected to be false
+# here, BEFORE any WS call. It is asserted true further down, after real WS use.
+if health.get("ha_ws_connected") is True:
+    print("  FAIL: a health probe opened the upstream WebSocket — probes must not connect", file=sys.stderr)
+    ok = False
+else:
+    print("  ok: a health probe does not open the upstream WebSocket (no lazy-connect)")
+sys.exit(0 if ok else 1)
+PY
+
+# REST proxy: real Home Assistant config comes back.
+core_body="$(curl -sf -X POST "$RELAY_URL/core" \
+  -H "Authorization: Bearer $RELAY_AUTH_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"method":"GET","path":"/api/config"}')"
+if echo "$core_body" | grep -q '"version"'; then
+  pass "REST proxy returns live Home Assistant data"
+else
+  fail "REST proxy did not return HA config: $core_body"
+fi
+
+# WS proxy: real registry data comes back.
+ws_body="$(curl -sf -X POST "$RELAY_URL/ws" \
+  -H "Authorization: Bearer $RELAY_AUTH_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"type":"config/area_registry/list"}')"
+if echo "$ws_body" | grep -q '"ok":true'; then
+  pass "WS proxy returns live Home Assistant data"
+else
+  fail "WS proxy failed: $ws_body"
+fi
+
+# ...and NOW health must honestly report the live WS connection that the call
+# above established. This is the pair that matters: probes do not connect, but
+# once there is a real connection, /health says so.
+health_after="$(curl -sf -H "Authorization: Bearer $RELAY_AUTH_TOKEN" "$RELAY_URL/health")"
+if echo "$health_after" | grep -q '"ha_ws_connected":true'; then
+  pass "health reports the live WebSocket connection after real WS traffic"
+else
+  fail "health should report ha_ws_connected=true after a WS call: $health_after"
+fi
+
+# A bare subscription must be rejected — the relay holds no long-lived subscriptions.
+bare="$(curl -s -o /dev/null -w '%{http_code}' -X POST "$RELAY_URL/ws" \
+  -H "Authorization: Bearer $RELAY_AUTH_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"type":"subscribe_events"}')"
+if [[ "$bare" == "400" ]]; then
+  pass "bare subscription rejected (400)"
+else
+  fail "bare subscription should be rejected, got HTTP $bare"
+fi
+
+# ...but a BOUNDED window is served and unsubscribes itself.
+window="$(curl -sf -X POST "$RELAY_URL/ws" \
+  -H "Authorization: Bearer $RELAY_AUTH_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"message":{"type":"subscribe_events","event_type":"state_changed"},"collect_events":{"max_events":3,"timeout_ms":3000,"on_limit":"return"}}')"
+if echo "$window" | grep -q '"events"'; then
+  pass "bounded event window is served (envelope v2)"
+else
+  fail "bounded window failed: $window"
+fi
+
+echo
+if [[ "$FAILED" == "1" ]]; then
+  echo "E2E FAILED" >&2
+  ( cd "$HERE" && docker compose logs relay | tail -30 )
+  exit 1
+fi
+echo "E2E PASSED — verified against a real Home Assistant $(date -u +%Y-%m-%d)"

--- a/scripts/e2e/disposable-ha/run.sh
+++ b/scripts/e2e/disposable-ha/run.sh
@@ -27,7 +27,14 @@ FAILED=0
 cleanup() {
   echo "--- tearing down"
   ( cd "$HERE" && docker compose down -v --remove-orphans > /dev/null 2>&1 || true )
-  rm -rf "$HERE/config"
+  # Home Assistant writes the bind mount as root (.storage and friends), so a
+  # non-root CI runner cannot remove it directly — a failing cleanup would turn
+  # a green evidence run red. Delete it from inside a container, which can.
+  if [[ -d "$HERE/config" ]]; then
+    docker run --rm -v "$HERE/config:/target" alpine:3 \
+      sh -c 'rm -rf /target/* /target/.[!.]* /target/..?* 2>/dev/null || true' > /dev/null 2>&1 || true
+    rmdir "$HERE/config" 2>/dev/null || rm -rf "$HERE/config" 2>/dev/null || true
+  fi
 }
 trap cleanup EXIT
 
@@ -57,12 +64,27 @@ access_token="$(curl -sf -X POST "$HA_URL/auth/token" \
   | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')"
 
 # Finish onboarding so the core config exists and integrations can load.
-for step in core_config analytics integration; do
-  curl -sf -X POST "$HA_URL/api/onboarding/$step" \
-    -H "Authorization: Bearer ${access_token}" \
-    -H 'Content-Type: application/json' \
-    -d '{"client_id":"http://127.0.0.1:8123/"}' > /dev/null 2>&1 || true
-done
+# The integration step needs a redirect_uri as well as a client_id.
+curl -sf -X POST "$HA_URL/api/onboarding/core_config" \
+  -H "Authorization: Bearer ${access_token}" -H 'Content-Type: application/json' \
+  -d '{"client_id":"http://127.0.0.1:8123/"}' > /dev/null
+curl -sf -X POST "$HA_URL/api/onboarding/analytics" \
+  -H "Authorization: Bearer ${access_token}" -H 'Content-Type: application/json' \
+  -d '{"client_id":"http://127.0.0.1:8123/"}' > /dev/null
+curl -sf -X POST "$HA_URL/api/onboarding/integration" \
+  -H "Authorization: Bearer ${access_token}" -H 'Content-Type: application/json' \
+  -d '{"client_id":"http://127.0.0.1:8123/","redirect_uri":"http://127.0.0.1:8123/"}' > /dev/null
+
+# Verify the RESULT rather than trusting the steps: /api/onboarding reports each
+# step's done flag. A half-onboarded Home Assistant would make every assertion
+# below meaningless, so this is a hard failure, not a warning.
+onboarding_state="$(curl -sf "$HA_URL/api/onboarding")"
+if echo "$onboarding_state" | python3 -c 'import json,sys; steps=json.load(sys.stdin); sys.exit(0 if all(s["done"] for s in steps) else 1)'; then
+  pass "onboarding completed (all steps report done)"
+else
+  echo "  FAIL: onboarding is incomplete: $onboarding_state" >&2
+  exit 1
+fi
 
 HA_LLAT="$(python3 "$HERE/mint-llat.py" "$HA_URL" "$access_token")"
 export HA_LLAT


### PR DESCRIPTION
## Summary
Masterplan C4 + C5 (wave 5). The trust story stops being adjectives and becomes **evidence**.

**`docs/reference/safety.md`** — every guarantee, the file that enforces it, the test that proves it. Writes (preview binding, typed delete tokens, read-back verification, the bounded revert stack *and an honest statement where revert does not exist*), tokens/privacy (HA token never leaves the server, relay token in the OS keychain, no telemetry), the relay itself (no unauthenticated surface, constant-time auth, path-traversal defense, bounded payloads, no long-lived subscriptions), and the **honesty rules** (persistence is not "it works"; accepted is not delivered; retained MQTT is not live traffic).

**`docs/reference/comparison.md`** — why skills instead of tools, dated and named. Credits ha-mcp as a good project, states plainly where it is **ahead** (YAML/filesystem editing, add-on + HACS management, screenshots, ZHA, maturity of reach) and where HA NOVA is (media/notify/MQTT domain rules, root-cause diagnosis as a workflow, the structural safety model, running on every HA install type). Credibility through symmetry.

**`scripts/e2e/disposable-ha/`** — boots a **real** Home Assistant container, completes onboarding through its API, mints a long-lived token, starts the standalone relay against it, and asserts what only a live system can prove. Weekly in CI, **non-blocking by design**: evidence, not a merge gate.

## The e2e immediately earned its keep
It caught a **wrong expectation of mine**: a health probe deliberately does *not* open the upstream WebSocket (`docs/choices.md`: no lazy-connect through probes), so `ha_ws_connected` is false until real traffic connects. The test now asserts **both halves** — probes must not connect, and `/health` must report the connection honestly once it exists — a stronger guarantee than the one I set out to write.

## Verification
```
E2E PASSED — verified against a real Home Assistant 2026-07-11
  ok: relay rejects unauthenticated requests (401)
  ok: relay reports its baked-in version (0.3.0)
  ok: a health probe does not open the upstream WebSocket (no lazy-connect)
  ok: REST proxy returns live Home Assistant data
  ok: WS proxy returns live Home Assistant data
  ok: health reports the live WebSocket connection after real WS traffic
  ok: bare subscription rejected (400)
  ok: bounded event window is served (envelope v2)
```
Plus: full suite 70 files / 650 tests green; root typecheck clean; pre-push hook green.

## Notes
- Docs live under `docs/reference/` per the documentation-governance rule.
- README untouched; links to these pages go into the release-prep PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UABh9QxzyCg8JhostzVUF