### PR TITLE
fix(cli): read the real health envelope so doctor warns on an outdated relay

### DIFF
--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -226,10 +226,20 @@ func runCheckUpdate(paths runtimePaths, args []string) int {
 	ensureClientsVerifiedForCurrentVersion(paths)
 
 	notice := humanNoticeFromUpdateCheckResult(result, *quiet)
+	if !notice.empty() {
+		printHumanNotice(notice)
+	}
+	// CLI/skills freshness is only half the answer: the relay in Home
+	// Assistant has its own version, and "up to date" would be misleading
+	// while it sits below min_relay_version. Stderr-only, exit code unchanged
+	// — the update check itself succeeded (the --json branch above stays
+	// machine-clean and untouched).
+	if relayNotice := relayFloorNotice(paths); !relayNotice.empty() {
+		printHumanNotice(relayNotice)
+	}
 	if notice.empty() {
 		return 0
 	}
-	printHumanNotice(notice)
 	return updateCheckExitCode(result)
 }
 

--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -231,11 +231,15 @@ func runCheckUpdate(paths runtimePaths, args []string) int {
 	}
 	// CLI/skills freshness is only half the answer: the relay in Home
 	// Assistant has its own version, and "up to date" would be misleading
-	// while it sits below min_relay_version. Stderr-only, exit code unchanged
-	// — the update check itself succeeded (the --json branch above stays
-	// machine-clean and untouched).
-	if relayNotice := relayFloorNotice(paths); !relayNotice.empty() {
-		printHumanNotice(relayNotice)
+	// while it sits below min_relay_version. Human path only: --quiet is the
+	// skill self-update channel whose contract is "UPDATE AVAILABLE or
+	// silence" — skill sessions already get the relay warning through the
+	// proxy version header. Stderr-only, exit code unchanged, --json above
+	// stays machine-clean.
+	if !*quiet {
+		if relayNotice := relayFloorNotice(paths); !relayNotice.empty() {
+			printHumanNotice(relayNotice)
+		}
 	}
 	if notice.empty() {
 		return 0

--- a/cli/command_update.go
+++ b/cli/command_update.go
@@ -129,6 +129,12 @@ func runUpdate(paths runtimePaths, args []string) int {
 	// may be the OLD (dev) binary whose compiled-in version predates the
 	// update (issue #245 showed "Updated to v0.7.1" while installing 0.8.0).
 	printHumanInfo("Updated to v%s", targetVersion)
+	// The freshly installed version.json may raise min_relay_version — the
+	// update moment is where the user can still act on it, instead of being
+	// interrupted mid-session by the proxy warning later.
+	if notice := relayFloorNotice(paths); !notice.empty() {
+		printHumanNotice(notice)
+	}
 	return 0
 }
 
@@ -192,9 +198,14 @@ func syncInstalledClientsForCurrentVersion(paths runtimePaths, currentVersion, t
 	}
 	if cmp > 0 {
 		printHumanInfo("Already on newer version v%s than target v%s", currentVersion, targetVersion)
-		return 0
+	} else {
+		printHumanInfo("Already up to date: v%s", currentVersion)
 	}
-	printHumanInfo("Already up to date: v%s", currentVersion)
+	// "Up to date" is misleading while the relay sits below the floor the
+	// installed skills need — say so here, where the user is looking.
+	if notice := relayFloorNotice(paths); !notice.empty() {
+		printHumanNotice(notice)
+	}
 	return 0
 }
 

--- a/cli/command_update.go
+++ b/cli/command_update.go
@@ -176,6 +176,12 @@ func runInternalReplace(paths runtimePaths, args []string) int {
 		printHumanWarn("updated to v%s, but could not remove the previous install backup: %s", localVersion(paths), err)
 	}
 	printHumanInfo("Updated to v%s", localVersion(paths))
+	// Windows finishes the update in this replacement process — the freshly
+	// installed version.json is live here, so the relay-floor warning belongs
+	// here too (the staging branch in runUpdate exits before it).
+	if notice := relayFloorNotice(paths); !notice.empty() {
+		printHumanNotice(notice)
+	}
 	return 0
 }
 

--- a/cli/release_test.go
+++ b/cli/release_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -469,6 +470,107 @@ func TestCheckRelayVersionWarnsOnUnsupportedRelayVersionFormat(t *testing.T) {
 	}
 	if !strings.Contains(notice.message, "unsupported relay version format") {
 		t.Fatalf("unexpected relay warning message: %q", notice.message)
+	}
+}
+
+func TestCheckRelayVersionReadsTheRealHealthEnvelope(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.VersionFile), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(paths.VersionFile, []byte(`{"skill_version":"0.14.0","min_relay_version":"0.4.0"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	// Verbatim shape of a live GET /health response: the version sits inside
+	// the relay's {"ok":true,"data":{...}} envelope, not at the top level. A
+	// parser that only reads a top-level "version" silently skips the check —
+	// doctor then reports a healthy setup while the relay is below the floor.
+	body := []byte(`{"ok":true,"data":{"status":"ok","ha_ws_connected":true,"version":"0.2.6","uptime_s":322135}}`)
+	notice := checkRelayVersion(paths, body)
+	if notice.kind != humanNoticeKindRelayOutdated {
+		t.Fatalf("notice.kind = %q, want %q (envelope body must not be skipped)", notice.kind, humanNoticeKindRelayOutdated)
+	}
+	if !strings.Contains(notice.message, "Relay outdated: v0.2.6 is below minimum v0.4.0") {
+		t.Fatalf("unexpected relay warning message: %q", notice.message)
+	}
+}
+
+func TestRelayFloorNoticeWarnsWhenLiveRelayIsBelowFloor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+
+	relay := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"data":{"status":"ok","ha_ws_connected":true,"version":"0.2.6"}}`))
+	}))
+	defer relay.Close()
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.VersionFile), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(paths.VersionFile, []byte(`{"skill_version":"0.14.0","min_relay_version":"0.4.0"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+	if err := saveConfig(paths, runtimeConfig{HAHost: "127.0.0.1", HAURL: "http://127.0.0.1:8123", RelayBaseURL: relay.URL}); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := writeRelayAuthToken("test-relay-token"); err != nil {
+		t.Fatalf("writeRelayAuthToken() error: %v", err)
+	}
+
+	notice := relayFloorNotice(paths)
+	if notice.kind != humanNoticeKindRelayOutdated {
+		t.Fatalf("notice.kind = %q, want %q", notice.kind, humanNoticeKindRelayOutdated)
+	}
+	if !strings.Contains(notice.message, "Relay outdated: v0.2.6 is below minimum v0.4.0") {
+		t.Fatalf("unexpected relay warning message: %q", notice.message)
+	}
+}
+
+func TestRelayFloorNoticeStaysSilentWhenRelayUnreachable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.VersionFile), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(paths.VersionFile, []byte(`{"skill_version":"0.14.0","min_relay_version":"0.4.0"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+	// Port 1 refuses connections without ever having been bound by this
+	// process — no close-then-rebind recycling risk (see #310).
+	if err := saveConfig(paths, runtimeConfig{HAHost: "127.0.0.1", HAURL: "http://127.0.0.1:8123", RelayBaseURL: "http://127.0.0.1:1"}); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := writeRelayAuthToken("test-relay-token"); err != nil {
+		t.Fatalf("writeRelayAuthToken() error: %v", err)
+	}
+
+	if notice := relayFloorNotice(paths); !notice.empty() {
+		t.Fatalf("expected silence for unreachable relay, got %q", notice.message)
 	}
 }
 

--- a/cli/version.go
+++ b/cli/version.go
@@ -213,13 +213,47 @@ func readMinRelayVersion(dir string) string {
 }
 
 func checkRelayVersion(paths runtimePaths, healthBody []byte) humanNotice {
+	// A live GET /health answers with the relay envelope
+	// {"ok":true,"data":{"version":...}} — the version is NOT top-level. The
+	// top-level field stays as a fallback for bare health bodies.
 	var health struct {
 		Version string `json:"version"`
+		Data    struct {
+			Version string `json:"version"`
+		} `json:"data"`
 	}
-	if json.Unmarshal(healthBody, &health) != nil || health.Version == "" {
+	if json.Unmarshal(healthBody, &health) != nil {
 		return humanNotice{}
 	}
-	return checkRelayVersionValue(paths, health.Version)
+	version := health.Data.Version
+	if version == "" {
+		version = health.Version
+	}
+	if version == "" {
+		return humanNotice{}
+	}
+	return checkRelayVersionValue(paths, version)
+}
+
+// relayFloorNotice fetches the relay health once and returns the
+// outdated-relay warning when the running relay is below min_relay_version.
+// Best-effort by design: a missing config, missing token, or unreachable
+// relay yields an empty notice — update/check-update must not fail or get
+// noisy because Home Assistant is offline.
+func relayFloorNotice(paths runtimePaths) humanNotice {
+	cfg, err := loadConfig(paths)
+	if err != nil || cfg.RelayBaseURL == "" {
+		return humanNotice{}
+	}
+	token, err := readRelayAuthTokenForDoctor()
+	if err != nil || token == "" {
+		return humanNotice{}
+	}
+	body, err := fetchRelayHealth(cfg.RelayBaseURL, token)
+	if err != nil {
+		return humanNotice{}
+	}
+	return checkRelayVersion(paths, body)
 }
 
 // checkRelayVersionValue compares a bare relay version (from the /health body


### PR DESCRIPTION
## Summary

Field report (real install, relay 0.2.6, CLI 0.14.0): `ha-nova doctor` printed "Doctor checks passed" although the relay sits far below `min_relay_version: 0.4.0`.

**Root cause:** `checkRelayVersion` unmarshals a **top-level** `version` field, but a live `GET /health` answers with the relay envelope `{"ok":true,"data":{"version":"0.2.6",...}}` → the field stayed empty → silent early return. Both body-based call sites (doctor, `relay health`) were dead; only the `x-ha-nova-relay-version` header path (skill proxy calls, 24h-throttled) ever worked. The bug was invisible until today because no supported relay had ever been below the floor — the 0.14.0 floor bump (0.4.0) is the first time it matters. Existing tests fed the parser flat `{"version":"..."}` fixtures modeled on the broken code, not on reality.

**Fix:**
- `checkRelayVersion` reads `data.version` with the top-level field as fallback; regression test uses the verbatim live response shape.
- New `relayFloorNotice(paths)` (best-effort: missing config/token or unreachable relay → silent) is surfaced after `ha-nova update` success, "Already up to date", and in human `check-update` — the moment the user is already in update mode, instead of the first hint arriving mid-session via the proxy warning. Exit codes unchanged, `--json` untouched (machine-clean), warning on stderr.

## Verification

- TDD: envelope regression test failed on the old parser, green after the fix.
- `TestRelayFloorNotice*`: warns via live-shaped httptest relay; stays silent on unreachable relay (port 1, no bind-recycling risk per #310).
- Full Go suite green (`go test ./...`, 152s).
- **Live on the reporting install** (relay 0.2.6): fixed `doctor` now prints `WARNING: Relay outdated: v0.2.6 is below minimum v0.4.0...`; fixed `check-update` prints `Up to date: v0.14.0` followed by the same warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnL7zQZRToTuH6V2RPUFBc