### PR TITLE
fix(release): survive release-list growth in the next-version check

### DIFF
--- a/scripts/release/verify-next-release-version.sh
+++ b/scripts/release/verify-next-release-version.sh
@@ -78,14 +78,33 @@ if (!repo) {
 
 let releases;
 try {
-  const pages = JSON.parse(
-    execFileSync("gh", ["api", "--paginate", "--slurp", `repos/${repo}/releases?per_page=100`], {
+  // Project down to the three fields this check reads BEFORE the payload
+  // crosses the process boundary: full release objects carry the complete
+  // notes body per release, and the default spawnSync maxBuffer (1 MiB)
+  // killed the v0.14.0 publish with ENOBUFS once the RC's notes pushed the
+  // total over it. The raised maxBuffer is the backstop for very long tag
+  // histories.
+  const ndjson = execFileSync(
+    "gh",
+    [
+      "api",
+      "--paginate",
+      "--jq",
+      ".[] | {tag_name, draft, prerelease}",
+      `repos/${repo}/releases?per_page=100`,
+    ],
+    {
       cwd: rootDir,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-    }),
+      maxBuffer: 64 * 1024 * 1024,
+    },
   );
-  releases = Array.isArray(pages) ? pages.flatMap((page) => (Array.isArray(page) ? page : [])) : [];
+  releases = ndjson
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
 } catch (error) {
   const detail = error.stderr || error.message || String(error);
   fail(`gh api failed for ${repo}: ${detail.trim()}`);

--- a/tests/onboarding/bump-version.test.ts
+++ b/tests/onboarding/bump-version.test.ts
@@ -54,7 +54,11 @@ describe("S-11: version bump", () => {
     expect(content.startsWith("#!/")).toBe(true);
     expect(content).toContain("gh");
     expect(content).toContain("--paginate");
-    expect(content).toContain("--slurp");
+    // --slurp is deliberately absent: it is incompatible with --jq, and the
+    // per-page --jq projection is what keeps the payload under spawnSync
+    // buffers (the v0.14.0 ENOBUFS publish failure).
+    expect(content).not.toContain("--slurp");
+    expect(content).toContain("--jq");
     expect(content).toContain("latest published stable");
     expect(content).toContain("already exists on GitHub releases");
     expect(content).toContain("HA_NOVA_ALLOW_EXISTING_RELEASE_TAG");

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -70,6 +70,15 @@ describe("release contract", () => {
     expect(releaseWorkflow).toContain("GORELEASER_CURRENT_TAG: ${{ github.ref_name }}");
   });
 
+  it("keeps the next-release-version check immune to release-payload growth", () => {
+    // The default spawnSync maxBuffer (1 MiB) failed the v0.14.0 publish with
+    // ENOBUFS once the release list outgrew it. The gh call must project the
+    // payload down to the fields it reads and carry an explicit buffer.
+    const versionCheck = readFileSync("scripts/release/verify-next-release-version.sh", "utf8");
+    expect(versionCheck).toContain('".[] | {tag_name, draft, prerelease}"');
+    expect(versionCheck).toContain("maxBuffer: 64 * 1024 * 1024");
+  });
+
   it("keeps the RC workflow free of winget artifacts and guidance", () => {
     expect(rcWorkflow).toContain("Build install bundles");
     expect(rcWorkflow).toContain("Upload RC artifacts");


### PR DESCRIPTION
## Summary

The v0.14.0 stable publish run failed at `Verify next release version` with `spawnSync gh ENOBUFS`: `gh api --paginate --slurp repos/.../releases` returns full release objects (notes bodies included), and the embedded Node's default 1 MiB buffer overflowed — the moment the v0.14.0-rc1 prerelease (published 40 minutes earlier by the rehearsal) pushed the total payload over the limit. The RC run passed because the list was still smaller; this is exactly the failure mode the tag-first rehearsal exists to catch.

Fix: project each page down to the three fields the check reads (`--jq '.[] | {tag_name, draft, prerelease}'`, NDJSON parsed per line — `--slurp` is incompatible with `--jq`), plus a 64 MiB `maxBuffer` backstop. Release-contract and bump-version pins lock the shape in.

## Verification (against the live, now-oversized payload)

- `npm run verify:next-release-version -- v0.14.0` → OK ✓
- `-- v0.14.0-rc1` → correctly rejected (tag exists) ✓
- `-- v0.13.0` → correctly rejected (not newer) ✓
- `tests/onboarding/bump-version.test.ts` + `release-contract.test.ts` → 23/23 ✓ (full pre-push suite green on push)

## Release plan

The unpublished `v0.14.0` tag (verify failed before GoReleaser; no release object exists) will be moved to the new reviewed merge commit; the rehearsal repeats there (`v0.14.0-rc2`) before the final tag, per docs/releasing.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnL7zQZRToTuH6V2RPUFBc