### PR TITLE
chore(release): 0.16.0 — batch confirmation, terminal-UX fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.15.0"
+    "version": "0.16.0"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,18 +85,12 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## New Features
 
-    - **Change previews you can actually read.** When the AI updates an automation, script, or helper, it now shows one clear before/after table instead of a wall of bullets — and nested changes name the thing you recognize ("condition sensor.kitchen_illumination" instead of "condition 2"). Every skill uses the same preview cards, in every AI client.
-    - **YAML file edits preview only the section that changes.** No developer diffs: you see the effect in plain words, the new section, and what it replaces — then you decide.
-    - **`--help` everywhere.** Every `ha-nova` command now answers `--help` with its usage and flags — so options like `update --force` are finally discoverable.
-    - **HA NOVA offers to update the relay for you.** When your NOVA Relay is outdated, the AI now asks whether it should install the App update right away instead of just pointing at a warning (container installs get honest manual pull guidance).
-
-    ## What To Watch
-
-    - Home Assistant will show a NOVA Relay update (0.4.1). It only refreshes the App's info page — no functional changes, update whenever convenient. Skills still require relay 0.4.0 or newer.
+    - **One confirmation for reviewed batch deletes.** Deleting a reviewed set of automations, helpers, scenes, dashboards, to-do lists, or stale MQTT discovery topics now takes ONE typed confirmation code bound to the exact list — instead of one confirmation per item. Per-item impact checks and verification stay, and anything outside the shown list still needs its own preview. Proven live: a zombie device with 25 retained MQTT topics, gone with a single code.
 
     ## Bug Fixes
 
-    - Reading Home Assistant logs works again on current HA versions: the skills now use the supported log source (`system_log/list`) instead of an endpoint recent Home Assistant releases removed.
+    - Terminal output: icons like 🗑️ and ⚠️ no longer swallow the following space in terminals that render them double-width.
+    - Confirmation prompts speak plain language now: the typed reply is called a "confirmation code" (localized to your language), never a technical "token".
     Stable install commands are release-pinned for this tag.
 
     **macOS / Linux:**

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We built this because we didn't trust AI with our own config either.
 
 1. **Researches first.** Finds your devices, checks your setup, resolves entity names. No guessing.
 2. **Shows you the change.** A clear before/after table of exactly what will change, before anything is written.
-3. **You approve it.** Deletes require a specific confirmation code — not just "yes."
+3. **You approve it.** Deletes require a specific confirmation code — not just "yes." A reviewed batch delete takes one code bound to the exact list of items.
 4. **Writes and verifies.** Reads the config back to confirm the change stuck.
 5. **Audits itself.** Checks for mistakes, conflicts, and reliability issues.
 6. **Lets you take it back.** Reply `revert` to undo the latest verified update. New items are removed through the same preview-and-confirm delete flow.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "home-assistant-js-websocket": "^9.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -53,16 +53,14 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
-  it("keeps v0.15.0 release-facing wording user-centric", () => {
+  it("keeps v0.16.0 release-facing wording user-centric", () => {
     // Shipped release-note bodies are archived (docs/archive/work/) and
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
-    expect(goreleaser).toContain("Change previews you can actually read");
-    expect(goreleaser).toContain("YAML file edits preview only the section that changes");
-    expect(goreleaser).toContain("`--help` everywhere");
-    expect(goreleaser).toContain("HA NOVA offers to update the relay for you");
-    expect(goreleaser).toContain("Skills still require relay 0.4.0 or newer");
-    expect(goreleaser).toContain("system_log/list");
+    expect(goreleaser).toContain("One confirmation for reviewed batch deletes");
+    expect(goreleaser).toContain("ONE typed confirmation code bound to the exact list");
+    expect(goreleaser).toContain("no longer swallow the following space");
+    expect(goreleaser).toContain('called a "confirmation code"');
     expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");
   });
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.15.0",
+  "skill_version": "0.16.0",
   "min_relay_version": "0.4.0"
 }


### PR DESCRIPTION
## Summary

Release-prep for **v0.16.0**. Ships the two user-facing deltas merged since v0.15.0:

- **One confirmation for reviewed batch deletes** (#331, closes the #327 spec): manifest-bound `confirm:batch-...` code, per-item impact checks and verification retained, caps with refuse-and-split, batch cards. **Live-proven today**: a zombie AWTRIX device with exactly 25 retained MQTT discovery topics was cleaned with a single confirmation code (25/25 succeeded, ledger clean, unrelated 89 MQTT devices verified untouched).
- **Terminal-UX fixes** (#329): two spaces after VS16 emoji (🗑️/⚠️) so terminals stop swallowing the gap, and user-facing "confirmation code" wording instead of "token".

## Changes

- `npm run bump -- 0.16.0`: `version.json`, `package.json`, `package-lock.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
- `.goreleaser.yml`: stable release notes replaced with the 0.16.0 body (short, user-centric per release-notes preference; no What To Watch — no relay change, floor stays 0.4.0)
- `README.md`: one release-bound sentence in Safe by Design (batch delete = one code bound to the exact list) — passes `readme-release-gate` via the `version.json` bump in this PR
- `tests/onboarding/release-contract.test.ts`: notes-wording pins moved to the 0.16.0 phrases

## Testing

- `npm run verify` green end-to-end (metadata sync, npm audits, TypeScript, safe suite, build/docs validation, Go CLI)
- `npm run verify:next-release-version -- v0.16.0` OK (newer than latest published stable v0.15.0)
- Release preflight: zero open PRs and issues at branch time

## After merge

Tag-first rehearsal per docs/releasing.md: strict pipeline audit → dispatched disposable-HA e2e → `v0.16.0-rc1` on the merge commit → verify public RC install → final `v0.16.0` on the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBmfxWsGK34rtzHfVTDG8Z