### PR TITLE
docs(skills): floor-based relay version guidance + version-claim drift guard

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -16,13 +16,13 @@ Active doc ownership lives in `docs/reference/documentation-governance.md`.
 
 ## Current Phase
 
-**Phase 1: Infrastructure + skill-system consolidation**
+**Post-masterplan-2026 program** — the active roadmap is `docs/work/masterplan-2026-h2.md`.
 
-Deliverables:
-1. Relay MVP: `GET /health`, `POST /ws`, `POST /core`
-2. Context skill: `ha-nova` (auto-loaded via SessionStart hook; sub-skills discovered independently)
-3. Sub-skills (flat under `skills/`): write, read, review, dashboard, organize, history, helper, health, calendar, entity-discovery, service-call, fallback, onboarding
-4. Shared references under `skills/ha-nova/` (`relay-api.md`, `best-practices.md`, `payload-schemas.md`, `helper-schemas.md`, `template-guidelines.md`, `safe-refactoring.md`, `automation-patterns.md`, `agents/`)
+Shipped and current:
+1. Relay: `GET /health`, `POST /ws`, `POST /core`, `POST /files` (opt-in, default off); App + standalone container from one codebase
+2. Go CLI: install, setup wizard, doctor, update (incl. guided relay update), uninstall (incl. guided server-side teardown), relay proxy
+3. Context skill `ha-nova` plus 28 task skills, flat under `skills/` — the dispatch table in `skills/ha-nova/SKILL.md` is the authoritative inventory
+4. Shared references under `skills/ha-nova/` (relay API contract, output rules, write safety, batch safety, schemas, agent templates)
 
 ## Tech Stack
 

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -259,7 +259,7 @@ Rules:
 Rules:
 - no repair/fix/ignore actions
 - no restart/reload/service calls
-- check `ha-nova relay health` and skip `system_health/info` when Relay App version is below 0.2.3
+- check `ha-nova relay health` and skip `system_health/info` when the relay is below the enforced floor (`min_relay_version`)
 - summarize by source and bind conclusions to evidence
 - keep Home Status compact: overall state, source coverage, capped examples, sanitized integration reasons
 - deprioritize noisy/stateless domains (`button`, `event`, `scene`, `stt`) in unavailable/unknown examples

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -370,7 +370,7 @@ Rules: never invent a `media_content_id`; volume jumps and announcements are dis
 
 ## Camera Architecture
 
-`ha-nova:camera` owns camera access and is the first consumer of the relay's binary path (relay >= 0.3.0):
+`ha-nova:camera` owns camera access and is the first consumer of the relay's binary path (guaranteed at the enforced relay floor, `version.json` → `min_relay_version`):
 - frames via `GET /api/camera_proxy/<entity_id>` with `--out-binary` ONLY (`--out`/`--jq` would write the JSON envelope instead of an image)
 - stream URL via WS `camera/stream` (needs the STREAM feature bit)
 - `camera.snapshot` / `camera.record` write on the HA host and need `allowlist_external_dirs` — previewed and confirmed
@@ -378,7 +378,7 @@ Rules: never invent a `media_content_id`; volume jumps and announcements are dis
 
 ## MQTT Architecture
 
-`ha-nova:mqtt` owns MQTT work and is the first consumer of envelope window mode (relay >= 0.3.0):
+`ha-nova:mqtt` owns MQTT work and is the first consumer of envelope window mode (guaranteed at the enforced relay floor):
 - listening is a bounded WINDOW (`mqtt/subscribe` inside `collect_events` with `on_limit: "return"`), never a stream; the relay unsubscribes when it closes
 - an empty window is a real answer ("nothing published"), reported as one — an `UPSTREAM_WS_TIMEOUT` (subscription never established) is a different finding
 - discovery/debug via WS `mqtt/device/debug_info` (device_id from the registry, never guessed)

--- a/scripts/test/safe-core-files.json
+++ b/scripts/test/safe-core-files.json
@@ -52,5 +52,6 @@
   "tests/skills/todo-contract.test.ts",
   "tests/skills/trace-contract.test.ts",
   "tests/skills/updates-contract.test.ts",
+  "tests/skills/version-claim-drift.test.ts",
   "tests/skills/write-delete-safety-contract.test.ts"
 ]

--- a/skills/camera/SKILL.md
+++ b/skills/camera/SKILL.md
@@ -21,7 +21,7 @@ Not in scope: creating automations around cameras (`ha-nova:write`), person/moti
 Verify relay CLI: `ha-nova relay health`
 If this fails: `ha-nova setup`
 
-Requires **Relay 0.3.0 or newer** (binary responses). Check `ha-nova relay health` -> `version`; if it is older, tell the user to update the NOVA Relay — an older relay would corrupt the image bytes.
+Binary responses are guaranteed by the skills' enforced relay floor (`skills/ha-nova/relay-api.md` -> Bounded Event Collection). If any relay command printed a relay-outdated warning, have the user update the NOVA Relay before fetching frames — an older relay would corrupt the image bytes.
 
 ## Relay Contract
 

--- a/skills/ha-nova/agents/apply-agent.md
+++ b/skills/ha-nova/agents/apply-agent.md
@@ -108,7 +108,7 @@ Use `ha-nova relay` for all HA communication. It handles auth, headers, and time
   - `passed=true` only when target is absent on read-back
   - config read-back not-found after DELETE is expected absence evidence
   - entity state not-found after DELETE is expected absence evidence when an entity_id is known
-  - `config/entity_registry/get` may return `UPSTREAM_WS_ERROR` (or `UPSTREAM_WS_COMMAND_ERROR` on Relay App >= 0.2.4) after deletion; do not retry alternate deletes from that error
+  - `config/entity_registry/get` may return `UPSTREAM_WS_COMMAND_ERROR` (legacy relays below the enforced floor: `UPSTREAM_WS_ERROR`) after deletion; do not retry alternate deletes from that error
   - if extra evidence is needed, use `config/entity_registry/list_for_display` and confirm no exact `entity_id` match
 
 ## Output Format (Structured Text)

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -10,7 +10,7 @@ Underlying HTTP contract (reference only, not for direct use): `Authorization: B
 
 ## Bounded Event Collection (envelope)
 
-Window mode (`on_limit`) and binary responses require **Relay 0.3.0 or newer**. An older relay silently ignores `on_limit` and falls back to strict mode (a timeout then fails the call instead of returning partial events). Check the running version with `ha-nova relay health` before relying on either feature, and tell the user to update the NOVA Relay App if it is older.
+Window mode (`on_limit`) and binary responses are supported by every relay at or above the skills' enforced floor — `min_relay_version` in `version.json`, currently **Relay 0.4.0**. The CLI checks that floor on every relay call and prints a relay-outdated warning when the installed relay is older; surface that warning and offer the update instead of version-gating manually. (Below the floor, `on_limit` is silently ignored and a timeout fails the call instead of returning partial events.)
 
 
 Some WS commands answer with events instead of a single response. Wrap them:
@@ -413,7 +413,7 @@ These are top-level HTTP errors produced by the relay itself. The response has `
 - `500 / INTERNAL_ERROR`: unexpected relay server error
 - `502 / UPSTREAM_WS_ERROR`: relay could not reach HA websocket
 - `502 / UPSTREAM_WS_TIMEOUT`: WS request to HA timed out
-- `502 / UPSTREAM_WS_COMMAND_ERROR` (Relay App >= 0.2.4): HA answered the WS command with a structured error; the message contains HA's own error code and text (e.g. `HA rejected 'x': unknown_command: ...`). The connection stays healthy — treat this as a command problem, not a connectivity problem. Older relays report these as generic `UPSTREAM_WS_ERROR`.
+- `502 / UPSTREAM_WS_COMMAND_ERROR`: HA answered the WS command with a structured error; the message contains HA's own error code and text (e.g. `HA rejected 'x': unknown_command: ...`). The connection stays healthy — treat this as a command problem, not a connectivity problem. Legacy relays below the enforced floor report these as generic `UPSTREAM_WS_ERROR`.
 - `502 / UPSTREAM_HTTP_ERROR`: core HTTP request to HA failed
 - `502 / UPSTREAM_HTTP_TIMEOUT`: core HTTP request to HA timed out
 

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -44,7 +44,7 @@ For WS payloads:
 - integration entries: `{"type":"config_entries/get"}`
 - system health: `{"message":{"type":"system_health/info"},"collect_events":{"until_type":"finish","max_events":100,"timeout_ms":10000}}`
 
-`system_health/info` is a finite event-response command. The Skill opts into generic Relay event collection through `collect_events`; the Relay only forwards the WS message and enforces `until_type`, `max_events`, and `timeout_ms`. A compatible relay returns `data.events` containing `initial`, zero or more `update`, and `finish` events. If the relay returns `data: null`, `UNSUPPORTED_WS_TYPE`, `VALIDATION_ERROR`, or another unsupported-event response, continue and say system-health details need Relay 0.2.3 or newer.
+`system_health/info` is a finite event-response command. The Skill opts into generic Relay event collection through `collect_events`; the Relay only forwards the WS message and enforces `until_type`, `max_events`, and `timeout_ms`. A compatible relay returns `data.events` containing `initial`, zero or more `update`, and `finish` events. If the relay returns `data: null`, `UNSUPPORTED_WS_TYPE`, `VALIDATION_ERROR`, or another unsupported-event response, continue and say system-health details need a relay at the enforced floor — every supported relay has event collection, so this points at an outdated App.
 
 ## Data Shapes
 
@@ -77,7 +77,7 @@ Low-battery detection must be structured:
 
 1. Read `/api/config`, `/api/components`, and `/api/states`.
 2. Read `repairs/list_issues` and `config_entries/get` through WS.
-3. If the relay version is below `0.2.3`, do not call `system_health/info`; say system-health details need Relay 0.2.3 or newer and include the current relay version.
+3. If a relay-outdated warning appeared this session, skip `system_health/info`; say system-health details need the relay updated to the enforced floor and include the current relay version.
 4. Otherwise read `system_health/info` through WS and parse `data.events` when available.
 5. Summarize:
    - overall: `ok` only when all read sources are available and there are no active repairs, non-disabled not-loaded integrations, important unavailable/unknown examples, or low battery/SOC findings; `limited` when a source is unavailable; otherwise `attention`

--- a/skills/mqtt/SKILL.md
+++ b/skills/mqtt/SKILL.md
@@ -21,7 +21,7 @@ Not in scope: the MQTT broker's own configuration, Zigbee2MQTT's web UI, or crea
 Verify relay CLI: `ha-nova relay health`
 If this fails: `ha-nova setup`
 
-Requires **Relay 0.3.0 or newer** (bounded subscription windows). Check `ha-nova relay health` -> `version`. An older relay silently ignores `on_limit`, which turns a normal quiet window into a hard error — tell the user to update the NOVA Relay instead of working around it.
+Bounded subscription windows are guaranteed by the skills' enforced relay floor (`skills/ha-nova/relay-api.md` -> Bounded Event Collection). If a relay-outdated warning appeared, have the user update the NOVA Relay instead of working around it — an older relay silently ignores `on_limit`, which turns a normal quiet window into a hard error.
 
 Requires the `mqtt` integration: check `GET /api/components` for `mqtt`. If it is absent, say so — this skill cannot add it.
 
@@ -64,7 +64,7 @@ MQTT topics never emit a "finish" event, so a listen is a WINDOW, not a request.
 ## Error Handling
 
 Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handling. MQTT specifics:
-- `UNSUPPORTED_WS_TYPE` on `mqtt/subscribe`: check YOUR request first. A BARE `mqtt/subscribe` is rejected by every relay version, including 0.3.0+ — that is by design, and it means the subscription was not wrapped in a `collect_events` envelope. Fix the request. Only if the request WAS enveloped does this error mean the relay is older than 0.3.0; confirm with `ha-nova relay health` before telling the user to update the App.
+- `UNSUPPORTED_WS_TYPE` on `mqtt/subscribe`: check YOUR request first. A BARE `mqtt/subscribe` is rejected by every relay version — that is by design, and it means the subscription was not wrapped in a `collect_events` envelope. Fix the request. Only if the request WAS enveloped does this error mean the relay predates bounded windows; confirm with `ha-nova relay health` before telling the user to update the App.
 - `400 VALIDATION_ERROR` mentioning `on_limit`: never expected — an older relay ignores the field silently rather than rejecting it, so this points at a malformed envelope.
 - `UPSTREAM_WS_TIMEOUT` in window mode means the subscription never even established (broker down, integration not loaded) — that is different from an empty window, and worth saying plainly.
 - `mqtt/device/debug_info` needs a device_id from the device registry; an entity_id is rejected.

--- a/tests/onboarding/project-docs-contract.test.ts
+++ b/tests/onboarding/project-docs-contract.test.ts
@@ -23,8 +23,9 @@ describe("project docs contract", () => {
   });
 
   it("tracks the active architecture surfaces and current skill inventory", () => {
-    expect(project).toContain("fallback");
-    expect(project).toContain("automation-patterns.md");
+    expect(project).toContain("docs/work/masterplan-2026-h2.md");
+    expect(project).toContain("the dispatch table in `skills/ha-nova/SKILL.md` is the authoritative inventory");
+    expect(project).toContain("`POST /files` (opt-in, default off)");
     expect(project).toContain("documentation-governance.md");
     expect(project).not.toContain("## Active Documentation");
     expect(project).not.toContain("## Current Product Surfaces");

--- a/tests/skills/health-calendar-contract.test.ts
+++ b/tests/skills/health-calendar-contract.test.ts
@@ -23,9 +23,9 @@ describe("health and calendar skill contracts", () => {
     expect(health).toContain('{"message":{"type":"system_health/info"},"collect_events":{"until_type":"finish","max_events":100,"timeout_ms":10000}}');
     expect(health).toContain("The Skill opts into generic Relay event collection through `collect_events`");
     expect(health).toContain("data.events");
-    expect(health).toContain("Relay 0.2.3 or newer");
+    expect(health).toContain("need a relay at the enforced floor");
     expect(health).toContain("Read `data.version` from the health response.");
-    expect(health).toContain("If the relay version is below `0.2.3`, do not call `system_health/info`");
+    expect(health).toContain("If a relay-outdated warning appeared this session, skip `system_health/info`");
     expect(health).toContain("include the current relay version");
     expect(health).toContain("## Data Shapes");
     expect(health).toContain("REST `/api/config`, `/api/components`, `/api/states`: use `.data.body`");
@@ -104,7 +104,7 @@ describe("health and calendar skill contracts", () => {
     expect(architecture).toContain("`ha-nova:health` is a read-only home-status skill");
     expect(architecture).toContain("integration setup/load status through `config_entries/get`");
     expect(architecture).toContain("generic bounded WS event collection for `system_health/info`");
-    expect(architecture).toContain("skip `system_health/info` when Relay App version is below 0.2.3");
+    expect(architecture).toContain("skip `system_health/info` when the relay is below the enforced floor (`min_relay_version`)");
     expect(architecture).toContain("capped examples, sanitized integration reasons");
     expect(architecture).toContain("deprioritize noisy/stateless domains");
     expect(architecture).not.toContain("current-session error log");

--- a/tests/skills/version-claim-drift.test.ts
+++ b/tests/skills/version-claim-drift.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// Version-claim drift guard (masterplan-2026-h2 Wave 0). Skill docs once told
+// users to manually version-gate on "Relay 0.3.0 or newer" long after the
+// enforced floor (version.json → min_relay_version) had moved past it. Any
+// relay version a skill doc names must therefore BE the current floor: when
+// the floor moves, this test fails and forces the docs to be revisited
+// instead of drifting silently.
+
+const SKILLS_ROOT = "skills";
+
+const ALL_SKILL_MD_FILES = ((): string[] => {
+  const files: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const p = join(dir, entry);
+      if (statSync(p).isDirectory()) walk(p);
+      else if (entry.endsWith(".md")) files.push(p);
+    }
+  };
+  walk(SKILLS_ROOT);
+  return files;
+})();
+
+const MIN_RELAY_VERSION: string = JSON.parse(readFileSync("version.json", "utf8"))
+  .min_relay_version;
+
+describe("relay version claims in skill docs", () => {
+  it("version.json declares a min_relay_version", () => {
+    expect(MIN_RELAY_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("every relay version a skill doc names equals the enforced floor", () => {
+    for (const file of ALL_SKILL_MD_FILES) {
+      const lines = readFileSync(file, "utf8").split("\n");
+      lines.forEach((line, idx) => {
+        if (!/relay/i.test(line)) return;
+        for (const match of line.matchAll(/\b(\d+\.\d+\.\d+)\b/g)) {
+          expect(
+            match[1],
+            `${file}:${idx + 1} names relay version ${match[1]}, but the enforced floor is ${MIN_RELAY_VERSION} — update the claim or raise the floor`,
+          ).toBe(MIN_RELAY_VERSION);
+        }
+      });
+    }
+  });
+});

--- a/tests/skills/version-claim-drift.test.ts
+++ b/tests/skills/version-claim-drift.test.ts
@@ -11,8 +11,9 @@ import { describe, expect, it } from "vitest";
 // instead of drifting silently.
 
 const SKILLS_ROOT = "skills";
+const REFERENCE_ROOT = "docs/reference";
 
-const ALL_SKILL_MD_FILES = ((): string[] => {
+const mdFilesUnder = (root: string): string[] => {
   const files: string[] = [];
   const walk = (dir: string) => {
     for (const entry of readdirSync(dir)) {
@@ -21,9 +22,12 @@ const ALL_SKILL_MD_FILES = ((): string[] => {
       else if (entry.endsWith(".md")) files.push(p);
     }
   };
-  walk(SKILLS_ROOT);
+  walk(root);
   return files;
-})();
+};
+
+const ALL_SKILL_MD_FILES = mdFilesUnder(SKILLS_ROOT);
+const ALL_REFERENCE_MD_FILES = mdFilesUnder(REFERENCE_ROOT);
 
 const MIN_RELAY_VERSION: string = JSON.parse(readFileSync("version.json", "utf8"))
   .min_relay_version;
@@ -43,6 +47,29 @@ describe("relay version claims in skill docs", () => {
             match[1],
             `${file}:${idx + 1} names relay version ${match[1]}, but the enforced floor is ${MIN_RELAY_VERSION} — update the claim or raise the floor`,
           ).toBe(MIN_RELAY_VERSION);
+        }
+      });
+    }
+  });
+
+  // Reference docs legitimately keep HISTORICAL relay stamps ("shipped with
+  // relay 0.4.0"), so only REQUIREMENT-shaped claims are pinned there.
+  it("every relay REQUIREMENT a reference doc states equals the enforced floor", () => {
+    const requirementPatterns = [
+      /relay\s*(?:>=|≥)\s*(\d+\.\d+\.\d+)/gi,
+      /relay\s+(\d+\.\d+\.\d+)\s+or\s+newer/gi,
+      /(?:requires?|needs?)\s+relay\s+(\d+\.\d+\.\d+)/gi,
+    ];
+    for (const file of ALL_REFERENCE_MD_FILES) {
+      const lines = readFileSync(file, "utf8").split("\n");
+      lines.forEach((line, idx) => {
+        for (const pattern of requirementPatterns) {
+          for (const match of line.matchAll(pattern)) {
+            expect(
+              match[1],
+              `${file}:${idx + 1} states a relay requirement of ${match[1]}, but the enforced floor is ${MIN_RELAY_VERSION} — update the claim or raise the floor`,
+            ).toBe(MIN_RELAY_VERSION);
+          }
         }
       });
     }

--- a/tests/skills/write-delete-safety-contract.test.ts
+++ b/tests/skills/write-delete-safety-contract.test.ts
@@ -181,7 +181,7 @@ describe("write delete safety contract", () => {
   it("treats post-delete absence evidence as successful verification without alternate delete retries", () => {
     expect(applyAgent).toContain("config read-back not-found after DELETE is expected absence evidence");
     expect(applyAgent).toContain("entity state not-found after DELETE is expected absence evidence");
-    expect(applyAgent).toContain("`config/entity_registry/get` may return `UPSTREAM_WS_ERROR` (or `UPSTREAM_WS_COMMAND_ERROR` on Relay App >= 0.2.4) after deletion");
+    expect(applyAgent).toContain("`config/entity_registry/get` may return `UPSTREAM_WS_COMMAND_ERROR` (legacy relays below the enforced floor: `UPSTREAM_WS_ERROR`) after deletion");
     expect(applyAgent).toContain("do not retry alternate deletes");
     expect(applyAgent).toContain("config/entity_registry/list_for_display");
     expect(applyAgent).toContain("no exact `entity_id` match");


### PR DESCRIPTION
## What

Wave 0 (c) of [masterplan-2026-h2](https://github.com/markusleben/ha-nova/blob/main/docs/work/masterplan-2026-h2.md): doc-drift cleanup plus the contract test that keeps this class of drift from recurring.

## Why

`relay-api.md` still told users to manually version-check for "Relay 0.3.0 or newer" although the enforced floor (`version.json` → `min_relay_version`) is 0.4.0 and the CLI already warns below it — stale guidance sending users to chase a gate the floor enforces.

## Changes

- **Floor-based wording**: relay-api.md, camera, mqtt (bootstrap + error taxonomy), health, and apply-agent now phrase version gating against the enforced floor ("surface the relay-outdated warning") instead of naming historical versions. Only relay-api.md and yaml-config name the concrete floor version.
- **NEW `tests/skills/version-claim-drift.test.ts`**: every relay version named in `skills/**/*.md` must equal `min_relay_version` — when the floor moves, the test fails and forces a doc revisit. It immediately caught **three more stale claims** beyond the audit's finding (apply-agent and relay-api error taxonomy still explaining 0.2.4 behavior; health gating on 0.2.3).
- **PROJECT.md**: the stale Phase-1 deliverables list (13 skills, 3 endpoints) now reflects the shipped component set and delegates the skill inventory to the dispatch table — one less list that can drift.
- `.codex/ONBOARDING.md` stub deliberately kept: it is a legacy redirect for old raw URLs; removing it would 404 them (decision recorded in docs/choices.md).
- Test pins updated accordingly (health-calendar, write-delete-safety, project-docs contracts); new test registered in `scripts/test/safe-core-files.json`.

## Verification

- Full `npm run test:safe` green via pre-push hook (314 targeted tests green incl. the new guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBmfxWsGK34rtzHfVTDG8Z