### PR TITLE
feat(relay): POST /backups — generic config-snapshot blob store (relay 0.5.0)

### DIFF
--- a/cli/help_test.go
+++ b/cli/help_test.go
@@ -36,7 +36,7 @@ func TestSubcommandHelpFlagPrintsUsageAndFlags(t *testing.T) {
 		{"trace get", func() int { return runTraceCommand(paths, []string{"get", "--help"}) }, "Usage: ha-nova trace get", "-json"},
 		{"trace latest", func() int { return runTraceCommand(paths, []string{"latest", "--help"}) }, "Usage: ha-nova trace latest", "-json"},
 		{"relay health", func() int { return runRelayCommand(paths, []string{"health", "--help"}) }, "Usage: ha-nova relay health", "-connect-timeout"},
-		{"relay (parent)", func() int { return runRelayCommand(paths, []string{"--help"}) }, "Usage: ha-nova relay <health|ws|core|files|jq|version>", "relay <subcommand> --help"},
+		{"relay (parent)", func() int { return runRelayCommand(paths, []string{"--help"}) }, "Usage: ha-nova relay <health|ws|core|files|backups|jq|version>", "relay <subcommand> --help"},
 		{"relay jq", func() int { return runRelayCommand(paths, []string{"jq", "--help"}) }, "Usage: ha-nova relay jq", "--jq-file"},
 		// Must answer even on a fresh install: help may not hide behind the
 		// config/token preflight of the proxy path.

--- a/cli/relay.go
+++ b/cli/relay.go
@@ -49,11 +49,11 @@ type relayRequestOptions struct {
 
 func runRelayCommand(paths runtimePaths, args []string) int {
 	if len(args) == 0 {
-		printErr("Usage: ha-nova relay <health|ws|core|files|jq|version> ...")
+		printErr("Usage: ha-nova relay <health|ws|core|files|backups|jq|version> ...")
 		return 1
 	}
 	if args[0] == "--help" || args[0] == "-h" || args[0] == "help" {
-		fmt.Println("Usage: ha-nova relay <health|ws|core|files|jq|version> ...")
+		fmt.Println("Usage: ha-nova relay <health|ws|core|files|backups|jq|version> ...")
 		fmt.Println("Run 'ha-nova relay <subcommand> --help' to see that subcommand's flags.")
 		return 0
 	}
@@ -67,6 +67,8 @@ func runRelayCommand(paths runtimePaths, args []string) int {
 		return runRelayProxy(paths, "core", args[1:])
 	case "files":
 		return runRelayProxy(paths, "files", args[1:])
+	case "backups":
+		return runRelayProxy(paths, "backups", args[1:])
 	case "jq":
 		return runJQ(args[1:])
 	case "version":
@@ -89,7 +91,7 @@ func parseRelayFlags(command string, args []string) (relayRequestOptions, error)
 
 	opts := relayRequestOptions{}
 	switch command {
-	case "ws", "files":
+	case "ws", "files", "backups":
 		fs.StringVar(&opts.InlineJSON, "data", "", "inline JSON payload")
 		fs.StringVar(&opts.InlineJSON, "d", "", "inline JSON payload")
 		fs.StringVar(&opts.JSONFile, "data-file", "", "path to JSON payload file")

--- a/docs/reference/relay-container.md
+++ b/docs/reference/relay-container.md
@@ -19,6 +19,7 @@ docker run -d --name ha-nova-relay --restart unless-stopped \
   -e RELAY_AUTH_TOKEN='<your relay token>' \
   -e HA_LLAT='<your Home Assistant long-lived access token>' \
   -e HA_URL='http://<home-assistant-host>:8123' \
+  -v ha-nova-snapshots:/data/ha_nova_snapshots \
   ghcr.io/markusleben/ha-nova-relay:latest
 ```
 
@@ -36,6 +37,11 @@ services:
       RELAY_AUTH_TOKEN: "<your relay token>"
       HA_LLAT: "<your Home Assistant long-lived access token>"
       HA_URL: "http://homeassistant:8123"
+    volumes:
+      - ha-nova-snapshots:/data/ha_nova_snapshots
+
+volumes:
+  ha-nova-snapshots:
 ```
 
 If Home Assistant runs in the same Compose project, `HA_URL` can use its service name; otherwise use the host's IP.
@@ -45,6 +51,7 @@ If Home Assistant runs in the same Compose project, `HA_URL` can use its service
 | Variable | Required | Default | Meaning |
 |----------|----------|---------|---------|
 | `RELAY_AUTH_TOKEN` | yes | — | Shared secret between the `ha-nova` CLI and the relay. Any long random secret (see Setup order). |
+| `SNAPSHOT_DIR` | no | `/data/ha_nova_snapshots` | Where config snapshots (`POST /backups`) are stored. Mount a volume there to persist them. |
 | `HA_LLAT` | yes | — | Home Assistant long-lived access token. **Stays on the server** — the AI client never sees it. |
 | `HA_URL` | no | `http://homeassistant:8123` | Where Home Assistant lives. |
 | `RELAY_PORT` | no | `8791` | Listen port. |
@@ -77,6 +84,10 @@ The interactive wizard is built around the Supervisor App (it walks you through 
 A guided "Docker" branch in the interactive wizard is planned; until then this is the supported path, and it is the one the documentation and tests cover.
 
 The security model is identical to the App: the LLAT lives only on the server side (in the container's environment), and the relay token is stored in your OS keychain — the AI client never sees your Home Assistant token.
+
+## Config snapshots
+
+The relay stores config snapshots (relay 0.5.0, `POST /backups`) under `/data/ha_nova_snapshots`. The image creates that directory writable, but it is EPHEMERAL unless you mount a volume there (the `-v ha-nova-snapshots:...` line above / the Compose volume). `SNAPSHOT_DIR` overrides the location. On App installs this needs no setup — the App data directory persists and full HA backups sweep it up.
 
 ## File access (optional)
 

--- a/nova/Dockerfile.standalone
+++ b/nova/Dockerfile.standalone
@@ -22,6 +22,11 @@ FROM node:22-alpine
 # and talks HTTP; a compromised process should not own the container.
 RUN addgroup -S nova && adduser -S nova -G nova
 
+# Config-snapshot store (POST /backups) — must be writable by the nova user or
+# every save fails EACCES. Ephemeral unless a volume is mounted here (see
+# docs/reference/relay-container.md); SNAPSHOT_DIR overrides the location.
+RUN mkdir -p /data/ha_nova_snapshots && chown -R nova:nova /data
+
 WORKDIR /app
 COPY --from=build --chown=nova:nova /app/dist ./dist
 COPY --from=build --chown=nova:nova /app/node_modules ./node_modules

--- a/nova/config.yaml
+++ b/nova/config.yaml
@@ -1,5 +1,5 @@
 name: NOVA Relay
-version: "0.4.1"
+version: "0.5.0"
 slug: ha_nova_relay
 description: Thin Home Assistant relay for WS proxy and skill workflows
 url: https://github.com/markusleben/ha-nova

--- a/nova/src/config/env.ts
+++ b/nova/src/config/env.ts
@@ -8,6 +8,7 @@ export interface EnvConfig {
   appOptionsPath: string;
   relayPort: number;
   logLevel: LogLevel;
+  snapshotDir: string;
 }
 
 const DEFAULT_RELAY_PORT = 8791;
@@ -15,6 +16,9 @@ const DEFAULT_LOG_LEVEL: LogLevel = "info";
 const DEFAULT_HA_URL = "http://homeassistant:8123";
 const DEFAULT_RELAY_VERSION = "dev";
 const DEFAULT_APP_OPTIONS_PATH = "/data/options.json";
+// Lives inside the App data dir so Supervised full backups sweep it up; the
+// standalone container overrides via SNAPSHOT_DIR (mount a volume to persist).
+const DEFAULT_SNAPSHOT_DIR = "/data/ha_nova_snapshots";
 const ALLOWED_LOG_LEVELS = new Set<LogLevel>([
   "trace",
   "debug",
@@ -41,6 +45,8 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): EnvConfig {
     throw new Error("LOG_LEVEL must be one of trace|debug|info|warn|error");
   }
 
+  const snapshotDir = parseRequiredLike(source.SNAPSHOT_DIR, DEFAULT_SNAPSHOT_DIR);
+
   return {
     relayAuthToken,
     haLlat,
@@ -48,7 +54,8 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): EnvConfig {
     relayVersion,
     appOptionsPath,
     relayPort,
-    logLevel: logRaw as LogLevel
+    logLevel: logRaw as LogLevel,
+    snapshotDir
   };
 }
 

--- a/nova/src/http/handlers/backups.ts
+++ b/nova/src/http/handlers/backups.ts
@@ -1,5 +1,5 @@
-import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { mkdir, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { gunzip, gzip } from "node:zlib";
 
@@ -162,6 +162,28 @@ function snapshotPath(root: string, file: string): string {
   return absolute;
 }
 
+// The lexical check above cannot see symlinks: a symlinked category dir on a
+// restored/mounted volume would pass it and route the fs call outside the
+// store. Resolve the file's parent with realpath and require it to sit under
+// the real root. A missing parent is fine — the later fs call yields ENOENT,
+// which the callers map to 404 (or mkdir it first, for save).
+async function assertRealParent(root: string, absolute: string): Promise<void> {
+  let realRoot: string;
+  let realParent: string;
+  try {
+    realRoot = await realpath(resolve(root));
+    realParent = await realpath(dirname(absolute));
+  } catch (error) {
+    if (isEnoent(error)) {
+      return;
+    }
+    throw error;
+  }
+  if (realParent !== realRoot && !realParent.startsWith(`${realRoot}/`)) {
+    throw new HttpError(400, "VALIDATION_ERROR", "file must stay inside the snapshot store");
+  }
+}
+
 function formatStamp(ms: number): string {
   // 20260714T123456789Z — sortable, path-safe, millisecond precision.
   const iso = new Date(ms).toISOString(); // 2026-07-14T12:34:56.789Z
@@ -247,6 +269,7 @@ async function saveSnapshot(
   const file = `${category}/${name}-${stamp}.json.gz`;
   const absolute = snapshotPath(root, file);
   await mkdir(join(root, category), { recursive: true });
+  await assertRealParent(root, absolute);
   try {
     await writeFile(absolute, compressed, { flag: "wx" });
   } catch (error) {
@@ -263,6 +286,7 @@ async function loadSnapshot(
   file: string
 ): Promise<{ data: unknown; bytes: number; created_at: string }> {
   const absolute = snapshotPath(root, file);
+  await assertRealParent(root, absolute);
   let compressed: Buffer;
   try {
     compressed = await readFile(absolute);
@@ -297,6 +321,7 @@ async function listSnapshots(root: string, category?: string): Promise<SnapshotE
 
 async function deleteSnapshot(root: string, file: string): Promise<{ deleted: true }> {
   const absolute = snapshotPath(root, file);
+  await assertRealParent(root, absolute);
   try {
     await rm(absolute);
   } catch (error) {

--- a/nova/src/http/handlers/backups.ts
+++ b/nova/src/http/handlers/backups.ts
@@ -1,0 +1,348 @@
+import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { gunzip, gzip } from "node:zlib";
+
+import { HttpError } from "../errors.js";
+import type { RouteContext, RouteHandler } from "../router.js";
+
+const gzipAsync = promisify(gzip);
+const gunzipAsync = promisify(gunzip);
+
+export const MAX_SNAPSHOT_FILES = 500;
+export const MAX_TOTAL_BYTES = 50 * 1024 * 1024;
+export const AUTO_NAME_PREFIX = "auto-";
+const DEFAULT_PRUNE_MAX_AGE_DAYS = 30;
+const DEFAULT_PRUNE_MAX_FILES = 100;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const SLUG_PATTERN = /^[a-z0-9-]{1,64}$/;
+// The only addressable shape: <category>/<name>-<stamp>.json.gz — everything
+// else is rejected before any filesystem call, which is the containment story
+// (no free-form paths ever reach resolve()).
+const FILE_PATTERN = /^([a-z0-9-]{1,64})\/([a-z0-9-]{1,64})-(\d{8}T\d{9}Z)\.json\.gz$/;
+
+export interface BackupsHandlerOptions {
+  snapshotRoot: string;
+  now?: () => number;
+}
+
+interface SnapshotEntry {
+  file: string;
+  category: string;
+  name: string;
+  bytes: number;
+  created_at: string;
+}
+
+/**
+ * Generic config-snapshot blob store. The relay never parses the stored data —
+ * opaque JSON in, opaque JSON out; which items get captured, diffed, and
+ * restored is entirely the skills' business (docs/work/2026-07-14-config-snapshots-spec.md).
+ */
+export function createBackupsHandler(options: BackupsHandlerOptions): RouteHandler {
+  const now = options.now ?? Date.now;
+  return async ({ body }: RouteContext) => {
+    const request = parseBackupsRequest(body);
+    switch (request.action) {
+      case "save":
+        return await saveSnapshot(options.snapshotRoot, request.category, request.name, request.data, now);
+      case "load":
+        return await loadSnapshot(options.snapshotRoot, request.file);
+      case "list":
+        return await listSnapshots(options.snapshotRoot, request.category);
+      case "delete":
+        return await deleteSnapshot(options.snapshotRoot, request.file);
+      case "prune":
+        return await pruneSnapshots(options.snapshotRoot, request, now);
+    }
+  };
+}
+
+type BackupsRequest =
+  | { action: "save"; category: string; name: string; data: unknown }
+  | { action: "load"; file: string }
+  | { action: "list"; category?: string }
+  | { action: "delete"; file: string }
+  | {
+      action: "prune";
+      category?: string;
+      maxAgeDays: number;
+      maxFiles: number;
+      keepNamed: boolean;
+    };
+
+function parseBackupsRequest(body: unknown): BackupsRequest {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new HttpError(400, "VALIDATION_ERROR", "Request body must be an object");
+  }
+  const raw = body as Record<string, unknown>;
+  const action = raw.action;
+
+  switch (action) {
+    case "save": {
+      const category = parseSlug(raw.category, "category");
+      const name = parseSlug(raw.name, "name");
+      if (!("data" in raw) || raw.data === undefined) {
+        throw new HttpError(400, "VALIDATION_ERROR", "save requires a 'data' JSON value");
+      }
+      return { action, category, name, data: raw.data };
+    }
+    case "load":
+    case "delete":
+      return { action, file: parseFileRef(raw.file) };
+    case "list":
+      return {
+        action,
+        ...(raw.category !== undefined ? { category: parseSlug(raw.category, "category") } : {})
+      };
+    case "prune": {
+      const maxAgeDays = parsePositiveInt(raw.max_age_days, "max_age_days", DEFAULT_PRUNE_MAX_AGE_DAYS);
+      const maxFiles = parsePositiveInt(raw.max_files, "max_files", DEFAULT_PRUNE_MAX_FILES);
+      if (raw.keep_named !== undefined && typeof raw.keep_named !== "boolean") {
+        throw new HttpError(400, "VALIDATION_ERROR", "keep_named must be a boolean");
+      }
+      return {
+        action,
+        maxAgeDays,
+        maxFiles,
+        keepNamed: raw.keep_named ?? true,
+        ...(raw.category !== undefined ? { category: parseSlug(raw.category, "category") } : {})
+      };
+    }
+    default:
+      throw new HttpError(
+        400,
+        "VALIDATION_ERROR",
+        "action must be one of: save, load, list, delete, prune"
+      );
+  }
+}
+
+function parseSlug(input: unknown, field: string): string {
+  if (typeof input !== "string" || !SLUG_PATTERN.test(input)) {
+    throw new HttpError(
+      400,
+      "VALIDATION_ERROR",
+      `${field} must be a lowercase slug ([a-z0-9-], max 64 chars)`
+    );
+  }
+  return input;
+}
+
+function parseFileRef(input: unknown): string {
+  if (typeof input !== "string" || !FILE_PATTERN.test(input)) {
+    throw new HttpError(
+      400,
+      "VALIDATION_ERROR",
+      "file must be a snapshot reference of the form <category>/<name>-<stamp>.json.gz"
+    );
+  }
+  return input;
+}
+
+function parsePositiveInt(input: unknown, field: string, fallback: number): number {
+  if (input === undefined) {
+    return fallback;
+  }
+  if (typeof input !== "number" || !Number.isInteger(input) || input < 1) {
+    throw new HttpError(400, "VALIDATION_ERROR", `${field} must be a positive integer`);
+  }
+  return input;
+}
+
+function snapshotPath(root: string, file: string): string {
+  // FILE_PATTERN already excludes separators/dots beyond the fixed shape;
+  // the resolve() check is defense in depth, mirroring files-paths.ts.
+  const absolute = resolve(join(root, file));
+  const rootAbsolute = resolve(root);
+  if (absolute !== rootAbsolute && !absolute.startsWith(`${rootAbsolute}/`)) {
+    throw new HttpError(400, "VALIDATION_ERROR", "file must stay inside the snapshot store");
+  }
+  return absolute;
+}
+
+function formatStamp(ms: number): string {
+  // 20260714T123456789Z — sortable, path-safe, millisecond precision.
+  const iso = new Date(ms).toISOString(); // 2026-07-14T12:34:56.789Z
+  return iso.replace(/[-:.]/g, "");
+}
+
+function stampToIso(stamp: string): string {
+  const m = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(\d{3})Z$/.exec(stamp);
+  if (!m) {
+    return new Date(0).toISOString();
+  }
+  return `${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}.${m[7]}Z`;
+}
+
+async function collectEntries(root: string, category?: string): Promise<SnapshotEntry[]> {
+  const entries: SnapshotEntry[] = [];
+  let categories: string[];
+  try {
+    const dirents = await readdir(root, { withFileTypes: true });
+    categories = dirents
+      .filter((d) => d.isDirectory() && SLUG_PATTERN.test(d.name))
+      .map((d) => d.name)
+      .filter((name) => category === undefined || name === category);
+  } catch (error) {
+    if (isEnoent(error)) {
+      return [];
+    }
+    throw error;
+  }
+
+  for (const cat of categories) {
+    let files: string[];
+    try {
+      files = await readdir(join(root, cat));
+    } catch (error) {
+      if (isEnoent(error)) {
+        continue;
+      }
+      throw error;
+    }
+    for (const fname of files) {
+      const ref = `${cat}/${fname}`;
+      const match = FILE_PATTERN.exec(ref);
+      if (!match) {
+        continue;
+      }
+      const info = await stat(join(root, cat, fname));
+      entries.push({
+        file: ref,
+        category: cat,
+        name: match[2] ?? "",
+        bytes: info.size,
+        created_at: stampToIso(match[3] ?? "")
+      });
+    }
+  }
+
+  entries.sort((a, b) => (a.created_at < b.created_at ? 1 : a.created_at > b.created_at ? -1 : 0));
+  return entries;
+}
+
+async function saveSnapshot(
+  root: string,
+  category: string,
+  name: string,
+  data: unknown,
+  now: () => number
+): Promise<{ file: string; bytes: number; created_at: string }> {
+  const compressed = await gzipAsync(Buffer.from(JSON.stringify(data), "utf8"));
+
+  const existing = await collectEntries(root);
+  const totalBytes = existing.reduce((sum, entry) => sum + entry.bytes, 0);
+  if (existing.length + 1 > MAX_SNAPSHOT_FILES || totalBytes + compressed.length > MAX_TOTAL_BYTES) {
+    throw new HttpError(
+      400,
+      "SNAPSHOT_STORE_FULL",
+      `Snapshot store is at its cap (${MAX_SNAPSHOT_FILES} files / ${MAX_TOTAL_BYTES} bytes) — run the prune action first.`
+    );
+  }
+
+  const stampMs = now();
+  const stamp = formatStamp(stampMs);
+  const file = `${category}/${name}-${stamp}.json.gz`;
+  const absolute = snapshotPath(root, file);
+  await mkdir(join(root, category), { recursive: true });
+  try {
+    await writeFile(absolute, compressed, { flag: "wx" });
+  } catch (error) {
+    if (isEexist(error)) {
+      throw new HttpError(409, "SNAPSHOT_EXISTS", "A snapshot with this name landed in the same millisecond — retry.");
+    }
+    throw error;
+  }
+  return { file, bytes: compressed.length, created_at: stampToIso(stamp) };
+}
+
+async function loadSnapshot(
+  root: string,
+  file: string
+): Promise<{ data: unknown; bytes: number; created_at: string }> {
+  const absolute = snapshotPath(root, file);
+  let compressed: Buffer;
+  try {
+    compressed = await readFile(absolute);
+  } catch (error) {
+    if (isEnoent(error)) {
+      throw new HttpError(404, "SNAPSHOT_NOT_FOUND", `No snapshot at ${file}`);
+    }
+    throw error;
+  }
+  let data: unknown;
+  try {
+    const raw = await gunzipAsync(compressed);
+    data = JSON.parse(raw.toString("utf8"));
+  } catch {
+    throw new HttpError(
+      500,
+      "SNAPSHOT_CORRUPT",
+      `Snapshot ${file} could not be decompressed/parsed — delete it and take a fresh one.`
+    );
+  }
+  const match = FILE_PATTERN.exec(file);
+  return {
+    data,
+    bytes: compressed.length,
+    created_at: stampToIso(match?.[3] ?? "")
+  };
+}
+
+async function listSnapshots(root: string, category?: string): Promise<SnapshotEntry[]> {
+  return await collectEntries(root, category);
+}
+
+async function deleteSnapshot(root: string, file: string): Promise<{ deleted: true }> {
+  const absolute = snapshotPath(root, file);
+  try {
+    await rm(absolute);
+  } catch (error) {
+    if (isEnoent(error)) {
+      throw new HttpError(404, "SNAPSHOT_NOT_FOUND", `No snapshot at ${file}`);
+    }
+    throw error;
+  }
+  return { deleted: true };
+}
+
+async function pruneSnapshots(
+  root: string,
+  request: { category?: string; maxAgeDays: number; maxFiles: number; keepNamed: boolean },
+  now: () => number
+): Promise<{ deleted: string[] }> {
+  const entries = await collectEntries(root, request.category);
+  const prunable = entries.filter(
+    (entry) => !request.keepNamed || entry.name.startsWith(AUTO_NAME_PREFIX)
+  );
+
+  const cutoffIso = new Date(now() - request.maxAgeDays * DAY_MS).toISOString();
+  const deleted: string[] = [];
+  const kept: SnapshotEntry[] = [];
+  for (const entry of prunable) {
+    if (entry.created_at < cutoffIso) {
+      deleted.push(entry.file);
+    } else {
+      kept.push(entry);
+    }
+  }
+  // kept is newest-first (collectEntries sort); everything beyond max_files goes too.
+  for (const entry of kept.slice(request.maxFiles)) {
+    deleted.push(entry.file);
+  }
+
+  for (const file of deleted) {
+    await rm(snapshotPath(root, file), { force: true });
+  }
+  return { deleted };
+}
+
+function isEnoent(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && (error as { code?: string }).code === "ENOENT");
+}
+
+function isEexist(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && (error as { code?: string }).code === "EEXIST");
+}

--- a/nova/src/http/handlers/backups.ts
+++ b/nova/src/http/handlers/backups.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { gunzip, gzip } from "node:zlib";
@@ -248,7 +248,12 @@ async function collectEntries(root: string, category?: string): Promise<Snapshot
       if (!match) {
         continue;
       }
-      const info = await stat(join(root, cat, fname));
+      // lstat, not stat: a leaf symlink must neither leak outside metadata
+      // into list results nor count its target's size toward the caps.
+      const info = await lstat(join(root, cat, fname));
+      if (!info.isFile()) {
+        continue;
+      }
       entries.push({
         file: ref,
         category: cat,

--- a/nova/src/http/handlers/backups.ts
+++ b/nova/src/http/handlers/backups.ts
@@ -14,6 +14,9 @@ export const MAX_TOTAL_BYTES = 50 * 1024 * 1024;
 export const AUTO_NAME_PREFIX = "auto-";
 const DEFAULT_PRUNE_MAX_AGE_DAYS = 30;
 const DEFAULT_PRUNE_MAX_FILES = 100;
+// Ten years: far above any sensible retention, far below the Date range a
+// huge value would blow past (turning a validation issue into a 500).
+const MAX_PRUNE_AGE_DAYS = 3650;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const SLUG_PATTERN = /^[a-z0-9-]{1,64}$/;
@@ -97,8 +100,8 @@ function parseBackupsRequest(body: unknown): BackupsRequest {
         ...(raw.category !== undefined ? { category: parseSlug(raw.category, "category") } : {})
       };
     case "prune": {
-      const maxAgeDays = parsePositiveInt(raw.max_age_days, "max_age_days", DEFAULT_PRUNE_MAX_AGE_DAYS);
-      const maxFiles = parsePositiveInt(raw.max_files, "max_files", DEFAULT_PRUNE_MAX_FILES);
+      const maxAgeDays = parsePositiveInt(raw.max_age_days, "max_age_days", DEFAULT_PRUNE_MAX_AGE_DAYS, MAX_PRUNE_AGE_DAYS);
+      const maxFiles = parsePositiveInt(raw.max_files, "max_files", DEFAULT_PRUNE_MAX_FILES, MAX_SNAPSHOT_FILES);
       if (raw.keep_named !== undefined && typeof raw.keep_named !== "boolean") {
         throw new HttpError(400, "VALIDATION_ERROR", "keep_named must be a boolean");
       }
@@ -141,12 +144,12 @@ function parseFileRef(input: unknown): string {
   return input;
 }
 
-function parsePositiveInt(input: unknown, field: string, fallback: number): number {
+function parsePositiveInt(input: unknown, field: string, fallback: number, max: number): number {
   if (input === undefined) {
     return fallback;
   }
-  if (typeof input !== "number" || !Number.isInteger(input) || input < 1) {
-    throw new HttpError(400, "VALIDATION_ERROR", `${field} must be a positive integer`);
+  if (typeof input !== "number" || !Number.isInteger(input) || input < 1 || input > max) {
+    throw new HttpError(400, "VALIDATION_ERROR", `${field} must be an integer between 1 and ${max}`);
   }
   return input;
 }

--- a/nova/src/http/handlers/backups.ts
+++ b/nova/src/http/handlers/backups.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { gunzip, gzip } from "node:zlib";
@@ -181,6 +181,21 @@ async function assertRealParent(root: string, absolute: string): Promise<void> {
   }
   if (realParent !== realRoot && !realParent.startsWith(`${realRoot}/`)) {
     throw new HttpError(400, "VALIDATION_ERROR", "file must stay inside the snapshot store");
+  }
+  // A pre-existing LEAF symlink would still route readFile/rm outside the
+  // store even with a clean parent — refuse it outright.
+  try {
+    const leaf = await lstat(absolute);
+    if (leaf.isSymbolicLink()) {
+      throw new HttpError(400, "VALIDATION_ERROR", "file must stay inside the snapshot store");
+    }
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw error;
+    }
+    if (!isEnoent(error)) {
+      throw error;
+    }
   }
 }
 

--- a/nova/src/index.ts
+++ b/nova/src/index.ts
@@ -7,6 +7,7 @@ import type {
   HaWsEventCollectionOptions,
   HaWsRequest,
 } from "./ha/ws-client.js";
+import { createBackupsHandler } from "./http/handlers/backups.js";
 import { createCoreProxyHandler } from "./http/handlers/core-proxy.js";
 import { createFilesHandler } from "./http/handlers/files.js";
 import { createHealthHandler } from "./http/handlers/health.js";
@@ -26,6 +27,7 @@ export interface AppOptions {
     ): Promise<HaWsEventCollection<unknown>>;
   };
   fileAccess: FileAccessConfig;
+  snapshotRoot: string;
   coreClient: {
     request(input: CoreProxyRequest): Promise<CoreProxyResponse>;
   };
@@ -84,6 +86,16 @@ export function createApp(options: AppOptions): App {
     createFilesHandler({
       fileAccess: options.fileAccess
     })
+  );
+
+  router.register(
+    "POST",
+    "/backups",
+    createBackupsHandler(
+      options.now
+        ? { snapshotRoot: options.snapshotRoot, now: options.now }
+        : { snapshotRoot: options.snapshotRoot }
+    )
   );
 
   const server = createHttpServer({

--- a/nova/src/runtime/start.ts
+++ b/nova/src/runtime/start.ts
@@ -92,6 +92,7 @@ export function bootstrapRuntime(dependencies: RuntimeDependencies = {}): Runtim
     version: env.relayVersion,
     wsClient,
     fileAccess,
+    snapshotRoot: env.snapshotDir,
     coreClient: {
       request: async (input: CoreProxyRequest): Promise<CoreProxyResponse> => coreClient.request(input)
     }
@@ -208,7 +209,8 @@ function logStartup(logger: Logger, runtime: RuntimeBootstrapResult): void {
     // Visible in the App log so an operator can always see whether file access
     // is on, and at which level — it is the one capability worth stating.
     file_access: runtime.fileAccess.mode,
-    config_root: runtime.fileAccess.configRoot || null
+    config_root: runtime.fileAccess.configRoot || null,
+    snapshot_dir: runtime.env.snapshotDir
   });
 
   for (const warning of runtime.upstreamAuth.warnings) {

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -25,17 +25,18 @@ echo ""
 
 # ── 1. LOC count ──
 # The relay must stay small enough that a person can read it. The ceiling moved
-# from 2000 to 2800 across relay 0.4.0: the opt-in file transport is ~500 lines,
-# split into three modules (gate / path security / operations), and most of that
-# is containment, deny rules and the code-execution boundary. Growth here is
-# security surface, and it is reviewed as such. The README's own number is
-# updated in the release-prep PR — README describes the STABLE release, not main.
+# from 2000 to 2800 across relay 0.4.0 (opt-in file transport: containment,
+# deny rules, code-execution boundary) and to 3200 across relay 0.5.0 (the
+# generic config-snapshot store, ~330 lines of validation, caps and prune).
+# Growth here is security surface, and it is reviewed as such. The README's own
+# number is updated in the release-prep PR — README describes the STABLE
+# release, not main.
 echo "[1] Relay LOC (must stay readable in one sitting)"
 ACTUAL_LOC=$(find "$REPO_ROOT/nova/src" -name '*.ts' -exec cat {} + | wc -l | tr -d ' ')
-if (( ACTUAL_LOC >= 1000 && ACTUAL_LOC <= 2800 )); then
-  pass "src/ = ${ACTUAL_LOC} LOC (within 1000–2800 range)"
+if (( ACTUAL_LOC >= 1000 && ACTUAL_LOC <= 3200 )); then
+  pass "src/ = ${ACTUAL_LOC} LOC (within 1000–3200 range)"
 else
-  fail "src/ = ${ACTUAL_LOC} LOC — outside the 1000–2800 range. If this is real growth, justify it and update the README claim in the release-prep PR."
+  fail "src/ = ${ACTUAL_LOC} LOC — outside the 1000–3200 range. If this is real growth, justify it and update the README claim in the release-prep PR."
 fi
 
 # ── 2. Skill count ──
@@ -85,16 +86,25 @@ else
 fi
 
 # ── 5. No unplanned feature creep ──
-# The relay must stay minimal: no backup endpoints, no streaming. File access
-# EXISTS (relay 0.4.0, for YAML-only configuration that has no API) but it is a
-# capability, not a default — so the check is stricter than "no filesystem":
-# it fails if the opt-in gate ever disappears.
-echo "[5] No backup/streaming endpoints; file access stays opt-in"
-CREEP_HITS=$(count_matches "backup_endpoint\|/backup\|/stream\|EventSource\|SSE" "$REPO_ROOT/nova/src/http/handlers/")
+# The relay must stay minimal: no streaming, and the config-snapshot store
+# (relay 0.5.0, POST /backups) must stay a GENERIC blob store — the moment it
+# imports the HA clients it has become a domain feature, which is the creep
+# this check exists to catch. File access EXISTS (relay 0.4.0) but it is a
+# capability, not a default — the check fails if the opt-in gate disappears.
+echo "[5] No streaming endpoints; snapshot store stays generic; file access stays opt-in"
+CREEP_HITS=$(count_matches "/stream\|EventSource\|SSE" "$REPO_ROOT/nova/src/http/handlers/")
 if (( CREEP_HITS != 0 )); then
-  fail "Found ${CREEP_HITS} hits for backup/streaming endpoints in handlers/ — the relay must stay minimal."
+  fail "Found ${CREEP_HITS} hits for streaming endpoints in handlers/ — the relay must stay minimal."
 else
-  pass "No backup/streaming endpoints found"
+  pass "No streaming endpoints found"
+fi
+if [[ -f "$REPO_ROOT/nova/src/http/handlers/backups.ts" ]]; then
+  DOMAIN_HITS=$(count_matches "ha/rest-client\|ha/ws-client\|coreClient\|wsClient" "$REPO_ROOT/nova/src/http/handlers/backups.ts")
+  if (( DOMAIN_HITS != 0 )); then
+    fail "backups.ts touches the HA clients — the snapshot store must stay a generic blob store."
+  else
+    pass "Snapshot store is a generic blob store (no HA client imports)"
+  fi
 fi
 
 if [[ -f "$REPO_ROOT/nova/src/http/handlers/files.ts" ]]; then

--- a/scripts/test/safe-core-files.json
+++ b/scripts/test/safe-core-files.json
@@ -21,6 +21,7 @@
   "tests/ha/socket.test.ts",
   "tests/ha/ws-client.test.ts",
   "tests/hooks/session-start.test.ts",
+  "tests/http/backups.test.ts",
   "tests/http/core-proxy.test.ts",
   "tests/http/error-envelope.test.ts",
   "tests/http/files-access.test.ts",

--- a/tests/bootstrap/app-wiring.test.ts
+++ b/tests/bootstrap/app-wiring.test.ts
@@ -26,6 +26,7 @@ describe("app wiring", () => {
   it("wires /health and /ws handlers in application router", async () => {
     const app = createApp({
       fileAccess: { mode: "off" as const, configRoot: "", warnings: [] },
+      snapshotRoot: "/tmp/nova-snapshots-test",
       authToken: "secret",
       version: "1.0.0",
       wsClient: {

--- a/tests/bootstrap/runtime-start.test.ts
+++ b/tests/bootstrap/runtime-start.test.ts
@@ -35,7 +35,8 @@ describe("runtime bootstrap", () => {
         relayVersion: "1.2.3",
         appOptionsPath: "/data/options.json",
         relayPort: 8791,
-        logLevel: "info"
+        logLevel: "info",
+        snapshotDir: "/tmp/nova-snapshots-test"
       }),
       readAppOptions: () => ({
         ha_llat: "app-llat"
@@ -75,7 +76,8 @@ describe("runtime bootstrap", () => {
           relayVersion: "1.2.3",
           appOptionsPath: "/data/options.json",
           relayPort: 8791,
-          logLevel: "info"
+          logLevel: "info",
+        snapshotDir: "/tmp/nova-snapshots-test"
         }),
         readAppOptions: () => ({})
       })
@@ -91,7 +93,8 @@ describe("runtime bootstrap", () => {
         relayVersion: "1.2.3",
         appOptionsPath: "/data/options.json",
         relayPort: 8791,
-        logLevel: "info"
+        logLevel: "info",
+        snapshotDir: "/tmp/nova-snapshots-test"
       }),
       readAppOptions: () => ({}),
       createWsClient: () => ({
@@ -150,7 +153,8 @@ describe("runtime bootstrap", () => {
         relayVersion: "1.2.3",
         appOptionsPath: "/data/options.json",
         relayPort: 8791,
-        logLevel: "info"
+        logLevel: "info",
+        snapshotDir: "/tmp/nova-snapshots-test"
       }),
       readAppOptions: () => ({}),
       createWsClient: () => ({
@@ -222,7 +226,8 @@ describe("runtime bootstrap", () => {
         relayVersion: "1.2.3",
         appOptionsPath: "/data/options.json",
         relayPort: 8791,
-        logLevel: "info"
+        logLevel: "info",
+        snapshotDir: "/tmp/nova-snapshots-test"
       }),
       readAppOptions: () => ({}),
       createWsClient: () => ({
@@ -256,7 +261,8 @@ describe("runtime bootstrap", () => {
         auth_source: "env_ha_llat",
         auth_capability: "full",
         file_access: "off",
-        config_root: null
+        config_root: null,
+        snapshot_dir: "/tmp/nova-snapshots-test"
       }
     });
     expect(warnLogs).toEqual([]);

--- a/tests/bootstrap/startup.test.ts
+++ b/tests/bootstrap/startup.test.ts
@@ -6,6 +6,7 @@ describe("startup bootstrap", () => {
   it("exports createApp factory and returns server + router", () => {
     const app = createApp({
       fileAccess: { mode: "off" as const, configRoot: "", warnings: [] },
+      snapshotRoot: "/tmp/nova-snapshots-test",
       authToken: "secret",
       version: "1.0.0",
       wsClient: {

--- a/tests/http/backups.test.ts
+++ b/tests/http/backups.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { gzipSync } from "node:zlib";
@@ -168,6 +168,32 @@ describe("backups handler", () => {
     expect(result.deleted).toHaveLength(1);
     expect(existsSync(join(root, "automations"))).toBe(true);
     expect(await call({ action: "list" })).toEqual([]);
+  });
+
+  it("refuses to operate through a symlinked category directory", async () => {
+    const outside = mkdtempSync(join(tmpdir(), "nova-backups-outside-"));
+    try {
+      symlinkSync(outside, join(root, "automations"));
+      await expectHttpError(
+        call({ action: "save", category: "automations", name: "escape", data: 1 }),
+        400,
+        "VALIDATION_ERROR"
+      );
+      writeFileSync(join(outside, "escape-20260714T120000000Z.json.gz"), gzipSync("{}"));
+      await expectHttpError(
+        call({ action: "load", file: "automations/escape-20260714T120000000Z.json.gz" }),
+        400,
+        "VALIDATION_ERROR"
+      );
+      await expectHttpError(
+        call({ action: "delete", file: "automations/escape-20260714T120000000Z.json.gz" }),
+        400,
+        "VALIDATION_ERROR"
+      );
+      expect(existsSync(join(outside, "escape-20260714T120000000Z.json.gz"))).toBe(true);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 
   it("never parses or mutates the stored payload", async () => {

--- a/tests/http/backups.test.ts
+++ b/tests/http/backups.test.ts
@@ -191,6 +191,22 @@ describe("backups handler", () => {
         "VALIDATION_ERROR"
       );
       expect(existsSync(join(outside, "escape-20260714T120000000Z.json.gz"))).toBe(true);
+
+      // Leaf symlink inside a REAL category dir must be refused too.
+      mkdirSync(join(root, "scenes"), { recursive: true });
+      writeFileSync(join(outside, "leaf.json.gz"), gzipSync("{}"));
+      symlinkSync(join(outside, "leaf.json.gz"), join(root, "scenes", "leak-20260714T120000000Z.json.gz"));
+      await expectHttpError(
+        call({ action: "load", file: "scenes/leak-20260714T120000000Z.json.gz" }),
+        400,
+        "VALIDATION_ERROR"
+      );
+      await expectHttpError(
+        call({ action: "delete", file: "scenes/leak-20260714T120000000Z.json.gz" }),
+        400,
+        "VALIDATION_ERROR"
+      );
+      expect(existsSync(join(outside, "leaf.json.gz"))).toBe(true);
     } finally {
       rmSync(outside, { recursive: true, force: true });
     }

--- a/tests/http/backups.test.ts
+++ b/tests/http/backups.test.ts
@@ -100,6 +100,8 @@ describe("backups handler", () => {
     await expectHttpError(call({ action: "save", category: "ok", name: "über", data: 1 }), 400, "VALIDATION_ERROR");
     await expectHttpError(call({ action: "save", category: "ok", name: "x" }), 400, "VALIDATION_ERROR");
     await expectHttpError(call({ action: "restore" }), 400, "VALIDATION_ERROR");
+    await expectHttpError(call({ action: "prune", max_age_days: 10_000_000 }), 400, "VALIDATION_ERROR");
+    await expectHttpError(call({ action: "prune", max_files: 100_000 }), 400, "VALIDATION_ERROR");
     await expectHttpError(call(null), 400, "VALIDATION_ERROR");
   });
 

--- a/tests/http/backups.test.ts
+++ b/tests/http/backups.test.ts
@@ -1,0 +1,181 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createBackupsHandler,
+  MAX_SNAPSHOT_FILES
+} from "../../nova/src/http/handlers/backups.js";
+import { HttpError } from "../../nova/src/http/errors.js";
+
+let root = "";
+let clockMs = Date.UTC(2026, 6, 14, 12, 0, 0, 0);
+
+async function call(body: unknown): Promise<unknown> {
+  return await createBackupsHandler({ snapshotRoot: root, now: () => clockMs })({ body } as never);
+}
+
+async function expectHttpError(promise: Promise<unknown>, status: number, code: string): Promise<void> {
+  await expect(promise).rejects.toSatisfy((error: unknown) => {
+    if (!(error instanceof HttpError)) return false;
+    expect(error.status).toBe(status);
+    expect(error.code).toBe(code);
+    return true;
+  });
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "nova-backups-root-"));
+  clockMs = Date.UTC(2026, 6, 14, 12, 0, 0, 0);
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("backups handler", () => {
+  it("saves and loads a snapshot roundtrip through gzip", async () => {
+    const data = { alias: "Porch light", triggers: [{ platform: "sun", event: "sunset" }] };
+    const saved = (await call({ action: "save", category: "automations", name: "porch", data })) as {
+      file: string;
+      bytes: number;
+      created_at: string;
+    };
+    expect(saved.file).toBe("automations/porch-20260714T120000000Z.json.gz");
+    expect(saved.created_at).toBe("2026-07-14T12:00:00.000Z");
+    expect(saved.bytes).toBeGreaterThan(0);
+
+    const loaded = (await call({ action: "load", file: saved.file })) as { data: unknown };
+    expect(loaded.data).toEqual(data);
+  });
+
+  it("lists snapshots newest first, optionally by category", async () => {
+    await call({ action: "save", category: "automations", name: "auto-one", data: 1 });
+    clockMs += 1000;
+    await call({ action: "save", category: "scenes", name: "movie", data: 2 });
+    clockMs += 1000;
+    await call({ action: "save", category: "automations", name: "auto-two", data: 3 });
+
+    const all = (await call({ action: "list" })) as Array<{ file: string; category: string }>;
+    expect(all.map((entry) => entry.category)).toEqual(["automations", "scenes", "automations"]);
+    expect(all[0]?.file).toContain("auto-two");
+
+    const scenes = (await call({ action: "list", category: "scenes" })) as Array<{ file: string }>;
+    expect(scenes).toHaveLength(1);
+    expect(scenes[0]?.file).toContain("movie");
+  });
+
+  it("returns an empty list when the store does not exist yet", async () => {
+    rmSync(root, { recursive: true, force: true });
+    expect(await call({ action: "list" })).toEqual([]);
+  });
+
+  it("deletes a snapshot and 404s on the second attempt", async () => {
+    const saved = (await call({ action: "save", category: "scenes", name: "movie", data: {} })) as {
+      file: string;
+    };
+    expect(await call({ action: "delete", file: saved.file })).toEqual({ deleted: true });
+    await expectHttpError(call({ action: "delete", file: saved.file }), 404, "SNAPSHOT_NOT_FOUND");
+    await expectHttpError(call({ action: "load", file: saved.file }), 404, "SNAPSHOT_NOT_FOUND");
+  });
+
+  it("rejects free-form file references before touching the filesystem", async () => {
+    for (const file of [
+      "../secrets.yaml",
+      "automations/../../etc/passwd",
+      "automations/porch.json.gz",
+      "automations/porch-20260714T120000000Z.json",
+      "AUTOMATIONS/porch-20260714T120000000Z.json.gz",
+      "a/b/c-20260714T120000000Z.json.gz"
+    ]) {
+      await expectHttpError(call({ action: "load", file }), 400, "VALIDATION_ERROR");
+    }
+  });
+
+  it("rejects invalid slugs, missing data, and unknown actions", async () => {
+    await expectHttpError(call({ action: "save", category: "Bad Cat", name: "x", data: 1 }), 400, "VALIDATION_ERROR");
+    await expectHttpError(call({ action: "save", category: "ok", name: "über", data: 1 }), 400, "VALIDATION_ERROR");
+    await expectHttpError(call({ action: "save", category: "ok", name: "x" }), 400, "VALIDATION_ERROR");
+    await expectHttpError(call({ action: "restore" }), 400, "VALIDATION_ERROR");
+    await expectHttpError(call(null), 400, "VALIDATION_ERROR");
+  });
+
+  it("refuses a save when the millisecond stamp collides", async () => {
+    await call({ action: "save", category: "scenes", name: "movie", data: 1 });
+    await expectHttpError(
+      call({ action: "save", category: "scenes", name: "movie", data: 2 }),
+      409,
+      "SNAPSHOT_EXISTS"
+    );
+  });
+
+  it("fails loud with a prune hint when the file-count cap is reached", async () => {
+    mkdirSync(join(root, "bulk"), { recursive: true });
+    for (let i = 0; i < MAX_SNAPSHOT_FILES; i += 1) {
+      writeFileSync(
+        join(root, "bulk", `auto-item${i}-20260101T${String(i).padStart(9, "0")}Z.json.gz`),
+        gzipSync("{}")
+      );
+    }
+    await expectHttpError(
+      call({ action: "save", category: "scenes", name: "movie", data: 1 }),
+      400,
+      "SNAPSHOT_STORE_FULL"
+    );
+  });
+
+  it("prunes auto snapshots by age and count while named ones survive", async () => {
+    // Named snapshot, 90 days old.
+    clockMs = Date.UTC(2026, 3, 15);
+    await call({ action: "save", category: "automations", name: "keeper", data: 1 });
+    // Auto snapshot, 90 days old — prunable by age.
+    clockMs += 1000;
+    await call({ action: "save", category: "automations", name: "auto-old", data: 2 });
+    // Fresh auto snapshots — 3 of them, count cap 2 removes the oldest.
+    clockMs = Date.UTC(2026, 6, 14, 9, 0, 0, 0);
+    await call({ action: "save", category: "automations", name: "auto-a", data: 3 });
+    clockMs += 1000;
+    await call({ action: "save", category: "automations", name: "auto-b", data: 4 });
+    clockMs += 1000;
+    await call({ action: "save", category: "automations", name: "auto-c", data: 5 });
+
+    clockMs = Date.UTC(2026, 6, 14, 12, 0, 0, 0);
+    const result = (await call({ action: "prune", max_age_days: 30, max_files: 2 })) as {
+      deleted: string[];
+    };
+    expect(result.deleted).toHaveLength(2);
+    expect(result.deleted.some((file) => file.includes("auto-old"))).toBe(true);
+    expect(result.deleted.some((file) => file.includes("auto-a"))).toBe(true);
+
+    const remaining = (await call({ action: "list" })) as Array<{ file: string }>;
+    const names = remaining.map((entry) => entry.file);
+    expect(names.some((file) => file.includes("keeper"))).toBe(true);
+    expect(names.some((file) => file.includes("auto-b"))).toBe(true);
+    expect(names.some((file) => file.includes("auto-c"))).toBe(true);
+    expect(names).toHaveLength(3);
+  });
+
+  it("prunes everything prunable when keep_named is false", async () => {
+    clockMs = Date.UTC(2026, 3, 15);
+    await call({ action: "save", category: "automations", name: "keeper", data: 1 });
+    clockMs = Date.UTC(2026, 6, 14, 12, 0, 0, 0);
+    const result = (await call({ action: "prune", max_age_days: 30, max_files: 10, keep_named: false })) as {
+      deleted: string[];
+    };
+    expect(result.deleted).toHaveLength(1);
+    expect(existsSync(join(root, "automations"))).toBe(true);
+    expect(await call({ action: "list" })).toEqual([]);
+  });
+
+  it("never parses or mutates the stored payload", async () => {
+    const opaque = { nested: { deeply: [1, "two", null, { ok: true }] } };
+    const saved = (await call({ action: "save", category: "yaml", name: "opaque", data: opaque })) as {
+      file: string;
+    };
+    const loaded = (await call({ action: "load", file: saved.file })) as { data: unknown };
+    expect(loaded.data).toEqual(opaque);
+  });
+});

--- a/tests/http/backups.test.ts
+++ b/tests/http/backups.test.ts
@@ -209,6 +209,10 @@ describe("backups handler", () => {
         "VALIDATION_ERROR"
       );
       expect(existsSync(join(outside, "leaf.json.gz"))).toBe(true);
+
+      // ... and the leaf symlink must not surface in list results either.
+      const listed = (await call({ action: "list", category: "scenes" })) as Array<{ file: string }>;
+      expect(listed.some((entry) => entry.file.includes("leak"))).toBe(false);
     } finally {
       rmSync(outside, { recursive: true, force: true });
     }

--- a/tests/security/auth.test.ts
+++ b/tests/security/auth.test.ts
@@ -51,7 +51,8 @@ describe("loadEnv", () => {
       relayVersion: "dev",
       appOptionsPath: "/data/options.json",
       relayPort: 9000,
-      logLevel: "debug"
+      logLevel: "debug",
+      snapshotDir: "/data/ha_nova_snapshots"
     });
   });
 
@@ -68,7 +69,8 @@ describe("loadEnv", () => {
       relayVersion: "dev",
       appOptionsPath: "/data/options.json",
       relayPort: 8791,
-      logLevel: "info"
+      logLevel: "info",
+      snapshotDir: "/data/ha_nova_snapshots"
     });
   });
 
@@ -85,7 +87,8 @@ describe("loadEnv", () => {
       relayVersion: "dev",
       appOptionsPath: "/data/options.json",
       relayPort: 8791,
-      logLevel: "info"
+      logLevel: "info",
+      snapshotDir: "/data/ha_nova_snapshots"
     });
   });
 


### PR DESCRIPTION
## What

Step 1 of [the config-snapshots spec](https://github.com/markusleben/ha-nova/blob/main/docs/work/2026-07-14-config-snapshots-spec.md) (masterplan-2026-h2 Wave 2): the relay's fifth route, a generic gzip'd blob store for KB-sized config snapshots.

## Design (charter-clean)

- **Fixed addressing, no free-form paths**: every file reference must match `<category>/<name>-<stamp>.json.gz` (validated before any filesystem call); `resolve()` containment as defense in depth (files-paths.ts pattern).
- **Actions**: save / load / list / delete / prune. Totals capped at 500 files / 50 MiB with a loud `SNAPSHOT_STORE_FULL` + prune hint; per-item ceiling is the server's existing 1 MiB raw body cap (per spec).
- **`auto-` name prefix** marks prunable snapshots; named ones survive `prune` unless `keep_named: false`. Injectable clock for deterministic tests.
- **Zero HA semantics**: the store never parses `data`; check-docs rule 5 now *verifies* that (no HA client imports in backups.ts) instead of banning the route name. LOC ceiling 2800 → 3200 with rationale.
- Storage: App data dir default (Supervised full backups sweep it); `SNAPSHOT_DIR` override for the standalone container. Relay version 0.4.1 → 0.5.0; `min_relay_version` deliberately stays 0.4.0 until skills adopt the endpoint (spec step 4).
- CLI: `ha-nova relay backups` passthrough (same flags as ws/files).

## Verification

- New `tests/http/backups.test.ts` (11 tests): gzip roundtrip, list order + category filter, missing-store list, delete 404, free-form-path rejection (traversal, case, depth), slug/action validation, ms-collision 409, count-cap failure, prune by age+count with `keep_named` both ways, opaque-payload integrity.
- Full `npm run typecheck`, targeted suites (124 tests incl. bootstrap wiring + env), `go build && go test ./cli`, `bash scripts/check-docs.sh` — all green; full `test:safe` via pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBmfxWsGK34rtzHfVTDG8Z