### PR TITLE
fix(skills): system_log/list is the primary log source; /api/error_log 404 is documented drift

### DIFF
--- a/docs/reference/ha-api-matrix.md
+++ b/docs/reference/ha-api-matrix.md
@@ -18,7 +18,7 @@ Which HA operations require REST, WS, or filesystem?
 | `/api/webhook/{webhook_id}` | POST | Invoke webhook |
 | `/api/history/period/{start_iso}` | GET | State history (with `?filter_entity_id=...&end_time=...`) |
 | `/api/logbook/{timestamp}` | GET | Logbook entries |
-| `/api/error_log` | GET | Error log of the current session — **404 on HA OS/Supervised since 2025.11** (log file moved to journald; official docs are stale). Re-enable: `ha core options --duplicate-log-file=true` (2026.1+). Prefer WS `system_log/list` |
+| `/api/error_log` | GET | Error log of the current session — **404 on HA OS/Supervised since 2025.11** (log file moved to journald; official docs are stale). Re-enable: `ha core options --duplicate-log-file=true` + `ha core rebuild` (2026.1+). Prefer WS `system_log/list` |
 | `/api/calendars` | GET | All calendars |
 | `/api/calendars/{entity_id}` | GET | Calendar events |
 | `/api/components` | GET | Loaded components |

--- a/docs/reference/ha-api-matrix.md
+++ b/docs/reference/ha-api-matrix.md
@@ -18,7 +18,7 @@ Which HA operations require REST, WS, or filesystem?
 | `/api/webhook/{webhook_id}` | POST | Invoke webhook |
 | `/api/history/period/{start_iso}` | GET | State history (with `?filter_entity_id=...&end_time=...`) |
 | `/api/logbook/{timestamp}` | GET | Logbook entries |
-| `/api/error_log` | GET | Error log of the current session — **404 on HA OS/Supervised since 2025.11** (log file moved to journald; official docs are stale). Re-enable: `ha core options --duplicate-log-file=true` + `ha core rebuild` (2026.1+). Prefer WS `system_log/list` |
+| `/api/error_log` | GET | Error log of the current session — **404 on HA OS/Supervised since 2025.11** (log file moved to journald; official docs are stale). Re-enable: `ha core options --duplicate-log-file=true` + `ha core rebuild` + `ha core restart` (2026.1+). Prefer WS `system_log/list` |
 | `/api/calendars` | GET | All calendars |
 | `/api/calendars/{entity_id}` | GET | Calendar events |
 | `/api/components` | GET | Loaded components |

--- a/docs/reference/ha-api-matrix.md
+++ b/docs/reference/ha-api-matrix.md
@@ -18,7 +18,7 @@ Which HA operations require REST, WS, or filesystem?
 | `/api/webhook/{webhook_id}` | POST | Invoke webhook |
 | `/api/history/period/{start_iso}` | GET | State history (with `?filter_entity_id=...&end_time=...`) |
 | `/api/logbook/{timestamp}` | GET | Logbook entries |
-| `/api/error_log` | GET | Error log of the current session |
+| `/api/error_log` | GET | Error log of the current session — **404 on HA OS/Supervised since 2025.11** (log file moved to journald; official docs are stale). Re-enable: `ha core options --duplicate-log-file=true` (2026.1+). Prefer WS `system_log/list` |
 | `/api/calendars` | GET | All calendars |
 | `/api/calendars/{entity_id}` | GET | Calendar events |
 | `/api/components` | GET | Loaded components |

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -335,7 +335,7 @@ Still excluded from `ha-nova:helper`:
 
 `ha-nova:diagnose` is the failure-root-cause skill (read-only apart from one gated mutation):
 - traces first (`ha-nova trace latest <entity_id> --json`, plus `trace list` / `trace get`) for automation/script symptoms
-- `/api/error_log` (plain text — read from file, never dump) and WS `system_log/list`
+- WS `system_log/list` as the primary log source; `/api/error_log` only where the log file exists (404 on HA OS/Supervised since 2025.11)
 - bounded logbook/history windows around the incident (default ±30 min)
 - `POST /api/template` to probe suspect conditions against live state
 - WS `diagnostics/list` + `/api/diagnostics/config_entry/<entry_id>` when an integration is the suspect

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -45,7 +45,7 @@ Recency honesty: `error_log` and `system_log/list` only cover the time since the
 
 ### Reading the error log
 
-Only where the log file exists (Container/Core installs; on HA OS/Supervised the user can restore it with `ha core options --duplicate-log-file=true`, since 2026.1). The upstream body is plain text, but the relay wraps it in the `/core` envelope — the whole log is one escaped string in `.data.body`, so searching the saved file line-wise does not work.
+Only where the log file exists (Container/Core installs; on HA OS/Supervised the user can restore it with `ha core options --duplicate-log-file=true` followed by `ha core rebuild`, since 2026.1). The upstream body is plain text, but the relay wraps it in the `/core` envelope — the whole log is one escaped string in `.data.body`, so searching the saved file line-wise does not work.
 
 1. `ha-nova relay core --method GET --path /api/error_log --out <envelope-file>`
 2. Filter the lines you need with a raw jq read (never dump the whole log):

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -34,8 +34,8 @@ File-based relay requests only:
 | Source | Call | Notes |
 |--------|------|-------|
 | Run traces | `ha-nova trace latest <entity_id> --json` (also `trace list <entity_id>`, `trace get <entity_id> <run_id>`) | First stop for automation/script failures: shows the exact step, condition results, and variables |
-| Error log | `GET /api/error_log` (upstream body is plain text, but the relay wraps it: the log lives in `.data.body` as one big string) | Save the envelope with `--out <envelope-file>`, then extract/filter LINES from it (see Reading the error log) — never search the raw envelope, whose newlines are escaped |
-| System log | WS `{"type":"system_log/list"}` | Structured warnings/errors with counts and sources |
+| System log | WS `{"type":"system_log/list"}` | PRIMARY log source: structured warnings/errors with counts and sources, works on every install type |
+| Error log | `GET /api/error_log` | **404 on HA OS/Supervised since 2025.11** (the log file moved to journald) — that is normal, not an error; stay with `system_log/list`. Where the file exists (Container/Core, or re-enabled), see Reading the error log |
 | Logbook window | `GET /api/logbook/<ISO-start>?end_time=<ISO-end>&entity=<entity_id>` | Human-readable events around the incident time |
 | State history | `GET /api/history/period/<ISO-start>?end_time=<ISO-end>&filter_entity_id=<ids>` | What states the involved entities actually had |
 | Template probe | `ha-nova relay core --method POST --path /api/template --body-file <payload-file>` with `{"template":"{{ ... }}"}` | Evaluate the exact condition/template against live state; the rendered result is the string in `.data.body` |
@@ -45,7 +45,7 @@ Recency honesty: `error_log` and `system_log/list` only cover the time since the
 
 ### Reading the error log
 
-The relay returns the `/core` envelope, so the saved file is JSON with the whole log escaped inside `.data.body` — searching that file directly does not work line-wise.
+Only where the log file exists (Container/Core installs; on HA OS/Supervised the user can restore it with `ha core options --duplicate-log-file=true`, since 2026.1). The upstream body is plain text, but the relay wraps it in the `/core` envelope — the whole log is one escaped string in `.data.body`, so searching the saved file line-wise does not work.
 
 1. `ha-nova relay core --method GET --path /api/error_log --out <envelope-file>`
 2. Filter the lines you need with a raw jq read (never dump the whole log):
@@ -62,7 +62,7 @@ The relay returns the `/core` envelope, so the saved file is JSON with the whole
 
 1. Pin the symptom: which entity/automation/script, what expected vs observed behavior, and WHEN (ask one question if the incident time is unknown — every later window depends on it).
 2. For automation/script symptoms, read the trace first (`ha-nova trace latest <entity_id> --json`; older runs via `trace list <entity_id>` + `trace get <entity_id> <run_id>`). The trace usually answers it: triggered or not, which condition stopped it, which step errored.
-3. Correlate logs: search the error log and `system_log/list` output for the involved entities, integrations, and the incident window. Quote only the relevant lines.
+3. Correlate logs: search `system_log/list` (and the error log where it exists) for the involved entities, integrations, and the incident window. Quote only the relevant lines.
 4. Reconstruct context: bounded logbook + history windows (default ±30 minutes around the incident) for the involved entities; probe suspect conditions/templates against live state (`relay core --method POST --path /api/template --body-file <payload-file>`, body `{"template":"{{ ... }}"}`; the rendered value comes back in `.data.body`).
 5. Debug escalation (optional, the only mutation): if evidence is insufficient and the user agrees, raise one integration's log level.
    - FIRST read the current levels: WS `{"type":"logger/log_info"}` → `[{"domain":..., "level": <numeric>}]`. `logger/log_info` reports NUMBERS but `logger.set_level` only accepts NAMES — map the recorded number back before building any payload: `10` → `debug`, `20` → `info`, `30` → `warning`, `40` → `error`, `50` → `critical`. A numeric level in a `set_level` payload is rejected by Home Assistant, which would leave debug logging raised until the next restart. Record the target logger's mapped level — that is the state you must restore. If it has no entry, the effective level is the configured default (HA's own default is `warning`, but `configuration.yaml` may set another).
@@ -74,7 +74,7 @@ The relay returns the `/core` envelope, so the saved file is JSON with the whole
 ## Error Handling
 
 Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handling. Diagnose specifics:
-- `/api/error_log` upstream body is plain text, but the relay always wraps it in the `/core` envelope: the log is the string in `.data.body`. Extract lines from there (see Reading the error log); do not expect a raw log file on disk.
+- `/api/error_log` 404: normal on HA OS/Supervised since 2025.11 — continue with `system_log/list` and mention the `--duplicate-log-file` re-enable only if the user asks for the raw file.
 - Missing traces (empty `trace list`): traces are kept per entity with a small cap and reset on reload/restart — say so instead of guessing.
 - `system_log/list` empty after a restart is normal; fall back to logbook/history windows.
 

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -45,7 +45,7 @@ Recency honesty: `error_log` and `system_log/list` only cover the time since the
 
 ### Reading the error log
 
-Only where the log file exists (Container/Core installs; on HA OS/Supervised the user can restore it with `ha core options --duplicate-log-file=true` followed by `ha core rebuild`, since 2026.1). The upstream body is plain text, but the relay wraps it in the `/core` envelope — the whole log is one escaped string in `.data.body`, so searching the saved file line-wise does not work.
+Only where the log file exists (Container/Core installs; on HA OS/Supervised the user can restore it with `ha core options --duplicate-log-file=true` followed by `ha core rebuild` and `ha core restart`, since 2026.1). The upstream body is plain text, but the relay wraps it in the `/core` envelope — the whole log is one escaped string in `.data.body`, so searching the saved file line-wise does not work.
 
 1. `ha-nova relay core --method GET --path /api/error_log --out <envelope-file>`
 2. Filter the lines you need with a raw jq read (never dump the whole log):


### PR DESCRIPTION
## Summary

Live behavior test against a real HA OS 2026.6.4 install: `GET /api/error_log` → **404**, while the diagnose skill documents it as a core evidence source. Research confirms this is real upstream drift, not a config quirk:

- HA **2025.11 removed `home-assistant.log`** on HA OS/Supervised (logging moved to journald); `/api/error_log` serves that file, so it 404s there. The official REST docs still list the endpoint (stale), and community threads confirm the silent removal.
- Since **2026.1** the file can be restored: `ha core options --duplicate-log-file=true` (+ rebuild/restart). Container/Core installs still write the file, so the endpoint keeps working there.

Skill fix (diagnose): WS `system_log/list` becomes the PRIMARY log source (works on every install type — verified live, 50 entries), the 404 is documented as normal with the re-enable path mentioned only on request, and "Reading the error log" is scoped to installs where the file exists. `ha-api-matrix.md` and the architecture doc carry the same note.

## Verification

- Skill contracts 257/257, `check-docs` green, diagnose word budget 1415/1449.
- Live: `system_log/list` returns real structured entries on the reporting install; `/api/error_log` 404 reproduced.

Sources: [community: What happened to /api/error_log?](https://community.home-assistant.io/t/what-happened-to-api-error-log/982722) · [community: 2025.11 removal of home-assistant.log](https://community.home-assistant.io/t/2025-11-removal-of-homeassistant-log-custom-integration-replacement/947907) · [REST API docs (stale)](https://developers.home-assistant.io/docs/api/rest/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnL7zQZRToTuH6V2RPUFBc