### PR TITLE
chore(release): 0.15.0 — readable change previews, --help everywhere, guided relay updates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.14.1"
+    "version": "0.15.0"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,21 +85,18 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## New Features
 
-    - **9 new skills — coverage across the whole home.** `diagnose` (root-cause "why didn't my automation run?"), `media` (players, volume, speaker groups, TTS announcements), `notify` (phone and persistent notifications), `camera` (the agent actually looks at the current frame), `mqtt` (listen to what a device really publishes), `assist` (test what your voice assistant understands — without speaking), `admin` (persons, zones, tags, user accounts — with hard owner guards), `yaml-config`, and `external-sources` (years of InfluxDB history the recorder purged long ago).
-    - **Runs on every Home Assistant install now.** The relay also ships as a standalone container (`ghcr.io/markusleben/ha-nova-relay`), so Home Assistant Container and Core users — who cannot install Apps — are no longer locked out. Same code, same security model: your Home Assistant token still never leaves the server.
-    - **YAML configuration you can finally edit.** Template, REST and command-line sensors, packages and themes have no Home Assistant API — they only exist as files. The new `ha-nova:yaml-config` skill edits them safely: read first, show a diff, back up, validate before reloading, verify afterwards. Only if you switch it on: the NOVA Relay's new `file_access` option defaults to `off`, and secrets, the recorder database, and anything executable stay off-limits in every mode.
-    - **Guided uninstall.** `ha-nova uninstall` now walks you through the Home Assistant side too: removing the NOVA Relay app, removing the repository, and revoking the "NOVA" access token. The cleanup checklist is always shown — even when Home Assistant is unreachable.
-    - **Update notices in every AI client.** Codex, OpenCode, Antigravity, and Hermes now surface HA NOVA updates during normal skill use; previously only Claude did.
+    - **Change previews you can actually read.** When the AI updates an automation, script, or helper, it now shows one clear before/after table instead of a wall of bullets — and nested changes name the thing you recognize ("condition sensor.kitchen_illumination" instead of "condition 2"). Every skill uses the same preview cards, in every AI client.
+    - **YAML file edits preview only the section that changes.** No developer diffs: you see the effect in plain words, the new section, and what it replaces — then you decide.
+    - **`--help` everywhere.** Every `ha-nova` command now answers `--help` with its usage and flags — so options like `update --force` are finally discoverable.
+    - **HA NOVA offers to update the relay for you.** When your NOVA Relay is outdated, the AI now asks whether it should install the App update right away instead of just pointing at a warning (container installs get honest manual pull guidance).
 
     ## What To Watch
 
-    - The NOVA Relay must be updated to 0.4.0 or newer (App: **Settings > Apps > NOVA Relay**; container: pull the new image). Camera and MQTT need 0.3.0's binary and bounded-listening support, YAML editing needs 0.4.0's opt-in file access — HA NOVA tells you if your relay is too old.
-    - Set `HA_NOVA_NO_UPDATE_NUDGE=1` to silence the new update notices.
+    - Home Assistant will show a NOVA Relay update (0.4.1). It only refreshes the App's info page — no functional changes, update whenever convenient. Skills still require relay 0.4.0 or newer.
 
     ## Bug Fixes
 
-    - `ha-nova doctor` now really checks the relay version: it read the wrong field of the health response and could report a healthy setup while your relay was too old for the installed skills. `ha-nova update` and `check-update` also tell you now when the relay in Home Assistant needs its own update — right when you are already updating.
-
+    - Reading Home Assistant logs works again on current HA versions: the skills now use the supported log source (`system_log/list`) instead of an endpoint recent Home Assistant releases removed.
     Stable install commands are release-pinned for this tag.
 
     **macOS / Linux:**

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We built this because we didn't trust AI with our own config either.
 **What happens when AI wants to change something:**
 
 1. **Researches first.** Finds your devices, checks your setup, resolves entity names. No guessing.
-2. **Shows you the change.** Full diff, before anything is written.
+2. **Shows you the change.** A clear before/after table of exactly what will change, before anything is written.
 3. **You approve it.** Deletes require a specific confirmation code — not just "yes."
 4. **Writes and verifies.** Reads the config back to confirm the change stuck.
 5. **Audits itself.** Checks for mistakes, conflicts, and reliability issues.

--- a/nova/CHANGELOG.md
+++ b/nova/CHANGELOG.md
@@ -9,6 +9,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/) and [Semantic
 Recent changes are tracked in [GitHub releases](https://github.com/markusleben/ha-nova/releases)
 and merged PRs. This changelog will be updated with the next tagged relay version.
 
+## [Relay 0.4.1] - 2026-07-12
+
+- The App info page now explains what the NOVA Relay is, what it deliberately does not do, and where the security model lives — instead of a one-line stub. No functional changes.
+
 ## [Relay 0.4.0] - 2026-07-11
 
 ### Added

--- a/nova/config.yaml
+++ b/nova/config.yaml
@@ -1,5 +1,5 @@
 name: NOVA Relay
-version: "0.4.0"
+version: "0.4.1"
 slug: ha_nova_relay
 description: Thin Home Assistant relay for WS proxy and skill workflows
 url: https://github.com/markusleben/ha-nova

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "home-assistant-js-websocket": "^9.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -53,17 +53,16 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
-  it("keeps v0.14.1 release-facing wording user-centric", () => {
+  it("keeps v0.15.0 release-facing wording user-centric", () => {
     // Shipped release-note bodies are archived (docs/archive/work/) and
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
-    expect(goreleaser).toContain("9 new skills — coverage across the whole home");
-    expect(goreleaser).toContain("Runs on every Home Assistant install now");
-    expect(goreleaser).toContain("ghcr.io/markusleben/ha-nova-relay");
-    expect(goreleaser).toContain("YAML configuration you can finally edit");
-    expect(goreleaser).toContain("The NOVA Relay must be updated to 0.4.0 or newer");
-    expect(goreleaser).toContain("HA_NOVA_NO_UPDATE_NUDGE=1");
-    expect(goreleaser).toContain("`ha-nova doctor` now really checks the relay version");
+    expect(goreleaser).toContain("Change previews you can actually read");
+    expect(goreleaser).toContain("YAML file edits preview only the section that changes");
+    expect(goreleaser).toContain("`--help` everywhere");
+    expect(goreleaser).toContain("HA NOVA offers to update the relay for you");
+    expect(goreleaser).toContain("Skills still require relay 0.4.0 or newer");
+    expect(goreleaser).toContain("system_log/list");
     expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");
   });
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.14.1",
+  "skill_version": "0.15.0",
   "min_relay_version": "0.4.0"
 }


### PR DESCRIPTION
Release-prep for **v0.15.0** (batches #317, #318, #319, #321, #322, #323, #324 and relay docs #320 as relay 0.4.1).

- `npm run bump -- 0.15.0`: version.json, package.json/lock, plugin.json, marketplace.json
- 0.15.0 release notes in the GoReleaser stable template + updated contract pins
- relay 0.4.1 (nova/config.yaml + CHANGELOG): App info page polish only, no functional change; `min_relay_version` stays 0.4.0
- README stable-truth line: the write flow shows a before/after table (ships with this release)

After merge: strict pipeline audit → dispatched e2e on the merge commit → `v0.15.0-rc1` rehearsal → final `v0.15.0` on the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnL7zQZRToTuH6V2RPUFBc