### PR TITLE
docs(relay): the App info page reads like a product page, stays a pointer

### DIFF
--- a/nova/README.md
+++ b/nova/README.md
@@ -1,9 +1,19 @@
 # NOVA Relay
 
-Thin relay for the HA NOVA product.
+The bridge between your AI assistant and Home Assistant — the server-side half of [HA NOVA](https://github.com/markusleben/ha-nova).
 
-Use:
-- `README.md` for the public product/install/support view
-- `nova/DOCS.md` for Home Assistant App / relay setup, endpoints, health, logs, and troubleshooting
+**What it does:** Your AI client (Claude Code, Codex, OpenCode, Google Antigravity, …) talks to this relay through the `ha-nova` CLI, and the relay forwards those calls to Home Assistant. Your Home Assistant access token stays here on the server — it never reaches your laptop and never appears in an AI conversation.
 
-This file is intentionally only a pointer so relay/operator truth lives in one place.
+**What it deliberately is not:** smart. The relay carries no Home Assistant domain logic, no caching, no interpretation — a handful of generic endpoints, small enough to read in one sitting. All the intelligence lives in plain, readable skill files on your computer.
+
+Good to know:
+
+- Setup happens on your computer with one command — start at the [HA NOVA README](https://github.com/markusleben/ha-nova#readme).
+- Relay configuration, health checks, logs, and troubleshooting live in the **Documentation** tab of this App ([`nova/DOCS.md`](https://github.com/markusleben/ha-nova/blob/main/nova/DOCS.md)).
+- The `file_access` option is **off by default**: the relay cannot touch your configuration files unless you opt in here.
+
+<!-- Governance: this file is intentionally only a pointer — product truth lives
+in the root README.md (public product/install/support view), relay/operator
+truth in nova/DOCS.md (Home Assistant App / relay setup, endpoints, health,
+logs, troubleshooting). Do not duplicate endpoints, ports, versions, or other
+operational detail here. -->

--- a/tests/onboarding/project-docs-contract.test.ts
+++ b/tests/onboarding/project-docs-contract.test.ts
@@ -54,12 +54,18 @@ describe("project docs contract", () => {
     expect(support).not.toContain("private GitHub issue");
   });
 
-  it("keeps nova/README.md as a pointer instead of a second relay truth surface", () => {
-    expect(novaReadme).toContain("Use:");
-    expect(novaReadme).toContain("`README.md` for the public product/install/support view");
-    expect(novaReadme).toContain("`nova/DOCS.md` for Home Assistant App / relay setup");
+  it("keeps nova/README.md a friendly pointer instead of a second relay truth surface", () => {
+    // Home Assistant renders this file as the App's info page, so it reads
+    // like a product page — but it stays a pointer: the governance comment
+    // (invisible in HA) anchors the rule, and the negative pins keep
+    // operational truth (endpoints, ports, connection details) out.
+    expect(novaReadme).toContain("server-side half of [HA NOVA]");
+    expect(novaReadme).toContain("access token stays here on the server");
+    expect(novaReadme).toContain("**Documentation** tab");
     expect(novaReadme).toContain("intentionally only a pointer");
+    expect(novaReadme).toContain("off by default");
     expect(novaReadme).not.toContain("Persistent WebSocket connection");
+    expect(novaReadme).not.toContain("8791");
   });
 
   it("keeps nova/DOCS.md aligned with the relay architecture reference", () => {


### PR DESCRIPTION
## Summary

Field feedback: Home Assistant renders `nova/README.md` as the App's **info page**, and users were greeted by documentation-governance prose ("This file is intentionally only a pointer …"). Against the project's UX-is-king mantra.

- The page now reads like a small product page: what the relay does (token stays server-side, never in an AI conversation), what it deliberately is not (no domain logic, readable in one sitting), setup entry point, where the Documentation tab lives, and that `file_access` is off by default.
- The governance rule stays enforced, not deleted: it moves into an HTML comment (invisible in HA's renderer, still in the file), and the contract test keeps pinning it — now with an extra negative pin (`8791` must not appear) so operational truth cannot creep back in.
- Bonus: the App store fetches this file from GitHub `main`, so the fix reaches existing installs on the next repository refresh — no release needed.

## Verification

- `project-docs-contract` green; `check-docs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnL7zQZRToTuH6V2RPUFBc