### PR TITLE
feat(diff): change table instead of bullets; Cards design system for previews

### DIFF
--- a/cli/diff.go
+++ b/cli/diff.go
@@ -356,9 +356,10 @@ func makeChange(segs []segment, before, after interface{}) configChange {
 		if bf == af {
 			// Same rendered text but a real change → a type/representation
 			// difference (e.g. number 5 vs string "5"). Disambiguate by type so
-			// the user never sees a confusing "5 | 5" row.
-			bf = fmt.Sprintf("%s (%s)", bf, jsonTypeName(before))
-			af = fmt.Sprintf("%s (%s)", af, jsonTypeName(after))
+			// the user never sees a confusing "5 | 5" row; the suffix is added
+			// cap-aware so long values cannot swallow it.
+			bf = withTypeSuffix(bf, jsonTypeName(before))
+			af = withTypeSuffix(af, jsonTypeName(after))
 		} else {
 			bf, af = focusDivergence(bf, af)
 		}

--- a/cli/diff.go
+++ b/cli/diff.go
@@ -359,6 +359,8 @@ func makeChange(segs []segment, before, after interface{}) configChange {
 			// the user never sees a confusing "5 | 5" row.
 			bf = fmt.Sprintf("%s (%s)", bf, jsonTypeName(before))
 			af = fmt.Sprintf("%s (%s)", af, jsonTypeName(after))
+		} else {
+			bf, af = focusDivergence(bf, af)
 		}
 		text = tableRow(label, bf, af)
 	}

--- a/cli/diff.go
+++ b/cli/diff.go
@@ -12,12 +12,13 @@ import (
 	"strings"
 )
 
-// runDiffCommand renders a deterministic, human-readable change list between two
-// Home Assistant config bodies (the "before" and "after" of an update). The
-// output is a stable artifact — like `git diff` — that the skill prints verbatim
-// under a localized "## Changes" heading. Keeping the rendering here, not in the
-// LLM, makes the diff identical on every run and across clients/models. The
-// presentation helpers (labels, value formatting) live in diff_format.go.
+// runDiffCommand renders a deterministic, human-readable change table between
+// two Home Assistant config bodies (the "before" and "after" of an update).
+// Every output line is one GFM table data row `| Field | before | after |`;
+// the skill adds its localized header row above and prints the rows verbatim.
+// The output is a stable artifact — like `git diff` — and keeping the
+// rendering here, not in the LLM, makes it identical on every run and across
+// clients/models. Presentation helpers (labels, cells) live in diff_format.go.
 func runDiffCommand(_ runtimePaths, args []string) int {
 	fs := flag.NewFlagSet("diff", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -163,7 +164,7 @@ func renderConfigChanges(before, after map[string]interface{}) []string {
 		if i > 0 && c.path == prev.path && c.text == prev.text {
 			continue
 		}
-		lines = append(lines, "- "+c.text)
+		lines = append(lines, c.text)
 		prev = c
 	}
 	return lines
@@ -245,7 +246,7 @@ func diffArrays(segs []segment, before, after []interface{}, changes *[]configCh
 		*changes = append(*changes, configChange{
 			order: topOrder(segs),
 			path:  pathString(segs),
-			text:  fmt.Sprintf("%s: %d → %d items", humanizeLabel(segs), len(before), len(after)),
+			text:  tableRow(humanizeLabel(segs), itemsCell(len(before)), itemsCell(len(after))),
 		})
 		diffAlignedItems(segs, before, after, changes)
 		diffNotificationCopyInCommonItems(segs, before, after, changes)
@@ -285,8 +286,8 @@ func diffAlignedItems(segs []segment, before, after []interface{}, changes *[]co
 		diffValues(appendSegment(segs, segment{index: prefix + paired, isIndex: true}), bMid[paired], aMid[paired], changes)
 		paired++
 	}
-	renderAlignedSide(segs, bMid[paired:], prefix+paired, "removed (was %s)", changes)
-	renderAlignedSide(segs, aMid[paired:], prefix+paired, "added (%s)", changes)
+	renderAlignedSide(segs, bMid[paired:], prefix+paired, true, changes)
+	renderAlignedSide(segs, aMid[paired:], prefix+paired, false, changes)
 }
 
 // alignedPairable reports whether two items are the same kind of step, so a
@@ -297,33 +298,41 @@ func alignedPairable(before, after interface{}) bool {
 	return kind != "" && kind == configItemKind(after)
 }
 
-func renderAlignedSide(segs []segment, items []interface{}, offset int, verbFormat string, changes *[]configChange) {
+// renderAlignedSide emits one table row per added/removed item; the empty
+// side of the row carries the absence marker, so the Before/After columns
+// encode add vs remove positionally.
+func renderAlignedSide(segs []segment, items []interface{}, offset int, removed bool, changes *[]configChange) {
 	rendered := len(items)
 	if rendered > maxAlignedItemsPerSide {
 		rendered = maxAlignedItemsPerSide
+	}
+	side := func(label, summary string) string {
+		if removed {
+			return tableRow(label, summary, "—")
+		}
+		return tableRow(label, "—", summary)
 	}
 	for i := 0; i < rendered; i++ {
 		itemSegs := appendSegment(segs, segment{index: offset + i, isIndex: true})
 		*changes = append(*changes, configChange{
 			order: topOrder(segs),
 			path:  pathString(itemSegs),
-			text:  fmt.Sprintf("%s: %s", humanizeLabel(itemSegs), fmt.Sprintf(verbFormat, summarizeConfigItem(items[i]))),
+			text:  side(humanizeLabel(itemSegs), summarizeConfigItem(items[i])),
 		})
 	}
 	if len(items) > rendered {
+		verb := "added"
+		if removed {
+			verb = "removed"
+		}
+		// The honest cap stays a table row: a plain line mid-output would
+		// terminate the GFM table and split it in two.
 		*changes = append(*changes, configChange{
 			order: topOrder(segs),
 			path:  pathString(appendSegment(segs, segment{index: offset + rendered, isIndex: true})),
-			text:  fmt.Sprintf("%s: … and %d more %s", humanizeLabel(segs), len(items)-rendered, alignedVerbWord(verbFormat)),
+			text:  side(humanizeLabel(segs), fmt.Sprintf("… and %d more %s", len(items)-rendered, verb)),
 		})
 	}
-}
-
-func alignedVerbWord(verbFormat string) string {
-	if strings.HasPrefix(verbFormat, "removed") {
-		return "removed"
-	}
-	return "added"
 }
 
 func appendSegment(segs []segment, s segment) []segment {
@@ -338,19 +347,20 @@ func makeChange(segs []segment, before, after interface{}) configChange {
 	var text string
 	switch {
 	case before == nil:
-		text = fmt.Sprintf("%s: added (%s)", label, formatValue(after))
+		// The empty Before column IS the "added" statement; no verbal wrapper.
+		text = tableRow(label, "—", formatValue(after))
 	case after == nil:
-		text = fmt.Sprintf("%s: removed (was %s)", label, formatValue(before))
+		text = tableRow(label, formatValue(before), "—")
 	default:
 		bf, af := formatValue(before), formatValue(after)
 		if bf == af {
 			// Same rendered text but a real change → a type/representation
 			// difference (e.g. number 5 vs string "5"). Disambiguate by type so
-			// the user never sees a confusing "5 → 5".
+			// the user never sees a confusing "5 | 5" row.
 			bf = fmt.Sprintf("%s (%s)", bf, jsonTypeName(before))
 			af = fmt.Sprintf("%s (%s)", af, jsonTypeName(after))
 		}
-		text = fmt.Sprintf("%s: %s → %s", label, bf, af)
+		text = tableRow(label, bf, af)
 	}
 	return configChange{order: topOrder(segs), path: pathString(segs), text: text}
 }

--- a/cli/diff_format.go
+++ b/cli/diff_format.go
@@ -94,6 +94,12 @@ func formatValue(v interface{}) string {
 		if t == "" {
 			return `""`
 		}
+		if t == "—" {
+			// A literal em dash as the user's value would be indistinguishable
+			// from the absence marker (`| Field | — | — |` on add/remove) —
+			// quote it, same pattern as the empty string above.
+			return `"—"`
+		}
 		// Raw on purpose: truncation and escaping happen exactly once, in
 		// escapeCell, when the value becomes a table cell.
 		return t

--- a/cli/diff_format.go
+++ b/cli/diff_format.go
@@ -311,3 +311,32 @@ func itemsCell(n int) string {
 	}
 	return fmt.Sprintf("%d items", n)
 }
+
+// divergenceContextBytes is how much shared text stays visible before the
+// first difference when focusDivergence trims a long common prefix.
+const divergenceContextBytes = 20
+
+// focusDivergence keeps the FIRST difference of a changed value pair visible.
+// Without it, two long values sharing their first maxCellBytes bytes (a
+// notification message edited near the end) would truncate into two identical
+// `<prefix>…` cells — and write-safety requires changed copy to be visible in
+// the preview. When either side would truncate, the shared prefix is cut to
+// divergenceContextBytes of context (rune-safe, marked with a leading `…`);
+// escapeCell still caps the tail afterwards.
+func focusDivergence(before, after string) (string, string) {
+	if len(before) <= maxCellBytes && len(after) <= maxCellBytes {
+		return before, after
+	}
+	p := 0
+	for p < len(before) && p < len(after) && before[p] == after[p] {
+		p++
+	}
+	if p <= divergenceContextBytes {
+		return before, after
+	}
+	start := p - divergenceContextBytes
+	for start > 0 && !utf8.RuneStart(before[start]) {
+		start--
+	}
+	return "…" + before[start:], "…" + after[start:]
+}

--- a/cli/diff_format.go
+++ b/cli/diff_format.go
@@ -316,6 +316,23 @@ func itemsCell(n int) string {
 // first difference when focusDivergence trims a long common prefix.
 const divergenceContextBytes = 20
 
+// withTypeSuffix appends the disambiguating type label so it survives the
+// cell cap: for identically-rendered values the type IS the only visible
+// change, so the value is pre-trimmed (rune-safe, `…`) to leave room for the
+// suffix inside maxCellBytes — escapeCell must never cut the label off.
+func withTypeSuffix(v, typeName string) string {
+	suffix := " (" + typeName + ")"
+	limit := maxCellBytes - len(suffix) - len("…")
+	if len(v)+len(suffix) > maxCellBytes {
+		cut := limit
+		for cut > 0 && !utf8.RuneStart(v[cut]) {
+			cut--
+		}
+		v = v[:cut] + "…"
+	}
+	return v + suffix
+}
+
 // focusDivergence keeps the FIRST difference of a changed value pair visible.
 // Without it, two long values sharing their first maxCellBytes bytes (a
 // notification message edited near the end) would truncate into two identical

--- a/cli/diff_format.go
+++ b/cli/diff_format.go
@@ -4,13 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 // This file holds the presentation half of `ha-nova diff`: turning a computed
-// change (a path plus before/after values) into the stable, human-readable text
-// the skill prints verbatim under the localized changes slot. The comparison and tree-walk
-// logic lives in diff.go; splitting the two keeps each file focused and under the
-// repo's size guardrail.
+// change (a path plus before/after values) into the stable GFM table data rows
+// (`| Field | before | after |`) the skill prints verbatim under its localized
+// header row. The comparison and tree-walk logic lives in diff.go; splitting
+// the two keeps each file focused and under the repo's size guardrail.
 
 // jsonTypeName names the JSON type of a decoded value for diff disambiguation.
 func jsonTypeName(v interface{}) string {
@@ -93,10 +94,9 @@ func formatValue(v interface{}) string {
 		if t == "" {
 			return `""`
 		}
-			// Escape control chars (newlines/tabs from a multiline description or
-			// template) and cap length so one value can't split a changes bullet
-			// into unprefixed lines — the skill prints this CLI output verbatim.
-		return truncate(escapeInline(t))
+		// Raw on purpose: truncation and escaping happen exactly once, in
+		// escapeCell, when the value becomes a table cell.
+		return t
 	case bool:
 		if t {
 			return "true"
@@ -108,9 +108,9 @@ func formatValue(v interface{}) string {
 		if isDurationMap(t) {
 			return formatDuration(t)
 		}
-		return truncate(compactJSON(t))
+		return compactJSON(t)
 	default:
-		return truncate(compactJSON(v))
+		return compactJSON(v)
 	}
 }
 
@@ -142,7 +142,7 @@ func formatDuration(m map[string]interface{}) string {
 		}
 	}
 	if len(parts) == 0 {
-		return truncate(compactJSON(m))
+		return compactJSON(m)
 	}
 	return strings.Join(parts, " ")
 }
@@ -158,25 +158,25 @@ func summarizeConfigItem(v interface{}) string {
 		return formatValue(v)
 	}
 	if alias, _ := m["alias"].(string); alias != "" {
-		return truncate(fmt.Sprintf("%q", escapeInline(alias)))
+		return fmt.Sprintf("%q", alias)
 	}
 	if action, _ := m["action"].(string); action != "" {
-		return truncate("action " + escapeInline(action))
+		return "action " + action
 	}
 	if service, _ := m["service"].(string); service != "" {
-		return truncate("action " + escapeInline(service))
+		return "action " + service
 	}
 	if platform, _ := m["platform"].(string); platform != "" {
-		return truncate("trigger " + escapeInline(platform))
+		return "trigger " + platform
 	}
 	if trigger, _ := m["trigger"].(string); trigger != "" {
-		return truncate("trigger " + escapeInline(trigger))
+		return "trigger " + trigger
 	}
 	if condition, _ := m["condition"].(string); condition != "" {
-		return truncate("condition " + escapeInline(condition))
+		return "condition " + condition
 	}
 	if delay, ok := m["delay"]; ok {
-		return truncate("delay " + formatValue(delay))
+		return "delay " + formatValue(delay)
 	}
 	if _, ok := m["wait_template"]; ok {
 		return "wait_template"
@@ -187,7 +187,7 @@ func summarizeConfigItem(v interface{}) string {
 	if blockSummary := summarizeBlockItem(m); blockSummary != "" {
 		return blockSummary
 	}
-	return truncate(compactJSON(m))
+	return compactJSON(m)
 }
 
 // configItemKind identifies what KIND of step an item is (which service call,
@@ -265,14 +265,49 @@ func compactJSON(v interface{}) string {
 	return string(out)
 }
 
-func truncate(s string) string {
-	const max = 180
-	if len(s) <= max {
-		return s
-	}
-	return s[:max] + "…"
+// maxCellBytes caps one table cell's raw content. 80 keeps ordinary
+// one-sentence notification copy whole while two value columns still fit a
+// terminal line; longer values truncate with `…` — the full text is always one
+// `show yaml` away, and write-safety obliges the summary to name what a
+// truncated value changed.
+const maxCellBytes = 80
+
+// tableRow renders one GFM table data row. Every cell passes through
+// escapeCell exactly once, here — callers hand over raw content and never
+// pre-escape.
+func tableRow(field, before, after string) string {
+	return "| " + escapeCell(field) + " | " + escapeCell(before) + " | " + escapeCell(after) + " |"
 }
 
-func escapeInline(s string) string {
-	return strings.NewReplacer("\n", `\n`, "\r", `\r`, "\t", `\t`).Replace(s)
+// escapeCell makes one cell safe inside a table row the skill prints
+// verbatim: rune-safe truncation to maxCellBytes, control-character escaping
+// (a raw newline would break the whole table, not just one bullet), and pipe
+// escaping so a value — Jinja templates love `|` — can never add a column.
+// Truncation runs first so an escape sequence is never cut in half; escapes
+// may push the final cell slightly past the cap, which bounds content, not
+// framing.
+func escapeCell(s string) string {
+	truncated := false
+	if len(s) > maxCellBytes {
+		cut := maxCellBytes
+		for cut > 0 && !utf8.RuneStart(s[cut]) {
+			cut--
+		}
+		s = s[:cut]
+		truncated = true
+	}
+	s = strings.NewReplacer("\n", `\n`, "\r", `\r`, "\t", `\t`, "|", `\|`).Replace(s)
+	if truncated {
+		s += "…"
+	}
+	return s
+}
+
+// itemsCell renders an array length as a self-labeling cell ("1 item",
+// "3 items") so a count row can never be misread as a numeric value change.
+func itemsCell(n int) string {
+	if n == 1 {
+		return "1 item"
+	}
+	return fmt.Sprintf("%d items", n)
 }

--- a/cli/diff_test.go
+++ b/cli/diff_test.go
@@ -108,6 +108,15 @@ func TestDiffCellTruncationIsRuneSafe(t *testing.T) {
 	}
 }
 
+func TestDiffLiteralEmDashValueIsQuoted(t *testing.T) {
+	// A user value that IS the em dash must not render identical to the
+	// absence marker — `| Note | — | — |` would show no visible difference.
+	assertLines(t, diffLines(t, `{"alias":"X"}`, `{"alias":"X","note":"—"}`),
+		[]string{`| Note | — | "—" |`})
+	assertLines(t, diffLines(t, `{"note":"—"}`, `{"note":"real text"}`),
+		[]string{`| Note | "—" | real text |`})
+}
+
 func TestDiffTypeSuffixSurvivesLongValues(t *testing.T) {
 	// A string that contains compact JSON vs the equivalent object renders
 	// identically; when that shared text is longer than a cell, the type

--- a/cli/diff_test.go
+++ b/cli/diff_test.go
@@ -108,6 +108,22 @@ func TestDiffCellTruncationIsRuneSafe(t *testing.T) {
 	}
 }
 
+func TestDiffTypeSuffixSurvivesLongValues(t *testing.T) {
+	// A string that contains compact JSON vs the equivalent object renders
+	// identically; when that shared text is longer than a cell, the type
+	// suffix must survive the cap — it is the only visible change.
+	inner := `{"a":"` + strings.Repeat("x", 90) + `"}`
+	before := `{"payload":` + `"` + strings.ReplaceAll(inner, `"`, `\"`) + `"` + `}`
+	after := `{"payload":` + inner + `}`
+	got := diffLines(t, before, after)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 change, got %#v", got)
+	}
+	if !strings.Contains(got[0], "… (string) |") || !strings.Contains(got[0], "… (object) |") {
+		t.Fatalf("type suffixes must survive truncation: %q", got[0])
+	}
+}
+
 func TestDiffLateDivergenceStaysVisible(t *testing.T) {
 	// Two long notification texts sharing their first >80 bytes must NOT render
 	// as two identical `<prefix>…` cells — the first difference has to be

--- a/cli/diff_test.go
+++ b/cli/diff_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func diffLines(t *testing.T, beforeJSON, afterJSON string) []string {
@@ -33,7 +34,7 @@ func assertLines(t *testing.T, got, want []string) {
 
 func TestDiffScalarChange(t *testing.T) {
 	got := diffLines(t, `{"mode":"single"}`, `{"mode":"restart"}`)
-	assertLines(t, got, []string{"- Mode: single → restart"})
+	assertLines(t, got, []string{"| Mode | single | restart |"})
 }
 
 func TestDiffMissingVsEmptyIsNotAChange(t *testing.T) {
@@ -48,14 +49,86 @@ func TestDiffMissingVsEmptyIsNotAChange(t *testing.T) {
 
 func TestDiffEscapesMultilineStringValues(t *testing.T) {
 	// A multiline string value (automation description/template) must not embed a
-	// raw newline/tab that splits the `## Changes` bullet into unprefixed lines —
-	// the skill prints `ha-nova diff` stdout verbatim.
+	// raw newline/tab: it would structurally break the GFM table the skill prints
+	// verbatim, not just one line.
 	got := diffLines(t, `{"description":"old\nline"}`, `{"description":"new\tval"}`)
 	if len(got) != 1 {
 		t.Fatalf("expected 1 change, got %#v", got)
 	}
 	if strings.ContainsAny(got[0], "\n\r\t") {
 		t.Fatalf("diff line must not contain a raw control char: %q", got[0])
+	}
+	if n := unescapedPipes(got[0]); n != 4 {
+		t.Fatalf("row must keep exactly 4 unescaped pipes, got %d: %q", n, got[0])
+	}
+}
+
+// unescapedPipes counts the structural pipes of a table row (escaped `\|`
+// sequences inside cell content do not count).
+func unescapedPipes(line string) int {
+	return strings.Count(line, "|") - strings.Count(line, `\|`)
+}
+
+func TestDiffEscapesPipesInCells(t *testing.T) {
+	// Jinja templates love pipes; an unescaped `|` inside a cell would add a
+	// phantom column and shift Before/After.
+	got := diffLines(t,
+		`{"value_template":"{{ states('sensor.x') }}"}`,
+		`{"value_template":"{{ states('sensor.x') | float }}"}`)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 change, got %#v", got)
+	}
+	if !strings.Contains(got[0], `\| float`) {
+		t.Fatalf("pipe in cell content must be escaped: %q", got[0])
+	}
+	if n := unescapedPipes(got[0]); n != 4 {
+		t.Fatalf("row must keep exactly 4 unescaped pipes, got %d: %q", n, got[0])
+	}
+}
+
+func TestDiffCellTruncationIsRuneSafe(t *testing.T) {
+	// 79 ASCII bytes + a two-byte umlaut straddling the 80-byte boundary: the cut
+	// must land on the rune start, keep valid UTF-8, and mark the cut with `…`.
+	long := strings.Repeat("a", 79) + "ä-und-noch-mehr-text"
+	got := diffLines(t, `{"description":"short"}`, `{"description":"`+long+`"}`)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 change, got %#v", got)
+	}
+	if !utf8.ValidString(got[0]) {
+		t.Fatalf("truncated row must stay valid UTF-8: %q", got[0])
+	}
+	if !strings.Contains(got[0], strings.Repeat("a", 79)+"…") {
+		t.Fatalf("expected rune-safe cut before the umlaut plus …, got %q", got[0])
+	}
+	// A value of exactly 80 bytes passes through whole.
+	exact := strings.Repeat("b", 80)
+	got = diffLines(t, `{"description":"short"}`, `{"description":"`+exact+`"}`)
+	if !strings.Contains(got[0], exact+" |") || strings.Contains(got[0], "…") {
+		t.Fatalf("80-byte value must not be truncated: %q", got[0])
+	}
+}
+
+func TestDiffEveryLineIsATableRow(t *testing.T) {
+	// The structural invariant that keeps the whole output one continuous GFM
+	// table: every emitted line — scalar, count, aligned item, honest cap,
+	// notification copy — is a 3-cell data row.
+	afterItems := make([]string, 0, 12)
+	for _, id := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"} {
+		afterItems = append(afterItems, `{"action":"script.`+id+`"}`)
+	}
+	before := `{"mode":"single","description":"x","actions":[{"action":"notify.phone","data":{"message":"Plan erstellt"}}]}`
+	after := `{"mode":"restart","actions":[{"action":"notify.phone","data":{"message":"Plan ist bereit"}},` + strings.Join(afterItems, ",") + `]}`
+	got := diffLines(t, before, after)
+	if len(got) < 5 {
+		t.Fatalf("expected a mixed multi-row diff, got %#v", got)
+	}
+	for _, line := range got {
+		if !strings.HasPrefix(line, "| ") || !strings.HasSuffix(line, " |") {
+			t.Fatalf("not a table row: %q", line)
+		}
+		if n := unescapedPipes(line); n != 4 {
+			t.Fatalf("row must have exactly 4 unescaped pipes, got %d: %q", n, line)
+		}
 	}
 }
 
@@ -65,7 +138,7 @@ func TestDiffKeepsNormalNotificationMessagesUntruncated(t *testing.T) {
 
 	got := diffLines(t, before, after)
 	assertLines(t, got, []string{
-		"- Step 1 (data › message): Das Script-Preview-Format wurde getestet. → Das geänderte Script-Preview-Format wurde wirklich final getestet.",
+		"| Step 1 (data › message) | Das Script-Preview-Format wurde getestet. | Das geänderte Script-Preview-Format wurde wirklich final getestet. |",
 	})
 }
 
@@ -112,15 +185,15 @@ func TestDiffTypeOnlyChangeShowsType(t *testing.T) {
 	// A number→string (or bool→string) change must not render a confusing "5 → 5";
 	// the type disambiguates it.
 	assertLines(t, diffLines(t, `{"max":5}`, `{"max":"5"}`),
-		[]string{"- Max: 5 (number) → 5 (string)"})
+		[]string{"| Max | 5 (number) | 5 (string) |"})
 	assertLines(t, diffLines(t, `{"on":true}`, `{"on":"true"}`),
-		[]string{"- On: true (boolean) → true (string)"})
+		[]string{"| On | true (boolean) | true (string) |"})
 }
 
 func TestDiffMissingVsNonEmptyIsAChange(t *testing.T) {
 	// A non-empty field appearing or disappearing IS a real change (not over-suppressed).
 	assertLines(t, diffLines(t, `{"alias":"X"}`, `{"alias":"X","description":"real"}`),
-		[]string{"- Description: added (real)"})
+		[]string{"| Description | — | real |"})
 	if lines := diffLines(t, `{"alias":"X","triggers":[{"trigger":"time"}]}`, `{"alias":"X"}`); len(lines) != 1 {
 		t.Fatalf("removed non-empty triggers should be one change, got %#v", lines)
 	}
@@ -130,7 +203,7 @@ func TestDiffDurationChange(t *testing.T) {
 	before := `{"mode":"single","actions":[{"action":"light.turn_on"},{"delay":{"minutes":5}},{"action":"light.turn_off"}]}`
 	after := `{"mode":"single","actions":[{"action":"light.turn_on"},{"delay":{"minutes":2}},{"action":"light.turn_off"}]}`
 	got := diffLines(t, before, after)
-	assertLines(t, got, []string{"- Action 2 (delay): 5 min → 2 min"})
+	assertLines(t, got, []string{"| Action 2 (delay) | 5 min | 2 min |"})
 }
 
 // Reproduces the live demo: a mode change AND a delay change, in stable order.
@@ -139,16 +212,16 @@ func TestDiffModeAndDelayInStableOrder(t *testing.T) {
 	after := `{"mode":"restart","actions":[{"action":"light.turn_on"},{"delay":{"minutes":2}},{"action":"light.turn_off"}]}`
 	got := diffLines(t, before, after)
 	assertLines(t, got, []string{
-		"- Mode: single → restart",
-		"- Action 2 (delay): 5 min → 2 min",
+		"| Mode | single | restart |",
+		"| Action 2 (delay) | 5 min | 2 min |",
 	})
 }
 
 func TestDiffArrayLengthChange(t *testing.T) {
 	got := diffLines(t, `{"triggers":[{"a":1}]}`, `{"triggers":[{"a":1},{"b":2}]}`)
 	assertLines(t, got, []string{
-		"- Triggers: 1 → 2 items",
-		`- Trigger 2: added ({"b":2})`,
+		"| Triggers | 1 item | 2 items |",
+		"| Trigger 2 | — | {\"b\":2} |",
 	})
 }
 
@@ -160,11 +233,11 @@ func TestDiffNestingActionsIntoIfBlockShowsWhatMoved(t *testing.T) {
 	after := `{"actions":[{"action":"script.a"},{"if":[{"condition":"state"}],"then":[{"action":"script.b"},{"action":"script.c"},{"action":"script.d"}]},{"action":"script.e"}]}`
 	got := diffLines(t, before, after)
 	assertLines(t, got, []string{
-		"- Actions: 5 → 3 items",
-		"- Action 2: removed (was action script.b)",
-		"- Action 2: added (if/then block (3 actions))",
-		"- Action 3: removed (was action script.c)",
-		"- Action 4: removed (was action script.d)",
+		"| Actions | 5 items | 3 items |",
+		"| Action 2 | action script.b | — |",
+		"| Action 2 | — | if/then block (3 actions) |",
+		"| Action 3 | action script.c | — |",
+		"| Action 4 | action script.d | — |",
 	})
 }
 
@@ -177,7 +250,7 @@ func TestDiffAlignedItemsCapIsHonest(t *testing.T) {
 	if len(got) != 1+maxAlignedItemsPerSide+1 {
 		t.Fatalf("expected header + %d items + honesty line, got %d lines: %#v", maxAlignedItemsPerSide, len(got), got)
 	}
-	if got[len(got)-1] != "- Actions: … and 4 more added" {
+	if got[len(got)-1] != "| Actions | — | … and 4 more added |" {
 		t.Fatalf("expected honest remainder line, got %q", got[len(got)-1])
 	}
 }
@@ -189,9 +262,9 @@ func TestDiffAlignedPairingKeepsFieldDiffForSameKind(t *testing.T) {
 	after := `{"actions":[{"action":"light.turn_on","data":{"brightness":50}},{"action":"script.extra"}]}`
 	got := diffLines(t, before, after)
 	assertLines(t, got, []string{
-		"- Actions: 1 → 2 items",
-		"- Action 1 (data › brightness): 100 → 50",
-		"- Action 2: added (action script.extra)",
+		"| Actions | 1 item | 2 items |",
+		"| Action 1 (data › brightness) | 100 | 50 |",
+		"| Action 2 | — | action script.extra |",
 	})
 }
 
@@ -200,9 +273,9 @@ func TestDiffShowsNotificationCopyChangeEvenWhenActionsLengthChanges(t *testing.
 	after := `{"actions":[{"action":"notify.mobile_app_phone","data":{"title":"Nachtladung","message":"Plan ist bereit","data":{"tag":"nachtladung"}}},{"action":"input_boolean.turn_on","target":{"entity_id":"input_boolean.nachtladung_plan_valid"}}]}`
 	got := diffLines(t, before, after)
 	assertLines(t, got, []string{
-		"- Actions: 1 → 2 items",
-		"- Action 1 (data › message): Plan erstellt → Plan ist bereit",
-		"- Action 2: added (action input_boolean.turn_on)",
+		"| Actions | 1 item | 2 items |",
+		"| Action 1 (data › message) | Plan erstellt | Plan ist bereit |",
+		"| Action 2 | — | action input_boolean.turn_on |",
 	})
 }
 
@@ -211,25 +284,25 @@ func TestDiffShowsMovedNotificationCopyChangeWhenActionsLengthChanges(t *testing
 	after := `{"actions":[{"action":"input_boolean.turn_on","target":{"entity_id":"input_boolean.nachtladung_plan_valid"}},{"action":"notify.mobile_app_phone","data":{"message":"Plan ist bereit"}}]}`
 	got := diffLines(t, before, after)
 	assertLines(t, got, []string{
-		"- Actions: 1 → 2 items",
-		"- Action 1: removed (was action notify.mobile_app_phone)",
-		"- Action 1: added (action input_boolean.turn_on)",
-		"- Action 2: added (action notify.mobile_app_phone)",
-		"- Action 2 (data › message): Plan erstellt → Plan ist bereit",
+		"| Actions | 1 item | 2 items |",
+		"| Action 1 | action notify.mobile_app_phone | — |",
+		"| Action 1 | — | action input_boolean.turn_on |",
+		"| Action 2 | — | action notify.mobile_app_phone |",
+		"| Action 2 (data › message) | Plan erstellt | Plan ist bereit |",
 	})
 }
 
 func TestDiffAddAndRemoveKey(t *testing.T) {
 	added := diffLines(t, `{"mode":"single"}`, `{"mode":"single","max":3}`)
-	assertLines(t, added, []string{"- Max: added (3)"})
+	assertLines(t, added, []string{"| Max | — | 3 |"})
 
 	removed := diffLines(t, `{"mode":"single","max":3}`, `{"mode":"single"}`)
-	assertLines(t, removed, []string{"- Max: removed (was 3)"})
+	assertLines(t, removed, []string{"| Max | 3 | — |"})
 }
 
 func TestDiffBooleanChange(t *testing.T) {
 	got := diffLines(t, `{"enabled":true}`, `{"enabled":false}`)
-	assertLines(t, got, []string{"- Enabled: true → false"})
+	assertLines(t, got, []string{"| Enabled | true | false |"})
 }
 
 func TestDiffPluralAliasIsNotAChange(t *testing.T) {
@@ -242,7 +315,7 @@ func TestDiffPluralAliasIsNotAChange(t *testing.T) {
 
 func TestDiffPluralAliasStillDetectsRealChange(t *testing.T) {
 	got := diffLines(t, `{"trigger":[{"to":"on"}]}`, `{"triggers":[{"to":"off"}]}`)
-	assertLines(t, got, []string{"- Trigger 1 (to): on → off"})
+	assertLines(t, got, []string{"| Trigger 1 (to) | on | off |"})
 }
 
 func TestDiffSingularObjectVsPluralListIsNotAChange(t *testing.T) {
@@ -280,9 +353,9 @@ func TestDiffStableTopLevelOrdering(t *testing.T) {
 	after := `{"mode":"restart","alias":"New","zone":"away"}`
 	got := diffLines(t, before, after)
 	assertLines(t, got, []string{
-		"- Alias: Old → New",
-		"- Mode: single → restart",
-		"- Zone: home → away",
+		"| Alias | Old | New |",
+		"| Mode | single | restart |",
+		"| Zone | home | away |",
 	})
 }
 
@@ -290,12 +363,12 @@ func TestDiffNestedConditionChange(t *testing.T) {
 	before := `{"conditions":[{"condition":"numeric_state","above":60}]}`
 	after := `{"conditions":[{"condition":"numeric_state","above":40}]}`
 	got := diffLines(t, before, after)
-	assertLines(t, got, []string{"- Condition 1 (above): 60 → 40"})
+	assertLines(t, got, []string{"| Condition 1 (above) | 60 | 40 |"})
 }
 
 func TestDiffMultiUnitDuration(t *testing.T) {
 	before := `{"actions":[{"delay":{"hours":1,"minutes":30}}]}`
 	after := `{"actions":[{"delay":{"minutes":45}}]}`
 	got := diffLines(t, before, after)
-	assertLines(t, got, []string{"- Action 1 (delay): 1 h 30 min → 45 min"})
+	assertLines(t, got, []string{"| Action 1 (delay) | 1 h 30 min | 45 min |"})
 }

--- a/cli/diff_test.go
+++ b/cli/diff_test.go
@@ -108,6 +108,29 @@ func TestDiffCellTruncationIsRuneSafe(t *testing.T) {
 	}
 }
 
+func TestDiffLateDivergenceStaysVisible(t *testing.T) {
+	// Two long notification texts sharing their first >80 bytes must NOT render
+	// as two identical `<prefix>…` cells — the first difference has to be
+	// visible, or the user confirms copy they never saw (write-safety:
+	// changed notification text must show old and new).
+	shared := strings.Repeat("Der Plan wurde erstellt und geprüft. ", 3) // 111 bytes shared prefix
+	before := `{"actions":[{"action":"notify.phone","data":{"message":"` + shared + `Start um 06:30."}}]}`
+	after := `{"actions":[{"action":"notify.phone","data":{"message":"` + shared + `Start um 06:00."}}]}`
+	got := diffLines(t, before, after)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 change, got %#v", got)
+	}
+	if !strings.Contains(got[0], "06:30") || !strings.Contains(got[0], "06:00") {
+		t.Fatalf("divergence must stay visible in both cells: %q", got[0])
+	}
+	if !strings.Contains(got[0], "| …") {
+		t.Fatalf("trimmed shared prefix must be marked with a leading …: %q", got[0])
+	}
+	// Short values keep their full text — no divergence trimming below the cap.
+	got = diffLines(t, `{"mode":"single"}`, `{"mode":"restart"}`)
+	assertLines(t, got, []string{"| Mode | single | restart |"})
+}
+
 func TestDiffEveryLineIsATableRow(t *testing.T) {
 	// The structural invariant that keeps the whole output one continuous GFM
 	// table: every emitted line — scalar, count, aligned item, honest cap,

--- a/cli/snapshot_command_test.go
+++ b/cli/snapshot_command_test.go
@@ -164,7 +164,7 @@ func TestRunDiffCommandContract(t *testing.T) {
 			t.Fatalf("diff: exit = %d, want 0", code)
 		}
 	})
-	if !strings.Contains(out, "Mode: single → restart") {
+	if !strings.Contains(out, "| Mode | single | restart |") {
 		t.Fatalf("diff stdout = %q, want the deterministic change line", out)
 	}
 
@@ -181,7 +181,7 @@ func TestRunDiffCommandContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := string(data), "- Mode: single → restart\n"; got != want {
+	if got, want := string(data), "| Mode | single | restart |\n"; got != want {
 		t.Fatalf("diff file = %q, want %q", got, want)
 	}
 }

--- a/scripts/test/safe-core-files.json
+++ b/scripts/test/safe-core-files.json
@@ -42,6 +42,7 @@
   "tests/skills/health-calendar-contract.test.ts",
   "tests/skills/helper-contract.test.ts",
   "tests/skills/maintenance-contract.test.ts",
+  "tests/skills/output-design-contract.test.ts",
   "tests/skills/review-contract.test.ts",
   "tests/skills/scene-contract.test.ts",
   "tests/skills/service-call-contract.test.ts",

--- a/skills/ha-nova/output-rules.md
+++ b/skills/ha-nova/output-rules.md
@@ -33,6 +33,48 @@ Apply these rules to every user-facing HA NOVA response, including direct sub-sk
 - Delete previews must say nothing has been deleted yet and must ask for the exact `confirm:<token>`; never render `apply`, `show yaml`, `cancel`, or a selectable menu for destructive confirmation.
 - Never hide the available next actions inside a paragraph.
 
+## Cards (Write-Flow Visual System)
+
+Write and action flows render one of three cards — the same shape every time, so users recognize them at a glance. Labels localize at runtime; emoji, literal keywords, entity IDs, state values, and CLI diff rows do not. Fixed emoji vocabulary: 📝 preview, 🗑️ delete preview, ✅ result, ⚠️ save status, plus the 🔴🟠🟡 severity markers — nothing else decorative, never color. Cards frame writes and runtime actions only; review and read output keep their own sections.
+
+**Preview Card** (create/update — values illustrative, labels localized at runtime):
+
+```
+📝 Preview: automation "Morning routine"
+The three light actions now only run when someone is home.
+
+| Field | Before | After |
+|---|---|---|
+| Condition 1 | — | condition state |
+| Mode | single | restart |
+
+Pre-write check: no concerns.
+⚠️ Nothing saved yet.
+Options: apply · show yaml · cancel
+```
+
+Title line: emoji + localized preview label + item type + name. Then one to three plain sentences on what the change DOES. The changes block: in diff-backed skills you author only the localized header row and the literal separator — the data rows are pasted verbatim from `ha-nova diff`, never invented and never re-aligned (mechanics: `skills/ha-nova/write-safety.md`); skills without a CLI diff author one short planned-change row or line per changed field; file-editing skills show the changed section as a snippet instead of a table. Existing per-skill slots map into the card: identity slots (name/mode/target) fold into the title line, `Planned change` is the changes block, `Save status` is the ⚠️ line, `Options` or the token prompt closes the card. Runtime actions use `apply · cancel` and an explicit not-executed-yet line.
+
+**Delete Card** (destructive — never a menu; the token prompt is always the last line):
+
+```
+🗑️ Delete: automation "Old morning routine"
+Turns all lights off at 23:00 — that stops when it is gone.
+Used by: nothing else found.
+⚠️ Nothing deleted yet.
+To delete, reply exactly: confirm:<token>
+```
+
+**Result Card** (after verification — name only the proven scope, per `skills/ha-nova/write-safety.md` → Verification Honesty; findings, if any, follow with 🔴🟠🟡):
+
+```
+✅ Saved: automation "Morning routine"
+Checked: config persisted, reload OK, entity live. Runtime behavior was not exercised.
+Reply revert to undo this update.
+```
+
+Read output: compact pipe tables (max 4 short columns — they degrade to plain pipe text in raw terminals) or grouped lists with counts; never raw JSON.
+
 ## Findings
 
 - Use only three visible severity markers: 🔴 high/critical, 🟠 medium, 🟡 low/info.

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -38,11 +38,13 @@ Best-practice freshness (`bp_status`) is an **internal gate input only**:
 ## Pre-Write Diff (`## Changes`)
 
 The diff is rendered by the CLI, not by you — so it is byte-identical on every
-run, every model, every client. Treat the `ha-nova diff` output like `git diff`:
-a stable artifact you print **verbatim**. Do not hand-format, reorder, relabel,
-translate, or summarize the change lines. The `-` change lines come ONLY from the
-command's stdout this turn — if you did not just run `ha-nova diff`, do not print
-a Changes block at all. There is no hand-computed fallback. `## Changes` is the
+run, every model, every client. It emits GFM table data rows
+(`| Field | before | after |`; an empty side shows `—`). Treat the `ha-nova diff`
+output like `git diff`: a stable artifact you print **verbatim**. Do not
+hand-format, reorder, relabel, translate, merge, or summarize the rows —
+do not re-align pipes or pad cells. The table rows come ONLY from the command's
+output this turn — if you did not just run `ha-nova diff`, do not print a
+Changes block at all. There is no hand-computed fallback. `## Changes` is the
 historical slot name, not a required literal Markdown heading; in terminal-like
 clients prefer a plain localized label for the changes slot.
 
@@ -50,9 +52,11 @@ clients prefer a plain localized label for the changes slot.
 1. Write the current config (resolve `CURRENT_CONFIG`) and the proposed draft to
    two files.
 2. Prefer `ha-nova diff --before <current-file> --after <draft-file> --out <diff-file>`, then read `<diff-file>` with the native file-reading tool. If `--out` is unavailable, use stdout only when the client will not truncate the command output.
-3. Print a localized label for the changes slot, then the diff file/stdout lines verbatim. If the
-   diff is empty, there is nothing to change — say so plainly instead of showing
-   an empty block.
+3. Print a localized label for the changes slot, then exactly two hand-written
+   lines — the localized table header row (field / before / after) and the
+   literal separator `|---|---|---|` (never localized, never re-aligned) — then
+   the diff file/stdout rows verbatim beneath. If the diff is empty, there is
+   nothing to change — say so plainly instead of showing an empty table.
 
 **create**: no diff (there is no "before") — give a one-line plain-language
 summary of what the new item does.
@@ -72,9 +76,10 @@ guess.
 
 Confirmation quality depends on it: a user who cannot tell what the payload
 changes cannot meaningfully confirm it. If the diff still contains a
-count-only or `… and N more` line for something the user's request touched,
-the summary MUST name what was added, removed, or nested there. If you cannot
-explain the behavioral effect of your own draft, stop and re-derive it —
+count-only or `… and N more` line — or a truncated (`…`) value — for something
+the user's request touched, the summary MUST name what was added, removed, or nested there,
+and spell out what a cut-off value says in full. If you cannot explain the
+behavioral effect of your own draft, stop and re-derive it —
 never ask for confirmation of a change you cannot describe.
 
 ### User-authored notification copy
@@ -95,7 +100,7 @@ offer it as a separate suggestion before preview; do not merge it into the draft
 unless the user accepts it.
 
 If notification copy does change, the Changes slot must show the old and new text or
-payload. A count-only array line such as `Actions: 7 → 8 items` is not enough
+payload. A count-only array line such as `| Actions | 7 items | 8 items |` is not enough
 when an existing notification title, message, or notification payload changed.
 
 ### Fixed update-preview shape
@@ -103,12 +108,17 @@ when an existing notification title, message, or notification payload changed.
 Render a terminal-friendly preview in this exact order, nothing extra — users
 should learn one shape and always recognize it:
 
-1. Preview-summary slot: target name and one to three plain-language sentences
-   (the behavior narrative lives here).
-2. Changes slot: the `ha-nova diff` file/stdout lines, verbatim.
+1. Preview-summary slot: 📝 title line (localized preview label + item type +
+   name), then one to three plain-language sentences (the behavior narrative
+   lives here).
+2. Changes slot: your localized header row + `|---|---|---|`, then the
+   `ha-nova diff` file/stdout rows, verbatim.
 3. Pre-write-check/impact slot: one or two short lines.
-4. Save-status slot: explicitly say that nothing has been saved yet.
+4. Save-status slot: explicitly say that nothing has been saved yet (the ⚠️ line).
 5. Options slot: explicit choices with literal `apply`, `show yaml`, and `cancel`.
+
+This is the Preview Card of `skills/ha-nova/output-rules.md` → Cards; the
+Result Card and Delete Card there frame the post-write and delete sides.
 
 Do **not** re-describe the whole automation (entities, every trigger/action) —
 the diff already states what changes. Keep it scannable.
@@ -125,18 +135,21 @@ A non-technical user reads the Changes slot, not raw YAML. So:
 Present the confirm/apply choice via the menu-or-numbered convention (see
 `skills/ha-nova/SKILL.md` → Interactive Choices).
 
-Shape (the `-` lines are exactly what `ha-nova diff` produced this turn — never
+Shape (the table rows are exactly what `ha-nova diff` produced this turn — never
 invent, shorten, pre-fill, or copy these from an example). The labels below are
 semantic placeholders; localize them before showing the user:
 
 ```
-<localized changes label>:
+📝 <localized preview label>: <type> "<name>"
+<behavior narrative, one to three sentences>
+
+| <localized field label> | <localized before label> | <localized after label> |
+|---|---|---|
 <paste the ha-nova diff file/stdout here, unchanged>
 
-<localized options label>:
-1. apply — save exactly this preview.
-2. show yaml — show the full proposed config.
-3. cancel — do not save anything.
+<pre-write check / impact line>
+⚠️ <localized: nothing saved yet>
+<localized options label>: apply · show yaml · cancel
 ```
 
 ## Verification Honesty (post-write wording)

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -421,7 +421,7 @@ Report only what has substance (same rule as the write flow — see `skills/writ
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete prompts, and results render as the Cards defined there.
 
 ### Storage-based family
 

--- a/skills/write/SKILL.md
+++ b/skills/write/SKILL.md
@@ -110,6 +110,8 @@ Do NOT invoke `ha-nova:review` separately.
 
 Apply `skills/ha-nova/output-rules.md`.
 
+Previews, delete prompts, and post-write results render as the Cards defined there; the diff mechanics stay in `skills/ha-nova/write-safety.md`.
+
 See `skills/ha-nova/SKILL.md` → Response Format.
 
 ## Safety

--- a/tests/skills/output-design-contract.test.ts
+++ b/tests/skills/output-design-contract.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+// The Cards section of output-rules.md is the single visual design system every
+// skill's previews, delete prompts, and results render through. These pins lock
+// the card shapes and the boundary that keeps review/read output out of them.
+describe("output design system (Cards)", () => {
+  const outputRules = readFileSync("skills/ha-nova/output-rules.md", "utf8");
+
+  it("defines the three cards with the fixed emoji vocabulary", () => {
+    expect(outputRules).toContain("## Cards (Write-Flow Visual System)");
+    expect(outputRules).toContain("**Preview Card**");
+    expect(outputRules).toContain("**Delete Card**");
+    expect(outputRules).toContain("**Result Card**");
+    expect(outputRules).toContain("📝 Preview:");
+    expect(outputRules).toContain("🗑️ Delete:");
+    expect(outputRules).toContain("✅ Saved:");
+    expect(outputRules).toContain("⚠️ Nothing saved yet.");
+    expect(outputRules).toContain("⚠️ Nothing deleted yet.");
+    expect(outputRules).toContain("nothing else decorative, never color");
+  });
+
+  it("shows the change table with the canonical header and verbatim-row rule", () => {
+    expect(outputRules).toContain("| Field | Before | After |");
+    expect(outputRules).toContain("|---|---|---|");
+    expect(outputRules).toContain("pasted verbatim from `ha-nova diff`");
+    expect(outputRules).toContain("never invented and never re-aligned");
+  });
+
+  it("keeps the options line and token prompt literal", () => {
+    expect(outputRules).toContain("Options: apply · show yaml · cancel");
+    expect(outputRules).toContain("To delete, reply exactly: confirm:<token>");
+    expect(outputRules).toContain("the token prompt is always the last line");
+  });
+
+  it("maps existing per-skill slots into the cards centrally", () => {
+    // This sentence is what lets dashboard/scene/organize/energy/updates adopt
+    // the cards with zero per-skill edits — their slot lists describe card
+    // content.
+    expect(outputRules).toContain("`Planned change` is the changes block");
+    expect(outputRules).toContain("`Save status` is the ⚠️ line");
+    expect(outputRules).toContain("fold into the title line");
+  });
+
+  it("bounds the cards to write/action flows and keeps read output tabular", () => {
+    expect(outputRules).toContain(
+      "Cards frame writes and runtime actions only; review and read output keep their own sections.",
+    );
+    expect(outputRules).toContain("max 4 short columns");
+    expect(outputRules).toContain("never raw JSON");
+  });
+
+  it("keeps the result card scope-honest", () => {
+    expect(outputRules).toContain("Runtime behavior was not exercised.");
+    expect(outputRules).toContain("Verification Honesty");
+  });
+});

--- a/tests/skills/write-delete-safety-contract.test.ts
+++ b/tests/skills/write-delete-safety-contract.test.ts
@@ -131,6 +131,21 @@ describe("write delete safety contract", () => {
     expect(writeSkill).toContain("prefer `--out <diff-file>`");
   });
 
+  it("splits the change table: agent-authored localized header, verbatim CLI rows", () => {
+    // The CLI emits data rows only; the two header lines are the agent's — and
+    // the ONLY hand-written lines inside the table. This split keeps
+    // Before/After in the user's language while every fact stays byte-identical
+    // CLI output.
+    expect(writeSafety).toContain("| Field | before | after |");
+    expect(writeSafety).toContain("exactly two hand-written");
+    expect(writeSafety).toContain("the localized table header row");
+    expect(writeSafety).toContain("|---|---|---|");
+    expect(writeSafety).toContain("do not re-align pipes or pad cells");
+    // The truncation marker joins the count-only rule: a cut-off value the
+    // request touched must be named in the summary.
+    expect(writeSafety).toContain("or a truncated (`…`) value");
+  });
+
   it("protects notification copy from unrequested rewrites", () => {
     expect(writeSafety).toContain("User-authored notification copy");
     expect(writeSafety).toContain("Notification text is user-authored copy");


### PR DESCRIPTION
## Summary

UX-is-king redesign of how config changes reach the user (maintainer decision: laypeople cannot read developer diffs — they need to SEE what changes at a glance, as a table).

**CLI (`ha-nova diff`):** emits GFM table data rows now — `| Field | before | after |`, absence as `—`, self-labeling counts (`| Triggers | 1 item | 2 items |`), honest cap as a row so the table never splits. `escapeCell` is the single choke point: rune-safe 80-byte cells, control-char + pipe escaping (Jinja `|`). Header stays agent-authored: the CLI never emits header rows, so **empty diff stays empty** — the snapshot/revert drift guard (`renderConfigChanges` length) is untouched. Byte-identical across runs (verified).

Example output (agent adds the localized header above):

```
| Mode | single | restart |
| Trigger 1 (at) | 06:30:00 | 06:00:00 |
| Conditions | 0 items | 1 item |
| Condition 1 | — | condition state |
| Action 2 (data › message) | Guten Morgen! Kaffee läuft. | Guten Morgen! Kaffee läuft — heute 30 Minuten früher. |
```

**Design system:** `output-rules.md` gains the Cards section — 📝 Preview / 🗑️ Delete / ✅ Result cards with canonical examples (the first concrete layout examples the skills ever had). The slot→card mapping sentence adopts dashboard/scene/organize/energy/updates & co. with zero per-skill edits. `write-safety.md` carries the header-split contract (exactly two hand-written lines: localized header + literal `|---|---|---|`; rows verbatim, never re-aligned; truncated values join the count-only narrative duty). write/helper point at the Cards.

**Tests:** 35 golden literals migrated; new: pipe escaping, rune-safe truncation boundary, every-line-is-a-table-row invariant; new `output-design-contract.test.ts` (registered in the safe-core manifest — the #302 orphan guard caught the miss) locks card shapes; header-split pins added to write-delete-safety-contract. All existing pins preserved (verified: `paste the ha-nova diff file/stdout`, `There is no hand-computed fallback`, #274 narrative pins, helper/cross-skill pins).

## Verification

- Full Go suite green (157s); all 264 skill contracts green; `check-docs` green.
- `ha-nova diff` twice on the same pair → byte-identical (`cmp`).
- Follow-ups per plan: PR 2 rolls the cards into yaml-config/service-call/review; PR 3 aligns reference docs. Live smoke on a real HA (German header over verbatim rows + revert drift guard) runs with the PR-2 demo.

## Release note

Part of the 0.15.0 batch (maintainer decision) — no immediate release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnL7zQZRToTuH6V2RPUFBc