### PR TITLE
feat(cli): relay-outdated warning asks to install the update via ha-nova:updates

### DIFF
--- a/cli/version.go
+++ b/cli/version.go
@@ -281,7 +281,7 @@ func checkRelayVersionValue(paths runtimePaths, relayVersion string) humanNotice
 		return humanNotice{
 			level:   humanNoticeWarning,
 			kind:    humanNoticeKindRelayOutdated,
-			message: fmt.Sprintf("Relay outdated: v%s is below minimum v%s. Inform the user: update the NOVA Relay in Home Assistant (App, or pull the new container image).", relayVersion, v.MinRelayVersion),
+			message: fmt.Sprintf("Relay outdated: v%s is below minimum v%s. Inform the user, then ask whether to install the relay update now — the updates skill (ha-nova:updates) handles the App update; a standalone container needs a manual image pull.", relayVersion, v.MinRelayVersion),
 		}
 	}
 	return humanNotice{}

--- a/docs/work/2026-07-12-relay-guided-update-spec.md
+++ b/docs/work/2026-07-12-relay-guided-update-spec.md
@@ -1,0 +1,40 @@
+# Spec: guided relay update from the CLI (stage 2)
+
+Status: `draft` — approved direction (maintainer, 2026-07-12); implementation queued for a later version.
+
+## Problem
+
+Since v0.14.1 the CLI warns when the relay sits below `min_relay_version` (doctor, update, check-update, proxy header path), and since stage 1 the agent asks whether to install the App update via `ha-nova:updates`. But a user running plain `ha-nova update` in a terminal — outside any AI session — still has to switch to Home Assistant and click through the App update themselves.
+
+## Goal
+
+`ha-nova update` (and `doctor`, TTY only) offers to install the relay App update right there, with explicit consent — ask first, never automatic.
+
+## Flow
+
+1. After a successful self-update (or doctor run) the existing `relayFloorNotice` fires.
+2. TTY + App-backed relay only: prompt `Install the relay update in Home Assistant now? [Y/n]` (reuse `promptWizardYesNoFromReader`).
+3. On yes:
+   - Resolve the App's `update.*` entity: `GET /api/states`, domain `update`, match the NOVA Relay App slug (the entity carries the App title; never guess — on ambiguity, print the manual path instead).
+   - `POST /api/services/update/install` via the existing `/core` proxy with `{"entity_id": ..., "backup": true}` (partial App backup, mirrors `skills/updates/SKILL.md`).
+   - Expect the relay to restart mid-call: tolerate the dropped response, then poll `GET /health` (existing `fetchRelayHealth`) every ~5 s for up to ~3 min until the reported version satisfies `min_relay_version`.
+   - Report the verified version, or a plain timeout message with the manual path.
+4. Non-TTY, `--yes`-style automation, or standalone container: keep today's warning only (a container cannot replace itself; ha-nova has no Docker-host access).
+
+## Boundaries
+
+- Ask-first always — an unprompted relay restart kills in-flight relay calls (project preview/confirm DNA).
+- Client-side only: generic HA endpoints through the existing proxy; no new relay endpoint, no HA domain logic in the relay (charter).
+- Detection of "App-backed vs container" comes from the update-entity lookup itself: no entity → treat as container/manual.
+
+## Tests
+
+- Entity resolution: exact match, no match (→ manual path), ambiguous match (→ manual path).
+- Install flow with a mock relay that drops the install response, then serves the new version on `/health` (restart simulation).
+- Poll timeout → honest failure message, exit code unchanged.
+- Non-TTY and container paths stay warning-only.
+
+## Out of scope
+
+- "Relay update available" (above-floor) notifications — needs the current relay version in release metadata; separate decision, mainly benefits container users.
+- Container auto-pull (Watchtower guidance stays documentation).

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -37,7 +37,7 @@ Before the first HA task in a session:
 2. Otherwise run: `ha-nova check-update --quiet`
 3. If the output contains `UPDATE AVAILABLE`, inform the user and offer to update.
 4. If the output is empty, continue silently.
-5. If any `ha-nova relay` command later prints an `[ha-nova]` update notice on stderr, surface it to the user once and continue the current task.
+5. If any `ha-nova relay` command later prints an `[ha-nova]` update notice on stderr, surface it to the user once and continue the current task. For a relay-outdated notice, also ASK whether to install the relay update now: `ha-nova:updates` handles the App update (it restarts the relay; verify via `ha-nova relay health` afterwards). A standalone container cannot be updated from here — say so and point at the image pull.
 
 When an update is available:
 1. Run: `ha-nova update`


### PR DESCRIPTION
## Summary

Stage 1 of the guided relay update (maintainer-approved direction):

- The relay-outdated warning (`cli/version.go`) now instructs the agent to **ask** whether to install the relay update right away — `ha-nova:updates` already handles the App self-update (restart + health re-verify per `skills/updates/SKILL.md`); standalone containers keep the manual image-pull wording.
- The context skill's Self-Update rule 5 mirrors that: surface the notice once, then ask; containers get the honest "cannot be updated from here".
- Stage 2 (TTY prompt in `ha-nova update`/`doctor` that resolves the App's `update.*` entity, calls `update.install` through `/core`, tolerates the relay restart, and polls health until the floor is met) is specced in `docs/work/2026-07-12-relay-guided-update-spec.md` — ask-first always, client-side only, no new relay endpoint.

## Verification

- Skill contracts + release contracts: 273/273 ✓; `check-docs` ✓; `go vet` + version-check tests ✓ (message pins are prefix-based, unaffected).
- Live against a real 0.2.6 relay: `doctor` prints the new ask-to-install wording.

## Release note

Not release-worthy on its own (wording/guidance; no shipped-bug fix) — batches into the next user-facing release per the release-worthiness rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnL7zQZRToTuH6V2RPUFBc