### PR TITLE
fix(skills): service-call owning-skill deferrals + high-consequence confirmation tier

### DIFF
--- a/skills/admin/SKILL.md
+++ b/skills/admin/SKILL.md
@@ -75,6 +75,7 @@ Render the Report shape (output-rules.md); person/zone/user inventories render t
 
 - Zone and person deletes take the typed token, and the preview must first name the automations that depend on them (`search/related`).
 - User deletion is the strictest operation in HA NOVA: owner, system-generated, and the relay's own account are refused outright, and everything else needs the typed token plus a plain statement of what is lost.
+- No delete here has a `revert`. Zones, persons, and tags are recreatable from their previewed fields — a tag keeps its physical `tag_id`, but other recreates mint new internal ids, so inbound references stay broken. A deleted user's password, tokens, and history are unrecoverable; the delete preview must say so.
 - Never surface credentials, tokens, or password state in output.
 
 ## Guardrails

--- a/skills/assist/SKILL.md
+++ b/skills/assist/SKILL.md
@@ -69,6 +69,7 @@ Render the Report shape (output-rules.md). For an utterance test: the exact resp
 - **A test utterance is a live command.** `conversation/process` executes what it understands. Anything that could change state gets a preview and confirmation, exactly like a service call.
 - Exposing entities to voice grants voice control over them — show the full list before changing exposure.
 - Pipeline updates resend every settings field: read first, or you silently drop settings.
+- No change here has a `revert`: restore exposure by re-toggling, restore a pipeline by resending its prior fields. A deleted pipeline recreates with a new `pipeline_id` — satellites pointing at the old one must be re-pointed.
 
 ## Guardrails
 

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -98,6 +98,7 @@ Skills reference this section as "context skill → Active Preview Confirmation"
 ### Confirmation Tiers
 
 - `create`/`update`: natural confirmation bound to active preview.
+- high-consequence runtime action (grants physical access or is physically irreversible): token confirmation `confirm:<token>`, same enforcement as destructive writes. Canonical set: unlocking locks, disarming alarm panels, opening garage/gate/entry-door covers — `device_class` and what the entity controls decide, never the domain alone. Owning-skill escalations (e.g. retained MQTT publishes) sit on this same rung.
 - `delete`/destructive: token confirmation `confirm:<token>`.
   **Strict token enforcement:** User MUST reply with the exact token string (e.g., `confirm:del-main-lights`). Any other response — including "yes", "sure, delete it", "do it", or any natural-language confirmation — is NOT valid. Reject and re-prompt with the exact code required. In user-facing output call it the "confirmation code" (localized), never a "token" (see `skills/ha-nova/output-rules.md` → Localization).
   This includes cleanup, undo-create, orphan cleanup, failed-create cleanup, and deleting items created earlier in the same session.
@@ -212,6 +213,9 @@ Match user intent to exactly one skill:
 **"Revert that"** / **"Undo the last change"** → re-invoke the skill that made it: `ha-nova:write` (automation/script) or `ha-nova:helper` (helper). `revert` is update-only and lives there (see `write-safety.md` → Update-Revert), never `ha-nova:fallback`; create cleanup uses delete flow, and delete rollback needs Backup/recreate.
 **"Create a scene called Movie Night"** → `ha-nova:scene`
 **"Activate the scene Movie Night"** → `ha-nova:service-call` (runtime action, not a config change)
+**"Unlock the front door"** → `ha-nova:service-call` (high-consequence: typed confirmation code)
+**"Install the firmware update for my kitchen light"** → `ha-nova:updates` (never raw `update.install` through service-call)
+**"Publish an MQTT message"** → `ha-nova:mqtt` (never raw `mqtt.publish` through service-call)
 **"Test the automation I just created"** → `ha-nova:write` Phase 5 test offer (plan per `skills/ha-nova/test-run.md`); a plain manual trigger stays `ha-nova:service-call`
 **"Show my main dashboard"** → `ha-nova:dashboard`
 **"Create a dashboard called Test Board"** → `ha-nova:dashboard`

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -285,4 +285,9 @@ expensive. Never suggest a backup for routine small edits.
 | `maintenance` | grouped preview + re-validate verify | spike adjust only (inverse call); clears/purges/removals irreversible | HA Backups (offered pre-bulk) |
 | `organize` | field preview | no (registry deletes irreversible) | HA Backups |
 | `service-call` | state-delta preview | no (runtime action, not config) | re-run corrective service call |
+| `admin` (persons/zones/tags/users) | field preview | no (deletes irreversible; user credentials/tokens unrecoverable) | recreate from previewed fields (tags keep their physical `tag_id`; other recreates mint new ids); HA Backups |
+| `assist` (pipelines/exposure) | change preview | no | re-toggle exposure / resend prior pipeline fields; deleted pipelines recreate with a new id |
+| `yaml-config` | File-Change Preview + `check_config` | one-step `.bak` restore (writes only; a second write overwrites it) | `.bak` restore; HA Backups |
+| `mqtt` (publish) | payload preview | no (broker/device state) | clear a retained message by publishing an empty retained payload; corrective publish |
+| `backup` (delete) | delete preview | no | none — a deleted archive is gone |
 | `fallback` (experimental writes) | payload preview + read-back verify | no | HA Backups |

--- a/skills/media/SKILL.md
+++ b/skills/media/SKILL.md
@@ -101,6 +101,7 @@ Render the Report shape (output-rules.md): what is playing where — player, sta
 
 - Volume: preview the target level; treat a large jump (or anything above ~0.8) as disruptive and confirm explicitly — a loud announcement at night is a real-world side effect.
 - Announcements interrupt whatever is playing; say so before sending one.
+- An announcement or TTS to a grouped player plays on every member — name the full member list in the preview, not just the target.
 - Grouping changes affect every listed speaker — preview the full member list.
 
 ## Guardrails

--- a/skills/service-call/SKILL.md
+++ b/skills/service-call/SKILL.md
@@ -29,6 +29,21 @@ Use file-based payloads for service writes:
 - `ha-nova relay core --method GET --path /api/states/<entity_id>`
 - `--out <result-file>` when the response is large
 
+## Owning-Skill Deferrals (Critical)
+
+"Call any service" never overrides a stricter owning skill. When the request matches a row below, STOP and continue in that skill — it carries gates this flow lacks (feature checks, backup offers, typed codes, restore duties):
+
+| Service(s) | Owning skill |
+|---|---|
+| `mqtt.publish` | `ha-nova:mqtt` |
+| `update.install` / `update.skip` / `update.clear_skipped` | `ha-nova:updates` |
+| `camera.snapshot` / `camera.record` | `ha-nova:camera` |
+| `media_player.*` / `tts.*` | `ha-nova:media` |
+| `notify.*` / `persistent_notification.*` | `ha-nova:notify` |
+| `logger.set_level` | `ha-nova:diagnose` |
+
+Runtime calls that stay here: `scene.turn_on`, `automation.trigger`, direct `script.*` (see Automation And Script Runtime Calls), and plain `lock`/`alarm_control_panel`/`cover` control under the high-consequence rule (see Safety).
+
 ## Response services
 
 Some services return data (`weather.get_forecasts`, `calendar.get_events`, `todo.get_items`, ...) and REQUIRE the `?return_response` query parameter — without it HA returns 400 "requires responses". Path shape: `/api/services/<domain>/<service>?return_response`; the data lives under `.data.body.service_response`. Pure data services (the examples above) are reads — no write confirmation. A response-capable ACTION service (for example direct `script.<script_id>`) still follows the full preview/confirmation flow below — the parameter only adds the response, it never downgrades an action to a read.
@@ -143,7 +158,8 @@ Previews are the runtime-action Preview Card (`apply · cancel`); results are th
 - For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
 
 - No token confirmation needed for ordinary service calls; confirmation is still bound to the active preview.
-- For potentially disruptive services (e.g., `homeassistant.restart`), warn and ask for explicit post-preview confirmation.
+- **High-consequence runtime actions take the typed `confirm:<token>`** like a destructive write: unlocking a lock, disarming an alarm panel, opening a garage door, gate, or entry-door cover. Check `device_class` and what the entity controls — a garage door exposed as `cover.*` belongs here, a living-room blind does not. These actions grant physical access; calling the opposite service afterwards does not undo the exposure window.
+- For potentially disruptive services (`homeassistant.restart`, `homeassistant.stop`), warn and ask for explicit post-preview confirmation.
 
 ## Guardrails
 

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -116,8 +116,10 @@ const WORD_BUDGETS: Record<string, number> = {
   health: 1200,
   mqtt: 1300,
   scene: 1400,
-  // test-offer single-confirmation + reference bullets (test-run.md).
-  "service-call": 1350,
+  // test-offer single-confirmation + reference bullets (test-run.md);
+  // ratcheted again for the owning-skill deferral table + high-consequence
+  // confirmation rule (masterplan-2026-h2 Wave 0).
+  "service-call": 1550,
   // Carries the canonical File-Change Preview example — the only layout
   // source for file edits; concrete examples are what make a card renderable.
   "yaml-config": 1250,


### PR DESCRIPTION
## What

Wave 0 (a) of [masterplan-2026-h2](https://github.com/markusleben/ha-nova/pull/339): closes the two safety seams the July deep audits rated most severe, and completes the safety-mechanism matrix.

## Why

- **Gate bypass**: `service-call`'s "call any service" scope could execute `mqtt.publish` (retained!), `update.install`, `camera.snapshot`, media/TTS, notify, and `logger.set_level` with weaker gates than the owning skills enforce (no feature checks, no backup offer, no typed code, no restore duty).
- **Inverted tiers**: unlocking the front door or disarming the alarm ran at the lightest natural confirmation while a retained MQTT publish required a typed code.

## Changes

- `skills/service-call/SKILL.md`: new **Owning-Skill Deferrals** table (STOP and continue in the owning skill); new **high-consequence rule** — unlock/disarm/garage-gate-entry covers take the typed `confirm:<token>`, decided by `device_class`, not domain; `homeassistant.stop` joins the disruptive-warn line.
- `skills/ha-nova/SKILL.md`: new **high-consequence runtime action** rung in Confirmation Tiers; three dispatch examples (unlock / update.install / mqtt.publish).
- `skills/ha-nova/write-safety.md`: safety matrix completed — `admin`, `assist`, `yaml-config`, `mqtt`, `backup` rows were missing entirely.
- `skills/admin/SKILL.md`, `skills/assist/SKILL.md`: in-skill no-revert recovery notes (previously stated no recovery path at all).
- `skills/media/SKILL.md`: grouped-player announcements must preview the full member list.
- `tests/skills/skill-template-contract.test.ts`: documented word-budget ratchet for service-call (1350 → 1550).

## Verification

- `npx vitest run tests/skills/` — 294/294 green (template order, Safety Core, budgets, English-only, check-code leak).
- Full `npm run test:safe` green via pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBmfxWsGK34rtzHfVTDG8Z