### PR TITLE
chore(release): prepare v0.14.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.14.0"
+    "version": "0.14.1"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,6 +96,10 @@ release:
     - The NOVA Relay must be updated to 0.4.0 or newer (App: **Settings > Apps > NOVA Relay**; container: pull the new image). Camera and MQTT need 0.3.0's binary and bounded-listening support, YAML editing needs 0.4.0's opt-in file access — HA NOVA tells you if your relay is too old.
     - Set `HA_NOVA_NO_UPDATE_NUDGE=1` to silence the new update notices.
 
+    ## Bug Fixes
+
+    - `ha-nova doctor` now really checks the relay version: it read the wrong field of the health response and could report a healthy setup while your relay was too old for the installed skills. `ha-nova update` and `check-update` also tell you now when the relay in Home Assistant needs its own update — right when you are already updating.
+
     Stable install commands are release-pinned for this tag.
 
     **macOS / Linux:**

--- a/docs/work/2026-07-12-v0.14.1-release-body.md
+++ b/docs/work/2026-07-12-v0.14.1-release-body.md
@@ -1,0 +1,9 @@
+# v0.14.1 Release Body (draft)
+
+Status: active — shipped wording lives in `.goreleaser.yml`; archive this file after the release.
+
+Patch release on top of v0.14.0 (same feature notes; users jumping from 0.13.x see the full v0.14 feature set in the release header).
+
+## Bug Fixes
+
+- `ha-nova doctor` now really checks the relay version: it read the wrong field of the health response and could report a healthy setup while your relay was too old for the installed skills. `ha-nova update` and `check-update` also tell you now when the relay in Home Assistant needs its own update — right when you are already updating.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "home-assistant-js-websocket": "^9.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -53,7 +53,7 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
-  it("keeps v0.14.0 release-facing wording user-centric", () => {
+  it("keeps v0.14.1 release-facing wording user-centric", () => {
     // Shipped release-note bodies are archived (docs/archive/work/) and
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
@@ -63,6 +63,7 @@ describe("release contract", () => {
     expect(goreleaser).toContain("YAML configuration you can finally edit");
     expect(goreleaser).toContain("The NOVA Relay must be updated to 0.4.0 or newer");
     expect(goreleaser).toContain("HA_NOVA_NO_UPDATE_NUDGE=1");
+    expect(goreleaser).toContain("`ha-nova doctor` now really checks the relay version");
     expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");
   });
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.14.0",
+  "skill_version": "0.14.1",
   "min_relay_version": "0.4.0"
 }


### PR DESCRIPTION
## Summary

Patch release-prep for **v0.14.1** — ships #314 (user-facing bug in v0.14.0: `doctor` read the wrong health field and reported a healthy setup while the relay sat below `min_relay_version`; `update`/`check-update` now also surface the relay floor on the human path). Release-worthy per the shipped-product bug rule; practically every install predating today runs a relay below the new 0.4.0 floor.

- Bump via `npm run bump -- 0.14.1` (all five version-bearing files, marketplace keeps `source: "./"`).
- GoReleaser notes: v0.14.0 feature set kept (0.13.x jumpers see the full picture) + `Bug Fixes` entry; `What To Watch` unchanged (0.4.0 floor line stays correct).
- `release-contract` pins moved to v0.14.1 (adds the Bug-Fixes pin).
- Dated release-body draft per convention; archive follows post-release.
- README untouched.

## Verification

- `npm run verify` ✓ (metadata sync 0.14.1, audit, typecheck, safe suite, build/docs, Go suite, release contracts 39/39)
- `npm run verify:next-release-version -- v0.14.1` runs in the tag flow (script fixed in #312 against payload growth)

## Release plan (after merge)

Strict-mode pipeline audit → `v0.14.1-rc1` on the merge commit → release.yml prerelease + 3-OS smoke → public RC install verify → final `v0.14.1` on the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnL7zQZRToTuH6V2RPUFBc