### PR TITLE
chore(release): 0.17.0 — post-write test offer, consistent output shapes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.16.0"
+    "version": "0.17.0"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,12 +85,8 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## New Features
 
-    - **One confirmation for reviewed batch deletes.** Deleting a reviewed set of automations, helpers, scenes, dashboards, to-do lists, or stale MQTT discovery topics now takes ONE typed confirmation code bound to the exact list — instead of one confirmation per item. Per-item impact checks and verification stay, and anything outside the shown list still needs its own preview. Proven live: a zombie device with 25 retained MQTT topics, gone with a single code.
-
-    ## Bug Fixes
-
-    - Terminal output: icons like 🗑️ and ⚠️ no longer swallow the following space in terminals that render them double-width.
-    - Confirmation prompts speak plain language now: the typed reply is called a "confirmation code" (localized to your language), never a technical "token".
+    - **Test it right after saving.** Every new or changed automation and script now ends with a test offer matched to its risk: a zero-impact logic check, an actions-only run, or a full real test that fires the actual trigger — always naming exactly which devices will switch, with one confirmation, an automatic trace check afterwards, and cleanup of any test state. High-consequence targets such as locks, garage doors, alarms, and heating are never presented as consequence-free.
+    - **One consistent look everywhere.** Suggestions, reports, lists, and status answers now follow the same recognizable shapes as the preview cards: improvement suggestions render as a compact 💡 block, read answers lead with the answer and close with a clear next step, and lists state their counts and caps honestly.
     Stable install commands are release-pinned for this tag.
 
     **macOS / Linux:**

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,7 +85,7 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## New Features
 
-    - **Test it right after saving.** Every new or changed automation and script now ends with a test offer matched to its risk: a zero-impact logic check, an actions-only run, or a full real test that fires the actual trigger — always naming exactly which devices will switch, with one confirmation, an automatic trace check afterwards, and cleanup of any test state. High-consequence targets such as locks, garage doors, alarms, and heating are never presented as consequence-free.
+    - **Test it right after saving.** Every new or changed automation and script now ends with a test offer matched to its risk: a zero-impact logic check, an actions-only run, or a full real test that fires the actual trigger — always naming exactly which devices will switch, with one confirmation; every real run gets an automatic trace check afterwards and cleanup of any test state. High-consequence targets such as locks, garage doors, alarms, and heating are never presented as consequence-free.
     - **One consistent look everywhere.** Suggestions, reports, lists, and status answers now follow the same recognizable shapes as the preview cards: improvement suggestions render as a compact 💡 block, read answers lead with the answer and close with a clear next step, and lists state their counts and caps honestly.
     Stable install commands are release-pinned for this tag.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ We built this because we didn't trust AI with our own config either.
 3. **You approve it.** Deletes require a specific confirmation code — not just "yes." A reviewed batch delete takes one code bound to the exact list of items.
 4. **Writes and verifies.** Reads the config back to confirm the change stuck.
 5. **Audits itself.** Checks for mistakes, conflicts, and reliability issues.
-6. **Lets you take it back.** Reply `revert` to undo the latest verified update. New items are removed through the same preview-and-confirm delete flow.
+6. **Offers a safe test.** After saving, you get a test plan matched to the risk — from a zero-impact logic check to a real run that names exactly which devices will switch before you say go.
+7. **Lets you take it back.** Reply `revert` to undo the latest verified update. New items are removed through the same preview-and-confirm delete flow.
 
 **The ground rules — always:**
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ We built this because we didn't trust AI with our own config either.
 3. **You approve it.** Deletes require a specific confirmation code — not just "yes." A reviewed batch delete takes one code bound to the exact list of items.
 4. **Writes and verifies.** Reads the config back to confirm the change stuck.
 5. **Audits itself.** Checks for mistakes, conflicts, and reliability issues.
-6. **Offers a safe test.** After saving, you get a test plan matched to the risk — from a zero-impact logic check to a real run that names exactly which devices will switch before you say go.
+6. **Offers a safe test.** After saving a new or changed automation or script, you get a test plan matched to the risk — from a zero-impact logic check to a real run that names exactly which devices will switch before you say go.
 7. **Lets you take it back.** Reply `revert` to undo the latest verified update. New items are removed through the same preview-and-confirm delete flow.
 
 **The ground rules — always:**

--- a/docs/work/0.17.0-release-body.md
+++ b/docs/work/0.17.0-release-body.md
@@ -2,5 +2,5 @@
 
 ## New Features
 
-- **Test it right after saving.** Every new or changed automation and script now ends with a test offer matched to its risk: a zero-impact logic check, an actions-only run, or a full real test that fires the actual trigger — always naming exactly which devices will switch, with one confirmation, an automatic trace check afterwards, and cleanup of any test state. High-consequence targets such as locks, garage doors, alarms, and heating are never presented as consequence-free. (#334)
+- **Test it right after saving.** Every new or changed automation and script now ends with a test offer matched to its risk: a zero-impact logic check, an actions-only run, or a full real test that fires the actual trigger — always naming exactly which devices will switch, with one confirmation; every real run gets an automatic trace check afterwards and cleanup of any test state. High-consequence targets such as locks, garage doors, alarms, and heating are never presented as consequence-free. (#334)
 - **One consistent look everywhere.** Suggestions, reports, lists, and status answers now follow the same recognizable shapes as the preview cards: improvement suggestions render as a compact 💡 block, read answers lead with the answer and close with a clear next step, and lists state their counts and caps honestly. (#335)

--- a/docs/work/0.17.0-release-body.md
+++ b/docs/work/0.17.0-release-body.md
@@ -1,0 +1,6 @@
+# 0.17.0 Release Body (draft — collects unreleased user-facing claims)
+
+## New Features
+
+- **Test it right after saving.** Every new or changed automation and script now ends with a test offer matched to its risk: a zero-impact logic check, an actions-only run, or a full real test that fires the actual trigger — always naming exactly which devices will switch, with one confirmation, an automatic trace check afterwards, and cleanup of any test state. High-consequence targets such as locks, garage doors, alarms, and heating are never presented as consequence-free. (#334)
+- **One consistent look everywhere.** Suggestions, reports, lists, and status answers now follow the same recognizable shapes as the preview cards: improvement suggestions render as a compact 💡 block, read answers lead with the answer and close with a clear next step, and lists state their counts and caps honestly. (#335)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "home-assistant-js-websocket": "^9.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -53,14 +53,14 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
-  it("keeps v0.16.0 release-facing wording user-centric", () => {
+  it("keeps v0.17.0 release-facing wording user-centric", () => {
     // Shipped release-note bodies are archived (docs/archive/work/) and
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
-    expect(goreleaser).toContain("One confirmation for reviewed batch deletes");
-    expect(goreleaser).toContain("ONE typed confirmation code bound to the exact list");
-    expect(goreleaser).toContain("no longer swallow the following space");
-    expect(goreleaser).toContain('called a "confirmation code"');
+    expect(goreleaser).toContain("Test it right after saving");
+    expect(goreleaser).toContain("naming exactly which devices will switch");
+    expect(goreleaser).toContain("never presented as consequence-free");
+    expect(goreleaser).toContain("One consistent look everywhere");
     expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");
   });
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.16.0",
+  "skill_version": "0.17.0",
   "min_relay_version": "0.4.0"
 }


### PR DESCRIPTION
## Release prep for v0.17.0 (minor)

Two user-facing features since v0.16.0 justify the minor bump:
- #334 — risk-graded post-write test offer (logic check / actions-only / full real-path, single confirmation, automatic trace follow-up, test-state cleanup)
- #335 — shared output shapes (Suggestion Block 💡, Report Shape, List Frame, Test Plan Card folded into the card system)

## Contents

- Version bump 0.16.0 → 0.17.0: `version.json` (SSOT), `package.json` + lock, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
- `.goreleaser.yml` stable-notes body: the two features, user-centric, no bug-fix section (nothing user-facing to report)
- `README.md` Safe by Design: new step 6 "Offers a safe test" (release-bound claim — ships with this version bump per the README gate)
- `tests/onboarding/release-contract.test.ts`: wording pins moved to the 0.17.0 body
- `docs/work/0.17.0-release-body.md`: release-body draft (archived after publish, like #333)

## Verification

- Full suite green: 761 tests (77 files), including the updated release contract.
- Preflight done: no open PRs (no Dependabot/workflow blockers).
- After merge: strict pipeline audit + disposable-HA e2e on the merge commit, then tag-first rehearsal `v0.17.0-rc1` → verify public RC install → final `v0.17.0` on the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBmfxWsGK34rtzHfVTDG8Z