### PR TITLE
feat(skills): shared output shapes — suggestions, reports, lists, test-plan card

### DIFF
--- a/skills/admin/SKILL.md
+++ b/skills/admin/SKILL.md
@@ -61,7 +61,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
-For persons: name, device trackers, linked user. For zones: name, radius, and which automations depend on them. For users: name, whether they are owner/active/system-generated — never their tokens or credentials. State what was verified after the write.
+Render the Report shape (output-rules.md); person/zone/user inventories render the List Frame. For persons: name, device trackers, linked user. For zones: name, radius, and which automations depend on them. For users: name, whether they are owner/active/system-generated — never their tokens or credentials. State what was verified after the write.
 
 ## Safety
 

--- a/skills/assist/SKILL.md
+++ b/skills/assist/SKILL.md
@@ -54,7 +54,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
-For an utterance test: the exact response text Assist gave, what it did (or did not) match, and which entities it touched. For pipelines: name, engines, language, and which one is preferred. Never paraphrase Assist's answer into something friendlier than it was.
+Render the Report shape (output-rules.md). For an utterance test: the exact response text Assist gave, what it did (or did not) match, and which entities it touched. For pipelines: name, engines, language, and which one is preferred. Never paraphrase Assist's answer into something friendlier than it was.
 
 ## Safety
 

--- a/skills/backup/SKILL.md
+++ b/skills/backup/SKILL.md
@@ -81,7 +81,7 @@ Apply `skills/ha-nova/output-rules.md` to all output.
 - `Verification`
 - `Next step`
 
-Use stable localized slot labels in this order; omit empty slots. Dates are ISO timestamps with offsets — convert to the user's local time; sizes human-readable — never raw JSON.
+Use stable localized slot labels in this order; omit empty slots. Status renders the Report shape; backup lists render the List Frame (output-rules.md). Dates are ISO timestamps with offsets — convert to the user's local time; sizes human-readable — never raw JSON.
 
 ## Safety
 

--- a/skills/calendar/SKILL.md
+++ b/skills/calendar/SKILL.md
@@ -63,7 +63,7 @@ Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 - `Events`
 - `Next step`
 
-For multiple calendars, group by calendar and keep each group short.
+These slots render the Report shape (output-rules.md); event groups follow the List Frame. For multiple calendars, group by calendar and keep each group short.
 
 ## Safety
 

--- a/skills/camera/SKILL.md
+++ b/skills/camera/SKILL.md
@@ -50,7 +50,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
-For a snapshot, describe what is visible in the frame and name the camera plus the time it was taken. For a stream, give the URL and say it is short-lived. Never claim to have seen something the frame does not show.
+Render the Report shape (output-rules.md). For a snapshot, describe what is visible in the frame and name the camera plus the time it was taken. For a stream, give the URL and say it is short-lived. Never claim to have seen something the frame does not show.
 
 ## Safety
 

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -143,7 +143,7 @@ For create/update/delete:
 - `Verification`
 - `Next step`
 
-Use stable localized slot labels in this order; omit empty slots, do not invent ad-hoc headings.
+Use stable localized slot labels in this order; omit empty slots, do not invent ad-hoc headings. List/read renders the Report shape; dashboard and resource inventories render the List Frame (output-rules.md).
 
 Do not dump the full dashboard JSON/YAML by default.
 

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -82,7 +82,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
-Diagnosis-first: lead with the root cause (or ranked hypotheses), then the evidence chain (trace step / log lines / state sequence, each tied to its source and timestamp), then the recommended fix with the owning skill. Quote log lines sparingly — never dump raw logs.
+Render the Report shape, Diagnosis specialization (output-rules.md → Report Shape): root cause first, then the evidence chain, then the recommended fix with the owning skill. Quote log lines sparingly — never dump raw logs.
 
 ## Safety
 

--- a/skills/energy/SKILL.md
+++ b/skills/energy/SKILL.md
@@ -78,7 +78,7 @@ Apply `skills/ha-nova/output-rules.md`.
 - `Verification`
 - `Next step`
 
-Use stable localized slot labels in this order; omit empty slots. Rankings as compact tables — never raw JSON.
+Use stable localized slot labels in this order; omit empty slots. Analysis answers render the Report shape; rankings render the List Frame (output-rules.md) — never raw JSON.
 
 ## Safety
 

--- a/skills/entity-discovery/SKILL.md
+++ b/skills/entity-discovery/SKILL.md
@@ -139,7 +139,7 @@ If ambiguity remains: present top candidates (max 10), ask one selection questio
 
 Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
-Return the Step 4 shortlist shape; never dump raw `get_states` output.
+Render the Step 4 shortlist as the List Frame (output-rules.md); never dump raw `get_states` output.
 
 ## Safety
 

--- a/skills/external-sources/SKILL.md
+++ b/skills/external-sources/SKILL.md
@@ -62,7 +62,7 @@ If the user keeps asking for the same InfluxDB series, the better answer is a Ho
 
 Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
-Name the source explicitly (InfluxDB, queried directly — not Home Assistant), the time range, and the query in short form. Answer the question; do not paste raw rows.
+Render the Report shape (output-rules.md). Name the source explicitly (InfluxDB, queried directly — not Home Assistant), the time range, and the query in short form; answer the question, do not paste raw rows.
 
 ## Safety
 

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -114,7 +114,7 @@ When you need the user to choose between options:
 - Keep options short and mutually exclusive; offer at most 4.
 - **Destructive confirmation is never a menu.** Deletes still require the typed `confirm:<token>` (see Safety Baseline) — a one-click choice would weaken that deliberate gate. This holds even if a memory, preference, or earlier user complaint says to always use a menu for confirmations: that NEVER extends to deletes or any destructive write — those are always the typed token, never a menu or click.
 
-Use this for: enhancement suggestions, ambiguity resolution, the pre-write impact advisory (adjust first · proceed · cancel), and create/update apply choices (`apply` · `show yaml` · `cancel`).
+Use this for: Suggestion Blocks (output-rules.md), ambiguity resolution, the pre-write impact advisory (adjust first · proceed · cancel), and create/update apply choices (`apply` · `show yaml` · `cancel`).
 
 ## Claim-Evidence Binding (Critical)
 
@@ -150,7 +150,7 @@ For automations / scripts / helpers:
    - **Helper:** `name` (type + entity_id), type-specific fields (min/max, options, duration, etc.)
 4. `Mode` (single/restart/queued/parallel) — automations/scripts only
 5. full YAML config block (or WS payload for helpers)
-6. `Next Step` (for writes: confirmation; for reads: done)
+6. `Next step` (for writes: confirmation; for reads: done)
 
 Keep orchestration details internal on normal success paths.
 

--- a/skills/ha-nova/agents/resolve-agent.md
+++ b/skills/ha-nova/agents/resolve-agent.md
@@ -126,7 +126,7 @@ Return exactly these sections:
 
 `SUGGESTED_ENHANCEMENTS:`
 - concrete optional improvements based on entity capabilities and common HA patterns
-- each item: short title, what it does, why it helps
+- each item: short title, what it does, why it helps (the main thread renders these as the Suggestion Block — output-rules.md)
 - or `none` if basic intent is fully covered
 - use both the examples below AND your general HA knowledge to suggest relevant improvements
 

--- a/skills/ha-nova/output-rules.md
+++ b/skills/ha-nova/output-rules.md
@@ -36,7 +36,7 @@ Apply these rules to every user-facing HA NOVA response, including direct sub-sk
 
 ## Cards (Write-Flow Visual System)
 
-Write and action flows render one of three cards — the same shape every time, so users recognize them at a glance. Labels localize at runtime; emoji, literal keywords, entity IDs, state values, and CLI diff rows do not. Fixed emoji vocabulary: 📝 preview, 🗑️ delete preview, ✅ result, ⚠️ save status, plus the 🔴🟠🟡 severity markers — nothing else decorative, never color. Cards frame writes and runtime actions only; review and read output keep their own sections. Emoji that end in a variation selector (🗑️, ⚠️) take two spaces before the following text — many terminals render them double-width over the next column and visually swallow a single space; the other card emoji keep one space.
+Write and action flows render one of four cards — the same shape every time, so users recognize them at a glance. Labels localize at runtime; emoji, literal keywords, entity IDs, state values, and CLI diff rows do not. Fixed emoji vocabulary: 📝 preview (write previews and the test-plan offer), 🗑️ delete preview, ✅ result, ⚠️ save status, 💡 suggestion, plus the 🔴🟠🟡 severity markers — nothing else decorative, never color. Cards frame writes and runtime actions only; review and read output keep their own sections. Emoji that end in a variation selector (🗑️, ⚠️) take two spaces before the following text — many terminals render them double-width over the next column and visually swallow a single space; the other card emoji keep one space.
 
 **Preview Card** (create/update — values illustrative, labels localized at runtime):
 
@@ -77,7 +77,86 @@ Checked: config persisted, reload OK, entity live. Runtime behavior was not exer
 Reply revert to undo this update.
 ```
 
-Read output: compact pipe tables (max 4 short columns — they degrade to plain pipe text in raw terminals) or grouped lists with counts; never raw JSON.
+**Test Plan Card** (test offer after create/update — feasibility logic, option
+selection, and post-run follow-up live in `skills/ha-nova/test-run.md`; menu
+mechanics: context skill → Interactive Choices):
+
+```
+📝 Test: automation.morning_lights (saved — runtime not exercised yet)
+1 (recommended) — Real test: what runs, what it proves, what it switches
+2 — Actions only: …
+skip — test later
+```
+
+Recommended option first and marked; at most 3 options plus `skip`; the option
+choice is the single confirmation bound to that exact card.
+
+## Report Shape (Read & Analysis Results)
+
+Every read or analysis answer follows one shape: lead with the answer in one or
+two sentences, then a grouped body (List Frame tables or grouped lists),
+optional evidence per context skill → Claim-Evidence Binding, and a closing
+`Next step` slot — omit it when nothing is actionable. Canonical label:
+`Next step` (localized; never `Next Step`).
+
+```
+The dryer used 42 kWh last month — about 18 % of total consumption.
+
+| Week | kWh |
+|---|---|
+| Jun 1–7 | 11.2 |
+
+Next step: add the dryer plug to the Energy dashboard for per-cycle tracking.
+```
+
+Diagnosis specialization (diagnose, review trace analysis): the lead is the
+root cause (or ranked hypotheses); the body is the evidence chain — trace step,
+log lines, state sequence, each tied to its source and timestamp; `Next step`
+is the recommended fix plus the owning-skill handoff.
+
+Skills with their own ordered slot lists (health, history, calendar, energy,
+backup, updates, maintenance, todo, scene) keep those slots — they are Report
+Shape specializations: the status/summary slot is the answer-first lead, and
+`Next step` closes.
+
+## List Frame (Inventories & Discovery)
+
+Any list of items — entities, configs, helpers, backups, updates, to-do items,
+media browse results: a count line first ("12 found, showing first 10" —
+state the cap whenever rows are truncated), then compact pipe tables
+(max 4 short columns — they degrade to plain pipe text in raw terminals) or
+grouped lists with counts; never raw JSON. Canonical column order: ID, Name,
+one or two domain-specific columns (Type, State, Reason), Area. Domains keep
+their own columns — the frame (count line, column order, stated cap) is what
+is shared.
+
+```
+23 automations found, showing first 10.
+
+| Entity ID | Name | Area |
+|---|---|---|
+| automation.morning | Morning routine | Hallway |
+```
+
+## Suggestion Block
+
+One shape for every improvement offer: write-flow enhancement suggestions,
+helper suggested defaults, review Suggestions items, and separate
+notification-copy offers. 💡 header line (single space after 💡), numbered
+items, max 4. Item shape: short title + what it does + why it helps; value
+suggestions (helper defaults) may use the value assignment as the title and
+drop the benefit when it is obvious. Menu mechanics follow context skill →
+Interactive Choices; skip/decline is always valid; omit the block entirely
+when there is nothing to offer; never post-write. Review's Suggestions section
+keeps its plain sectioned header — review output is sectioned, not card-framed
+— but its items follow this item shape.
+
+```
+💡 Suggestions for "Morning routine":
+1. Presence condition — runs only when someone is home · avoids empty-house runs
+2. Restart mode — re-trigger restarts the timer · prevents overlapping runs
+Accept numbers (e.g. "1 and 2"), or "skip".
+```
 
 ## Findings
 

--- a/skills/ha-nova/test-run.md
+++ b/skills/ha-nova/test-run.md
@@ -28,7 +28,7 @@ This file defines only how the test plan is chosen, presented, and verified.
   afterwards.
 - Transparency duty: every run option names the physical devices it will
   touch and the expected end state before the user chooses.
-- Single confirmation: the Test Plan card doubles as the runtime-call
+- Single confirmation: the Test Plan Card doubles as the runtime-call
   preview (exact service, target, payload, `skip_condition` value, device
   delta). The user's option choice is the natural confirmation bound to that
   exact preview — do not ask a second time. Any change to the plan expires
@@ -180,10 +180,11 @@ it without asking again:
 - A failed test never auto-triggers a config change; every fix goes through
   the regular write preview and confirmation.
 
-## Offer Format (Test Plan card)
+## Offer Format (Test Plan Card)
 
-Follows `skills/ha-nova/SKILL.md` → Interactive Choices and the card rules
-in `skills/ha-nova/output-rules.md` (labels localized at runtime):
+This is the Test Plan Card of `skills/ha-nova/output-rules.md` → Cards; menu
+mechanics follow `skills/ha-nova/SKILL.md` → Interactive Choices (labels
+localized at runtime):
 
 - Recommended option first and marked; at most 3 options plus `skip`.
 - One line per option: what runs, what it proves, what it switches.

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -96,8 +96,8 @@ user explicitly asks to change notification wording or notification behavior:
 Do not silently restyle, relocalize, shorten, expand, or restructure existing
 notification text during a rename, refactor, timing change, trigger/condition
 change, helper change, or service-call change. If the copy looks improvable,
-offer it as a separate suggestion before preview; do not merge it into the draft
-unless the user accepts it.
+offer it as a separate Suggestion Block item (output-rules.md) before preview;
+do not merge it into the draft unless the user accepts it.
 
 If notification copy does change, the Changes slot must show the old and new text or
 payload. A count-only array line such as `| Actions | 7 items | 8 items |` is not enough
@@ -168,7 +168,7 @@ Wording rules for the result and the collapsed no-findings line:
 - Where a real run is meaningful, offer it as an explicit optional step: a
   manual trigger via `ha-nova:service-call` (its own preview + confirmation —
   it may actuate real devices; never run it unrequested). For automations and
-  scripts, structure that offer as the Test Plan card in
+  scripts, structure that offer as the Test Plan Card in
   `skills/ha-nova/test-run.md` (write flow → Phase 5); helper writes keep
   this plain single offer. If the user
   declines, the uncertainty stays in the final wording — do not let the

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -108,7 +108,7 @@ These names are semantic output slots, not literal headings. Do not mix English 
 - `System`
 - `Next step`
 
-Keep it compact. Compute overall internally as `ok`, `attention`, or `limited`, but show the overall value as a localized human phrase, not the raw enum. Include localized labels for overall status, checked time, and source coverage in `Status`. Keep Home Assistant state values such as `unavailable`, `unknown`, `setup_error`, `setup_retry`, and `not_loaded` literal when they are evidence, with a short localized explanation when helpful. Do not dump raw JSON, full logs, full entity lists, full component lists, or full integration-entry lists.
+These slots are the Report shape (output-rules.md): `Status` is the answer-first lead, `Next step` closes. Keep it compact. Compute overall internally as `ok`, `attention`, or `limited`, but show the overall value as a localized human phrase, not the raw enum. Include localized labels for overall status, checked time, and source coverage in `Status`. Keep Home Assistant state values such as `unavailable`, `unknown`, `setup_error`, `setup_retry`, and `not_loaded` literal when they are evidence, with a short localized explanation when helpful. Do not dump raw JSON, full logs, full entity lists, full component lists, or full integration-entry lists.
 
 Choose one safe `Next step`:
 - repairs first

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -99,9 +99,9 @@ If 0 results: try synonyms or shorter stems. Never dump entire domains.
 2. Use-case defaults (create only, skip on update/delete):
    - Infer use-case from helper name + type using general HA knowledge.
    - Consult `skills/ha-nova/helper-schemas.md` → Suggested Defaults for principles and field name reminders.
-   - If sensible defaults can be inferred: show max 4 as numbered list. Group related fields into one item.
+   - If sensible defaults can be inferred: render them as the Suggestion Block (output-rules.md), max 4 as numbered list. Group related fields into one item.
      ```
-     Suggested defaults for "{name}" ({type}):
+     💡 Suggested defaults for "{name}" ({type}):
      1. min: 16, max: 30, step: 0.5
      2. unit_of_measurement: "°C"
      3. mode: slider
@@ -435,7 +435,7 @@ After reading a helper config, present:
 - {type-specific fields}
 ```
 
-For list operations, use:
+For list operations, render the List Frame (output-rules.md):
 
 ```text
 | Entity ID | Name | Type | Area |
@@ -456,11 +456,11 @@ After reading a helper config, present:
 - **Current editable fields:** {field summary from the current options step when available}
 ```
 
-For list operations, use:
+For list operations, render the List Frame (output-rules.md; options-flow support and linked entities stay in the per-helper detail read above):
 
 ```text
-| Title | Domain | Entry ID | State | Supports Options-Flow Editing | Linked Entities |
-|-------|--------|----------|-------|--------------------------------|-----------------|
+| Title | Domain | Entry ID | State |
+|-------|--------|----------|-------|
 ```
 
 Never show raw JSON to the user.

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -191,13 +191,11 @@ If the user gives only a linked `entity_id`, resolve it back to `config_entry_id
    with `{"type":"config/entity_registry/list"}`.
 3. Filter config entries to the ten supported domains.
 4. Join linked entities by matching `config_entry_id`.
-5. Present a compact table with:
-   - title
-   - domain
-   - `entry_id`
-   - state
-   - `supports_options`
-   - linked entities (compact comma-separated summary)
+5. Present the List Frame table (output-rules.md): title, domain, `entry_id`,
+   state. Options-flow support and linked entities stay in the per-helper
+   detail read; when several entries share a domain or similar titles, add a
+   short disambiguation line under the table with each candidate's linked
+   entities (compact comma-separated summary).
 
 #### Keyword search
 

--- a/skills/history/SKILL.md
+++ b/skills/history/SKILL.md
@@ -85,7 +85,7 @@ Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 - `Key events`, `Key transitions`, or `Key periods`
 - `Next step`
 
-Keep default output compact. Raw payload dumps are opt-in only.
+These slots render the Report shape (output-rules.md). Keep default output compact. Raw payload dumps are opt-in only.
 
 ## Safety
 

--- a/skills/maintenance/SKILL.md
+++ b/skills/maintenance/SKILL.md
@@ -75,7 +75,7 @@ Apply `skills/ha-nova/output-rules.md`.
 - `Verification`
 - `Next step`
 
-Use stable localized slot labels in this order; omit empty slots. Grouped counts + capped example lists — never raw JSON.
+Use stable localized slot labels in this order; omit empty slots. Triage renders the Report shape; grouped ID lists render the List Frame (capped example lists) — never raw JSON.
 
 ## Safety
 

--- a/skills/media/SKILL.md
+++ b/skills/media/SKILL.md
@@ -87,7 +87,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
-Report what is playing where: player, state, current media, volume, source, and group members when relevant. For browse results, show a short navigable list (title + type), never the raw tree.
+Render the Report shape (output-rules.md): what is playing where — player, state, current media, volume, source, and group members when relevant. Browse results render the List Frame (title + type), never the raw tree.
 
 ## Safety
 

--- a/skills/mqtt/SKILL.md
+++ b/skills/mqtt/SKILL.md
@@ -73,7 +73,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
-For a listen: the topic, the window length, how many messages arrived (live versus retained — never merge those two), the distinct topics seen, and a few representative payloads — never the raw dump. Say explicitly when nothing arrived, and when everything that arrived was a retained replay. For a publish: the topic, payload, and whether it was retained.
+Render the Report shape (output-rules.md). For a listen: the topic, the window length, how many messages arrived (live versus retained — never merge those two), the distinct topics seen, and a few representative payloads — never the raw dump. Say explicitly when nothing arrived, and when everything that arrived was a retained replay. For a publish: the topic, payload, and whether it was retained.
 
 ## Safety
 

--- a/skills/notify/SKILL.md
+++ b/skills/notify/SKILL.md
@@ -80,7 +80,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
-State the resolved target, the sent title/message, and any extras used. Report acceptance honestly (accepted by Home Assistant, not confirmed on the device). For discovery, return a short list of real targets grouped by surface (entities vs mobile-app services).
+Render the Report shape (output-rules.md): the resolved target, the sent title/message, and any extras used. Report acceptance honestly (accepted by Home Assistant, not confirmed on the device). Discovery renders the List Frame, grouped by surface (entities vs mobile-app services).
 
 ## Safety
 

--- a/skills/organize/SKILL.md
+++ b/skills/organize/SKILL.md
@@ -113,7 +113,7 @@ Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
 Use stable localized slot labels in this order for previews; omit empty slots, but do not invent ad-hoc headings.
 
-Default to a compact field summary, not raw registry JSON.
+Metadata reads render the Report shape; registry inventories render the List Frame (output-rules.md). Default to a compact field summary, not raw registry JSON.
 
 ## Safety
 

--- a/skills/read/SKILL.md
+++ b/skills/read/SKILL.md
@@ -160,7 +160,7 @@ triggers: ...
 actions: ...
 ```
 
-For list operations, use a compact table:
+For list operations, render the List Frame (output-rules.md) with these columns:
 
 ```
 | Entity ID | Name | Area |

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -415,7 +415,7 @@ For resolved targets `== 1`, keep this 8-section output in the same order every 
 
 **Section 6 — Suggestions:**
 - confident improvement ideas only
-- each: short title + what it does + why it helps
+- each item follows the Suggestion Block item shape (output-rules.md): short title + what it does + why it helps; the section header stays plain — review output is sectioned, not card-framed
 - rank by intervention depth: Fix existing → Simplify existing → Extend existing → Add new
 - do not place intent-uncertain removals/simplifications here
 - or localized equivalent of "No confident suggestions."

--- a/skills/scene/SKILL.md
+++ b/skills/scene/SKILL.md
@@ -116,7 +116,7 @@ Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 - `Verification`
 - `Next step`
 
-Use stable localized slot labels in this order; omit empty slots.
+Use stable localized slot labels in this order; omit empty slots. Reads render the Report shape; scene lists render the List Frame (output-rules.md).
 
 ## Safety
 

--- a/skills/service-call/SKILL.md
+++ b/skills/service-call/SKILL.md
@@ -115,7 +115,7 @@ Rules:
 - Ask for confirmation bound to that exact runtime-call preview before execution.
 - After execution, verify only the target automation/script state and any user-approved helper/state assertions; do not infer device safety from a successful service response alone.
 - Post-write test runs: plan structure, real-path recipes, and the post-run follow-up live in `skills/ha-nova/test-run.md`.
-- When a Test Plan card already showed the concrete preview (service, target, payload, `skip_condition`), the user's option choice on that card IS the bound confirmation — do not ask again.
+- When a Test Plan Card already showed the concrete preview (service, target, payload, `skip_condition`), the user's option choice on that card IS the bound confirmation — do not ask again.
 
 ## Error Handling
 
@@ -130,7 +130,7 @@ Service-call specifics:
 
 Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
-Previews are the runtime-action Preview Card (`apply · cancel`); results are the Result Card. Report the executed service, its target, and the verified state change (or the discrepancy); summarize response-service data instead of dumping it.
+Previews are the runtime-action Preview Card (`apply · cancel`); results are the Result Card. Report the executed service, its target, and the verified state change (or the discrepancy); summarize response-service data as the Report shape (output-rules.md) instead of dumping it.
 
 ## Safety
 

--- a/skills/todo/SKILL.md
+++ b/skills/todo/SKILL.md
@@ -112,7 +112,7 @@ Apply `skills/ha-nova/output-rules.md` to all output.
 - `Verification`
 - `Next step`
 
-Use stable localized slot labels in this order; omit empty slots. Present items compactly — never raw JSON.
+Use stable localized slot labels in this order; omit empty slots. Item lists render the List Frame (output-rules.md) — never raw JSON.
 
 ## Safety
 

--- a/skills/updates/SKILL.md
+++ b/skills/updates/SKILL.md
@@ -89,7 +89,7 @@ Apply `skills/ha-nova/output-rules.md`.
 - `Verification`
 - `Next step`
 
-Use stable localized slot labels in this order; omit empty slots. Group counts + pending list — never raw JSON.
+Use stable localized slot labels in this order; omit empty slots. The overview renders the Report shape; pending lists render the List Frame (group counts + capped pending list) — never raw JSON.
 
 ## Safety
 

--- a/skills/write/SKILL.md
+++ b/skills/write/SKILL.md
@@ -48,7 +48,7 @@ Multi-target logical changes: present the plan first per `skills/ha-nova/write-s
    - Treat notification copy as user-authored content: preserve notification titles, messages, templates, metadata. Rename/timing changes must not restyle, relocalize, or restructure existing text; requested wording changes change only the requested copy.
 2. BP gate (`skills/ha-nova/write-safety.md`): fresh/stale+simple->continue, stale+complex->block.
 3. Suggestions + Pre-Write Checks (skip for `delete`):
-   - **3a) Suggestions**: Show `suggested_enhancements` (max 4, numbered/menu). User accepts numbers or "skip" → merge accepted into config BEFORE preview. Skip when `SUGGESTED_ENHANCEMENTS: none`.
+   - **3a) Suggestions**: Render `suggested_enhancements` as the Suggestion Block (output-rules.md; max 4, numbered/menu). User accepts numbers or "skip" → merge accepted into config BEFORE preview. Skip when `SUGGESTED_ENHANCEMENTS: none`.
    - **3b) Static Checks**: Use `skills/review/checks.md` → Application (family matrix + evidence boundaries). Run S/R/P/M checks analytically on the draft YAML — no relay calls (scripts: F-01..F-08; helper refs: H-01..H-08. Defer H-09/H-10 to Phase 4).
      One pre-write verdict line before apply:
      - clean draft → localized equivalent of "Pre-write check: no issues worth flagging before save."
@@ -109,13 +109,13 @@ Do NOT invoke `ha-nova:review` separately.
 
 ### Phase 5: Test Offer (create/update only)
 
-After the Post-Write Review output, build a Test Plan card per `skills/ha-nova/test-run.md`: classify trigger type and action risk, pick ONE recommended option (real run included where acceptable — with the devices it will switch named), show at most 3 options plus `skip`. Never execute anything unconsented; the user's option choice is the confirmation bound to that exact card (single confirmation — no second prompt). Runs follow the service-call runtime rules (`mqtt` triggers via `ha-nova:mqtt`; logic check via `POST /api/template`), then the automatic post-run follow-up in test-run.md (trace, state verify, restore). After one skip, de-escalate to a single line for later writes. Skip this phase for deletes.
+After the Post-Write Review output, build a Test Plan Card per `skills/ha-nova/test-run.md`: classify trigger type and action risk, pick ONE recommended option (real run included where acceptable — with the devices it will switch named), show at most 3 options plus `skip`. Never execute anything unconsented; the user's option choice is the confirmation bound to that exact card (single confirmation — no second prompt). Runs follow the service-call runtime rules (`mqtt` triggers via `ha-nova:mqtt`; logic check via `POST /api/template`), then the automatic post-run follow-up in test-run.md (trace, state verify, restore). After one skip, de-escalate to a single line for later writes. Skip this phase for deletes.
 
 ## Output Format
 
 Apply `skills/ha-nova/output-rules.md`.
 
-Previews, delete prompts, and post-write results render as the Cards defined there; the diff mechanics stay in `skills/ha-nova/write-safety.md`.
+Previews, delete prompts, post-write results, and the Phase 5 test offer render as the Cards defined there (Test Plan Card mechanics: `skills/ha-nova/test-run.md`); the diff mechanics stay in `skills/ha-nova/write-safety.md`.
 
 See `skills/ha-nova/SKILL.md` → Response Format.
 

--- a/tests/skills/ha-nova-contract.test.ts
+++ b/tests/skills/ha-nova-contract.test.ts
@@ -180,7 +180,7 @@ describe("ha-nova contract", () => {
     expect(context).toContain("Triggers");
     expect(context).toContain("Actions");
     expect(context).toContain("full YAML config");
-    expect(context).toContain("Next Step");
+    expect(context).toContain("Next step");
   });
 
   it("documents the review confidence split in the shared output rules", () => {

--- a/tests/skills/helper-contract.test.ts
+++ b/tests/skills/helper-contract.test.ts
@@ -155,6 +155,8 @@ describe("helper contract", () => {
       // List Frame trim (max 4 short columns): options-flow support and linked
       // entities live in the per-helper detail read, not the list table.
       expect(skillDoc).toContain("| Title | Domain | Entry ID | State |");
+      // Ambiguous entries still get their linked-entity context for selection.
+      expect(skillDoc).toContain("add a\n   short disambiguation line");
       expect(skillDoc).toContain("Current flow step:");
       expect(skillDoc).toContain("Current editable fields:");
       expect(skillDoc).toContain("mark its value as unavailable instead of guessing");

--- a/tests/skills/helper-contract.test.ts
+++ b/tests/skills/helper-contract.test.ts
@@ -152,7 +152,9 @@ describe("helper contract", () => {
       expect(skillDoc).toContain("start an options flow");
       expect(skillDoc).toContain("current editable options snapshot");
       expect(skillDoc).toContain("Supports options-flow editing:");
-      expect(skillDoc).toContain("Supports Options-Flow Editing");
+      // List Frame trim (max 4 short columns): options-flow support and linked
+      // entities live in the per-helper detail read, not the list table.
+      expect(skillDoc).toContain("| Title | Domain | Entry ID | State |");
       expect(skillDoc).toContain("Current flow step:");
       expect(skillDoc).toContain("Current editable fields:");
       expect(skillDoc).toContain("mark its value as unavailable instead of guessing");

--- a/tests/skills/output-design-contract.test.ts
+++ b/tests/skills/output-design-contract.test.ts
@@ -8,16 +8,20 @@ import { describe, expect, it } from "vitest";
 describe("output design system (Cards)", () => {
   const outputRules = readFileSync("skills/ha-nova/output-rules.md", "utf8");
 
-  it("defines the three cards with the fixed emoji vocabulary", () => {
+  it("defines the four cards with the fixed emoji vocabulary", () => {
     expect(outputRules).toContain("## Cards (Write-Flow Visual System)");
+    expect(outputRules).toContain("one of four cards");
     expect(outputRules).toContain("**Preview Card**");
     expect(outputRules).toContain("**Delete Card**");
     expect(outputRules).toContain("**Result Card**");
+    expect(outputRules).toContain("**Test Plan Card**");
     expect(outputRules).toContain("📝 Preview:");
+    expect(outputRules).toContain("📝 Test:");
     expect(outputRules).toContain("🗑️  Delete:");
     expect(outputRules).toContain("✅ Saved:");
     expect(outputRules).toContain("⚠️  Nothing saved yet.");
     expect(outputRules).toContain("⚠️  Nothing deleted yet.");
+    expect(outputRules).toContain("💡 suggestion");
     expect(outputRules).toContain("nothing else decorative, never color");
   });
 
@@ -77,6 +81,75 @@ describe("output design system (Cards)", () => {
   it("keeps the result card scope-honest", () => {
     expect(outputRules).toContain("Runtime behavior was not exercised.");
     expect(outputRules).toContain("Verification Honesty");
+  });
+
+  it("defines the shared read-flow shapes", () => {
+    expect(outputRules).toContain("## Report Shape (Read & Analysis Results)");
+    expect(outputRules).toContain("## List Frame (Inventories & Discovery)");
+    expect(outputRules).toContain("## Suggestion Block");
+    // Answer first, canonical closing slot, honest truncation, diagnosis lead.
+    expect(outputRules).toContain("lead with the answer");
+    expect(outputRules).toContain("`Next step` (localized; never `Next Step`)");
+    expect(outputRules).toContain("state the cap whenever rows are truncated");
+    expect(outputRules).toContain("root cause (or ranked hypotheses)");
+  });
+
+  it("rolls the suggestion block into every offer site", () => {
+    const write = readFileSync("skills/write/SKILL.md", "utf8");
+    const helper = readFileSync("skills/helper/SKILL.md", "utf8");
+    const review = readFileSync("skills/review/SKILL.md", "utf8");
+    const writeSafety = readFileSync("skills/ha-nova/write-safety.md", "utf8");
+    expect(write).toContain("as the Suggestion Block");
+    expect(helper).toContain("render them as the Suggestion Block");
+    expect(helper).toContain('💡 Suggested defaults for "{name}"');
+    // Review keeps its plain sectioned header; only the item shape is shared.
+    expect(review).toContain("Suggestion Block item shape");
+    expect(writeSafety).toContain("separate Suggestion Block item");
+    // One shape everywhere: title + what + why, capped, skippable, never forced.
+    expect(outputRules).toContain("short title + what it does + why it helps");
+    expect(outputRules).toContain("omit the block entirely");
+    // The producing agent knows how its items will render.
+    const resolveAgent = readFileSync("skills/ha-nova/agents/resolve-agent.md", "utf8");
+    expect(resolveAgent).toContain("renders these as the Suggestion Block");
+  });
+
+  it("routes the freeform read skills through the shared shapes", () => {
+    for (const skill of [
+      "diagnose",
+      "media",
+      "notify",
+      "camera",
+      "mqtt",
+      "assist",
+      "admin",
+      "external-sources",
+      "dashboard",
+      "organize",
+    ]) {
+      const content = readFileSync(`skills/${skill}/SKILL.md`, "utf8");
+      expect(content, `skills/${skill}/SKILL.md must render the Report shape`).toContain(
+        "Report shape",
+      );
+    }
+    for (const skill of ["entity-discovery", "read"]) {
+      const content = readFileSync(`skills/${skill}/SKILL.md`, "utf8");
+      expect(content, `skills/${skill}/SKILL.md must render the List Frame`).toContain(
+        "List Frame",
+      );
+    }
+  });
+
+  it("folds the test plan card into the central card system", () => {
+    const testRun = readFileSync("skills/ha-nova/test-run.md", "utf8");
+    const write = readFileSync("skills/write/SKILL.md", "utf8");
+    expect(testRun).toContain("Test Plan Card of `skills/ha-nova/output-rules.md`");
+    expect(write).toContain("Test Plan Card mechanics: `skills/ha-nova/test-run.md`");
+    expect(outputRules).toContain("skills/ha-nova/test-run.md");
+  });
+
+  it("keeps the canonical Next step label free of drift", () => {
+    const contextSkill = readFileSync("skills/ha-nova/SKILL.md", "utf8");
+    expect(contextSkill).not.toContain("Next Step");
   });
 
   it("rolls the cards into the three special-format skills", () => {

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -112,8 +112,10 @@ const WORD_BUDGETS: Record<string, number> = {
   // write again for the Phase 5 test offer (test-run.md).
   write: 1600,
   diagnose: 1450,
+  // Report-shape declaration line (shared output shapes).
+  health: 1200,
   mqtt: 1300,
-  scene: 1350,
+  scene: 1400,
   // test-offer single-confirmation + reference bullets (test-run.md).
   "service-call": 1350,
   // Carries the canonical File-Change Preview example — the only layout
@@ -127,7 +129,8 @@ const WORD_BUDGETS: Record<string, number> = {
   maintenance: 1300,
   fallback: 2300,
   helper: 3600,
-  review: 4300,
+  // Suggestion Block item-shape pointer (shared output shapes).
+  review: 4400,
 };
 const DEFAULT_WORD_BUDGET = 1150;
 

--- a/tests/skills/test-run-contract.test.ts
+++ b/tests/skills/test-run-contract.test.ts
@@ -46,8 +46,8 @@ describe("post-write test-offer contract", () => {
     expect(testRun).toContain("`skip_condition: true` as higher risk");
   });
 
-  it("binds a single confirmation to the Test Plan card — no double gate", () => {
-    expect(testRun).toContain("Single confirmation: the Test Plan card doubles as the runtime-call");
+  it("binds a single confirmation to the Test Plan Card — no double gate", () => {
+    expect(testRun).toContain("Single confirmation: the Test Plan Card doubles as the runtime-call");
     expect(testRun).toContain("do not ask a second time");
     expect(testRun).toContain("Any change to the plan expires");
     expect(serviceCall).toContain("the user's option choice on that card IS the bound confirmation");


### PR DESCRIPTION
## What

The Cards system (📝/🗑️/✅, test-pinned) gave **writes** a consistent, recognizable UX — but improvement suggestions and everything read-shaped rendered freeform per skill ("feels unloved"). A full audit across all skills found: bare enhancement suggestions in the write flow, three divergent suggestion shapes, ~15 skills with freeform or self-invented read layouts, label drift (`Next Step` vs `Next step`), and the Test Plan Card living outside the central schema.

`skills/ha-nova/output-rules.md` (95 → 174 lines) now owns the missing shapes:

- **`## Suggestion Block`** — one shape for every improvement offer (write enhancement suggestions, helper suggested defaults, review Suggestions items, notification-copy offers): 💡 header (new in the fixed emoji vocabulary), numbered, max 4, item = short title + what it does + why it helps, skip always valid, never post-write. The resolve agent's return contract now names the render target.
- **`## Report Shape (Read & Analysis Results)`** — answer-first lead → grouped body → optional evidence → closing `Next step` slot; diagnosis specialization (root cause → evidence chain → fix + owning-skill handoff).
- **`## List Frame (Inventories & Discovery)`** — count line first, stated cap on truncation, max 4 short columns, canonical column order.
- **Test Plan Card** folded into the Cards section as the fourth card (mechanics stay in `test-run.md`); `Test Plan card`→`Test Plan Card` casing normalized.

20 skills now reference the shared shapes instead of bespoke prose (diagnose, media, notify, camera, mqtt, assist, admin, external-sources, dashboard, organize, energy, updates, backup, maintenance, todo, scene, health, history, calendar, read, entity-discovery, helper, service-call response data); slot-list skills stay as declared specializations. Cleanups: helper config-entry list table trimmed to the already-pinned max-4-column rule (details stay in the per-helper detail read), `Next Step` label drift normalized with a guard pin.

## Verification

- Full suite green: **761 tests** (77 files).
- New pins in `output-design-contract.test.ts`: the three new H2 shapes, 💡 vocabulary, all four suggestion sites, read-skill routing loop, test-plan folding, `Next Step` guard.
- Expected pin adjustments: `ha-nova-contract` (`Next step`), `helper-contract` (trimmed 4-column table — the dropped columns live in the detail read). Word-budget ratchets: health 1200 (new), scene 1400, review 4400.
- No README / manifest / runtime changes — skill markdown + tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBmfxWsGK34rtzHfVTDG8Z