### PR TITLE
feat(skills): confirmation-code wording and VS16 emoji spacing

### DIFF
--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -99,7 +99,7 @@ Skills reference this section as "context skill → Active Preview Confirmation"
 
 - `create`/`update`: natural confirmation bound to active preview.
 - `delete`/destructive: token confirmation `confirm:<token>`.
-  **Strict token enforcement:** User MUST reply with the exact token string (e.g., `confirm:del-main-lights`). Any other response — including "yes", "sure, delete it", "do it", or any natural-language confirmation — is NOT valid. Reject and re-prompt with the exact token required.
+  **Strict token enforcement:** User MUST reply with the exact token string (e.g., `confirm:del-main-lights`). Any other response — including "yes", "sure, delete it", "do it", or any natural-language confirmation — is NOT valid. Reject and re-prompt with the exact code required. In user-facing output call it the "confirmation code" (localized), never a "token" (see `skills/ha-nova/output-rules.md` → Localization).
   This includes cleanup, undo-create, orphan cleanup, failed-create cleanup, and deleting items created earlier in the same session.
 
 ### Write Routing Gate

--- a/skills/ha-nova/output-rules.md
+++ b/skills/ha-nova/output-rules.md
@@ -11,6 +11,7 @@ Apply these rules to every user-facing HA NOVA response, including direct sub-sk
 - Keep Home Assistant state values, API names, commands, entity IDs, and service names literal when they are evidence.
 - Keep typed safety keywords literal in every language: `revert`, `show yaml`, `confirm:<token>`.
 - Localize the surrounding sentence around those keywords.
+- The user-facing name for the typed destructive keyword is the "confirmation code" (localized, e.g. German "Bestätigungscode"). Never call it a "token" in user-facing output — "token" is internal spec language, and it also collides with the unrelated access-token concept users know from onboarding.
 
 ## Technical Noise
 
@@ -35,7 +36,7 @@ Apply these rules to every user-facing HA NOVA response, including direct sub-sk
 
 ## Cards (Write-Flow Visual System)
 
-Write and action flows render one of three cards — the same shape every time, so users recognize them at a glance. Labels localize at runtime; emoji, literal keywords, entity IDs, state values, and CLI diff rows do not. Fixed emoji vocabulary: 📝 preview, 🗑️ delete preview, ✅ result, ⚠️ save status, plus the 🔴🟠🟡 severity markers — nothing else decorative, never color. Cards frame writes and runtime actions only; review and read output keep their own sections.
+Write and action flows render one of three cards — the same shape every time, so users recognize them at a glance. Labels localize at runtime; emoji, literal keywords, entity IDs, state values, and CLI diff rows do not. Fixed emoji vocabulary: 📝 preview, 🗑️ delete preview, ✅ result, ⚠️ save status, plus the 🔴🟠🟡 severity markers — nothing else decorative, never color. Cards frame writes and runtime actions only; review and read output keep their own sections. Emoji that end in a variation selector (🗑️, ⚠️) take two spaces before the following text — many terminals render them double-width over the next column and visually swallow a single space; the other card emoji keep one space.
 
 **Preview Card** (create/update — values illustrative, labels localized at runtime):
 
@@ -49,7 +50,7 @@ The three light actions now only run when someone is home.
 | Mode | single | restart |
 
 Pre-write check: no concerns.
-⚠️ Nothing saved yet.
+⚠️  Nothing saved yet.
 Options: apply · show yaml · cancel
 ```
 
@@ -58,10 +59,10 @@ Title line: emoji + localized preview label + item type + name. Then one to thre
 **Delete Card** (destructive — never a menu; the token prompt is always the last line):
 
 ```
-🗑️ Delete: automation "Old morning routine"
+🗑️  Delete: automation "Old morning routine"
 Turns all lights off at 23:00 — that stops when it is gone.
 Used by: nothing else found.
-⚠️ Nothing deleted yet.
+⚠️  Nothing deleted yet.
 To delete, reply exactly: confirm:<token>
 ```
 

--- a/skills/ha-nova/output-rules.md
+++ b/skills/ha-nova/output-rules.md
@@ -11,7 +11,7 @@ Apply these rules to every user-facing HA NOVA response, including direct sub-sk
 - Keep Home Assistant state values, API names, commands, entity IDs, and service names literal when they are evidence.
 - Keep typed safety keywords literal in every language: `revert`, `show yaml`, `confirm:<token>`.
 - Localize the surrounding sentence around those keywords.
-- The user-facing name for the typed destructive keyword is the "confirmation code" (localized, e.g. German "Bestätigungscode"). Never call it a "token" in user-facing output — "token" is internal spec language, and it also collides with the unrelated access-token concept users know from onboarding.
+- The user-facing name for the typed destructive keyword is the "confirmation code" (localized to the user's language). Never call it a "token" in user-facing output — "token" is internal spec language, and it also collides with the unrelated access-token concept users know from onboarding.
 
 ## Technical Noise
 

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -148,7 +148,7 @@ semantic placeholders; localize them before showing the user:
 <paste the ha-nova diff file/stdout here, unchanged>
 
 <pre-write check / impact line>
-⚠️ <localized: nothing saved yet>
+⚠️  <localized: nothing saved yet>
 <localized options label>: apply · show yaml · cancel
 ```
 

--- a/skills/yaml-config/SKILL.md
+++ b/skills/yaml-config/SKILL.md
@@ -70,7 +70,7 @@ New section (the only part that changes):
     - name: "Any window open"
 
 Replaces: nothing — this section is new. A backup (.bak) is written first.
-⚠️ Nothing saved yet.
+⚠️  Nothing saved yet.
 Options: apply · show yaml · cancel   (show yaml = the whole resulting file)
 ```
 

--- a/tests/skills/output-design-contract.test.ts
+++ b/tests/skills/output-design-contract.test.ts
@@ -14,11 +14,34 @@ describe("output design system (Cards)", () => {
     expect(outputRules).toContain("**Delete Card**");
     expect(outputRules).toContain("**Result Card**");
     expect(outputRules).toContain("📝 Preview:");
-    expect(outputRules).toContain("🗑️ Delete:");
+    expect(outputRules).toContain("🗑️  Delete:");
     expect(outputRules).toContain("✅ Saved:");
-    expect(outputRules).toContain("⚠️ Nothing saved yet.");
-    expect(outputRules).toContain("⚠️ Nothing deleted yet.");
+    expect(outputRules).toContain("⚠️  Nothing saved yet.");
+    expect(outputRules).toContain("⚠️  Nothing deleted yet.");
     expect(outputRules).toContain("nothing else decorative, never color");
+  });
+
+  it("pads variation-selector emoji with two spaces in every template", () => {
+    // 🗑️ and ⚠️ end in U+FE0F; many terminals render them double-width over
+    // the next column and visually swallow a single following space.
+    expect(outputRules).toContain("take two spaces before the following text");
+    const templates = [
+      outputRules,
+      readFileSync("skills/ha-nova/write-safety.md", "utf8"),
+      readFileSync("skills/yaml-config/SKILL.md", "utf8"),
+    ];
+    for (const content of templates) {
+      // No template line (these start with the emoji) may follow a VS16 emoji
+      // with exactly one space; inline prose mentions are exempt.
+      expect(content).not.toMatch(/^[🗑⚠]️ [^ ]/mu);
+    }
+  });
+
+  it("names the typed keyword a confirmation code toward users, never a token", () => {
+    expect(outputRules).toContain('is the "confirmation code" (localized');
+    expect(outputRules).toContain('Never call it a "token" in user-facing output');
+    const contextSkill = readFileSync("skills/ha-nova/SKILL.md", "utf8");
+    expect(contextSkill).toContain('call it the "confirmation code" (localized), never a "token"');
   });
 
   it("shows the change table with the canonical header and verbatim-row rule", () => {


### PR DESCRIPTION
## Summary

Two terminal-UX fixes reported from live use:

**1. "Confirmation code" instead of "token" toward users.** When a delete needs the typed `confirm:<...>` reply, follow-up output sometimes called it a "Token" — jargon that normal users do not understand and that collides with the access-token concept from onboarding. `output-rules.md` → Localization now pins the user-facing name as the "confirmation code" (localized, e.g. German "Bestätigungscode"), and the context skill's strict-enforcement rule points at it. The literal `confirm:<token>` spec notation and all typed keywords stay unchanged — users never see the placeholder, only the actual code.

**2. Two spaces after variation-selector emoji.** 🗑️ and ⚠️ end in U+FE0F; many terminals render them double-width over the next column, so the single following space gets visually swallowed (`🗑️Löschen` instead of `🗑️ Löschen`). All card templates (output-rules.md, write-safety.md, yaml-config) now use two spaces after those two emoji, and the Cards section pins the rule. The non-VS16 emoji (📝, ✅) keep one space.

## Testing

- `npx vitest run tests/skills/` — 21 files / 267 tests green
- Full `npm test` — 733 tests green
- New contract anchors: exact two-space template strings, a multiline guard rejecting any template line that follows a VS16 emoji with a single space, and the confirmation-code naming rule in both output-rules.md and the context skill

## Notes

- The canonical per-skill safety-baseline sentence ("requires the typed token `confirm:<token>` verbatim") is intentionally unchanged: it is internal spec language enforced by the template linter; the output-rules localization rule is the binding lever for user-facing output.
- The upcoming batch-confirmation work (#327) will adopt both conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBmfxWsGK34rtzHfVTDG8Z