### PR TITLE
feat(e2e): live /files readwrite roundtrip; releasing.md requires a dispatched e2e run

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -133,7 +133,7 @@ the final tag may safely point at the same commit.
    the weekly schedule alone is NOT release evidence (the v0.14.0 release
    shipped before the workflow had ever fired):
    ```bash
-   gh workflow run e2e-disposable-ha.yml --ref main && gh run watch
+   gh workflow run e2e-disposable-ha.yml --ref main && gh run watch --exit-status
    # or locally, with Docker: bash scripts/e2e/disposable-ha/run.sh
    ```
    It boots a real Home Assistant plus the relay built from the commit and

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -129,6 +129,17 @@ the final tag may safely point at the same commit.
    ```bash
    HA_NOVA_RELEASE_AUDIT_REQUIRE_BYPASS=1 bash scripts/release/verify-release-pipeline.sh
    ```
+   Then run the live disposable-HA e2e on that same commit and wait for green —
+   the weekly schedule alone is NOT release evidence (the v0.14.0 release
+   shipped before the workflow had ever fired):
+   ```bash
+   gh workflow run e2e-disposable-ha.yml --ref main && gh run watch
+   # or locally, with Docker: bash scripts/e2e/disposable-ha/run.sh
+   ```
+   It boots a real Home Assistant plus the relay built from the commit and
+   asserts the live guarantees (auth, version report, health semantics, real
+   REST/WS data, bounded event windows, `/files` off by default AND the
+   readwrite roundtrip on a mounted config).
 2. Push the rehearsal tag on that exact commit (maintainer bypass):
    ```bash
    git tag vX.Y.Z-rcN <reviewed-merge-sha>
@@ -208,6 +219,7 @@ Minimum automated gate:
 - `npm run verify:next-release-version -- vX.Y.Z-rcN` before an RC tag
 - `npm run verify:next-release-version -- vX.Y.Z` before the final tag
 - `HA_NOVA_RELEASE_AUDIT_REQUIRE_BYPASS=1 bash scripts/release/verify-release-pipeline.sh` before any release tag/publish step
+- one green `e2e-disposable-ha.yml` run (dispatched, not the weekly cron) on the commit being tagged
 
 Minimum manual gate before calling an RC ready:
 

--- a/scripts/e2e/disposable-ha/docker-compose.yml
+++ b/scripts/e2e/disposable-ha/docker-compose.yml
@@ -41,3 +41,28 @@ services:
       HA_URL: "http://homeassistant:8123"
     ports:
       - "8791:8791"
+
+  # Second relay with file access opted in — proves the /files readwrite path
+  # live, while the primary relay above keeps proving the off-by-default
+  # guarantee. Runs as root ONLY because Home Assistant writes the throwaway
+  # bind mount as root; this verifies /files semantics, not Unix permissions.
+  relay-files:
+    build:
+      context: ../../../nova
+      dockerfile: Dockerfile.standalone
+      args:
+        RELAY_VERSION: "${RELAY_VERSION:-e2e}"
+    container_name: nova-e2e-relay-files
+    user: "0:0"
+    depends_on:
+      homeassistant:
+        condition: service_healthy
+    volumes:
+      - ./config:/config
+    environment:
+      RELAY_AUTH_TOKEN: "${RELAY_AUTH_TOKEN:-}"
+      HA_LLAT: "${HA_LLAT:-}"
+      HA_URL: "http://homeassistant:8123"
+      FILE_ACCESS: "readwrite"
+    ports:
+      - "8792:8791"

--- a/scripts/e2e/disposable-ha/run.sh
+++ b/scripts/e2e/disposable-ha/run.sh
@@ -192,7 +192,7 @@ fi
 # config directory with FILE_ACCESS=readwrite and must serve the full
 # write -> read-back -> deny -> delete roundtrip the yaml-config skill uses.
 echo "--- file access: readwrite roundtrip (second relay on :8792)"
-( cd "$HERE" && docker compose up -d relay-files > /dev/null 2>&1 )
+( cd "$HERE" && docker compose up -d --build relay-files > /dev/null 2>&1 )
 FILES_URL="http://127.0.0.1:8792"
 for i in $(seq 1 30); do
   code="$(curl -s -o /dev/null -w '%{http_code}' "$FILES_URL/health" || true)"

--- a/scripts/e2e/disposable-ha/run.sh
+++ b/scripts/e2e/disposable-ha/run.sh
@@ -188,10 +188,75 @@ else
   fail "file access should be disabled by default, got HTTP $files_off"
 fi
 
+# The opted-in side of the same guarantee: a second relay mounts the real HA
+# config directory with FILE_ACCESS=readwrite and must serve the full
+# write -> read-back -> deny -> delete roundtrip the yaml-config skill uses.
+echo "--- file access: readwrite roundtrip (second relay on :8792)"
+( cd "$HERE" && docker compose up -d relay-files > /dev/null 2>&1 )
+FILES_URL="http://127.0.0.1:8792"
+for i in $(seq 1 30); do
+  code="$(curl -s -o /dev/null -w '%{http_code}' "$FILES_URL/health" || true)"
+  if [[ "$code" == "401" ]]; then break; fi
+  if [[ "$i" == "30" ]]; then echo "relay-files did not start (last: ${code:-none})" >&2; ( cd "$HERE" && docker compose logs relay-files ); exit 1; fi
+  sleep 2
+done
+
+files_call() {
+  curl -s -X POST "$FILES_URL/files" \
+    -H "Authorization: Bearer $RELAY_AUTH_TOKEN" -H 'Content-Type: application/json' -d "$1"
+}
+files_code() {
+  curl -s -o /dev/null -w '%{http_code}' -X POST "$FILES_URL/files" \
+    -H "Authorization: Bearer $RELAY_AUTH_TOKEN" -H 'Content-Type: application/json' -d "$1"
+}
+
+listing="$(files_call '{"action":"list_dir","path":"/config"}')"
+if echo "$listing" | grep -q 'configuration.yaml'; then
+  pass "list_dir sees the real Home Assistant config"
+else
+  fail "list_dir did not show configuration.yaml: $listing"
+fi
+
+wrote="$(files_call '{"action":"write_file","path":"/config/ha_nova/e2e-roundtrip.yaml","content":"e2e_marker: disposable-ha\n"}')"
+if echo "$wrote" | grep -q '"ok":true'; then
+  pass "write_file creates a file under /config/ha_nova/"
+else
+  fail "write_file failed: $wrote"
+fi
+
+readback="$(files_call '{"action":"read_file","path":"/config/ha_nova/e2e-roundtrip.yaml"}')"
+if echo "$readback" | grep -q 'e2e_marker: disposable-ha'; then
+  pass "read_file returns the written content verbatim"
+else
+  fail "read-back did not match: $readback"
+fi
+
+secrets_deny="$(files_code '{"action":"write_file","path":"/config/secrets.yaml","content":"x: y\n"}')"
+if [[ "$secrets_deny" == "403" ]]; then
+  pass "secrets.yaml stays unreachable even with readwrite (403)"
+else
+  fail "secrets.yaml write should be denied, got HTTP $secrets_deny"
+fi
+
+exec_deny="$(files_code '{"action":"write_file","path":"/config/ha_nova/evil.sh","content":"#!/bin/sh\n"}')"
+if [[ "$exec_deny" == "403" ]]; then
+  pass "non-configuration file types are refused (403)"
+else
+  fail ".sh write should be denied, got HTTP $exec_deny"
+fi
+
+deleted="$(files_call '{"action":"delete_file","path":"/config/ha_nova/e2e-roundtrip.yaml"}')"
+gone="$(files_code '{"action":"read_file","path":"/config/ha_nova/e2e-roundtrip.yaml"}')"
+if echo "$deleted" | grep -q '"ok":true' && [[ "$gone" == "404" ]]; then
+  pass "delete_file removes the file (read-back 404)"
+else
+  fail "delete roundtrip failed: delete=$deleted read-back=HTTP $gone"
+fi
+
 echo
 if [[ "$FAILED" == "1" ]]; then
   echo "E2E FAILED" >&2
-  ( cd "$HERE" && docker compose logs relay | tail -30 )
+  ( cd "$HERE" && docker compose logs relay relay-files | tail -40 )
   exit 1
 fi
 echo "E2E PASSED — verified against a real Home Assistant $(date -u +%Y-%m-%d)"

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -147,6 +147,17 @@ describe("release contract", () => {
     expect(releasing).toContain("GORELEASER_CURRENT_TAG");
   });
 
+  it("requires a dispatched live e2e run as release evidence", () => {
+    // The weekly cron is monitoring, not release evidence: v0.14.0 shipped
+    // before the workflow had ever fired. The rehearsal must dispatch it on
+    // the exact commit being tagged and wait for green.
+    expect(releasing).toContain("gh workflow run e2e-disposable-ha.yml");
+    expect(releasing).toContain("one green `e2e-disposable-ha.yml` run (dispatched, not the weekly cron) on the commit being tagged");
+    const e2e = readFileSync("scripts/e2e/disposable-ha/run.sh", "utf8");
+    expect(e2e).toContain("readwrite roundtrip");
+    expect(e2e).toContain("secrets.yaml stays unreachable even with readwrite");
+  });
+
   it("keeps the Linux real-machine onboarding lane documented for Linux setup changes", () => {
     expect(releasing).toContain("Linux real-machine onboarding:");
     expect(releasing).toContain("scripts/smoke/linux-headless-setup-check.sh");


### PR DESCRIPTION
## Summary

Follow-up to the honest answer on "was v0.14 really verified end to end?": the weekly disposable-HA e2e had **never run** when v0.14.0 shipped (cron not yet fired, never dispatched), and it only proved `/files` in its default-off state.

- **releasing.md**: the tag-first rehearsal now requires dispatching `e2e-disposable-ha.yml` on the exact commit being tagged and waiting for green (`gh workflow run … && gh run watch`, or `bash scripts/e2e/disposable-ha/run.sh` locally); added to the minimum automated gate. Contract-pinned in `release-contract.test.ts` — the weekly cron alone is monitoring, not release evidence.
- **E2E extension**: a second relay service (`relay-files`, port 8792) mounts the same live HA config with `FILE_ACCESS=readwrite` (root only because HA writes the throwaway bind mount as root — this verifies `/files` semantics, not Unix permissions). New live assertions: `list_dir` sees the real config, `write_file` → verbatim `read_file`, `secrets.yaml` write denied (403) even with readwrite, `.sh` refused (403), `delete_file` → read-back 404. The primary relay keeps proving off-by-default.

## Verification

- Full run locally against a real Home Assistant (Docker): **18/18 assertions green**, including the 6 new roundtrip checks.
- `bash -n` clean; release-contract 17/17; `check-docs` green.
- Reference: dispatched run on main earlier today (pre-extension) was green — https://github.com/markusleben/ha-nova/actions/runs/29188784579

## Release note

Test/process-only — batches into the next release; no shipped-product change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnL7zQZRToTuH6V2RPUFBc