### PR TITLE
feat(skills): post-write test offer with safety-graded run options

### DIFF
--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -557,6 +557,8 @@ After any mutation (automation, script, or helper):
    - Omit any section with nothing to report — never print an empty "none" bucket. When all are empty, collapse to one scope-honest confirmation line (write-safety → Verification Honesty; never a bare "verified").
    - Do not emit `Questions to consider`, `Suggestions`, or `Instant help` in post-write mode.
 
+After the review, the `write` skill offers a structured test plan (feasibility, one recommended option, single bound confirmation) per `skills/ha-nova/test-run.md` (Phase 5: Test Offer) — offer only; execution follows `ha-nova:service-call` → Automation And Script Runtime Calls. The `helper` skill keeps the plain Verification Honesty offer.
+
 ## Adding a New Skill — Checklist
 
 When creating a new skill under `skills/{name}/SKILL.md`:

--- a/scripts/test/safe-core-files.json
+++ b/scripts/test/safe-core-files.json
@@ -48,6 +48,7 @@
   "tests/skills/scene-contract.test.ts",
   "tests/skills/service-call-contract.test.ts",
   "tests/skills/skill-template-contract.test.ts",
+  "tests/skills/test-run-contract.test.ts",
   "tests/skills/todo-contract.test.ts",
   "tests/skills/trace-contract.test.ts",
   "tests/skills/updates-contract.test.ts",

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -212,6 +212,7 @@ Match user intent to exactly one skill:
 **"Revert that"** / **"Undo the last change"** → re-invoke the skill that made it: `ha-nova:write` (automation/script) or `ha-nova:helper` (helper). `revert` is update-only and lives there (see `write-safety.md` → Update-Revert), never `ha-nova:fallback`; create cleanup uses delete flow, and delete rollback needs Backup/recreate.
 **"Create a scene called Movie Night"** → `ha-nova:scene`
 **"Activate the scene Movie Night"** → `ha-nova:service-call` (runtime action, not a config change)
+**"Test the automation I just created"** → `ha-nova:write` Phase 5 test offer (plan per `skills/ha-nova/test-run.md`); a plain manual trigger stays `ha-nova:service-call`
 **"Show my main dashboard"** → `ha-nova:dashboard`
 **"Create a dashboard called Test Board"** → `ha-nova:dashboard`
 **"Delete the Test dashboard"** → `ha-nova:dashboard`

--- a/skills/ha-nova/test-run.md
+++ b/skills/ha-nova/test-run.md
@@ -143,7 +143,8 @@ and no trace — report the rendered condition/template results instead of
 reading traces. For runs, the chosen plan includes this follow-up — execute
 it without asking again:
 
-1. Capture the latest run_id before the run (`ha-nova trace list`). After
+1. Capture the latest run_id before the run
+   (`ha-nova trace list <entity_id> --json`). After
    the run, read `ha-nova trace latest <entity_id> --json` (entity is
    positional) and accept it only if its run_id is new — otherwise treat it
    as "no new trace", never report a stale run as the test result. Extract:

--- a/skills/ha-nova/test-run.md
+++ b/skills/ha-nova/test-run.md
@@ -43,8 +43,13 @@ Action risk (drives the recommendation):
 | Action block touches | Recommended test |
 |---|---|
 | notifications, logbook, `input_*` helpers, timers, variables only | real run — low consequence |
-| ordinary devices: lights, switches, covers, media, fans, comfort climate | real run — name every device plus the restore plan |
+| ordinary devices: lights, switches, media, fans, non-access covers, comfort climate | real run — name every device plus the restore plan |
 | high consequence: locks, garage doors, alarm panels, valves, water heaters, heating setpoints, `homeassistant.restart`, anything irreversible | logic check first; a real run stays available but carries an explicit warning line and is never presented as consequence-free |
+
+Domain alone is not enough for covers and climate: check `device_class` and
+what the entity controls before using the ordinary row — a garage door,
+gate, or entry door exposed as `cover.*` and any heating/cooling setpoint
+change belong in the high-consequence row.
 
 Co-listeners escalate: the risk class covers everything the run can set in
 motion, not just the tested automation's own actions. If a named co-listener
@@ -138,10 +143,13 @@ and no trace — report the rendered condition/template results instead of
 reading traces. For runs, the chosen plan includes this follow-up — execute
 it without asking again:
 
-1. Read the trace: `ha-nova trace latest <entity_id> --json` (entity is
-   positional). Extract: which trigger fired, which condition passed or
-   stopped the run, which action steps ran or errored. Automations keep only
-   the last 5 traces by default.
+1. Capture the latest run_id before the run (`ha-nova trace list`). After
+   the run, read `ha-nova trace latest <entity_id> --json` (entity is
+   positional) and accept it only if its run_id is new — otherwise treat it
+   as "no new trace", never report a stale run as the test result. Extract:
+   which trigger fired, which condition passed or stopped the run, which
+   action steps ran or errored. Automations keep only the last 5 traces by
+   default.
 2. Read the states of the acted-on entities — never infer device safety from
    a successful service response alone.
 3. Restore what the confirmed card planned: manipulated trigger sources, an

--- a/skills/ha-nova/test-run.md
+++ b/skills/ha-nova/test-run.md
@@ -114,6 +114,12 @@ the card that other event listeners cannot be ruled out.
 - `state` / `numeric_state` on a controllable source (helpers, switches,
   lights): set or toggle the source entity via the service-call flow; plan
   the restore of the source in the same card.
+- Triggers with a `for:` duration or a numeric threshold fire only after
+  the state holds, or crosses from the non-matching side: start from a
+  non-matching state, cross the threshold, and wait out the full `for:`
+  window before reading the trace or restoring — an early restore resets
+  the pending trigger and produces a false "did not fire". When that wait
+  is impractical, fall back to actions-only or the logic check and say so.
 - `state` on a physical sensor (motion, door, presence): there is no honest
   service to fake it — ask the user to trigger the device physically, then
   read the trace; otherwise fall back to "run actions now".

--- a/skills/ha-nova/test-run.md
+++ b/skills/ha-nova/test-run.md
@@ -66,8 +66,8 @@ Trigger type (drives which options exist):
   scheduled occurrence (name the expected time). Never change the system
   clock or temporarily edit the trigger to force a test.
 - Scripts have no trigger: parameterized runs replace the real-path option.
-- If the automation is disabled, enabling it is part of the plan and must be
-  named on the card.
+- If the automation is disabled, enabling it is part of the plan, must be
+  named on the card, and the post-run restore returns it to disabled.
 - Multi-target changes (write-safety → Multi-Target Changes): build ONE
   consolidated offer for the whole logical change — recommend the riskiest
   or most representative target first, never one card per target.
@@ -135,10 +135,11 @@ A chosen test plan includes its follow-up — run it without asking again:
    the last 5 traces by default.
 2. Read the states of the acted-on entities — never infer device safety from
    a successful service response alone.
-3. Restore what the confirmed card planned: manipulated trigger sources
-   and — when the card said so — actuated devices back to their pre-test
-   state (read before the run). Leave no test residue. Anything the card
-   did not name needs its own previewed call.
+3. Restore what the confirmed card planned: manipulated trigger sources, an
+   automation enabled only for the test (back to disabled), and — when the
+   card said so — actuated devices back to their pre-test state (read before
+   the run). Leave no test residue. Anything the card did not name needs its
+   own previewed call.
 4. Report compactly: path taken, deciding condition, end state of the
    devices, restore status.
 5. Honesty line: one passing run proves this path once — not every branch,

--- a/skills/ha-nova/test-run.md
+++ b/skills/ha-nova/test-run.md
@@ -52,11 +52,13 @@ gate, or entry door exposed as `cover.*` and any heating/cooling setpoint
 change belong in the high-consequence row.
 
 Co-listeners escalate: the risk class covers everything the run can set in
-motion, not just the tested automation's own actions. If a named co-listener
-performs physical or high-consequence actions (the classic pattern: a helper
-toggle that another automation answers by unlocking a door), the real-path
-option inherits that risk level — even when the tested automation's actions
-are purely logical.
+motion, not just the tested automation's own actions. Before recommending
+any run option, check `search/related` on every entity the test will change
+— manipulated trigger sources and action targets alike. If a named
+co-listener performs physical or high-consequence actions (the classic
+pattern: a helper toggle that another automation answers by unlocking a
+door), that run option inherits the risk level — even when the tested
+automation's actions are purely logical.
 
 Unavailable targets: read the action-target states while building the card;
 if one is `unavailable`, say that a run cannot prove physical behavior right

--- a/skills/ha-nova/test-run.md
+++ b/skills/ha-nova/test-run.md
@@ -127,7 +127,10 @@ the card that other event listeners cannot be ruled out.
 
 ## Post-Run Verification (automatic after any consented run)
 
-A chosen test plan includes its follow-up — run it without asking again:
+Applies to actions-only and real-path runs. A logic check creates no run
+and no trace — report the rendered condition/template results instead of
+reading traces. For runs, the chosen plan includes this follow-up — execute
+it without asking again:
 
 1. Read the trace: `ha-nova trace latest <entity_id> --json` (entity is
    positional). Extract: which trigger fired, which condition passed or

--- a/skills/ha-nova/test-run.md
+++ b/skills/ha-nova/test-run.md
@@ -71,8 +71,10 @@ Trigger type (drives which options exist):
   scheduled occurrence (name the expected time). Never change the system
   clock or temporarily edit the trigger to force a test.
 - Scripts have no trigger: parameterized runs replace the real-path option.
-- If the automation is disabled, enabling it is part of the plan, must be
-  named on the card, and the post-run restore returns it to disabled.
+- If the automation is disabled: `automation.trigger` runs the actions even
+  while it is off, so actions-only tests never enable it. Only a full
+  real-path test needs temporary enablement — name it on the card, and the
+  post-run restore returns it to disabled.
 - Multi-target changes (write-safety → Multi-Target Changes): build ONE
   consolidated offer for the whole logical change — recommend the riskiest
   or most representative target first, never one card per target.

--- a/skills/ha-nova/test-run.md
+++ b/skills/ha-nova/test-run.md
@@ -1,0 +1,196 @@
+# HA NOVA Test Run (Post-Write Test Offer)
+
+Canonical path: `skills/ha-nova/test-run.md`
+
+How to build, present, and follow up the optional test offer after an
+automation or script write (write flow → Phase 5: Test Offer). Skill source
+stays English; localize labels at runtime per
+`skills/ha-nova/output-rules.md`.
+
+Execution rules and confirmation validity stay owned by
+`ha-nova:service-call` → Automation And Script Runtime Calls and
+`skills/ha-nova/SKILL.md` → Safety Baseline → Active Preview Confirmation.
+This file defines only how the test plan is chosen, presented, and verified.
+
+## Purpose & Invariants
+
+- The test is an offer. Never execute actions, triggers, or events before
+  the user picks an option. Side-effect-free reads (entity states, a
+  `POST /api/template` render of the conditions) are allowed while building
+  the card — use them to annotate the options.
+- Condition awareness: if a rendered condition is currently false, say so on
+  the affected options ("the run would stop at <condition> right now") and
+  recommend accordingly — never let a real-path test die silently at a
+  condition the card did not mention.
+- Home Assistant has no dry run: every executed action sequence actuates the
+  real devices it targets. Safety comes from choosing what to run, naming
+  the devices that will act and the state they end in, and verifying
+  afterwards.
+- Transparency duty: every run option names the physical devices it will
+  touch and the expected end state before the user chooses.
+- Single confirmation: the Test Plan card doubles as the runtime-call
+  preview (exact service, target, payload, `skip_condition` value, device
+  delta). The user's option choice is the natural confirmation bound to that
+  exact preview — do not ask a second time. Any change to the plan expires
+  the choice and requires a fresh card.
+
+## Feasibility & Recommendation
+
+Classify the just-written config on two axes, then recommend ONE option.
+
+Action risk (drives the recommendation):
+
+| Action block touches | Recommended test |
+|---|---|
+| notifications, logbook, `input_*` helpers, timers, variables only | real run — low consequence |
+| ordinary devices: lights, switches, covers, media, fans, comfort climate | real run — name every device plus the restore plan |
+| high consequence: locks, garage doors, alarm panels, valves, water heaters, heating setpoints, `homeassistant.restart`, anything irreversible | logic check first; a real run stays available but carries an explicit warning line and is never presented as consequence-free |
+
+Co-listeners escalate: the risk class covers everything the run can set in
+motion, not just the tested automation's own actions. If a named co-listener
+performs physical or high-consequence actions (the classic pattern: a helper
+toggle that another automation answers by unlocking a door), the real-path
+option inherits that risk level — even when the tested automation's actions
+are purely logical.
+
+Unavailable targets: read the action-target states while building the card;
+if one is `unavailable`, say that a run cannot prove physical behavior right
+now and recommend the logic check or waiting until the device is back.
+
+Trigger type (drives which options exist):
+
+- `state` / `numeric_state` / `template` / `event` / `mqtt` — the full real
+  path is testable (recipes below).
+- `time` / `time_pattern` / `sun` / `calendar` — the real path cannot be
+  faked honestly. Offer "run actions now" plus a trace check after the next
+  scheduled occurrence (name the expected time). Never change the system
+  clock or temporarily edit the trigger to force a test.
+- Scripts have no trigger: parameterized runs replace the real-path option.
+- If the automation is disabled, enabling it is part of the plan and must be
+  named on the card.
+- Multi-target changes (write-safety → Multi-Target Changes): build ONE
+  consolidated offer for the whole logical change — recommend the riskiest
+  or most representative target first, never one card per target.
+
+## Test Options
+
+Three option types. Each card line states what runs, what it proves, and
+what it touches.
+
+### Logic check (nothing switches)
+
+Render the automation's conditions and templates against live state via
+`POST /api/template` (relay core). Zero side effects. Proves the logic under
+the current state only — not that the trigger fires, not that actions work.
+
+### Run actions now
+
+- Automations: `automation.trigger`. Always set `skip_condition` explicitly
+  in the payload — HA defaults it to `true` (conditions bypassed). Label
+  `skip_condition: true` as higher risk on the card (service-call rule).
+- Scripts: `script.<script_id>` (blocking; pass representative `variables`
+  for parameterized scripts — one run per branch worth proving) or
+  `script.turn_on` (fire-and-forget).
+- Proves the action sequence executes. Does not exercise the trigger and
+  cannot test branches keyed on `trigger.id` or trigger variables — say so
+  when the config has them (real-path test or wait for a real run).
+- Actions containing `delay` or `wait_*` can keep a blocking call open:
+  prefer `script.turn_on` for long-running scripts and verify via trace. A
+  slow service response is not a failure (relay-api → Timeout and Retry
+  Guidance).
+
+### Full real-path test
+
+Fire the actual trigger source so trigger → condition → action runs exactly
+as in production. Highest fidelity, widest blast radius: the state change or
+event reaches every listener, not just the new automation. Before offering,
+find co-listeners and name them on the card: `search/related` on a
+manipulated entity; for fired events `search/related` does not index
+listeners — scan automation configs for the same `event_type`, or state on
+the card that other event listeners cannot be ruled out.
+
+## Real-Path Recipes
+
+- `state` / `numeric_state` on a controllable source (helpers, switches,
+  lights): set or toggle the source entity via the service-call flow; plan
+  the restore of the source in the same card.
+- `state` on a physical sensor (motion, door, presence): there is no honest
+  service to fake it — ask the user to trigger the device physically, then
+  read the trace; otherwise fall back to "run actions now".
+- `template`: run the logic check first; then manipulate the underlying
+  entities as above.
+- `event`: `POST /api/events/<event_type>` with the payload the trigger
+  expects. Fires for every listener in the instance — name co-listeners.
+- `mqtt`: publish the expected topic and payload via `ha-nova:mqtt`.
+- Branches keyed on `trigger.id`: one real-path run per branch, each via its
+  own trigger source.
+
+## Post-Run Verification (automatic after any consented run)
+
+A chosen test plan includes its follow-up — run it without asking again:
+
+1. Read the trace: `ha-nova trace latest <entity_id> --json` (entity is
+   positional). Extract: which trigger fired, which condition passed or
+   stopped the run, which action steps ran or errored. Automations keep only
+   the last 5 traces by default.
+2. Read the states of the acted-on entities — never infer device safety from
+   a successful service response alone.
+3. Restore what the confirmed card planned: manipulated trigger sources
+   and — when the card said so — actuated devices back to their pre-test
+   state (read before the run). Leave no test residue. Anything the card
+   did not name needs its own previewed call.
+4. Report compactly: path taken, deciding condition, end state of the
+   devices, restore status.
+5. Honesty line: one passing run proves this path once — not every branch,
+   not future timing. Keep the untested scope in the wording.
+
+## When the Test Fails
+
+- No new trace after the run: the trigger did not fire. Report that plainly
+  — do not guess. For a user-assisted physical test, check the source
+  entity's recent history once to tell "device never reacted" apart from
+  "trigger config did not match".
+- Trace stopped at a condition or an action errored, or a device did not
+  reach the expected state: report the exact stop point, then offer the next
+  step — fix it (normal write flow), root-cause analysis (`ha-nova:diagnose`),
+  or for updates the already-saved `revert` from the post-write review.
+- A failed test never auto-triggers a config change; every fix goes through
+  the regular write preview and confirmation.
+
+## Offer Format (Test Plan card)
+
+Follows `skills/ha-nova/SKILL.md` → Interactive Choices and the card rules
+in `skills/ha-nova/output-rules.md` (labels localized at runtime):
+
+- Recommended option first and marked; at most 3 options plus `skip`.
+- One line per option: what runs, what it proves, what it switches.
+- Real-run options carry a consequence line: the devices that will act, the
+  end state, and the restore plan (including whether actuated devices are
+  returned to their pre-test state).
+- Options lead with what the user will experience in plain words; the
+  technical binding (service, payload, `skip_condition`) stays on the card
+  but never opens the line.
+- High-consequence actions add an explicit warning line (for example: "this
+  unlocks the front door for real").
+- `skip` is always valid. On skip, the Verification Honesty wording
+  (write-safety) keeps the untested scope in the closing sentence.
+- Session de-escalation: after the user skips once, later writes in the same
+  session shrink the offer to one line ("A test run is available — say the
+  word."). An explicit user request re-expands the full card.
+
+Example card (labels localized at runtime):
+
+```
+📝 Test: automation.morning_lights (saved — runtime not exercised yet)
+Right now: presence + time conditions are met — a run would go through.
+1 (recommended) — Real test: walk past the hall motion sensor and the
+   hallway light comes on at 40% (full trigger path; also reacts:
+   automation.hall_night_alert).
+2 — Actions only: the hallway light comes on at 40% exactly as the
+   automation would do it, without the motion trigger (automation.trigger,
+   skip_condition: false).
+3 — Logic check: I show how each condition evaluates right now; nothing
+   switches.
+skip — test later (I can check the trace after the next real run)
+After a run I read the trace, verify the light, and switch it back off.
+```

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -167,7 +167,10 @@ Wording rules for the result and the collapsed no-findings line:
   entity live. Runtime behavior was not exercised."
 - Where a real run is meaningful, offer it as an explicit optional step: a
   manual trigger via `ha-nova:service-call` (its own preview + confirmation —
-  it may actuate real devices; never run it unrequested). If the user
+  it may actuate real devices; never run it unrequested). For automations and
+  scripts, structure that offer as the Test Plan card in
+  `skills/ha-nova/test-run.md` (write flow → Phase 5); helper writes keep
+  this plain single offer. If the user
   declines, the uncertainty stays in the final wording — do not let the
   closing sentence sound more conclusive than the checks were.
 

--- a/skills/service-call/SKILL.md
+++ b/skills/service-call/SKILL.md
@@ -114,6 +114,8 @@ Rules:
 - Treat `skip_condition: true` as higher risk because it bypasses automation conditions.
 - Ask for confirmation bound to that exact runtime-call preview before execution.
 - After execution, verify only the target automation/script state and any user-approved helper/state assertions; do not infer device safety from a successful service response alone.
+- Post-write test runs: plan structure, real-path recipes, and the post-run follow-up live in `skills/ha-nova/test-run.md`.
+- When a Test Plan card already showed the concrete preview (service, target, payload, `skip_condition`), the user's option choice on that card IS the bound confirmation — do not ask again.
 
 ## Error Handling
 

--- a/skills/write/SKILL.md
+++ b/skills/write/SKILL.md
@@ -98,7 +98,7 @@ Do NOT invoke `ha-nova:review` separately.
    - **Dedup**: findings from Phase 2 Step 3b that the user saw MUST NOT repeat. Track by check type.
     - Exception: if R-18 still matches on persisted read-back config, report it again as a persisted runtime risk.
     - `R-19` follows normal dedup; R-23/R-24 do too. If already shown pre-write, do not repeat unless it becomes a new category.
-    - If persisted R-18 remains, inspect traces after the next real run. Do not auto-trigger or auto-read traces.
+    - If persisted R-18 remains, inspect traces after the next real run. Do not auto-trigger or auto-read traces outside an accepted Phase 5 test plan.
     - If actions reference helpers: always run H-01..H-10.
 3. Collision scan: `{"type":"search/related","item_type":"entity","item_id":"<entity_id>"}` via `ha-nova relay ws --data-file <payload-file>`; read max 3 related configs.
 4. Post-Write Review output (localized; see `skills/ha-nova/output-rules.md`) — report only what has substance; scans still run, only empty output is suppressed:
@@ -106,6 +106,10 @@ Do NOT invoke `ha-nova:review` separately.
    - If nothing is worth reporting, collapse to one scope-honest confirmation line (write-safety → Verification Honesty).
    - Never emit `Questions to consider`, `Suggestions`, or `Instant help` post-write; never repeat an item across **Findings** and **Advisory**.
 5. Update-Revert: updates only → **run `ha-nova snapshot save`** and offer `revert` (see `skills/ha-nova/write-safety.md`). Creates → cleanup via normal HA NOVA delete flow with preview, `confirm:<token>`, and absence verification. Deletes → Home Assistant Backups.
+
+### Phase 5: Test Offer (create/update only)
+
+After the Post-Write Review output, build a Test Plan card per `skills/ha-nova/test-run.md`: classify trigger type and action risk, pick ONE recommended option (real run included where acceptable — with the devices it will switch named), show at most 3 options plus `skip`. Never execute anything unconsented; the user's option choice is the confirmation bound to that exact card (single confirmation — no second prompt). Runs follow the service-call runtime rules (`mqtt` triggers via `ha-nova:mqtt`; logic check via `POST /api/template`), then the automatic post-run follow-up in test-run.md (trace, state verify, restore). After one skip, de-escalate to a single line for later writes. Skip this phase for deletes.
 
 ## Output Format
 
@@ -146,3 +150,4 @@ On demand — read only when the trigger applies:
 - `skills/ha-nova/template-guidelines.md` — the draft contains Jinja templates
 - `skills/ha-nova/safe-refactoring.md` — rename, migrate, or orphan-cleanup tasks
 - `skills/ha-nova/update-revert.md` — the user asks to revert, undo, or restore a verified update (create cleanup and delete recovery stay out — see write-safety)
+- `skills/ha-nova/test-run.md` — Phase 5 test offer: feasibility, options, post-run follow-up

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -108,12 +108,14 @@ const SAFETY_CORE_BLOCKS = ((): { mutation: string; readOnly: string } => {
 // TRANSITIVE load (lazy references), not these file sizes — write carries the
 // on-demand trigger list itself.
 const WORD_BUDGETS: Record<string, number> = {
-  // write/mqtt ratcheted for the batch-safety opt-in lines (#327).
-  write: 1450,
+  // write/mqtt ratcheted for the batch-safety opt-in lines (#327);
+  // write again for the Phase 5 test offer (test-run.md).
+  write: 1600,
   diagnose: 1450,
   mqtt: 1300,
   scene: 1350,
-  "service-call": 1250,
+  // test-offer single-confirmation + reference bullets (test-run.md).
+  "service-call": 1350,
   // Carries the canonical File-Change Preview example — the only layout
   // source for file edits; concrete examples are what make a card renderable.
   "yaml-config": 1250,

--- a/tests/skills/test-run-contract.test.ts
+++ b/tests/skills/test-run-contract.test.ts
@@ -108,8 +108,12 @@ describe("post-write test-offer contract", () => {
     expect(testRun).toContain("Anything the card did not name needs its\n   own previewed call");
     // Codex P2 (#334): an automation enabled only for the test must not stay
     // enabled in production afterwards.
-    expect(testRun).toContain("the post-run restore returns it to disabled");
+    expect(testRun).toContain("post-run restore returns it to disabled");
     expect(testRun).toContain("enabled only for the test (back to disabled)");
+    // Codex P2 (#334), live-verified: automation.trigger runs the actions of
+    // a disabled automation — actions-only tests must not enable it first.
+    expect(testRun).toContain("actions-only tests never enable it");
+    expect(testRun).toContain("Only a full\n  real-path test needs temporary enablement");
     // Write skill allows the consented follow-up without weakening the default.
     expect(writeSkill).toContain(
       "Do not auto-trigger or auto-read traces outside an accepted Phase 5 test plan",

--- a/tests/skills/test-run-contract.test.ts
+++ b/tests/skills/test-run-contract.test.ts
@@ -63,6 +63,10 @@ describe("post-write test-offer contract", () => {
     expect(testRun).toContain("inherits that risk level");
     // An unavailable target makes any run unprovable — the card must say so.
     expect(testRun).toContain("cannot prove physical behavior right\nnow");
+    // Codex P2 (#334): a garage door exposed as cover.* or a heating setpoint
+    // must not slip into the ordinary-device row on domain alone.
+    expect(testRun).toContain("check `device_class`");
+    expect(testRun).toContain("belong in the high-consequence row");
   });
 
   it("keeps real-path recipes honest per trigger type", () => {
@@ -91,6 +95,10 @@ describe("post-write test-offer contract", () => {
     // `trace latest` there would report a stale run as the test result.
     expect(testRun).toContain("A logic check creates no run");
     expect(testRun).toContain("report the rendered condition/template results instead");
+    // Codex P2 (#334): trace latest can serve a stale prior run — require a
+    // fresh run_id before treating the trace as the test result.
+    expect(testRun).toContain("Capture the latest run_id before the run");
+    expect(testRun).toContain("accept it only if its run_id is new");
     expect(testRun).toContain("ha-nova trace latest <entity_id> --json");
     expect(testRun).toContain("never infer device safety from");
     expect(testRun).toContain("Leave no test residue");

--- a/tests/skills/test-run-contract.test.ts
+++ b/tests/skills/test-run-contract.test.ts
@@ -68,6 +68,10 @@ describe("post-write test-offer contract", () => {
   it("keeps real-path recipes honest per trigger type", () => {
     expect(testRun).toContain("## Real-Path Recipes");
     expect(testRun).toContain("ask the user to trigger the device physically");
+    // Codex P2 (#334): `for:` durations and numeric thresholds need a hold
+    // from the non-matching side — an early restore resets the pending trigger.
+    expect(testRun).toContain("wait out the full `for:`");
+    expect(testRun).toContain("an early restore resets\n  the pending trigger");
     expect(testRun).toContain("POST /api/events/<event_type>");
     expect(testRun).toContain("`ha-nova:mqtt`");
     // Time-based triggers cannot be faked; never bend the clock or the config.

--- a/tests/skills/test-run-contract.test.ts
+++ b/tests/skills/test-run-contract.test.ts
@@ -60,7 +60,11 @@ describe("post-write test-offer contract", () => {
     // Live-verified on a real instance: logical-only actions can still unlock
     // a door via a co-listening automation — the risk class must escalate.
     expect(testRun).toContain("Co-listeners escalate");
-    expect(testRun).toContain("inherits that risk level");
+    expect(testRun).toContain("inherits the risk level");
+    // Codex P2 (#334): actions-only runs change action targets too — the
+    // co-listener check covers every entity the test will change.
+    expect(testRun).toContain("Before recommending\nany run option");
+    expect(testRun).toContain("manipulated trigger sources and action targets alike");
     // An unavailable target makes any run unprovable — the card must say so.
     expect(testRun).toContain("cannot prove physical behavior right\nnow");
     // Codex P2 (#334): a garage door exposed as cover.* or a heating setpoint

--- a/tests/skills/test-run-contract.test.ts
+++ b/tests/skills/test-run-contract.test.ts
@@ -98,6 +98,7 @@ describe("post-write test-offer contract", () => {
     // Codex P2 (#334): trace latest can serve a stale prior run — require a
     // fresh run_id before treating the trace as the test result.
     expect(testRun).toContain("Capture the latest run_id before the run");
+    expect(testRun).toContain("ha-nova trace list <entity_id> --json");
     expect(testRun).toContain("accept it only if its run_id is new");
     expect(testRun).toContain("ha-nova trace latest <entity_id> --json");
     expect(testRun).toContain("never infer device safety from");

--- a/tests/skills/test-run-contract.test.ts
+++ b/tests/skills/test-run-contract.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const testRun = readFileSync("skills/ha-nova/test-run.md", "utf8");
+const writeSkill = readFileSync("skills/write/SKILL.md", "utf8");
+const writeSafety = readFileSync("skills/ha-nova/write-safety.md", "utf8");
+const serviceCall = readFileSync("skills/service-call/SKILL.md", "utf8");
+
+describe("post-write test-offer contract", () => {
+  it("is wired into write, write-safety, and service-call", () => {
+    expect(writeSkill).toContain("### Phase 5: Test Offer (create/update only)");
+    expect(writeSkill).toContain("skills/ha-nova/test-run.md");
+    expect(writeSafety).toContain("skills/ha-nova/test-run.md");
+    expect(serviceCall).toContain("skills/ha-nova/test-run.md");
+    // Ownership split: test-run defines the plan, service-call owns execution.
+    expect(testRun).toContain("Automation And Script Runtime Calls");
+    expect(testRun).toContain("This file defines only how the test plan is chosen, presented, and verified");
+  });
+
+  it("keeps the offer-only invariant and the no-dry-run honesty", () => {
+    expect(testRun).toContain("Never execute actions, triggers, or events before");
+    expect(testRun).toContain("the user picks an option");
+    expect(testRun).toContain("Home Assistant has no dry run");
+    // Transparency duty: run options must name devices and end state.
+    expect(testRun).toContain("names the physical devices it will");
+    expect(writeSkill).toContain("Never execute anything unconsented");
+    // Read-only probes are allowed for card building — and must surface
+    // currently-false conditions instead of letting a real test die silently.
+    expect(testRun).toContain("Side-effect-free reads");
+    expect(testRun).toContain("never let a real-path test die silently at a");
+  });
+
+  it("defines the three option types with their proof limits", () => {
+    expect(testRun).toContain("### Logic check (nothing switches)");
+    expect(testRun).toContain("### Run actions now");
+    expect(testRun).toContain("### Full real-path test");
+    expect(testRun).toContain("POST /api/template");
+    expect(testRun).toContain("Does not exercise the trigger");
+    expect(testRun).toContain("`trigger.id`");
+  });
+
+  it("forces an explicit skip_condition and labels bypassing as higher risk", () => {
+    expect(testRun).toContain("Always set `skip_condition` explicitly");
+    expect(testRun).toContain("HA defaults it to `true`");
+    expect(testRun).toContain("`skip_condition: true` as higher risk");
+  });
+
+  it("binds a single confirmation to the Test Plan card — no double gate", () => {
+    expect(testRun).toContain("Single confirmation: the Test Plan card doubles as the runtime-call");
+    expect(testRun).toContain("do not ask a second time");
+    expect(testRun).toContain("Any change to the plan expires");
+    expect(serviceCall).toContain("the user's option choice on that card IS the bound confirmation");
+  });
+
+  it("recommends by action risk and never sells high-consequence runs as safe", () => {
+    expect(testRun).toContain("## Feasibility & Recommendation");
+    expect(testRun).toContain("high consequence: locks, garage doors, alarm panels, valves");
+    expect(testRun).toContain("never presented as consequence-free");
+    // Live-verified on a real instance: logical-only actions can still unlock
+    // a door via a co-listening automation — the risk class must escalate.
+    expect(testRun).toContain("Co-listeners escalate");
+    expect(testRun).toContain("inherits that risk level");
+    // An unavailable target makes any run unprovable — the card must say so.
+    expect(testRun).toContain("cannot prove physical behavior right\nnow");
+  });
+
+  it("keeps real-path recipes honest per trigger type", () => {
+    expect(testRun).toContain("## Real-Path Recipes");
+    expect(testRun).toContain("ask the user to trigger the device physically");
+    expect(testRun).toContain("POST /api/events/<event_type>");
+    expect(testRun).toContain("`ha-nova:mqtt`");
+    // Time-based triggers cannot be faked; never bend the clock or the config.
+    expect(testRun).toContain("cannot be");
+    expect(testRun).toContain("Never change the system");
+    expect(testRun).toContain("clock or temporarily edit the trigger");
+    // Blast radius: fired states/events reach every listener. Live-verified:
+    // search/related does NOT index event listeners — events need a config scan.
+    expect(testRun).toContain("reaches every listener");
+    expect(testRun).toContain("search/related");
+    expect(testRun).toContain("does not index\nlisteners");
+  });
+
+  it("runs the consented post-run follow-up: trace, state verify, restore", () => {
+    expect(testRun).toContain("## Post-Run Verification (automatic after any consented run)");
+    expect(testRun).toContain("ha-nova trace latest <entity_id> --json");
+    expect(testRun).toContain("never infer device safety from");
+    expect(testRun).toContain("Leave no test residue");
+    expect(testRun).toContain("one passing run proves this path once");
+    // Restore covers only what the confirmed card named — no surprise writes.
+    expect(testRun).toContain("Anything the card");
+    expect(testRun).toContain("did not name needs its own previewed call");
+    // Write skill allows the consented follow-up without weakening the default.
+    expect(writeSkill).toContain(
+      "Do not auto-trigger or auto-read traces outside an accepted Phase 5 test plan",
+    );
+  });
+
+  it("handles the failure path honestly and routes fixes through review gates", () => {
+    expect(testRun).toContain("## When the Test Fails");
+    expect(testRun).toContain("the trigger did not fire");
+    expect(testRun).toContain("report the exact stop point");
+    expect(testRun).toContain("`ha-nova:diagnose`");
+    expect(testRun).toContain("already-saved `revert`");
+    expect(testRun).toContain("A failed test never auto-triggers a config change");
+  });
+
+  it("covers long-running actions and multi-target changes", () => {
+    // Blocking calls on delay/wait actions would hang — trace is the truth.
+    expect(testRun).toContain("Actions containing `delay` or `wait_*`");
+    expect(testRun).toContain("slow service response is not a failure");
+    expect(testRun).toContain("never one card per target");
+    // Cards speak user language first; the technical binding stays secondary.
+    expect(testRun).toContain("Options lead with what the user will experience in plain words");
+  });
+
+  it("keeps the offer compact and de-escalates after a skip", () => {
+    expect(testRun).toContain("at most 3 options plus `skip`");
+    expect(testRun).toContain("Session de-escalation");
+    // Card stays inside the fixed emoji vocabulary (📝 = preview).
+    expect(testRun).toContain("📝 Test: automation.morning_lights");
+    expect(writeSkill).toContain("de-escalate to a single line");
+    expect(writeSkill).toContain("Skip this phase for deletes");
+  });
+});

--- a/tests/skills/test-run-contract.test.ts
+++ b/tests/skills/test-run-contract.test.ts
@@ -88,8 +88,11 @@ describe("post-write test-offer contract", () => {
     expect(testRun).toContain("Leave no test residue");
     expect(testRun).toContain("one passing run proves this path once");
     // Restore covers only what the confirmed card named — no surprise writes.
-    expect(testRun).toContain("Anything the card");
-    expect(testRun).toContain("did not name needs its own previewed call");
+    expect(testRun).toContain("Anything the card did not name needs its\n   own previewed call");
+    // Codex P2 (#334): an automation enabled only for the test must not stay
+    // enabled in production afterwards.
+    expect(testRun).toContain("the post-run restore returns it to disabled");
+    expect(testRun).toContain("enabled only for the test (back to disabled)");
     // Write skill allows the consented follow-up without weakening the default.
     expect(writeSkill).toContain(
       "Do not auto-trigger or auto-read traces outside an accepted Phase 5 test plan",

--- a/tests/skills/test-run-contract.test.ts
+++ b/tests/skills/test-run-contract.test.ts
@@ -83,6 +83,10 @@ describe("post-write test-offer contract", () => {
 
   it("runs the consented post-run follow-up: trace, state verify, restore", () => {
     expect(testRun).toContain("## Post-Run Verification (automatic after any consented run)");
+    // Codex P2 (#334): a logic check has no run and no trace — reading
+    // `trace latest` there would report a stale run as the test result.
+    expect(testRun).toContain("A logic check creates no run");
+    expect(testRun).toContain("report the rendered condition/template results instead");
     expect(testRun).toContain("ha-nova trace latest <entity_id> --json");
     expect(testRun).toContain("never infer device safety from");
     expect(testRun).toContain("Leave no test residue");


### PR DESCRIPTION
## What

After every automation/script create or update, the `write` flow now offers a structured **test plan** (new Phase 5: Test Offer) instead of the previous vague "you could trigger it manually" hint — including a real run (devices actually switch) as a first-class, clearly labeled option.

- **New shared reference `skills/ha-nova/test-run.md`** (SSOT): feasibility logic (trigger type × action risk), three option types — logic check (`POST /api/template`, zero side effects), actions-only (`automation.trigger` with explicit `skip_condition`; HA defaults it to `true`), full real-path (fire the actual trigger source) — real-path recipes per trigger type, automatic post-run follow-up (trace + state verify + restore), and a failure path (no-trace honesty, fix / `diagnose` / `revert` next steps).
- **UX**: one recommended option + max 2 alternatives + `skip`; the Test Plan card doubles as the runtime-call preview, so the user's choice is the bound confirmation (no double gate); session de-escalation after a skip; options lead with plain language.
- **Safety**: offer-only invariant (side-effect-free reads allowed for card building), high-consequence actions never presented as consequence-free, **co-listener risk escalation**, unavailable-target honesty, time triggers are never faked.

## Wiring

`write` Phase 5 + on-demand reference · `write-safety` Verification-Honesty seam · `service-call` single-confirmation rule · `skill-architecture` post-write standard · dispatch example in the context skill.

## Verification

- New contract test `tests/skills/test-run-contract.test.ts` (registered in `safe-core-files.json`); word-budget ratchets write 1600 / service-call 1350. Full suite green: **756 tests**.
- **Live-verified against a real HA instance**: full cycle (create → condition render → actions-only run with trace `trigger: null` → real-path event run with trace showing the event trigger → state/notification verify → restore → delete, zero residue), plus card simulation on three real automations (ordinary device, lock-adjacent RTO helper, time trigger). Two spec gaps found live and fixed: `search/related` does not index event listeners, and logical-only actions can still unlock a door via a co-listening automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBmfxWsGK34rtzHfVTDG8Z