### PR TITLE
feat(cli): guided relay update from the terminal (stage 2)

### DIFF
--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -103,6 +103,12 @@ func runDoctor(paths runtimePaths, args []string) int {
 			}
 			if !fixed {
 				status = 1
+			} else {
+				// The relay just restarted: the readiness captured before the
+				// update is stale (its WS may still be reconnecting, or fail
+				// on the new version) — the checks below must judge the relay
+				// that is running NOW.
+				readiness = checkRelayReadiness(cfg.RelayBaseURL, token)
 			}
 		}
 		if haReachable {

--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -94,6 +94,7 @@ func runDoctor(paths runtimePaths, args []string) int {
 		if notice := checkRelayVersion(paths, readiness.HealthBody); !notice.empty() {
 			printHumanNotice(notice)
 			status = 1
+			maybeOfferGuidedRelayUpdate(paths, notice)
 		}
 		if haReachable {
 			switch {
@@ -245,7 +246,6 @@ func runCheckUpdate(paths runtimePaths, args []string) int {
 	if !*quiet {
 		if relayNotice := relayFloorNotice(paths); !relayNotice.empty() {
 			printHumanNotice(relayNotice)
-			maybeOfferGuidedRelayUpdate(paths, relayNotice)
 		}
 	}
 	if notice.empty() {

--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -93,11 +93,16 @@ func runDoctor(paths runtimePaths, args []string) int {
 		doctorInfo("Relay health reachable: %s/health", cfg.RelayBaseURL)
 		if notice := checkRelayVersion(paths, readiness.HealthBody); !notice.empty() {
 			printHumanNotice(notice)
-			status = 1
 			// --quiet is a machine/diagnostic contract: warning-only, never
 			// an interactive question that could block or trigger a restart.
+			// A guided update that ends verified clears THIS failure — doctor
+			// must not exit 1 over a problem the user just fixed.
+			fixed := false
 			if !*quiet {
-				maybeOfferGuidedRelayUpdate(paths, notice)
+				fixed = maybeOfferGuidedRelayUpdate(paths, notice)
+			}
+			if !fixed {
+				status = 1
 			}
 		}
 		if haReachable {

--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -245,6 +245,7 @@ func runCheckUpdate(paths runtimePaths, args []string) int {
 	if !*quiet {
 		if relayNotice := relayFloorNotice(paths); !relayNotice.empty() {
 			printHumanNotice(relayNotice)
+			maybeOfferGuidedRelayUpdate(paths, relayNotice)
 		}
 	}
 	if notice.empty() {

--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -94,7 +94,11 @@ func runDoctor(paths runtimePaths, args []string) int {
 		if notice := checkRelayVersion(paths, readiness.HealthBody); !notice.empty() {
 			printHumanNotice(notice)
 			status = 1
-			maybeOfferGuidedRelayUpdate(paths, notice)
+			// --quiet is a machine/diagnostic contract: warning-only, never
+			// an interactive question that could block or trigger a restart.
+			if !*quiet {
+				maybeOfferGuidedRelayUpdate(paths, notice)
+			}
 		}
 		if haReachable {
 			switch {

--- a/cli/command_update.go
+++ b/cli/command_update.go
@@ -137,6 +137,7 @@ func runUpdate(paths runtimePaths, args []string) int {
 	// interrupted mid-session by the proxy warning later.
 	if notice := relayFloorNotice(paths); !notice.empty() {
 		printHumanNotice(notice)
+		maybeOfferGuidedRelayUpdate(paths, notice)
 	}
 	return 0
 }
@@ -214,6 +215,7 @@ func syncInstalledClientsForCurrentVersion(paths runtimePaths, currentVersion, t
 	// installed skills need — say so here, where the user is looking.
 	if notice := relayFloorNotice(paths); !notice.empty() {
 		printHumanNotice(notice)
+		maybeOfferGuidedRelayUpdate(paths, notice)
 	}
 	return 0
 }

--- a/cli/command_update.go
+++ b/cli/command_update.go
@@ -182,9 +182,15 @@ func runInternalReplace(paths runtimePaths, args []string) int {
 	printHumanInfo("Updated to v%s", localVersion(paths))
 	// Windows finishes the update in this replacement process — the freshly
 	// installed version.json is live here, so the relay-floor warning belongs
-	// here too (the staging branch in runUpdate exits before it).
+	// here too (the staging branch in runUpdate exits before it). No guided
+	// prompt here on purpose: this helper runs in the background with stdin
+	// unwired (windowsHelperLaunchProfile attaches output only) and the
+	// console is already back at the shell — the documented Windows contract
+	// is background-complete, never same-console-interactive. Point at the
+	// interactive path instead.
 	if notice := relayFloorNotice(paths); !notice.empty() {
 		printHumanNotice(notice)
+		printHumanInfo("Run `ha-nova doctor` in a terminal to be offered the guided relay update.")
 	}
 	return 0
 }

--- a/cli/platform.go
+++ b/cli/platform.go
@@ -16,6 +16,16 @@ func isInteractiveTTY() bool {
 	return false
 }
 
+// stdoutIsInteractiveTTY reports whether stdout still reaches a terminal. A
+// prompt written to a redirected stdout (`ha-nova update > update.log`) would
+// block on invisible input — callers that ask questions must check BOTH ends.
+func stdoutIsInteractiveTTY() bool {
+	if fi, err := os.Stdout.Stat(); err == nil && (fi.Mode()&os.ModeCharDevice) != 0 {
+		return true
+	}
+	return false
+}
+
 func promptLine(label, defaultValue string) (string, error) {
 	fmt.Fprint(os.Stdout, label)
 	if defaultValue != "" {

--- a/cli/relay_guided_update.go
+++ b/cli/relay_guided_update.go
@@ -30,7 +30,7 @@ var (
 	relayUpdatePollTimeout  = 3 * time.Minute
 )
 
-const relayUpdateManualPath = "Manual path: open Home Assistant > Settings > Add-ons > NOVA Relay and install the update there; a standalone container needs a manual image pull."
+const relayUpdateManualPath = "Manual path: open Home Assistant > Settings > Apps > NOVA Relay (older HA calls it Add-ons) and install the update there; a standalone container needs a manual image pull."
 
 // maybeOfferGuidedRelayUpdate follows a printed relay-outdated notice and
 // reports whether the relay ended up updated AND verified — doctor uses that

--- a/cli/relay_guided_update.go
+++ b/cli/relay_guided_update.go
@@ -68,8 +68,10 @@ func runGuidedRelayUpdate(paths runtimePaths, cfg config, token string, in *bufi
 	fmt.Fprintf(out, "Installing the NOVA Relay App update (%s) with a partial backup — the relay restarts during the install.\n", entityID)
 	// The relay dies mid-call when the install lands, so a dropped response
 	// is the EXPECTED shape of success here; polling decides the outcome.
-	// Only an explicit upstream rejection (an answer that says no) skips the
-	// three-minute wait.
+	// An ok:false envelope is a relay-side transport problem (the relay's
+	// upstream client times out at 10s — a backup easily exceeds that) and
+	// polls too. Only Home Assistant itself answering >= 400 (ok:true) is an
+	// explicit rejection that skips the three-minute wait.
 	body, err := relayCoreRequest(cfg, token, "POST", "/api/services/update/install",
 		[]byte(fmt.Sprintf(`{"entity_id":%q,"backup":true}`, entityID)))
 	if err == nil {
@@ -79,7 +81,7 @@ func runGuidedRelayUpdate(paths runtimePaths, cfg config, token string, in *bufi
 				Status int `json:"status"`
 			} `json:"data"`
 		}
-		if json.Unmarshal(body, &envelope) == nil && (!envelope.OK || envelope.Data.Status >= 400) {
+		if json.Unmarshal(body, &envelope) == nil && envelope.OK && envelope.Data.Status >= 400 {
 			fmt.Fprintf(out, "Home Assistant rejected the install call.\n%s\n", relayUpdateManualPath)
 			return false
 		}

--- a/cli/relay_guided_update.go
+++ b/cli/relay_guided_update.go
@@ -32,36 +32,38 @@ var (
 
 const relayUpdateManualPath = "Manual path: open Home Assistant > Settings > Add-ons > NOVA Relay and install the update there; a standalone container needs a manual image pull."
 
-// maybeOfferGuidedRelayUpdate follows a printed relay-outdated notice. It is
+// maybeOfferGuidedRelayUpdate follows a printed relay-outdated notice and
+// reports whether the relay ended up updated AND verified — doctor uses that
+// to not fail a run whose only problem the user just fixed. It is
 // deliberately best-effort: a non-TTY session, a "no", a missing update
 // entity (standalone container), or any transport problem falls back to the
 // manual path without touching the caller's exit code.
-func maybeOfferGuidedRelayUpdate(paths runtimePaths, notice humanNotice) {
+func maybeOfferGuidedRelayUpdate(paths runtimePaths, notice humanNotice) bool {
 	// Both ends must be a terminal: with stdout redirected the question would
 	// land in a file while the command silently blocks on stdin.
 	if notice.kind != humanNoticeKindRelayOutdated || !isInteractiveTTY() || !stdoutIsInteractiveTTY() {
-		return
+		return false
 	}
 	cfg, err := loadConfig(paths)
 	if err != nil || cfg.RelayBaseURL == "" {
-		return
+		return false
 	}
 	token, err := readRelayAuthTokenForDoctor()
 	if err != nil || token == "" {
-		return
+		return false
 	}
-	runGuidedRelayUpdate(paths, cfg, token, bufio.NewReader(os.Stdin), os.Stdout)
+	return runGuidedRelayUpdate(paths, cfg, token, bufio.NewReader(os.Stdin), os.Stdout)
 }
 
-func runGuidedRelayUpdate(paths runtimePaths, cfg config, token string, in *bufio.Reader, out io.Writer) {
+func runGuidedRelayUpdate(paths runtimePaths, cfg config, token string, in *bufio.Reader, out io.Writer) bool {
 	yes, err := promptWizardYesNoFromReader(in, out, "Install the relay update in Home Assistant now?", true)
 	if err != nil || !yes {
-		return
+		return false
 	}
 	entityID, reason := resolveRelayUpdateEntity(cfg, token)
 	if entityID == "" {
 		fmt.Fprintf(out, "Cannot start the App update from here: %s\n%s\n", reason, relayUpdateManualPath)
-		return
+		return false
 	}
 	fmt.Fprintf(out, "Installing the NOVA Relay App update (%s) with a partial backup — the relay restarts during the install.\n", entityID)
 	// The relay dies mid-call when the install lands, so a dropped response
@@ -79,15 +81,16 @@ func runGuidedRelayUpdate(paths runtimePaths, cfg config, token string, in *bufi
 		}
 		if json.Unmarshal(body, &envelope) == nil && (!envelope.OK || envelope.Data.Status >= 400) {
 			fmt.Fprintf(out, "Home Assistant rejected the install call.\n%s\n", relayUpdateManualPath)
-			return
+			return false
 		}
 	}
 	version, ok := waitForRelayFloor(paths, cfg, token)
 	if !ok {
 		fmt.Fprintf(out, "The relay did not report a new version within %s.\n%s\n", relayUpdatePollTimeout, relayUpdateManualPath)
-		return
+		return false
 	}
 	fmt.Fprintf(out, "Relay updated and verified: v%s is running.\n", version)
+	return true
 }
 
 // resolveRelayUpdateEntity finds the NOVA Relay App's update.* entity via

--- a/cli/relay_guided_update.go
+++ b/cli/relay_guided_update.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// Stage 2 of the guided relay update
+// (docs/work/2026-07-12-relay-guided-update-spec.md): after the
+// relay-outdated warning on an interactive terminal, `ha-nova update` and
+// `ha-nova doctor` offer to install the App update right there — ask first,
+// never automatic. Everything here is client-side and generic HA transport
+// through the existing /core proxy; the relay stays dumb.
+
+// relayUpdateEntityTitle is the App name the update entity carries
+// (nova/config.yaml `name:`). Resolution matches on it exactly — on zero or
+// several matches the flow prints the manual path instead of guessing.
+const relayUpdateEntityTitle = "NOVA Relay"
+
+// Poll pacing is a variable so tests can shrink the restart wait.
+var (
+	relayUpdatePollInterval = 5 * time.Second
+	relayUpdatePollTimeout  = 3 * time.Minute
+)
+
+const relayUpdateManualPath = "Manual path: open Home Assistant > Settings > Add-ons > NOVA Relay and install the update there; a standalone container needs a manual image pull."
+
+// maybeOfferGuidedRelayUpdate follows a printed relay-outdated notice. It is
+// deliberately best-effort: a non-TTY session, a "no", a missing update
+// entity (standalone container), or any transport problem falls back to the
+// manual path without touching the caller's exit code.
+func maybeOfferGuidedRelayUpdate(paths runtimePaths, notice humanNotice) {
+	if notice.kind != humanNoticeKindRelayOutdated || !isInteractiveTTY() {
+		return
+	}
+	cfg, err := loadConfig(paths)
+	if err != nil || cfg.RelayBaseURL == "" {
+		return
+	}
+	token, err := readRelayAuthTokenForDoctor()
+	if err != nil || token == "" {
+		return
+	}
+	runGuidedRelayUpdate(paths, cfg, token, bufio.NewReader(os.Stdin), os.Stdout)
+}
+
+func runGuidedRelayUpdate(paths runtimePaths, cfg config, token string, in *bufio.Reader, out io.Writer) {
+	yes, err := promptWizardYesNoFromReader(in, out, "Install the relay update in Home Assistant now?", true)
+	if err != nil || !yes {
+		return
+	}
+	entityID, reason := resolveRelayUpdateEntity(cfg, token)
+	if entityID == "" {
+		fmt.Fprintf(out, "Cannot start the App update from here: %s\n%s\n", reason, relayUpdateManualPath)
+		return
+	}
+	fmt.Fprintf(out, "Installing the NOVA Relay App update (%s) with a partial backup — the relay restarts during the install.\n", entityID)
+	// The relay dies mid-call when the install lands, so a dropped response
+	// is the EXPECTED shape of success here; polling decides the outcome.
+	// Only an explicit upstream rejection (an answer that says no) skips the
+	// three-minute wait.
+	body, err := relayCoreRequest(cfg, token, "POST", "/api/services/update/install",
+		[]byte(fmt.Sprintf(`{"entity_id":%q,"backup":true}`, entityID)))
+	if err == nil {
+		var envelope struct {
+			OK   bool `json:"ok"`
+			Data struct {
+				Status int `json:"status"`
+			} `json:"data"`
+		}
+		if json.Unmarshal(body, &envelope) == nil && (!envelope.OK || envelope.Data.Status >= 400) {
+			fmt.Fprintf(out, "Home Assistant rejected the install call.\n%s\n", relayUpdateManualPath)
+			return
+		}
+	}
+	version, ok := waitForRelayFloor(paths, cfg, token)
+	if !ok {
+		fmt.Fprintf(out, "The relay did not report a new version within %s.\n%s\n", relayUpdatePollTimeout, relayUpdateManualPath)
+		return
+	}
+	fmt.Fprintf(out, "Relay updated and verified: v%s is running.\n", version)
+}
+
+// resolveRelayUpdateEntity finds the NOVA Relay App's update.* entity via
+// GET /api/states. It returns the entity id, or "" plus the human reason
+// (no entity → container/manual install; several → ambiguous, never guess).
+func resolveRelayUpdateEntity(cfg config, token string) (string, string) {
+	body, err := relayCoreRequest(cfg, token, "GET", "/api/states", nil)
+	if err != nil {
+		return "", fmt.Sprintf("could not read Home Assistant states (%s)", err)
+	}
+	var envelope struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Status int             `json:"status"`
+			Body   json.RawMessage `json:"body"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil || !envelope.OK || envelope.Data.Status != http.StatusOK {
+		return "", "could not read Home Assistant states"
+	}
+	var states []struct {
+		EntityID   string `json:"entity_id"`
+		Attributes struct {
+			Title string `json:"title"`
+		} `json:"attributes"`
+	}
+	if err := json.Unmarshal(envelope.Data.Body, &states); err != nil {
+		return "", "could not read Home Assistant states"
+	}
+	var matches []string
+	for _, s := range states {
+		if strings.HasPrefix(s.EntityID, "update.") && s.Attributes.Title == relayUpdateEntityTitle {
+			matches = append(matches, s.EntityID)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], ""
+	case 0:
+		return "", "no NOVA Relay App update entity found (standalone container, or the App is not installed)"
+	default:
+		return "", fmt.Sprintf("several update entities carry the title %q — not guessing", relayUpdateEntityTitle)
+	}
+}
+
+// waitForRelayFloor polls GET /health until the reported version satisfies
+// min_relay_version, then returns it. Connection errors are the normal
+// restart window and just keep the loop going.
+func waitForRelayFloor(paths runtimePaths, cfg config, token string) (string, bool) {
+	deadline := time.Now().Add(relayUpdatePollTimeout)
+	for {
+		body, err := fetchRelayHealth(cfg.RelayBaseURL, token)
+		if err == nil {
+			version := parseRelayHealthVersion(body)
+			if version != "" && checkRelayVersionValue(paths, version).empty() {
+				return version, true
+			}
+		}
+		if time.Now().After(deadline) {
+			return "", false
+		}
+		time.Sleep(relayUpdatePollInterval)
+	}
+}
+
+// relayCoreRequest posts one request through the relay's /core proxy and
+// returns the raw envelope body.
+func relayCoreRequest(cfg config, token, method, path string, requestBody []byte) ([]byte, error) {
+	payload := []byte(fmt.Sprintf(`{"method":%q,"path":%q`, method, path))
+	if len(requestBody) > 0 {
+		payload = append(payload, []byte(`,"body":`)...)
+		payload = append(payload, requestBody...)
+	}
+	payload = append(payload, '}')
+	req, err := http.NewRequest("POST", strings.TrimRight(cfg.RelayBaseURL, "/")+"/core", bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return readAllLimited(resp.Body, maxRelayResponseBytes)
+}

--- a/cli/relay_guided_update.go
+++ b/cli/relay_guided_update.go
@@ -37,7 +37,9 @@ const relayUpdateManualPath = "Manual path: open Home Assistant > Settings > Add
 // entity (standalone container), or any transport problem falls back to the
 // manual path without touching the caller's exit code.
 func maybeOfferGuidedRelayUpdate(paths runtimePaths, notice humanNotice) {
-	if notice.kind != humanNoticeKindRelayOutdated || !isInteractiveTTY() {
+	// Both ends must be a terminal: with stdout redirected the question would
+	// land in a file while the command silently blocks on stdin.
+	if notice.kind != humanNoticeKindRelayOutdated || !isInteractiveTTY() || !stdoutIsInteractiveTTY() {
 		return
 	}
 	cfg, err := loadConfig(paths)

--- a/cli/relay_guided_update_test.go
+++ b/cli/relay_guided_update_test.go
@@ -249,6 +249,46 @@ func TestGuidedRelayUpdateRejectedInstallSkipsTheWait(t *testing.T) {
 	}
 }
 
+func TestGuidedRelayUpdateRelayTimeoutEnvelopeStillPolls(t *testing.T) {
+	// The relay's upstream client times out at 10s and maps that to an
+	// ok:false envelope while the App update keeps installing — that is a
+	// restart candidate, not a rejection, and must continue into the poll.
+	paths := guidedUpdatePaths(t)
+	shrinkGuidedUpdatePolling(t, time.Second)
+	var installed atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			version := "0.2.6"
+			if installed.Load() {
+				version = "0.4.0"
+			}
+			fmt.Fprintf(w, `{"ok":true,"data":{"version":%q}}`, version)
+			return
+		}
+		var req struct {
+			Path string `json:"path"`
+		}
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.Path == "/api/states" {
+			w.Write(statesEnvelope(t, []map[string]interface{}{
+				relayUpdateEntity("update.nova_relay_update", "NOVA Relay"),
+			}))
+			return
+		}
+		installed.Store(true)
+		w.Write([]byte(`{"ok":false,"error":{"code":"UPSTREAM_TIMEOUT","message":"HA REST call timed out"}}`))
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	if !runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("y\n")), &out) {
+		t.Fatalf("relay-side timeout must poll and verify; output: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "Relay updated and verified: v0.4.0 is running.") {
+		t.Fatalf("missing verified report: %s", out.String())
+	}
+}
+
 func TestGuidedRelayUpdateDeclinedTouchesNothing(t *testing.T) {
 	paths := guidedUpdatePaths(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/relay_guided_update_test.go
+++ b/cli/relay_guided_update_test.go
@@ -167,7 +167,10 @@ func TestGuidedRelayUpdateInstallsThroughTheRestartAndVerifies(t *testing.T) {
 	defer server.Close()
 
 	var out bytes.Buffer
-	runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("\n")), &out)
+	verified := runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("\n")), &out)
+	if !verified {
+		t.Fatalf("verified install must report success; output: %s", out.String())
+	}
 	if !installed.Load() {
 		t.Fatalf("update/install was never called; output: %s", out.String())
 	}
@@ -201,7 +204,9 @@ func TestGuidedRelayUpdatePollTimeoutStaysHonest(t *testing.T) {
 	defer server.Close()
 
 	var out bytes.Buffer
-	runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("y\n")), &out)
+	if runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("y\n")), &out) {
+		t.Fatalf("timeout must not report success")
+	}
 	if !strings.Contains(out.String(), "did not report a new version") {
 		t.Fatalf("missing honest timeout message: %s", out.String())
 	}
@@ -233,7 +238,9 @@ func TestGuidedRelayUpdateRejectedInstallSkipsTheWait(t *testing.T) {
 	defer server.Close()
 
 	var out bytes.Buffer
-	runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("y\n")), &out)
+	if runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("y\n")), &out) {
+		t.Fatalf("rejection must not report success")
+	}
 	if !strings.Contains(out.String(), "Home Assistant rejected the install call.") {
 		t.Fatalf("missing rejection message: %s", out.String())
 	}
@@ -250,7 +257,9 @@ func TestGuidedRelayUpdateDeclinedTouchesNothing(t *testing.T) {
 	defer server.Close()
 
 	var out bytes.Buffer
-	runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("n\n")), &out)
+	if runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("n\n")), &out) {
+		t.Fatalf("a declined prompt must not report success")
+	}
 }
 
 func TestGuidedRelayUpdateContainerFallsBackToManualPath(t *testing.T) {
@@ -261,7 +270,9 @@ func TestGuidedRelayUpdateContainerFallsBackToManualPath(t *testing.T) {
 	defer server.Close()
 
 	var out bytes.Buffer
-	runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("y\n")), &out)
+	if runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("y\n")), &out) {
+		t.Fatalf("container fallback must not report success")
+	}
 	if !strings.Contains(out.String(), "no NOVA Relay App update entity found") {
 		t.Fatalf("missing container reason: %s", out.String())
 	}

--- a/cli/relay_guided_update_test.go
+++ b/cli/relay_guided_update_test.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func guidedUpdatePaths(t *testing.T) runtimePaths {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.VersionFile), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(paths.VersionFile, []byte(`{"skill_version":"0.15.0","min_relay_version":"0.4.0"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+	return paths
+}
+
+func statesEnvelope(t *testing.T, states []map[string]interface{}) []byte {
+	t.Helper()
+	body, err := json.Marshal(map[string]interface{}{
+		"ok":   true,
+		"data": map[string]interface{}{"status": 200, "body": states},
+	})
+	if err != nil {
+		t.Fatalf("marshal states envelope: %v", err)
+	}
+	return body
+}
+
+func relayUpdateEntity(id, title string) map[string]interface{} {
+	return map[string]interface{}{
+		"entity_id":  id,
+		"attributes": map[string]interface{}{"title": title},
+	}
+}
+
+func TestResolveRelayUpdateEntity(t *testing.T) {
+	cases := []struct {
+		name       string
+		states     []map[string]interface{}
+		wantEntity string
+		wantReason string
+	}{
+		{
+			name: "exact match",
+			states: []map[string]interface{}{
+				relayUpdateEntity("update.home_assistant_core_update", "Home Assistant Core"),
+				relayUpdateEntity("update.nova_relay_update", "NOVA Relay"),
+				// A non-update domain carrying the title must not match.
+				relayUpdateEntity("sensor.nova_relay_update", "NOVA Relay"),
+			},
+			wantEntity: "update.nova_relay_update",
+		},
+		{
+			name: "no match means container or missing App",
+			states: []map[string]interface{}{
+				relayUpdateEntity("update.home_assistant_core_update", "Home Assistant Core"),
+			},
+			wantReason: "no NOVA Relay App update entity found",
+		},
+		{
+			name: "ambiguity is never guessed",
+			states: []map[string]interface{}{
+				relayUpdateEntity("update.nova_relay_update", "NOVA Relay"),
+				relayUpdateEntity("update.nova_relay_update_2", "NOVA Relay"),
+			},
+			wantReason: "several update entities",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/core" {
+					t.Errorf("unexpected path %q", r.URL.Path)
+				}
+				w.Write(statesEnvelope(t, tc.states))
+			}))
+			defer server.Close()
+			entity, reason := resolveRelayUpdateEntity(config{RelayBaseURL: server.URL}, "token")
+			if entity != tc.wantEntity {
+				t.Fatalf("entity = %q, want %q (reason %q)", entity, tc.wantEntity, reason)
+			}
+			if tc.wantReason != "" && !strings.Contains(reason, tc.wantReason) {
+				t.Fatalf("reason = %q, want it to contain %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func shrinkGuidedUpdatePolling(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	oldInterval, oldTimeout := relayUpdatePollInterval, relayUpdatePollTimeout
+	relayUpdatePollInterval = time.Millisecond
+	relayUpdatePollTimeout = timeout
+	t.Cleanup(func() {
+		relayUpdatePollInterval = oldInterval
+		relayUpdatePollTimeout = oldTimeout
+	})
+}
+
+func TestGuidedRelayUpdateInstallsThroughTheRestartAndVerifies(t *testing.T) {
+	paths := guidedUpdatePaths(t)
+	shrinkGuidedUpdatePolling(t, time.Second)
+	var installed atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			version := "0.2.6"
+			if installed.Load() {
+				version = "0.4.0"
+			}
+			fmt.Fprintf(w, `{"ok":true,"data":{"version":%q}}`, version)
+		case "/core":
+			var req struct {
+				Path string `json:"path"`
+				Body struct {
+					EntityID string `json:"entity_id"`
+					Backup   bool   `json:"backup"`
+				} `json:"body"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode core payload: %v", err)
+			}
+			if req.Path == "/api/states" {
+				w.Write(statesEnvelope(t, []map[string]interface{}{
+					relayUpdateEntity("update.nova_relay_update", "NOVA Relay"),
+				}))
+				return
+			}
+			if req.Path != "/api/services/update/install" {
+				t.Errorf("unexpected core path %q", req.Path)
+				return
+			}
+			if req.Body.EntityID != "update.nova_relay_update" || !req.Body.Backup {
+				t.Errorf("install payload = %+v, want resolved entity with backup:true", req.Body)
+			}
+			installed.Store(true)
+			// The install restarts the relay mid-call: drop the connection
+			// instead of answering — the flow must treat this as normal.
+			conn, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Errorf("hijack: %v", err)
+				return
+			}
+			conn.Close()
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("\n")), &out)
+	if !installed.Load() {
+		t.Fatalf("update/install was never called; output: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "Relay updated and verified: v0.4.0 is running.") {
+		t.Fatalf("missing verified-version report in output: %s", out.String())
+	}
+}
+
+func TestGuidedRelayUpdatePollTimeoutStaysHonest(t *testing.T) {
+	paths := guidedUpdatePaths(t)
+	shrinkGuidedUpdatePolling(t, 20*time.Millisecond)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			// The relay never comes back with a new version.
+			fmt.Fprint(w, `{"ok":true,"data":{"version":"0.2.6"}}`)
+		case "/core":
+			var req struct {
+				Path string `json:"path"`
+			}
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Path == "/api/states" {
+				w.Write(statesEnvelope(t, []map[string]interface{}{
+					relayUpdateEntity("update.nova_relay_update", "NOVA Relay"),
+				}))
+				return
+			}
+			w.Write([]byte(`{"ok":true,"data":{"status":200}}`))
+		}
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("y\n")), &out)
+	if !strings.Contains(out.String(), "did not report a new version") {
+		t.Fatalf("missing honest timeout message: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "Manual path:") {
+		t.Fatalf("timeout must include the manual path: %s", out.String())
+	}
+}
+
+func TestGuidedRelayUpdateRejectedInstallSkipsTheWait(t *testing.T) {
+	paths := guidedUpdatePaths(t)
+	shrinkGuidedUpdatePolling(t, time.Second)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			t.Errorf("an explicit rejection must not start the health poll")
+			return
+		}
+		var req struct {
+			Path string `json:"path"`
+		}
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.Path == "/api/states" {
+			w.Write(statesEnvelope(t, []map[string]interface{}{
+				relayUpdateEntity("update.nova_relay_update", "NOVA Relay"),
+			}))
+			return
+		}
+		w.Write([]byte(`{"ok":true,"data":{"status":403}}`))
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("y\n")), &out)
+	if !strings.Contains(out.String(), "Home Assistant rejected the install call.") {
+		t.Fatalf("missing rejection message: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "Manual path:") {
+		t.Fatalf("rejection must include the manual path: %s", out.String())
+	}
+}
+
+func TestGuidedRelayUpdateDeclinedTouchesNothing(t *testing.T) {
+	paths := guidedUpdatePaths(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("declined prompt must not call the relay, got %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("n\n")), &out)
+}
+
+func TestGuidedRelayUpdateContainerFallsBackToManualPath(t *testing.T) {
+	paths := guidedUpdatePaths(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(statesEnvelope(t, nil))
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("y\n")), &out)
+	if !strings.Contains(out.String(), "no NOVA Relay App update entity found") {
+		t.Fatalf("missing container reason: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "Manual path:") {
+		t.Fatalf("container path must stay manual: %s", out.String())
+	}
+}
+
+func TestMaybeOfferGuidedRelayUpdateIgnoresOtherNoticeKinds(t *testing.T) {
+	paths := guidedUpdatePaths(t)
+	// Wrong kind returns before any prompt or network use; under `go test`
+	// stdin is a pipe, so the TTY gate also holds the relay-outdated kind.
+	maybeOfferGuidedRelayUpdate(paths, humanNotice{kind: humanNoticeKindUpdateAvailable, level: humanNoticeWarning})
+	maybeOfferGuidedRelayUpdate(paths, humanNotice{kind: humanNoticeKindRelayOutdated, level: humanNoticeWarning})
+}

--- a/cli/version.go
+++ b/cli/version.go
@@ -213,9 +213,18 @@ func readMinRelayVersion(dir string) string {
 }
 
 func checkRelayVersion(paths runtimePaths, healthBody []byte) humanNotice {
-	// A live GET /health answers with the relay envelope
-	// {"ok":true,"data":{"version":...}} — the version is NOT top-level. The
-	// top-level field stays as a fallback for bare health bodies.
+	version := parseRelayHealthVersion(healthBody)
+	if version == "" {
+		return humanNotice{}
+	}
+	return checkRelayVersionValue(paths, version)
+}
+
+// parseRelayHealthVersion extracts the relay version from a /health body. A
+// live GET /health answers with the relay envelope
+// {"ok":true,"data":{"version":...}} — the version is NOT top-level. The
+// top-level field stays as a fallback for bare health bodies.
+func parseRelayHealthVersion(healthBody []byte) string {
 	var health struct {
 		Version string `json:"version"`
 		Data    struct {
@@ -223,16 +232,12 @@ func checkRelayVersion(paths runtimePaths, healthBody []byte) humanNotice {
 		} `json:"data"`
 	}
 	if json.Unmarshal(healthBody, &health) != nil {
-		return humanNotice{}
+		return ""
 	}
-	version := health.Data.Version
-	if version == "" {
-		version = health.Version
+	if health.Data.Version != "" {
+		return health.Data.Version
 	}
-	if version == "" {
-		return humanNotice{}
-	}
-	return checkRelayVersionValue(paths, version)
+	return health.Version
 }
 
 // relayFloorNotice fetches the relay health once and returns the

--- a/docs/work/2026-07-12-relay-guided-update-spec.md
+++ b/docs/work/2026-07-12-relay-guided-update-spec.md
@@ -1,6 +1,6 @@
 # Spec: guided relay update from the CLI (stage 2)
 
-Status: `draft` — approved direction (maintainer, 2026-07-12); implementation queued for a later version.
+Status: `implemented` (2026-07-12) — `cli/relay_guided_update.go`; ships with the next user-facing release.
 
 ## Problem
 

--- a/docs/work/2026-07-12-relay-guided-update-spec.md
+++ b/docs/work/2026-07-12-relay-guided-update-spec.md
@@ -19,7 +19,8 @@ Since v0.14.1 the CLI warns when the relay sits below `min_relay_version` (docto
    - `POST /api/services/update/install` via the existing `/core` proxy with `{"entity_id": ..., "backup": true}` (partial App backup, mirrors `skills/updates/SKILL.md`).
    - Expect the relay to restart mid-call: tolerate the dropped response, then poll `GET /health` (existing `fetchRelayHealth`) every ~5 s for up to ~3 min until the reported version satisfies `min_relay_version`.
    - Report the verified version, or a plain timeout message with the manual path.
-4. Non-TTY, `--yes`-style automation, or standalone container: keep today's warning only (a container cannot replace itself; ha-nova has no Docker-host access).
+4. Non-TTY, `--yes`-style automation, `doctor --quiet`, or standalone container: keep today's warning only (a container cannot replace itself; ha-nova has no Docker-host access).
+5. Windows self-update: the replacement finishes in the background helper (stdin unwired, console already returned to the shell — the documented background-complete contract), so it stays warning-only and prints a pointer to the interactive `ha-nova doctor` path, which offers the prompt.
 
 ## Boundaries
 


### PR DESCRIPTION
Implements the approved stage-2 spec (docs/work/2026-07-12-relay-guided-update-spec.md): after the relay-outdated warning on an interactive terminal, `ha-nova update` and `ha-nova doctor` offer to install the relay App update right there — ask first, never automatic.

- Entity resolution via `GET /api/states`: exact title match on the `update.*` domain; zero matches → container/manual path, several → never guess
- `update/install` with `backup: true` through the existing `/core` proxy; a dropped response mid-restart is the expected success shape, an explicit upstream rejection skips the wait
- `/health` poll (5 s / 3 min) until `min_relay_version` is verified; honest timeout message with the manual path
- Non-TTY, container, and `--quiet`/machine paths stay warning-only
- Tests: resolution (exact/none/ambiguous), full install-through-restart flow, poll timeout, rejection early-exit, declined prompt, container fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnL7zQZRToTuH6V2RPUFBc