### PR TITLE
docs: record the masterplan status and the pick-up point

### DIFF
--- a/docs/work/masterplan-2026.md
+++ b/docs/work/masterplan-2026.md
@@ -141,13 +141,35 @@ Dispatch sharpness at 28 skills: `diagnose` = root-cause a concrete failure, `he
 
 | Wave | Theme | Contents | Status |
 |------|-------|----------|--------|
-| **1** | Lifecycle & parity | C1 guided teardown + C2 update nudge | shipped to main (#288, #289) |
-| **2** | Template & portability | Workstream A: template v2 + linter + normalization, Safety Core, Execution Mode, token diet, frontmatter alignment | in progress |
-| **3** | Coverage wave 1 | `diagnose` + `media` + `notify` + fallback catalog (B11) | open |
-| **4** | Runs everywhere | Docker relay + wizard branch + disposable-HA e2e + platform claims (release-body draft) | open |
-| **5** | Trust & compare | `docs/safety.md` + dated eval report + `docs/comparison.md` + Relay 0.3.0 (envelope v2 + binary) + `camera`/`mqtt` | open |
-| **6** | Coverage wave 2 | `assist`, `admin`, Relay 0.4.0 (`/files`) + `yaml-config`, `external-sources`, weather row | open |
-| **Final release gate** | | (a) all 4 HA install types validated; (b) lifecycle symmetric + parity everywhere; (c) safety.md fully evidence-linked with green scheduled run; (d) top domains shipped (media/notify/camera/logs); (e) Windows gold test (open breadcrumb); (f) no known false-success write path; (g) comparison page live; (h) release-prep PR (version bump + notes + README updates) followed immediately by the RC/final tag flow | open |
+| **1** | Lifecycle & parity | C1 guided teardown + C2 update nudge | **DONE** — #288, #289 |
+| **2** | Template & portability | Template v2 + structural linter, bootstrap-independent Safety Core, Execution Mode, token diet (write path −~9k tokens), Agent-Skills frontmatter | **DONE** — #290, #291, #292, #293, #294 |
+| **3** | Coverage wave 1 | `diagnose`, `media`, `notify`, `camera`, `mqtt` + fallback catalog; Relay 0.3.0 (envelope v2 window mode + binary responses) | **DONE** — #295, #296, #297, #298 |
+| **4** | Runs everywhere | Standalone container relay (HA Container/Core), GHCR publish with smoke-then-promote, one-codebase guard | **DONE** — #299 |
+| **5** | Trust & compare | `docs/reference/safety.md` (guarantee → enforced by → verified by), `docs/reference/comparison.md` (named, dated, honest both ways), live disposable-HA e2e (weekly, non-blocking) | **DONE** — #301 |
+| **6** | Coverage wave 2 | Relay 0.4.0 `/files` (opt-in, default off) **DONE** — #302. Skills `yaml-config`, `assist`, `admin`, `external-sources` + weather row: **branch `feat/wave6-skills` (ae3dcda), pushed, NOT yet a PR** | **IN PROGRESS** |
+| **Final release gate** | | See "Where to pick up" below | open |
+
+## Where to pick up (2026-07-12)
+
+**Everything through wave 5 is on `main`.** 17 PRs merged; `main` is green (typecheck, 74 test files / 721 tests, Go suite, docs fact-check, live e2e against a real Home Assistant).
+
+**Immediate next step — finish wave 6:**
+1. `git checkout feat/wave6-skills && git merge main` (the branch predates the relay-0.4.0 merge; it carries `min_relay_version: 0.4.0`, which only becomes valid once #302 is in — it now is).
+2. `npm run typecheck && npm run test:safe && bash scripts/check-docs.sh` — the skill-directory count in `scripts/check-docs.sh` is already set to 29 on that branch; the linter classes, dispatch table, fallback map, Hermes readiness list and architecture doc are wired.
+3. Add the code-execution boundary to `skills/yaml-config/SKILL.md`: the relay now refuses `custom_components`, `python_scripts`, `www` and only writes `.yaml/.yml/.conf/.json/.txt/.md` — the skill must say so instead of discovering it as an error.
+4. PR → `@codex` → fix findings → merge (standard cycle).
+
+**Then the release (the only thing left):**
+- Release-prep PR (README is stable-truth and may ONLY change here, together with a `version.json` bump — that is what `readme-release-gate` enforces):
+  - `version.json`: `skill_version` 0.13.0 → the release number (0.14.0 is the working assumption).
+  - `README.md`: "19 task skills" → 28; relay size "~1.5K lines" → ~2.6K; add the platform claim (App **or** standalone container → runs on every HA install type); link `docs/reference/safety.md` and `docs/reference/comparison.md`.
+  - Release notes: use `docs/work/0.14.0-release-body.md` (already written; keep it short and user-centric per the release-notes rule).
+- Then the tag flow per `docs/releasing.md`: strict-mode `verify-release-pipeline.sh` → push `vX.Y.Z-rc1` on the reviewed commit → verify the public install → tag the final `vX.Y.Z` on that same commit.
+
+**Known open items (not release blockers):**
+- Windows gold test (carried over from before this program).
+- The setup wizard has no guided "Docker" branch yet; Container/Core users follow `docs/reference/relay-container.md` (non-interactive `ha-nova setup --non-interactive --ha-url ... --relay-url ... --relay-token ...`). Documented as planned.
+- `skills/helper/SKILL.md` is 489 lines (over the ~400 guidance) — split candidate, deliberately deferred.
 
 Every wave follows repo rules: one topic one branch, PR merge checklist, Codex review cycle; the single release at the end follows the full release rehearsal gate.
 

--- a/docs/work/masterplan-2026.md
+++ b/docs/work/masterplan-2026.md
@@ -161,9 +161,9 @@ Dispatch sharpness at 28 skills: `diagnose` = root-cause a concrete failure, `he
 
 **Then the release (the only thing left):**
 - Release-prep PR (README is stable-truth and may ONLY change here, together with a `version.json` bump — that is what `readme-release-gate` enforces):
-  - `version.json`: `skill_version` 0.13.0 → the release number (0.14.0 is the working assumption).
-  - `README.md`: "19 task skills" → 28; relay size "~1.5K lines" → ~2.6K; add the platform claim (App **or** standalone container → runs on every HA install type); link `docs/reference/safety.md` and `docs/reference/comparison.md`.
-  - Release notes: use `docs/work/0.14.0-release-body.md` (already written; keep it short and user-centric per the release-notes rule).
+  - Version bump via `npm run bump -- <version>` (0.14.0 is the working assumption). `scripts/bump-version.sh` updates every version-bearing file — `version.json`, `package.json`, `package-lock.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`; a `version.json`-only edit is not enough. The bump touches manifests → add `manifest-review:approved` per the PR checklist.
+  - `README.md`: "19 task skills" → 28; relay size "~1.5K lines" → ~2.7K; add the platform claim (App **or** standalone container → runs on every HA install type); link `docs/reference/safety.md` and `docs/reference/comparison.md`.
+  - Release notes: refresh `docs/work/0.14.0-release-body.md` against the shipped wave-6 state before use — the wave-6 PR moves the relay floor to 0.4.0 and adds the wave-6 skill bullets; verify the draft carries them rather than trusting "already written". Keep it short and user-centric per the release-notes rule.
 - Then the tag flow per `docs/releasing.md`: strict-mode `verify-release-pipeline.sh` → push `vX.Y.Z-rc1` on the reviewed commit → verify the public install → tag the final `vX.Y.Z` on that same commit.
 
 **Known open items (not release blockers):**


### PR DESCRIPTION
## Summary
Updates `docs/work/masterplan-2026.md` so any session (or any person) can resume the program without reconstructing state from PR history.

- **Wave table** now reflects reality: waves 1–5 are **done and on `main`** (17 PRs), wave 6 is half-done (relay 0.4.0 `/files` merged in #302; the four skills sit on `feat/wave6-skills`, pushed, no PR yet).
- **New "Where to pick up" section** with the exact next steps: merge `main` into `feat/wave6-skills`, add the code-execution boundary to the `yaml-config` skill (the relay refuses `custom_components`/`python_scripts`/`www` and only writes config formats — the skill must state it rather than discover it), then the standard PR cycle.
- Then the only remaining work: the **release-prep PR** (the one place README may change, together with the `version.json` bump — that is what `readme-release-gate` enforces) and the RC/final tag flow per `docs/releasing.md`.
- Known open items recorded as non-blockers: Windows gold test, the missing guided Docker branch in the setup wizard, the oversized `helper/SKILL.md`.

## Verification
Docs only. `docs/breadcrumbs.md` is deliberately NOT in this PR — it is gitignored by design (the `repo-hygiene` check fails if it is tracked); the session journal stays local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UABh9QxzyCg8JhostzVUF