### PR TITLE
feat(skills): safety-backup offers before irreversible deletes + fallback catalog completion

### DIFF
--- a/skills/admin/SKILL.md
+++ b/skills/admin/SKILL.md
@@ -76,6 +76,7 @@ Render the Report shape (output-rules.md); person/zone/user inventories render t
 - Zone and person deletes take the typed token, and the preview must first name the automations that depend on them (`search/related`).
 - User deletion is the strictest operation in HA NOVA: owner, system-generated, and the relay's own account are refused outright, and everything else needs the typed token plus a plain statement of what is lost.
 - No delete here has a `revert`. Zones, persons, and tags are recreatable from their previewed fields — a tag keeps its physical `tag_id`, but other recreates mint new internal ids, so inbound references stay broken. A deleted user's password, tokens, and history are unrecoverable; the delete preview must say so.
+- Offer a safety backup via `ha-nova:backup` before zone, person, and user deletes (not for tag deletes or routine updates).
 - Never surface credentials, tokens, or password state in output.
 
 ## Guardrails

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -159,6 +159,7 @@ Do not dump the full dashboard JSON/YAML by default.
 
 - No guessed `url_path` or `dashboard_id` values.
 - Dashboard/resource/card delete uses exact token confirmation only, even for items created earlier in the same session. Dashboard writes have no `revert`; the recovery path is Home Assistant Backups.
+- Before a dashboard/resource delete or a save that removes views or cards, offer a safety backup via `ha-nova:backup` (its flow checks for a recent one first). Never offer it for routine small edits.
 - If the change needs a broad re-layout instead of a targeted edit, say so before writing.
 
 ## Guardrails

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -191,7 +191,7 @@ ha-nova relay ws --data-file <payload-file>
 
 ### Integration Onboarding -- RELAY-READY
 
-Add a new integration or re-authenticate an existing one via the config-flow API — the same flow endpoints as the config-entry helper section above (`POST /api/config/config_entries/flow` to start, submit steps by `flow_id`; in-progress flows, including re-auth prompts, list via GET on the same path).
+Add a new integration or re-authenticate an existing one via the config-flow API — the same flow endpoints as the config-entry helper section above (`POST /api/config/config_entries/flow` to start, then `GET`/`POST`/`DELETE .../flow/{flow_id}` for a specific flow). Discover pending flows, including re-auth prompts, via WS `config_entries/flow/progress` — the collection path itself is POST-only, a GET on it returns 405.
 
 **Search:** `home assistant config_entries flow add integration api 2026`
 

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -74,12 +74,15 @@ For every Relay-Ready call in this skill:
 | Other Config-Entry Helpers | Relay-Ready | this skill |
 | Statistics repair / Purge / Entity registry remove | Covered | maintenance |
 | Device config-entry detach | Relay-Ready | this skill |
+| Integration onboarding (add / re-auth an integration via config flow) | Relay-Ready | this skill |
+| Firing custom events / triggering webhooks | Relay-Ready | this skill |
 | Event Subscriptions | Roadmap Phase 1c | -- |
 | Backups (status, create, inspect, delete) | Covered | backup |
 | Updates (pending, release notes, install, skip) | Covered | updates |
 | Apps / Supervisor | External | -- |
 | HACS | External | -- |
 | Zigbee / Z-Wave Config | External | -- (MQTT-level inspection of a Zigbee2MQTT setup: `mqtt`) |
+| Alarm / lock code management (lock user codes, alarm PINs) | External | -- (arming/disarming/locking itself: `service-call`, high-consequence confirmation) |
 
 ## Flow
 
@@ -114,9 +117,14 @@ List and import automation/script blueprints from the community or custom URLs.
 **Experimental relay calls (no skill guardrails):**
 ```text
 ha-nova relay ws --data-file <payload-file>
+
+# payload examples (verify current schema via web search first):
+# {"type":"blueprint/list","domain":"automation"}
+# {"type":"blueprint/import","url":"https://community.home-assistant.io/t/..."}   (fetches + previews, does not save)
+# {"type":"blueprint/save","domain":"automation","path":"<folder/name.yaml>","yaml":"<blueprint yaml>"}
 ```
 
-**Risks:** Imported blueprints execute when instantiated. Review blueprint source before import.
+**Risks:** Imported blueprints execute when instantiated. Review blueprint source before import. Instantiating a blueprint into an automation (`use_blueprint`) is a normal automation create — hand off to `ha-nova:write`.
 
 ### Other Config-Entry Helpers -- RELAY-READY
 
@@ -180,6 +188,31 @@ ha-nova relay ws --data-file <payload-file>
 ```
 
 **Risks:** Device detach depends on integration support (`supports_remove_device`) and can sever the current device/config-entry relationship. Preview impact first.
+
+### Integration Onboarding -- RELAY-READY
+
+Add a new integration or re-authenticate an existing one via the config-flow API — the same flow endpoints as the config-entry helper section above (`POST /api/config/config_entries/flow` to start, submit steps by `flow_id`; in-progress flows, including re-auth prompts, list via GET on the same path).
+
+**Search:** `home assistant config_entries flow add integration api 2026`
+
+**Risks:** Flows are multi-step and integration-specific (discovery confirmations, OAuth handoffs that must finish in the HA UI). Never guess step fields — each response carries the next step's schema. Abort unfinished flows (`DELETE .../flow/{flow_id}`) instead of leaving them dangling.
+
+### Events / Webhooks -- RELAY-READY
+
+Fire a custom event on the HA event bus or trigger an inbound webhook.
+
+**Search:** `home assistant fire event REST api webhook 2026`
+
+**Experimental relay calls (no skill guardrails):**
+```text
+# Fire event: POST /api/events/{event_type}, body = event data JSON
+ha-nova relay core --method POST --path /api/events/<event_type> --body-file <payload-file>
+
+# Trigger webhook: POST /api/webhook/{webhook_id} (body as the webhook expects)
+ha-nova relay core --method POST --path /api/webhook/<webhook_id> --body-file <payload-file>
+```
+
+**Risks:** Every automation listening to that event/webhook fires — enumerate listeners in the preview when resolvable (`search/related` on the automations). Webhook IDs are secrets; never print full IDs in output.
 
 ## Roadmap Features
 

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -212,7 +212,7 @@ ha-nova relay core --method POST --path /api/events/<event_type> --body-file <pa
 ha-nova relay core --method POST --path /api/webhook/<webhook_id> --body-file <payload-file>
 ```
 
-**Risks:** Every automation listening to that event/webhook fires — enumerate listeners in the preview when resolvable (`search/related` on the automations). Webhook IDs are secrets; never print full IDs in output.
+**Risks:** Every automation listening to that event/webhook fires. `search/related` does NOT index event listeners — scan automation configs for the same `event_type`/webhook trigger before previewing, or state in the preview that other listeners cannot be ruled out (pattern: `skills/ha-nova/test-run.md`). Webhook IDs are secrets; never print full IDs in output.
 
 ## Roadmap Features
 

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -419,7 +419,7 @@ Report only what has substance (same rule as the write flow — see `skills/writ
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete prompts, and results render as the Cards defined there.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete prompts, and results render as the Cards defined there. The bold labels in both read templates below are semantic slots — localize them at runtime, never print them as literal English headings.
 
 ### Storage-based family
 

--- a/skills/organize/SKILL.md
+++ b/skills/organize/SKILL.md
@@ -126,6 +126,7 @@ Metadata reads render the Report shape; registry inventories render the List Fra
 - For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
 
 - Delete uses token confirmation only, even for cleanup of items created earlier in the same session.
+- Registry deletes (areas, floors, labels, categories) are irreversible and a recreate mints a new id — inbound references stay broken. Offer a safety backup via `ha-nova:backup` before them (never for metadata edits).
 - If the user asks for entity removal, stop and hand off to `ha-nova:maintenance` (dead registry entries only — for live entities offer disable here instead). For device category assignment or config-entry detachment, hand off to `ha-nova:fallback`.
 
 ## Guardrails

--- a/skills/read/SKILL.md
+++ b/skills/read/SKILL.md
@@ -140,7 +140,7 @@ If id is ambiguous, ask one clarifying question. Never use raw `get_states`.
 
 Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
-After reading a config, present:
+After reading a config, present (the bold labels below are semantic slots — localize them at runtime per output-rules.md, never print them as literal English headings):
 
 ```
 **{Automation|Script}: {alias}**

--- a/skills/scene/SKILL.md
+++ b/skills/scene/SKILL.md
@@ -129,6 +129,6 @@ Use stable localized slot labels in this order; omit empty slots. Reads render t
 - For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
 
 - Create/update use natural confirmation after preview; delete uses exact token confirmation only, even for scenes created earlier in the same session.
-- Scene writes have no `revert`; the recovery path is Home Assistant Backups — say so before destructive operations.
+- Scene writes have no `revert`; the recovery path is Home Assistant Backups — say so before destructive operations, and offer a safety backup via `ha-nova:backup` before a scene delete (never for routine edits).
 - One scene per mutation; verify read-back, not just the save response.
 - Activation hands off to `ha-nova:service-call` — `scene.turn_on` supports `transition` (lights only); `scene.apply` applies a one-off state set without storing a scene.

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -124,13 +124,17 @@ const WORD_BUDGETS: Record<string, number> = {
   // source for file edits; concrete examples are what make a card renderable.
   "yaml-config": 1250,
   todo: 1200,
-  // batch-safety opt-in with the merged-save card rule (#327).
-  dashboard: 1200,
+  // batch-safety opt-in with the merged-save card rule (#327);
+  // safety-backup offer before destructive dashboard writes (2026-h2 Wave 0).
+  dashboard: 1250,
   updates: 1200,
   // batch-safety alignment: batch code format + cap-split rule (#327).
   maintenance: 1300,
-  fallback: 2300,
-  helper: 3600,
+  // integration-onboarding + events/webhooks Relay-Ready sections and the
+  // blueprint payload examples (masterplan-2026-h2 Wave 0).
+  fallback: 2450,
+  // semantic-slot note on the read templates (2026-h2 Wave 0).
+  helper: 3650,
   // Suggestion Block item-shape pointer (shared output shapes).
   review: 4400,
 };


### PR DESCRIPTION
## What

Wave 0 (b) of [masterplan-2026-h2](https://github.com/markusleben/ha-nova/blob/main/docs/work/masterplan-2026-h2.md): backup-gate consistency, fallback catalog completion, and the semantic-slot label fix.

## Why

- `dashboard`/`scene`/`organize`/`admin` delete irreversibly but only mentioned HA Backups as recovery *after* the fact, while `maintenance`/`updates` proactively offer one — an uneven gate for the ops with no revert.
- The fallback capability map was missing rows for integration onboarding (config flows), events/webhooks, and alarm/lock codes — requests in those domains fell through with no guidance. The blueprint Relay-Ready section gave a bare `ws` command with no payload shape.
- `helper`/`read` read templates carried hard-coded English bold labels contradicting output-rules.md's semantic-slot/localization rule.

## Changes

- Safety-backup offer (via `ha-nova:backup`, which checks for a recent one first) before: dashboard/resource deletes and content-dropping saves, scene deletes, registry deletes (areas/floors/labels/categories), zone/person/user deletes. Explicitly never for routine edits; wording is snapshot-migratable for the Wave-2 config-snapshot layer.
- Fallback: 2 new Relay-Ready rows + sections (Integration Onboarding, Events/Webhooks with payload examples and listener-enumeration risk), 1 External row (alarm/lock codes → service-call high-consequence pointer), blueprint payload examples (`blueprint/list`/`import`/`save`) + `use_blueprint` handoff to `write`.
- `helper`/`read`: templates now state bold labels are semantic slots localized at runtime.
- Word-budget ratchets with documented reasons (dashboard 1250, fallback 2450, helper 3650).

## Verification

- `npx vitest run tests/skills/` — 294/294 green.
- Full `npm run test:safe` green via pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBmfxWsGK34rtzHfVTDG8Z