### PR TITLE
feat(relay): diagnosability — disconnect reasons, request logging, timing fix, server timeouts

### DIFF
--- a/docs/reference/bridge-architecture.md
+++ b/docs/reference/bridge-architecture.md
@@ -62,8 +62,11 @@ Response 200:
   "data": {
     "status": "ok",
     "ha_ws_connected": true,
-    "version": "0.2.5",
-    "uptime_s": 3600
+    "ha_ws_disconnect_reason": null,
+    "version": "0.5.0",
+    "uptime_s": 3600,
+    "file_access": "off",
+    "snapshots": { "files": 3, "bytes": 4096 }
   }
 }
 ```

--- a/nova/src/ha/ws-client.ts
+++ b/nova/src/ha/ws-client.ts
@@ -1,3 +1,4 @@
+import { HaSocketAuthError } from "./socket.js";
 import { TimeoutError, withTimeout } from "../shared/timeout.js";
 
 export type HaWsClientErrorCode =
@@ -369,12 +370,28 @@ function describeUpstreamCommandError(error: unknown): string | undefined {
 // numeric error payloads from home-assistant-js-websocket; map them to
 // readable transport messages.
 // haws transport codes 2 (invalid auth) and 6 (invalid auth callback) are the
-// token problems; everything else is reachability.
+// token problems — and so is HaSocketAuthError, which the real socket path
+// (createAuthenticatedHaSocket) throws on an auth_invalid handshake instead
+// of a numeric code. Walk the cause chain: haws wraps rejections.
 function classifyConnectFailure(error: unknown): "auth" | "network" {
-  const direct = typeof error === "number" ? error : undefined;
-  const payload = unwrapRejectionPayload(error);
-  const code = direct ?? (payload && typeof payload.code === "number" ? payload.code : undefined);
-  return code === 2 || code === 6 ? "auth" : "network";
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current !== undefined && current !== null; depth += 1) {
+    if (current instanceof HaSocketAuthError) {
+      return "auth";
+    }
+    const direct = typeof current === "number" ? current : undefined;
+    const payload = unwrapRejectionPayload(current);
+    const code =
+      direct ?? (payload && typeof payload.code === "number" ? payload.code : undefined);
+    if (code === 2 || code === 6) {
+      return "auth";
+    }
+    current =
+      current && typeof current === "object" && "cause" in current
+        ? (current as { cause?: unknown }).cause
+        : undefined;
+  }
+  return "network";
 }
 
 const HAWS_TRANSPORT_ERRORS: Record<number, string> = {

--- a/nova/src/ha/ws-client.ts
+++ b/nova/src/ha/ws-client.ts
@@ -28,6 +28,14 @@ export interface HaWsClient {
     options?: HaWsEventCollectionOptions
   ): Promise<HaWsEventCollection<T>>;
   isConnected(): boolean;
+  getConnectionStatus(): HaWsConnectionStatus;
+}
+
+export interface HaWsConnectionStatus {
+  connected: boolean;
+  // Why /health reports ha_ws_connected: false — the difference between "fix
+  // the token" and "HA is restarting" is the whole diagnosis.
+  disconnect_reason: "auth" | "network" | "never_connected" | null;
 }
 
 // Window mode budgets the ack separately from the collection window: the WS
@@ -80,6 +88,8 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
   // auto-reconnects and outlives HA outages, so `connection !== undefined`
   // would report connected while HA is down.
   let connected = false;
+  let everConnected = false;
+  let lastConnectFailure: "auth" | "network" | null = null;
 
   return {
     async sendMessage<T>(message: HaWsRequest): Promise<T> {
@@ -246,6 +256,18 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
     },
     isConnected(): boolean {
       return connected;
+    },
+    getConnectionStatus(): HaWsConnectionStatus {
+      if (connected) {
+        return { connected: true, disconnect_reason: null };
+      }
+      if (lastConnectFailure) {
+        return { connected: false, disconnect_reason: lastConnectFailure };
+      }
+      return {
+        connected: false,
+        disconnect_reason: everConnected ? "network" : "never_connected"
+      };
     }
   };
 
@@ -261,6 +283,8 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
     try {
       connection = await connectingPromise;
       connected = true;
+      everConnected = true;
+      lastConnectFailure = null;
       // The connection reconnects on its own; only the tracked flag flips so
       // /health stays truthful between requests without extra probes.
       // resetConnection() abandons rather than closes the old connection, so
@@ -278,6 +302,7 @@ export function createHaWsClient(options: HaWsClientOptions): HaWsClient {
       });
       return current;
     } catch (error) {
+      lastConnectFailure = classifyConnectFailure(error);
       throw new HaWsClientError(
         "UPSTREAM_WS_CONNECT_ERROR",
         "Failed to connect to Home Assistant WebSocket",
@@ -343,6 +368,15 @@ function describeUpstreamCommandError(error: unknown): string | undefined {
 // Connection-level rejections arrive as bare numeric codes or wrapped
 // numeric error payloads from home-assistant-js-websocket; map them to
 // readable transport messages.
+// haws transport codes 2 (invalid auth) and 6 (invalid auth callback) are the
+// token problems; everything else is reachability.
+function classifyConnectFailure(error: unknown): "auth" | "network" {
+  const direct = typeof error === "number" ? error : undefined;
+  const payload = unwrapRejectionPayload(error);
+  const code = direct ?? (payload && typeof payload.code === "number" ? payload.code : undefined);
+  return code === 2 || code === 6 ? "auth" : "network";
+}
+
 const HAWS_TRANSPORT_ERRORS: Record<number, string> = {
   1: "cannot connect to Home Assistant WebSocket",
   2: "invalid Home Assistant authentication",

--- a/nova/src/http/handlers/backups.ts
+++ b/nova/src/http/handlers/backups.ts
@@ -338,6 +338,16 @@ async function loadSnapshot(
   };
 }
 
+export async function summarizeSnapshotStore(
+  root: string
+): Promise<{ files: number; bytes: number }> {
+  const entries = await collectEntries(root);
+  return {
+    files: entries.length,
+    bytes: entries.reduce((sum, entry) => sum + entry.bytes, 0)
+  };
+}
+
 async function listSnapshots(root: string, category?: string): Promise<SnapshotEntry[]> {
   return await collectEntries(root, category);
 }

--- a/nova/src/http/handlers/health.ts
+++ b/nova/src/http/handlers/health.ts
@@ -1,33 +1,61 @@
+import type { HaWsConnectionStatus } from "../../ha/ws-client.js";
 import type { RouteHandler } from "../router.js";
+import { summarizeSnapshotStore } from "./backups.js";
 
 export interface HealthHandlerOptions {
   version: string;
   wsClient: {
     isConnected(): boolean;
+    getConnectionStatus?(): HaWsConnectionStatus;
   };
   startedAtMs: number;
+  fileAccessMode: string;
+  snapshotRoot: string;
   now?: () => number;
 }
 
 export interface HealthPayload {
   status: "ok";
   ha_ws_connected: boolean;
+  // Why the WS is down — "auth" (fix the token), "network" (HA unreachable /
+  // restarting), "never_connected" (no successful handshake since relay
+  // start), or null while connected. The onboarding skill keys its diagnosis
+  // on this instead of guessing.
+  ha_ws_disconnect_reason: "auth" | "network" | "never_connected" | null;
   version: string;
   uptime_s: number;
+  file_access: string;
+  snapshots: { files: number; bytes: number };
 }
 
 export function createHealthHandler(options: HealthHandlerOptions): RouteHandler {
   const now = options.now ?? (() => Date.now());
 
-  return () => {
+  return async () => {
     const uptimeMs = Math.max(0, now() - options.startedAtMs);
     const uptimeSeconds = Math.floor(uptimeMs / 1000);
 
+    const wsStatus: HaWsConnectionStatus = options.wsClient.getConnectionStatus
+      ? options.wsClient.getConnectionStatus()
+      : { connected: options.wsClient.isConnected(), disconnect_reason: null };
+
+    // Counting a ≤500-file store is cheap; a broken store must not take
+    // /health down with it — report zeros instead.
+    let snapshots = { files: 0, bytes: 0 };
+    try {
+      snapshots = await summarizeSnapshotStore(options.snapshotRoot);
+    } catch {
+      // deliberately swallowed: /health stays available
+    }
+
     const payload: HealthPayload = {
       status: "ok",
-      ha_ws_connected: options.wsClient.isConnected(),
+      ha_ws_connected: wsStatus.connected,
+      ha_ws_disconnect_reason: wsStatus.connected ? null : wsStatus.disconnect_reason,
       version: options.version,
-      uptime_s: uptimeSeconds
+      uptime_s: uptimeSeconds,
+      file_access: options.fileAccessMode,
+      snapshots
     };
 
     return payload;

--- a/nova/src/http/server.ts
+++ b/nova/src/http/server.ts
@@ -11,7 +11,17 @@ export interface HttpServerOptions {
   router: Router;
   maxJsonBodyBytes?: number;
   version?: string;
+  logger?: {
+    warn(message: string, context?: Record<string, unknown>): void;
+    error(message: string, context?: Record<string, unknown>): void;
+  };
 }
+
+// A client must send headers and body within these windows; a stalled or
+// drip-feeding connection is dropped instead of holding a socket forever.
+// Upstream HA calls are bounded at 10 s, so 30 s leaves generous margin.
+export const SERVER_REQUEST_TIMEOUT_MS = 30_000;
+export const SERVER_HEADERS_TIMEOUT_MS = 31_000;
 
 // Lets CLI callers of /ws and /core detect an outdated relay without an
 // extra /health round-trip; /health remains the full health signal.
@@ -20,13 +30,20 @@ export const RELAY_VERSION_HEADER = "x-ha-nova-relay-version";
 export function createHttpServer(options: HttpServerOptions): Server {
   const maxJsonBodyBytes = options.maxJsonBodyBytes ?? DEFAULT_MAX_JSON_BODY_BYTES;
 
-  return createServer(async (request, response) => {
+  const server = createServer(async (request, response) => {
     if (options.version) {
       response.setHeader(RELAY_VERSION_HEADER, options.version);
     }
     try {
       const authResult = authorizeRequest(request.headers.authorization, options.authToken);
       if (!authResult.ok) {
+        // Visible in the App log: repeated 401s are the operator's only signal
+        // for a misconfigured client or someone probing the port.
+        options.logger?.warn("Rejected unauthorized request", {
+          method: request.method ?? "GET",
+          path: toPathname(request.url),
+          remote: request.socket.remoteAddress ?? "unknown"
+        });
         writeJson(response, authResult.status, {
           ok: false,
           error: {
@@ -52,9 +69,22 @@ export function createHttpServer(options: HttpServerOptions): Server {
       });
     } catch (error) {
       const mapped = toErrorResponse(error);
+      if (mapped.status === 500) {
+        // The envelope stays generic on purpose; the App log carries the cause
+        // so an unexpected crash path is diagnosable.
+        options.logger?.error("Unhandled relay error", {
+          method: request.method ?? "GET",
+          path: toPathname(request.url),
+          error: error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+        });
+      }
       writeJson(response, mapped.status, mapped.body);
     }
   });
+
+  server.requestTimeout = SERVER_REQUEST_TIMEOUT_MS;
+  server.headersTimeout = SERVER_HEADERS_TIMEOUT_MS;
+  return server;
 }
 
 function toPathname(urlValue: string | undefined): string {

--- a/nova/src/index.ts
+++ b/nova/src/index.ts
@@ -3,6 +3,7 @@ import type { Server } from "node:http";
 import type { FileAccessConfig } from "./config/file-access.js";
 import type { CoreProxyRequest, CoreProxyResponse } from "./types/api.js";
 import type {
+  HaWsConnectionStatus,
   HaWsEventCollection,
   HaWsEventCollectionOptions,
   HaWsRequest,
@@ -20,11 +21,16 @@ export interface AppOptions {
   version: string;
   wsClient: {
     isConnected(): boolean;
+    getConnectionStatus?(): HaWsConnectionStatus;
     sendMessage(message: HaWsRequest): Promise<unknown>;
     collectMessageEvents(
       message: HaWsRequest,
       options?: HaWsEventCollectionOptions
     ): Promise<HaWsEventCollection<unknown>>;
+  };
+  logger?: {
+    warn(message: string, context?: Record<string, unknown>): void;
+    error(message: string, context?: Record<string, unknown>): void;
   };
   fileAccess: FileAccessConfig;
   snapshotRoot: string;
@@ -48,7 +54,9 @@ export function createApp(options: AppOptions): App {
   const healthOptions = {
     version: options.version,
     wsClient: options.wsClient,
-    startedAtMs
+    startedAtMs,
+    fileAccessMode: options.fileAccess.mode,
+    snapshotRoot: options.snapshotRoot
   } as const;
 
   router.register(
@@ -101,7 +109,8 @@ export function createApp(options: AppOptions): App {
   const server = createHttpServer({
     authToken: options.authToken,
     router,
-    version: options.version
+    version: options.version,
+    ...(options.logger ? { logger: options.logger } : {})
   });
 
   return {

--- a/nova/src/runtime/start.ts
+++ b/nova/src/runtime/start.ts
@@ -87,12 +87,14 @@ export function bootstrapRuntime(dependencies: RuntimeDependencies = {}): Runtim
     },
     (path: string) => probeConfigRoot(path)
   );
+  const serverLogger = dependencies.logger ?? createConsoleLogger(env.logLevel);
   const app = createApp({
     authToken: env.relayAuthToken,
     version: env.relayVersion,
     wsClient,
     fileAccess,
     snapshotRoot: env.snapshotDir,
+    logger: serverLogger,
     coreClient: {
       request: async (input: CoreProxyRequest): Promise<CoreProxyResponse> => coreClient.request(input)
     }
@@ -108,8 +110,8 @@ export function bootstrapRuntime(dependencies: RuntimeDependencies = {}): Runtim
 }
 
 export async function startRelay(dependencies: RuntimeDependencies = {}): Promise<StartRelayResult> {
-  const logger = dependencies.logger ?? createConsoleLogger();
   const runtime = bootstrapRuntime(dependencies);
+  const logger = dependencies.logger ?? createConsoleLogger(runtime.env.logLevel);
 
   logStartup(logger, runtime);
 
@@ -185,16 +187,35 @@ function buildTokenResolutionInput(env: EnvConfig): ResolveUpstreamTokenInput {
   return input;
 }
 
-function createConsoleLogger(): Logger {
+const LOG_LEVEL_ORDER: Record<LogLevel, number> = {
+  trace: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4
+};
+
+export function levelAtLeast(level: LogLevel, minimum: LogLevel): boolean {
+  return LOG_LEVEL_ORDER[level] >= LOG_LEVEL_ORDER[minimum];
+}
+
+// LOG_LEVEL finally has a consumer: lines below the configured minimum are
+// dropped. Startup/bootstrap errors always surface (error >= every minimum).
+export function createConsoleLogger(minimumLevel: LogLevel = "info"): Logger {
+  const emit = (level: LogLevel, message: string, context?: Record<string, unknown>) => {
+    if (levelAtLeast(level, minimumLevel)) {
+      logLine(level, message, context);
+    }
+  };
   return {
     info(message, context) {
-      logLine("info", message, context);
+      emit("info", message, context);
     },
     warn(message, context) {
-      logLine("warn", message, context);
+      emit("warn", message, context);
     },
     error(message, context) {
-      logLine("error", message, context);
+      emit("error", message, context);
     }
   };
 }

--- a/nova/src/security/auth.ts
+++ b/nova/src/security/auth.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 
 export interface AuthSuccess {
   ok: true;
@@ -43,12 +43,9 @@ function unauthorized(message: string): AuthFailure {
 }
 
 function constantTimeEqual(left: string, right: string): boolean {
-  const leftBuffer = Buffer.from(left);
-  const rightBuffer = Buffer.from(right);
-
-  if (leftBuffer.length !== rightBuffer.length) {
-    return false;
-  }
-
-  return timingSafeEqual(leftBuffer, rightBuffer);
+  // Hashing both sides first makes the comparison length-independent — the
+  // old early return on length mismatch leaked the token length via timing.
+  const leftDigest = createHash("sha256").update(left).digest();
+  const rightDigest = createHash("sha256").update(right).digest();
+  return timingSafeEqual(leftDigest, rightDigest);
 }

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -27,16 +27,18 @@ echo ""
 # The relay must stay small enough that a person can read it. The ceiling moved
 # from 2000 to 2800 across relay 0.4.0 (opt-in file transport: containment,
 # deny rules, code-execution boundary) and to 3200 across relay 0.5.0 (the
-# generic config-snapshot store, ~330 lines of validation, caps and prune).
+# generic config-snapshot store, ~330 lines of validation, caps and prune;
+# and to 3300 for the diagnosability wave: disconnect reasons, request
+# logging, server timeouts).
 # Growth here is security surface, and it is reviewed as such. The README's own
 # number is updated in the release-prep PR — README describes the STABLE
 # release, not main.
 echo "[1] Relay LOC (must stay readable in one sitting)"
 ACTUAL_LOC=$(find "$REPO_ROOT/nova/src" -name '*.ts' -exec cat {} + | wc -l | tr -d ' ')
-if (( ACTUAL_LOC >= 1000 && ACTUAL_LOC <= 3200 )); then
-  pass "src/ = ${ACTUAL_LOC} LOC (within 1000–3200 range)"
+if (( ACTUAL_LOC >= 1000 && ACTUAL_LOC <= 3300 )); then
+  pass "src/ = ${ACTUAL_LOC} LOC (within 1000–3300 range)"
 else
-  fail "src/ = ${ACTUAL_LOC} LOC — outside the 1000–3200 range. If this is real growth, justify it and update the README claim in the release-prep PR."
+  fail "src/ = ${ACTUAL_LOC} LOC — outside the 1000–3300 range. If this is real growth, justify it and update the README claim in the release-prep PR."
 fi
 
 # ── 2. Skill count ──

--- a/scripts/test/safe-core-files.json
+++ b/scripts/test/safe-core-files.json
@@ -22,6 +22,7 @@
   "tests/ha/ws-client.test.ts",
   "tests/hooks/session-start.test.ts",
   "tests/http/backups.test.ts",
+  "tests/http/server-limits.test.ts",
   "tests/http/core-proxy.test.ts",
   "tests/http/error-envelope.test.ts",
   "tests/http/files-access.test.ts",

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -27,7 +27,7 @@ If missing: `ha-nova setup`
    - `401/403`: relay auth token mismatch
    - `404`: endpoint/path mismatch
    - connect error / status `000`: relay unreachable
-   - `ha_ws_connected=false`: relay is reachable but not proven ready yet; confirm with `/ws` or `ha-nova doctor` before blaming LLAT
+   - `ha_ws_connected=false`: read `ha_ws_disconnect_reason` from the same health payload — `auth` means the HA token (`ha_llat`) is invalid/revoked (recreate it in the HA profile, update the App option, restart the App); `network` means HA is unreachable or restarting (wait/verify HA is up — NOT a token problem); `never_connected` means the relay started but never reached HA (check `HA_URL` and the network path). Older relays omit the field — then confirm with `/ws` or `ha-nova doctor` before blaming LLAT
    - `/ws` proves `LLAT is required`: Home Assistant access token (`ha_llat`) is missing or wrong
 3. Return one concrete remediation step.
 

--- a/tests/bootstrap/app-wiring.test.ts
+++ b/tests/bootstrap/app-wiring.test.ts
@@ -58,8 +58,11 @@ describe("app wiring", () => {
       data: {
         status: "ok",
         ha_ws_connected: true,
+        ha_ws_disconnect_reason: null,
         version: "1.0.0",
-        uptime_s: 4
+        uptime_s: 4,
+        file_access: "off",
+        snapshots: { files: 0, bytes: 0 }
       }
     });
 

--- a/tests/bootstrap/runtime-start.test.ts
+++ b/tests/bootstrap/runtime-start.test.ts
@@ -45,6 +45,7 @@ describe("runtime bootstrap", () => {
         seenSource = input.upstreamAuth.source;
         return {
           isConnected: () => true,
+        getConnectionStatus: () => ({ connected: true, disconnect_reason: null }) as const,
           sendMessage: async <T>() => ({ ok: true } as T),
           collectMessageEvents: async <T>() => ({ events: [] as T[], truncated: false })
         };
@@ -99,6 +100,7 @@ describe("runtime bootstrap", () => {
       readAppOptions: () => ({}),
       createWsClient: () => ({
         isConnected: () => true,
+        getConnectionStatus: () => ({ connected: true, disconnect_reason: null }) as const,
         sendMessage: async <T>() => ({ type: "pong" } as T),
         collectMessageEvents: async <T>() => ({ events: [] as T[], truncated: false })
       })
@@ -117,8 +119,11 @@ describe("runtime bootstrap", () => {
       data: {
         status: "ok",
         ha_ws_connected: true,
+        ha_ws_disconnect_reason: null,
         version: "1.2.3",
-        uptime_s: expect.any(Number)
+        uptime_s: expect.any(Number),
+        file_access: "off",
+        snapshots: { files: 0, bytes: 0 }
       }
     });
 
@@ -159,6 +164,7 @@ describe("runtime bootstrap", () => {
       readAppOptions: () => ({}),
       createWsClient: () => ({
         isConnected: () => true,
+        getConnectionStatus: () => ({ connected: true, disconnect_reason: null }) as const,
         sendMessage: async <T>() => ({ type: "pong" } as T),
         collectMessageEvents: async <T>() => ({ events: [] as T[], truncated: false })
       }),
@@ -232,6 +238,7 @@ describe("runtime bootstrap", () => {
       readAppOptions: () => ({}),
       createWsClient: () => ({
         isConnected: () => true,
+        getConnectionStatus: () => ({ connected: true, disconnect_reason: null }) as const,
         sendMessage: async <T>() => ({ type: "pong" } as T),
         collectMessageEvents: async <T>() => ({ events: [] as T[], truncated: false })
       }),

--- a/tests/ha/ws-client.test.ts
+++ b/tests/ha/ws-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { HaWsClientError, createHaWsClient } from "../../nova/src/ha/ws-client.js";
+import { HaSocketAuthError } from "../../nova/src/ha/socket.js";
 
 describe("ha ws client", () => {
   it("connects once and reuses the same connection for multiple requests", async () => {
@@ -467,5 +468,50 @@ describe("ha ws client wrapped connection-loss rejections", () => {
       message: "Something odd"
     } satisfies Partial<HaWsClientError>);
     expect(client.isConnected()).toBe(false);
+  });
+});
+
+describe("connection status classification", () => {
+  it("reports never_connected before any attempt succeeds or fails", () => {
+    const client = createHaWsClient({
+      createConnection: async () => {
+        throw new Error("unused");
+      }
+    });
+    expect(client.getConnectionStatus()).toEqual({
+      connected: false,
+      disconnect_reason: "never_connected"
+    });
+  });
+
+  it("classifies HaSocketAuthError (the real socket path) as auth", async () => {
+    const client = createHaWsClient({
+      createConnection: async () => {
+        throw new HaSocketAuthError("HA rejected the long-lived access token");
+      }
+    });
+    await expect(client.sendMessage({ type: "ping" })).rejects.toBeInstanceOf(HaWsClientError);
+    expect(client.getConnectionStatus()).toEqual({ connected: false, disconnect_reason: "auth" });
+  });
+
+  it("classifies wrapped haws code 2 as auth and other failures as network", async () => {
+    const authClient = createHaWsClient({
+      createConnection: async () => {
+        throw Object.assign(new Error("wrapped"), { cause: 2 });
+      }
+    });
+    await expect(authClient.sendMessage({ type: "ping" })).rejects.toBeInstanceOf(HaWsClientError);
+    expect(authClient.getConnectionStatus().disconnect_reason).toBe("auth");
+
+    const networkClient = createHaWsClient({
+      createConnection: async () => {
+        throw new Error("ECONNREFUSED");
+      }
+    });
+    await expect(networkClient.sendMessage({ type: "ping" })).rejects.toBeInstanceOf(HaWsClientError);
+    expect(networkClient.getConnectionStatus()).toEqual({
+      connected: false,
+      disconnect_reason: "network"
+    });
   });
 });

--- a/tests/http/health.test.ts
+++ b/tests/http/health.test.ts
@@ -1,3 +1,8 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createHealthHandler } from "../../nova/src/http/handlers/health.js";
@@ -36,6 +41,8 @@ describe("health endpoint", () => {
         version: "1.0.0",
         wsClient: { isConnected: () => true },
         startedAtMs: 1_000,
+        fileAccessMode: "off",
+        snapshotRoot: "/nonexistent-snapshot-root-for-tests",
         now: () => 4_500
       })
     );
@@ -53,10 +60,58 @@ describe("health endpoint", () => {
       data: {
         status: "ok",
         ha_ws_connected: true,
+        ha_ws_disconnect_reason: null,
         version: "1.0.0",
-        uptime_s: 3
+        uptime_s: 3,
+        file_access: "off",
+        snapshots: { files: 0, bytes: 0 }
       }
     });
+  });
+
+  it("surfaces the disconnect reason and snapshot counters", async () => {
+    const snapshotRoot = mkdtempSync(join(tmpdir(), "nova-health-snapshots-"));
+    mkdirSync(join(snapshotRoot, "scenes"), { recursive: true });
+    writeFileSync(join(snapshotRoot, "scenes", "movie-20260714T120000000Z.json.gz"), gzipSync("{}"));
+
+    const router = createRouter();
+    router.register(
+      "GET",
+      "/health",
+      createHealthHandler({
+        version: "1.0.0",
+        wsClient: {
+          isConnected: () => false,
+          getConnectionStatus: () => ({ connected: false, disconnect_reason: "auth" })
+        },
+        startedAtMs: 1_000,
+        fileAccessMode: "readwrite",
+        snapshotRoot,
+        now: () => 4_500
+      })
+    );
+
+    try {
+      const { baseUrl } = await startServer(servers, router);
+      const response = await fetch(`${baseUrl}/health`, {
+        headers: { authorization: `Bearer ${TEST_AUTH_TOKEN}` }
+      });
+      const payload = (await response.json()) as {
+        data: {
+          ha_ws_connected: boolean;
+          ha_ws_disconnect_reason: string | null;
+          file_access: string;
+          snapshots: { files: number; bytes: number };
+        };
+      };
+      expect(payload.data.ha_ws_connected).toBe(false);
+      expect(payload.data.ha_ws_disconnect_reason).toBe("auth");
+      expect(payload.data.file_access).toBe("readwrite");
+      expect(payload.data.snapshots.files).toBe(1);
+      expect(payload.data.snapshots.bytes).toBeGreaterThan(0);
+    } finally {
+      rmSync(snapshotRoot, { recursive: true, force: true });
+    }
   });
 
   it("returns 401 without token", async () => {
@@ -68,6 +123,8 @@ describe("health endpoint", () => {
         version: "1.0.0",
         wsClient: { isConnected: () => false },
         startedAtMs: 1_000,
+        fileAccessMode: "off",
+        snapshotRoot: "/nonexistent-snapshot-root-for-tests",
         now: () => 2_000
       })
     );

--- a/tests/http/server-limits.test.ts
+++ b/tests/http/server-limits.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createRouter } from "../../nova/src/http/router.js";
+import {
+  createHttpServer,
+  SERVER_HEADERS_TIMEOUT_MS,
+  SERVER_REQUEST_TIMEOUT_MS
+} from "../../nova/src/http/server.js";
+import { levelAtLeast } from "../../nova/src/runtime/start.js";
+
+const TEST_AUTH_TOKEN = "secret";
+
+type LoggedLine = { level: string; message: string; context?: Record<string, unknown> };
+
+describe("http server limits and logging", () => {
+  const servers: Array<ReturnType<typeof createHttpServer>> = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.map(
+        (server) =>
+          new Promise<void>((resolve) => {
+            server.close(() => resolve());
+          })
+      )
+    );
+    servers.length = 0;
+  });
+
+  async function start(options: {
+    maxJsonBodyBytes?: number;
+    logged?: LoggedLine[];
+    handler?: () => unknown;
+  }): Promise<string> {
+    const router = createRouter();
+    router.register("POST", "/echo", options.handler ?? (({ body }) => body));
+    const logged = options.logged;
+    const server = createHttpServer({
+      authToken: TEST_AUTH_TOKEN,
+      router,
+      ...(options.maxJsonBodyBytes ? { maxJsonBodyBytes: options.maxJsonBodyBytes } : {}),
+      ...(logged
+        ? {
+            logger: {
+              warn: (message: string, context?: Record<string, unknown>) =>
+                logged.push({ level: "warn", message, ...(context ? { context } : {}) }),
+              error: (message: string, context?: Record<string, unknown>) =>
+                logged.push({ level: "error", message, ...(context ? { context } : {}) })
+            }
+          }
+        : {})
+    });
+    servers.push(server);
+    const port = await new Promise<number>((resolve, reject) => {
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          reject(new Error("no tcp address"));
+          return;
+        }
+        resolve(address.port);
+      });
+      server.on("error", reject);
+    });
+    return `http://127.0.0.1:${port}`;
+  }
+
+  it("rejects an oversized body with 413 before dispatch", async () => {
+    const baseUrl = await start({ maxJsonBodyBytes: 64 });
+    const response = await fetch(`${baseUrl}/echo`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ filler: "x".repeat(256) })
+    });
+    expect(response.status).toBe(413);
+    const payload = (await response.json()) as { ok: boolean; error: { code: string } };
+    expect(payload.ok).toBe(false);
+    expect(payload.error.code).toBe("PAYLOAD_TOO_LARGE");
+  });
+
+  it("logs rejected 401s with method, path, and remote", async () => {
+    const logged: LoggedLine[] = [];
+    const baseUrl = await start({ logged });
+    const response = await fetch(`${baseUrl}/echo`, {
+      method: "POST",
+      headers: { authorization: "Bearer wrong" },
+      body: "{}"
+    });
+    expect(response.status).toBe(401);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]?.level).toBe("warn");
+    expect(logged[0]?.context).toMatchObject({ method: "POST", path: "/echo" });
+    expect(logged[0]?.context?.remote).toBeTruthy();
+  });
+
+  it("logs the cause of an unhandled 500 while keeping the envelope generic", async () => {
+    const logged: LoggedLine[] = [];
+    const baseUrl = await start({
+      logged,
+      handler: () => {
+        throw new TypeError("boom from the handler");
+      }
+    });
+    const response = await fetch(`${baseUrl}/echo`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+        "content-type": "application/json"
+      },
+      body: "{}"
+    });
+    expect(response.status).toBe(500);
+    const payload = (await response.json()) as { error: { code: string; message: string } };
+    expect(payload.error.code).toBe("INTERNAL_ERROR");
+    expect(payload.error.message).toBe("Internal server error");
+    expect(logged).toHaveLength(1);
+    expect(logged[0]?.level).toBe("error");
+    expect(logged[0]?.context?.error).toContain("boom from the handler");
+  });
+
+  it("sets explicit request and headers timeouts", async () => {
+    const router = createRouter();
+    const server = createHttpServer({ authToken: TEST_AUTH_TOKEN, router });
+    servers.push(server);
+    expect(server.requestTimeout).toBe(SERVER_REQUEST_TIMEOUT_MS);
+    expect(server.headersTimeout).toBe(SERVER_HEADERS_TIMEOUT_MS);
+  });
+
+  it("orders log levels for the LOG_LEVEL filter", () => {
+    expect(levelAtLeast("error", "info")).toBe(true);
+    expect(levelAtLeast("info", "info")).toBe(true);
+    expect(levelAtLeast("debug", "info")).toBe(false);
+    expect(levelAtLeast("trace", "warn")).toBe(false);
+    expect(levelAtLeast("warn", "trace")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Wave 5 of [masterplan-2026-h2](https://github.com/markusleben/ha-nova/blob/main/docs/work/masterplan-2026-h2.md) — the diagnosability half of the Relay 0.5.0 train (joins the snapshot store, #348).

## Changes

- **`/health` answers WHY**: new `ha_ws_disconnect_reason` — `auth` (haws transport codes 2/6 on connect: fix the token) vs `network` (HA unreachable/restarting) vs `never_connected` (URL/network path since relay start). Plus `file_access` mode and `snapshots {files, bytes}` counters — a read-only mount or a filling store is visible without App-log digging. `skills/onboarding` keys its failure classification on the new field (graceful wording for older relays); bridge-architecture payload doc updated.
- **`LOG_LEVEL` finally consumed**: the console logger drops lines below the configured minimum (was validated-but-dead since 0.1).
- **Request logging**: 401s log method/path/remote (the operator's only probing signal); unhandled 500s log their cause while the envelope stays generic (`errors.ts` previously swallowed it).
- **Timing-leak fix**: `constantTimeEqual` compares sha256 digests — the early length-mismatch return leaked token length.
- **Server timeouts**: explicit `requestTimeout`/`headersTimeout` (30/31 s) bound stalled/drip-feeding connections.
- **Tests**: the previously untested 413 path, 401/500 logging, timeout values, log-level ordering, new health fields (124 targeted tests green). LOC ceiling 3200 → 3300 with rationale.

`nova/config.yaml` stays 0.5.0 — same release train, no floor bump.

## Verification

- Full `npm run typecheck`, `npx vitest run` (787 tests), `go build`, `bash scripts/check-docs.sh` — green; full `test:safe` via pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBmfxWsGK34rtzHfVTDG8Z