### PR TITLE
feat(skills): add integration setup flow

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -21,7 +21,7 @@ Active doc ownership lives in `docs/reference/documentation-governance.md`.
 Shipped and current:
 1. Relay: `GET /health`, `POST /ws`, `POST /core`, `POST /files` (opt-in, default off); App + standalone container from one codebase
 2. Go CLI: install, setup wizard, doctor, update (incl. guided relay update), uninstall (incl. guided server-side teardown), relay proxy
-3. Context skill `ha-nova` plus 28 task skills, flat under `skills/` — the dispatch table in `skills/ha-nova/SKILL.md` is the authoritative inventory
+3. Context skill `ha-nova` plus 29 task skills, flat under `skills/` — the dispatch table in `skills/ha-nova/SKILL.md` is the authoritative inventory
 4. Shared references under `skills/ha-nova/` (relay API contract, output rules, write safety, batch safety, schemas, agent templates)
 
 ## Tech Stack

--- a/cli/client_hermes.go
+++ b/cli/client_hermes.go
@@ -27,6 +27,7 @@ var hermesRequiredSkillDirs = []string{
 	"ha-nova-health",
 	"ha-nova-helper",
 	"ha-nova-history",
+	"ha-nova-integration-setup",
 	"ha-nova-maintenance",
 	"ha-nova-media",
 	"ha-nova-mqtt",

--- a/docs/reference/ha-api-matrix.md
+++ b/docs/reference/ha-api-matrix.md
@@ -29,6 +29,9 @@ Which HA operations require REST, WS, or filesystem?
 | `/api/config/script/config/{id}` | POST | Create/update script |
 | `/api/config/script/config/{id}` | DELETE | Delete script |
 | `/api/config/config_entries/entry/{id}/reload` | POST | Reload config entry |
+| `/api/config/config_entries/flow_handlers` | GET | List config-flow handler domains |
+| `/api/config/config_entries/flow` | POST | Start an integration/helper config flow |
+| `/api/config/config_entries/flow/{flow_id}` | GET / POST / DELETE | Read, submit, or cancel one config flow |
 
 **Auth header:** `Authorization: Bearer {LONG_LIVED_TOKEN}`
 
@@ -73,13 +76,20 @@ Which HA operations require REST, WS, or filesystem?
 | Transport | Command / Path | Purpose |
 |-----------|----------------|---------|
 | WS | `config_entries/get` | Retrieve config-entry metadata |
+| WS | `manifest/list` | Map integration domains to manifest names and config-flow capability |
+| WS | `config_entries/flow/progress` | Retrieve in-progress flows, including `reauth` |
+| `/core` | `GET /api/config/config_entries/flow_handlers` | List available config-flow handlers |
 | `/core` | `POST /api/config/config_entries/flow` | Start flow |
+| `/core` | `GET /api/config/config_entries/flow/{flow_id}` | Read current flow step |
 | `/core` | `POST /api/config/config_entries/flow/{flow_id}` | Submit flow step |
+| `/core` | `DELETE /api/config/config_entries/flow/{flow_id}` | Cancel an unfinished flow |
 | `/core` | `POST /api/config/config_entries/options/flow` | Start options flow for an existing entry |
 | `/core` | `POST /api/config/config_entries/options/flow/{flow_id}` | Submit options-flow step |
 | `/core` | `DELETE /api/config/config_entries/entry/{entry_id}` | Delete config entry |
 
 Observed locally on a real HA instance on 2026-03-19: raw WS `config_entries/flow` did not succeed in this session; relay `/core` returned the expected config-flow responses.
+
+**Integration flow ownership:** `ha-nova:integration-setup` owns integration add and pending `reauth` continuation; it uses the live response schema and hands secrets/external steps to the HA UI.
 
 **Helper-owned config-entry domains:** utility_meter, derivative, integration, min_max, threshold, tod, statistics, group, history_stats, template
 `group` is menu-driven; the live-proven end-to-end subtype is `sensor`, and other subtypes must stay anchored to the live step schema instead of guessed fields.

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-HA NOVA uses a flat skill layout with one context skill and 28 independent sub-skills under `skills/`.
+HA NOVA uses a flat skill layout with one context skill and 29 independent sub-skills under `skills/`.
 
 The repo skill tree is the single source of truth. Client installers adapt that same tree to each client's packaging rules:
 - Claude: plugin marketplace payload
@@ -31,6 +31,7 @@ skills/
   read/SKILL.md                         (ha-nova:read — automation/script list/get/trace)
   write/SKILL.md                        (ha-nova:write — automation/script create/update/delete)
   helper/SKILL.md                       (ha-nova:helper — helper CRUD: list/read/create/update/delete)
+  integration-setup/SKILL.md            (ha-nova:integration-setup — add integrations and continue pending reauth flows)
   dashboard/SKILL.md                    (ha-nova:dashboard — storage dashboards, Lovelace resources, card operations)
   scene/SKILL.md                        (ha-nova:scene — storage-scene list/read/create/update/delete)
   organize/SKILL.md                     (ha-nova:organize — areas/floors/labels/categories/entity+device metadata)
@@ -99,6 +100,7 @@ Current mapping:
 | read | inline | 1-2 calls, direct output |
 | write | **agents** | 5-7 calls, entity resolution fallback, singular/plural normalization, domain reload |
 | helper | inline | response-driven relay flows, direct preview/confirm loop, no agent-only normalization requirement |
+| integration-setup | inline | response-driven config flows with direct preview/confirm and HA UI handoff for secrets/external steps |
 | dashboard | inline | read → merge → preview → full-save → readback verify, all user-facing |
 | scene | inline | 2-4 calls, flat entities payload, read → merge → preview → full-save → readback verify |
 | organize | inline | field-level registry mutations with direct preview/readback |
@@ -277,6 +279,17 @@ Rules:
 - always use a bounded event window
 - resolve ambiguous calendar names before querying events
 - no event create/update/delete actions
+
+## Integration Setup Architecture
+
+`ha-nova:integration-setup` owns UI-configurable integration add and pending reauthentication flows:
+- add starts through REST `POST /api/config/config_entries/flow` after resolving an exact handler from `/api/config/config_entries/flow_handlers`
+- reauthentication continues an existing `context.source == "reauth"` flow discovered through WS `config_entries/flow/progress`; it never synthesizes a reauth flow
+- menu/form steps use only the live response schema and require a preview-bound confirmation before each submit
+- credential-bearing, external/OAuth, or progress add steps started through the Relay are canceled and restarted in the Home Assistant UI; user-started flows are omitted from `config_entries/flow/progress`, and the Relay cannot supply the frontend-origin header
+- credential-bearing, external/OAuth, or progress steps on pre-existing reauth flows hand off to the matching Home Assistant UI card; secrets never enter chat and the reauth flow stays preserved
+- config-entry existence/state is primary verification evidence; linked devices/entities are secondary
+- agent-created canceled add flows are deleted; Home Assistant-created reauth flows are preserved
 
 ## Review Architecture
 
@@ -487,9 +500,11 @@ Scope → Bootstrap (once per session) → Relay Contract → [domain] → Flow 
 - **Output Format** — first line starts with ``Apply `skills/ha-nova/output-rules.md` `` ; then what the user receives
 - **Safety** — risk mitigations, confirmation rules, relay-only constraint
 
-**Required for config-persisting skills** (write, helper):
+**Required for behavior-config-persisting skills** (write, helper):
 - **Post-Write Review** — mandatory inline review phase after every create/update/delete (a Flow phase, not a separate H2)
 - **References** — links to schema docs, relay API, review checks
+
+`integration-setup` persists config entries through Home Assistant-owned flows. It verifies the resulting config entry instead of applying automation/helper quality checks.
 
 **Optional:**
 - **Error Handling** — error classification + remediation (recommended for external calls); when present it sits directly before Output Format
@@ -531,7 +546,7 @@ Read-only sub-skills open `## Safety` with this block instead:
 
 Skill-specific safety bullets follow the core block; bullets that merely restate a core line are removed, domain nuances (confirmation tiering, no-revert notes, session-cleanup rules) stay.
 
-A skill may declare an explicit, named exception to a single core bullet directly below the core block — it must reference the core rule it narrows ("Declared exception to the core ... rule above") so a bare agent never sees two contradicting instructions. Current declared exceptions: `todo` item removes (`todo.remove_item`, `todo.remove_completed_items`) stay at natural preview confirmation; list deletion keeps the typed token.
+A skill may declare an explicit, named exception to a single core bullet directly below the core block — it must reference the core rule it narrows ("Declared exception to the core ... rule above") so a bare agent never sees two contradicting instructions. Current declared exceptions: `todo` item removes (`todo.remove_item`, `todo.remove_completed_items`) stay at natural preview confirmation while list deletion keeps the typed token; `integration-setup` may delete only an unfinished add flow that it started when a credential, external/OAuth, or progress step requires a UI restart.
 
 ## Post-Write Review Standard
 
@@ -572,8 +587,8 @@ When creating a new skill under `skills/{name}/SKILL.md`:
 6. `docs/reference/skill-architecture.md` — add to skill tree + add Architecture section
 7. `docs/reference/skill-architecture.md` — add to Agent vs Inline table
 8. `scripts/onboarding/install-local-skills.sh` — verify dynamic discovery picks up new skill
-9. `README.md` / `PROJECT.md` — add skill to overview table/list
-10. `version.json` — bump patch version
+9. `PROJECT.md` — update the active inventory; defer `README.md` feature claims to the release-prep PR
+10. `version.json` — bump only in the release-prep PR that publishes the skill
 11. For file-based clients, re-run `npm run dev:install:<client>-skill` and start a new session. Use `npm run dev:sync` only when you need the Claude cache sync helper or already have a repo-local install to refresh.
 
 ## Review Check Single Source of Truth

--- a/docs/work/2026-07-15-wave-4-coverage-spec.md
+++ b/docs/work/2026-07-15-wave-4-coverage-spec.md
@@ -1,0 +1,48 @@
+# Wave 4 Coverage Spec
+
+Status: active
+Date: 2026-07-15
+Sequencing SSOT: `docs/work/masterplan-2026-h2.md` → Wave 4
+
+## Goal
+
+Close the remaining high-value skill coverage gaps without adding Relay business logic.
+
+## Delivery lanes
+
+1. `integration-setup`
+   - Add UI-configurable integrations through `/api/config/config_entries/flow`.
+   - Continue existing `reauth` flows discovered through `config_entries/flow/progress`.
+   - Reuse the response-driven menu/form loop proven by `helper` Family 2.
+   - Never collect passwords, PINs, OAuth grants, access/API keys, tokens, or private key material in chat. Relay-started add flows that reach credential, external/OAuth, or progress steps restart in the Home Assistant UI; user-started flows are omitted from the pending-flow feed, and the Relay cannot provide the frontend-origin header.
+   - Verify add/reauth at the config-entry layer.
+2. Calendar writes
+   - Create through `calendar.create_event`.
+   - Update/delete through `calendar/event/update|delete` WebSocket commands; Home Assistant 2026.7 does not expose update/delete as calendar services.
+   - Gate every operation with `supported_features`, preview/confirm, exact event identity, recurrence-scope handling, and read-back verification.
+3. Runtime event/security coverage
+   - Move custom event firing and webhook triggering from experimental fallback to `service-call`; both are runtime actions that can execute automations.
+   - Keep listener-impact scanning, payload preview, bounded verification, and webhook-ID secrecy.
+   - Add explicit alarm modes, lock/open capability gates, and secret-code handling. Codes never enter chat; code-required actions finish in the Home Assistant UI.
+
+## PR boundaries
+
+- PR A: new `integration-setup` skill, dispatch/inventory/docs/contracts, fallback ownership flip.
+- PR B: calendar create/update/delete, architecture/contracts.
+- PR C: event/webhook ownership plus alarm/lock guidance, architecture/contracts.
+
+Each PR completes the repository PR merge checklist independently. No release/version bump or README feature claim lands in Wave 4; release-bound truth stays deferred to release prep.
+
+## Research basis
+
+- Home Assistant config flows are response-driven data-entry flows with form, menu, external, progress, create-entry, and abort results.
+- The current frontend starts/fetches/submits/deletes config flows through `/api/config/config_entries/flow`, lists handlers through `/flow_handlers`, and discovers pending flows through WS `config_entries/flow/progress`.
+- Current Home Assistant Core registers calendar create as a service and calendar update/delete as feature-gated WebSocket commands.
+- Webhook IDs are authentication secrets; a webhook is owned by one automation and should remain local-only unless remote access is required.
+
+## Acceptance
+
+- Dedicated contract tests pin routing, transport, capability gates, confirmation binding, secret handling, and verification.
+- Dynamic installers discover the new skill without installer-specific logic.
+- `npm run verify` and documentation checks pass.
+- Every PR receives a real clean Codex result on its final SHA, all threads are resolved, and the merge uses squash/delete-branch only after the mandatory checklist is complete.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -42,14 +42,14 @@ else
 fi
 
 # ── 2. Skill count ──
-# Active skill inventory expects 29 top-level skill directories
-# (context skill + 28 sub-skills; yaml-config/assist/admin/external-sources added 2026-07-11)
-echo "[2] Skill directory count (current inventory expects 29)"
+# Active skill inventory expects 30 top-level skill directories
+# (context skill + 29 sub-skills; integration-setup added 2026-07-15)
+echo "[2] Skill directory count (current inventory expects 30)"
 SKILL_COUNT=$(find "$REPO_ROOT/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
-if (( SKILL_COUNT == 29 )); then
+if (( SKILL_COUNT == 30 )); then
   pass "skills/ has ${SKILL_COUNT} directories"
 else
-  fail "skills/ has ${SKILL_COUNT} directories — active docs/contracts expect 29. Update README and architecture docs."
+  fail "skills/ has ${SKILL_COUNT} directories — active docs/contracts expect 30. Update PROJECT and architecture docs; update README only in release prep."
 fi
 
 # ── 2b. One relay codebase, two distributions ──

--- a/scripts/test/safe-core-files.json
+++ b/scripts/test/safe-core-files.json
@@ -45,6 +45,7 @@
   "tests/skills/ha-safety-contract.test.ts",
   "tests/skills/health-calendar-contract.test.ts",
   "tests/skills/helper-contract.test.ts",
+  "tests/skills/integration-setup-contract.test.ts",
   "tests/skills/maintenance-contract.test.ts",
   "tests/skills/output-design-contract.test.ts",
   "tests/skills/review-contract.test.ts",

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -74,7 +74,7 @@ For every Relay-Ready call in this skill:
 | Other Config-Entry Helpers | Relay-Ready | this skill |
 | Statistics repair / Purge / Entity registry remove | Covered | maintenance |
 | Device config-entry detach | Relay-Ready | this skill |
-| Integration onboarding (add / re-auth an integration via config flow) | Relay-Ready | this skill |
+| Integration onboarding (add / re-auth an integration via config flow) | Covered | integration-setup |
 | Firing custom events / triggering webhooks | Relay-Ready | this skill |
 | Event Subscriptions | Roadmap Phase 1c | -- |
 | Backups (status, create, inspect, delete) | Covered | backup |
@@ -189,14 +189,6 @@ ha-nova relay ws --data-file <payload-file>
 ```
 
 **Risks:** Device detach depends on integration support (`supports_remove_device`) and can sever the current device/config-entry relationship. Preview impact first.
-
-### Integration Onboarding -- RELAY-READY
-
-Add a new integration or re-authenticate an existing one via the config-flow API — the same flow endpoints as the config-entry helper section above (`POST /api/config/config_entries/flow` to start, then `GET`/`POST`/`DELETE .../flow/{flow_id}` for a specific flow). Discover pending flows, including re-auth prompts, via WS `config_entries/flow/progress` — the collection path itself is POST-only, a GET on it returns 405.
-
-**Search:** `home assistant config_entries flow add integration api 2026`
-
-**Risks:** Flows are multi-step and integration-specific (discovery confirmations, OAuth handoffs that must finish in the HA UI). Never guess step fields — each response carries the next step's schema. Abort unfinished flows (`DELETE .../flow/{flow_id}`) instead of leaving them dangling.
 
 ### Events / Webhooks -- RELAY-READY
 

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -182,6 +182,7 @@ Match user intent to exactly one skill:
 | show history, logbook timelines, or long-term statistics | `ha-nova:history` |
 | check home status, repairs, system health, integration issues, unavailable entities, or low batteries | `ha-nova:health` |
 | find out WHY a specific automation, script, device, or integration failed or misbehaved (traces, error/system logs, root cause) | `ha-nova:diagnose` |
+| add an integration or continue a pending integration reauthentication flow | `ha-nova:integration-setup` |
 | play, pause, skip, set volume, change source, group speakers, browse media, or announce over a speaker | `ha-nova:media` |
 | send a notification to a phone or another notify target, or manage Home Assistant's persistent notifications | `ha-nova:notify` |
 | look at a camera (snapshot), get a stream URL, or record | `ha-nova:camera` |
@@ -232,6 +233,8 @@ Match user intent to exactly one skill:
 **"Why didn't my morning automation run?"** → `ha-nova:diagnose` (concrete failure → traces + logs)
 **"Why is the light turning on at random times?"** → `ha-nova:diagnose`
 **"Show me the error log"** → `ha-nova:diagnose`
+**"Add the Hue integration"** → `ha-nova:integration-setup`
+**"Reconnect my expired integration login"** → `ha-nova:integration-setup` (continues an existing Home Assistant `reauth` flow; credentials stay in the HA UI)
 **"Turn up the volume in the kitchen"** → `ha-nova:media`
 **"What's playing in the living room?"** → `ha-nova:media`
 **"Announce that dinner is ready"** → `ha-nova:media` (TTS to a speaker)

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -336,6 +336,33 @@ Observed locally on a real HA instance on 2026-03-19:
 
 See `skills/ha-nova/helper-flow-schemas.md` for the observed field sets and domain-specific notes.
 
+## Integration Config Flows
+
+`ha-nova:integration-setup` uses the generic config-flow surface:
+
+```json
+{"method":"GET","path":"/api/config/config_entries/flow_handlers"}
+{"type":"manifest/list"}
+{"type":"config_entries/flow/progress"}
+{"type":"config_entries/get"}
+{"method":"POST","path":"/api/config/config_entries/flow","body":{"handler":"hue"}}
+{"method":"GET","path":"/api/config/config_entries/flow/{flow_id}"}
+{"method":"POST","path":"/api/config/config_entries/flow/{flow_id}","body":{"step_field":"value"}}
+{"method":"DELETE","path":"/api/config/config_entries/flow/{flow_id}"}
+```
+
+Rules:
+
+- available handler domains come from `flow_handlers`; join them to `manifest/list` by `domain` for display-name resolution and never guess between matches
+- pending reauthentication comes from `config_entries/flow/progress` with `context.source == "reauth"` and a matching `context.entry_id`; never create a replacement reauth flow
+- each response's `type`, `data_schema`, `menu_options`, `flow_id`, and `step_id` define the next action
+- form submit bodies contain only fields exposed by the current live step
+- `config_entries/flow/progress` omits flows whose `context.source` is `user`; a relay-started add flow cannot rely on appearing as an in-progress UI card
+- a credential-bearing, external/OAuth, or progress step from a relay-started add flow is canceled and restarted in the HA UI; the Relay also does not provide the frontend-origin header used to construct OAuth redirects
+- pre-existing reauth flows are preserved and continue through their matching Home Assistant UI card when one of those UI-only steps is reached
+- add verification uses terminal `result.entry_id`, or a constrained before/after `config_entries/get` diff when it is absent
+- successful reauth uses terminal abort reason `reauth_successful`, the same surviving `entry_id`, and absence of the completed pending flow
+
 ## Domain Payload Rules
 
 Automation fields: `alias`, `triggers`, `conditions`, `actions`, `mode`

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -298,6 +298,7 @@ operations and for relays whose `/backups` answers 404.
 | `write` (automation/script) | yes (`ha-nova diff`) | yes (verified updates, last 5 targets) | config snapshot (auto before delete, identity-preserving restore); HA Backups |
 | `helper` storage family | yes | yes (verified updates, last 5 targets) | config snapshot (auto before delete; recreate mints a new id); HA Backups |
 | `helper` config-entry family | diff only | no (multi-step options flow) | HA Backups |
+| `integration-setup` | flow-step preview + config-entry read-back | no (multi-step add/reauth flow) | cancel only an unfinished add flow started in this session; after entry creation, manage or remove it in Home Assistant UI |
 | `dashboard` | preview + read-back verify | no | config snapshot (auto before delete / content-dropping save); HA Backups |
 | `scene` | preview + read-back verify | no | config snapshot (auto before delete, identity-preserving restore); HA Backups |
 | `todo` | preview + read-back verify | no (list delete irreversible) | re-add items; HA Backups for lists |

--- a/skills/integration-setup/SKILL.md
+++ b/skills/integration-setup/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: integration-setup
+description: Use when adding a Home Assistant integration or continuing an integration reauthentication flow through HA NOVA Relay.
+license: MIT
+compatibility: Requires the ha-nova CLI (run 'ha-nova setup' first) and the HA NOVA Relay in Home Assistant (App, or standalone container on Container/Core).
+---
+
+# HA NOVA Integration Setup
+
+## Scope
+
+Add integrations that expose a Home Assistant config flow and continue pending integration reauthentication (`reauth`) flows.
+
+Not handled here:
+
+- integration options, reconfigure, subentry, enable/disable, reload, or delete operations
+- helper config-entry flows (use `ha-nova:helper`)
+- YAML-only integrations (use `ha-nova:yaml-config`)
+- diagnosing setup failures after a flow finishes (use `ha-nova:diagnose`)
+
+Credential-bearing, external/OAuth, and progress steps finish in the Home Assistant UI; this skill never collects secrets in chat.
+
+## Bootstrap (once per session)
+
+Verify relay CLI: `ha-nova relay health`
+If this fails: `ha-nova setup`
+
+## Relay Contract
+
+Use response-driven config flows through the relay:
+
+- `ha-nova relay core --method GET --path /api/config/config_entries/flow_handlers --out <handlers-file>`
+- `ha-nova relay ws --data-file <payload-file> --out <manifests-file>` with `{"type":"manifest/list"}`
+- `ha-nova relay ws --data-file <payload-file> --out <flows-file>` with `{"type":"config_entries/flow/progress"}`
+- `ha-nova relay ws --data-file <payload-file> --out <entries-file>` with `{"type":"config_entries/get"}`
+- `ha-nova relay core --method GET|POST|DELETE --path /api/config/config_entries/flow[/<flow_id>] --body-file <payload-file> --out <flow-file>`
+
+Omit `--body-file` on GET and DELETE. Relay-core response data is under `.data.body`.
+
+## Flow
+
+### Resolve the operation
+
+1. For add, list flow handlers and integration manifests. Join manifest `domain` to the handler list, then resolve one exact domain or clear manifest-name match. Ask one blocking question when several match; never guess.
+2. For reauthentication:
+   - read `config_entries/get` and resolve the exact existing `entry_id`
+   - read `config_entries/flow/progress`
+   - select an existing flow only when `context.source == "reauth"` and its `handler` plus `context.entry_id` match the resolved entry
+   - if no matching pending flow exists, report that Home Assistant is not currently requesting reauthentication; never synthesize a reauth flow
+3. Limit one integration flow per operation.
+
+### Start or continue
+
+For add:
+
+1. Capture `config_entries/get` as the verification baseline.
+2. Preview the exact integration domain and flow start. State that no integration has been added yet.
+3. Ask for natural confirmation bound to this preview.
+4. POST `{"handler":"<domain>"}` to `/api/config/config_entries/flow`; extract `flow_id` or fail loud.
+
+For reauthentication, GET the matched `/api/config/config_entries/flow/<flow_id>`; do not create a second flow.
+
+### Iterate live steps
+
+Treat every response as authoritative:
+
+- `menu`: show only returned options and state that choosing one submits that exact menu step. The user's selection is the bound confirmation for `{"next_step_id":"<choice>"}`.
+- `form`: first inspect the returned `data_schema`. If it requests a secret, use the UI-only rule below without building or previewing a body. Otherwise, use only fields returned by the live `data_schema`, build the full step body, preview it, then ask for confirmation bound to that body before POSTing it.
+- validation errors: show the returned field errors and stop; never guess a replacement.
+- `external` or `progress`: for an add flow started here, DELETE the unfinished flow and ask the user to restart the integration at **Settings > Devices & services**. User-started flows are omitted from `config_entries/flow/progress`, and the Relay cannot supply the frontend-origin header OAuth redirects depend on. For a pre-existing reauth flow, preserve it and direct the user to its matching in-progress card. Never claim completion.
+- any form requesting a password, PIN/code, OAuth grant, access/API key, token, certificate, or private key material: never build or submit its body. For an add flow started here, DELETE the unfinished flow and ask the user to restart the integration at **Settings > Devices & services**. For a pre-existing reauth flow, preserve it and direct the user to its matching in-progress card. Never ask for or echo the secret.
+- `create_entry`: proceed to verification. Follow `next_flow` only when it is another config flow; options/subentry flows stay out of scope.
+- `abort`: report the returned reason. For reauth, only `reason == "reauth_successful"` is a success result, and only after config-entry verification.
+
+If the user cancels an add flow created by this skill, DELETE that unfinished `flow_id`. Never delete a pre-existing reauth flow.
+
+### Verify
+
+1. Re-read `config_entries/get`.
+2. Add passes when the terminal response's `result.entry_id` exists. If the result omits it, diff the baseline by `entry_id`; exactly one new entry with the requested domain must exist or verification is ambiguous.
+3. Reauth passes only when the same `entry_id` still exists, the matching reauth flow is gone, and the terminal result reports success. Report the current config-entry state exactly; do not call a non-`loaded` entry healthy.
+4. Linked devices/entities are secondary evidence only.
+
+## Error Handling
+
+- Relay/upstream failures follow `skills/ha-nova/relay-api.md` → Error Handling.
+- `404`: flow expired or handler unavailable — re-read handlers/progress before retrying.
+- `405`: wrong method — use POST for the collection start, GET/POST/DELETE for a specific flow.
+- `abort` or form errors: surface Home Assistant's reason; do not retry with guessed fields.
+
+## Output Format
+
+Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+
+Use the Preview Card for flow start, menu selection, and each non-secret form submit. The menu choice block is its bound confirmation. Results name the integration, operation, config-entry state, and the exact verification scope. UI handoffs state what remains and never display secret fields or values.
+
+## Safety
+
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
+
+- Declared exception to the core delete rule above: canceling an unfinished add flow created by this skill, including cleanup before a required credential, external/OAuth, or progress UI restart, deletes only ephemeral flow state; an explicit `cancel` or the UI-restart branch is sufficient, and this exception never applies to a config entry.
+- Never request, echo, persist, or submit credentials from chat; finish credential-bearing steps in the Home Assistant UI.
+- Starting or submitting a flow may contact an external service; always use the bound preview.
+- Never leave an agent-created canceled add flow dangling; never delete a Home Assistant-created reauth flow.
+
+## Guardrails
+
+- One integration flow at a time.
+- Live `data_schema` and menu options are the only accepted field source.
+- Config-entry identity/existence is primary verification evidence.
+
+## References
+
+- Relay API: `skills/ha-nova/relay-api.md`
+- Shared write safety: `skills/ha-nova/write-safety.md`

--- a/tests/skills/ha-nova-contract.test.ts
+++ b/tests/skills/ha-nova-contract.test.ts
@@ -447,6 +447,7 @@ describe("ha-nova contract", () => {
       "skills/write/SKILL.md",
       "skills/read/SKILL.md",
       "skills/helper/SKILL.md",
+      "skills/integration-setup/SKILL.md",
       "skills/entity-discovery/SKILL.md",
       "skills/onboarding/SKILL.md",
       "skills/service-call/SKILL.md",
@@ -489,6 +490,7 @@ describe("ha-nova contract", () => {
       "skills/history/SKILL.md",
       "skills/write/SKILL.md",
       "skills/read/SKILL.md",
+      "skills/integration-setup/SKILL.md",
       "skills/entity-discovery/SKILL.md",
       "skills/onboarding/SKILL.md",
     ];
@@ -518,6 +520,7 @@ describe("ha-nova contract", () => {
       "skills/read/SKILL.md",
       "skills/review/SKILL.md",
       "skills/helper/SKILL.md",
+      "skills/integration-setup/SKILL.md",
       "skills/entity-discovery/SKILL.md",
       "skills/fallback/SKILL.md",
       "skills/service-call/SKILL.md",

--- a/tests/skills/health-calendar-contract.test.ts
+++ b/tests/skills/health-calendar-contract.test.ts
@@ -98,7 +98,7 @@ describe("health and calendar skill contracts", () => {
     const fallback = readFileSync("skills/fallback/SKILL.md", "utf8");
     const history = readFileSync("skills/history/SKILL.md", "utf8");
 
-    expect(architecture).toContain("28 independent sub-skills");
+    expect(architecture).toContain("29 independent sub-skills");
     expect(architecture).toContain("health/SKILL.md");
     expect(architecture).toContain("calendar/SKILL.md");
     expect(architecture).toContain("`ha-nova:health` is a read-only home-status skill");

--- a/tests/skills/integration-setup-contract.test.ts
+++ b/tests/skills/integration-setup-contract.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const skill = readFileSync("skills/integration-setup/SKILL.md", "utf8");
+const context = readFileSync("skills/ha-nova/SKILL.md", "utf8");
+const fallback = readFileSync("skills/fallback/SKILL.md", "utf8");
+const architecture = readFileSync("docs/reference/skill-architecture.md", "utf8");
+
+describe("integration setup skill contract", () => {
+  it("owns add and pending reauth config flows", () => {
+    expect(skill).toContain("name: integration-setup");
+    expect(skill).toContain("/api/config/config_entries/flow_handlers");
+    expect(skill).toContain('{"type":"config_entries/flow/progress"}');
+    expect(skill).toContain('{"type":"config_entries/get"}');
+    expect(skill).toContain('{"type":"manifest/list"}');
+    expect(skill).toContain("context.source == \"reauth\"");
+    expect(skill).toContain("never synthesize a reauth flow");
+    expect(skill).toContain('/api/config/config_entries/flow[/<flow_id>]');
+  });
+
+  it("keeps the flow loop response-driven and preview-bound", () => {
+    expect(skill).toContain("Treat every response as authoritative");
+    expect(skill).toContain('`menu`');
+    expect(skill).toContain('`form`');
+    expect(skill).toContain('`external`');
+    expect(skill).toContain('`progress`');
+    expect(skill).toContain('`create_entry`');
+    expect(skill).toContain('`abort`');
+    expect(skill).toContain('reason == "reauth_successful"');
+    expect(skill).toContain("use only fields returned by the live `data_schema`");
+    expect(skill).toContain("confirmation bound to this preview");
+    expect(skill).toContain("selection is the bound confirmation");
+    expect(skill).toContain("validation errors");
+    expect(skill).toContain("never guess a replacement");
+  });
+
+  it("keeps credentials out of chat and preserves HA-owned reauth flows", () => {
+    expect(skill).toContain("never collects secrets in chat");
+    expect(skill).toContain("Never ask for or echo the secret");
+    expect(skill).toContain("Home Assistant UI");
+    expect(skill).toContain("Settings > Devices & services");
+    expect(skill).toContain("frontend-origin header");
+    expect(skill).toContain("User-started flows are omitted from `config_entries/flow/progress`");
+    expect(skill).toContain("never build or submit its body");
+    expect(skill).toContain("Never delete a pre-existing reauth flow");
+    expect(skill).toContain("Never request, echo, persist, or submit credentials from chat");
+    expect(skill).toContain("Declared exception to the core delete rule above");
+  });
+
+  it("verifies config entries without entity-first guesses", () => {
+    expect(skill).toContain("terminal response's `result.entry_id`");
+    expect(skill).toContain("exactly one new entry");
+    expect(skill).toContain("the same `entry_id` still exists");
+    expect(skill).toContain("matching reauth flow is gone");
+    expect(skill).toContain("Linked devices/entities are secondary evidence only");
+  });
+
+  it("wires dispatch, fallback ownership, and architecture", () => {
+    expect(context).toContain(
+      "| add an integration or continue a pending integration reauthentication flow | `ha-nova:integration-setup` |",
+    );
+    expect(context).toContain('"Add the Hue integration"** → `ha-nova:integration-setup`');
+    expect(fallback).toContain(
+      "| Integration onboarding (add / re-auth an integration via config flow) | Covered | integration-setup |",
+    );
+    expect(fallback).not.toContain("### Integration Onboarding -- RELAY-READY");
+    expect(architecture).toContain("integration-setup/SKILL.md");
+    expect(architecture).toContain("## Integration Setup Architecture");
+  });
+});

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -79,6 +79,7 @@ const MUTATION_SKILLS = new Set([
   "energy",
   "maintenance",
   "service-call",
+  "integration-setup",
   "fallback",
   "review",
 ]);
@@ -149,8 +150,8 @@ const WORD_BUDGETS: Record<string, number> = {
   // purge quantification, glob expansion, apply_filter semantics
   // (2026-h2 Wave 1b).
   maintenance: 1400,
-  // integration-onboarding + events/webhooks Relay-Ready sections and the
-  // blueprint payload examples (masterplan-2026-h2 Wave 0).
+  // events/webhooks Relay-Ready section and the blueprint payload examples
+  // (integration onboarding moved to its own skill in Wave 4).
   fallback: 2450,
   // semantic-slot note on the read templates (Wave 0); pre-write cross-field
   // constraint checks + drift-check step (Wave 1); pre-delete snapshot


### PR DESCRIPTION
## Summary

- add a dedicated `integration-setup` skill for integration add and pending reauthentication flows
- keep credentials in the Home Assistant UI and restart Relay-created add flows when UI-only steps are reached
- update dispatch, fallback ownership, architecture/API references, installer inventory, and contract coverage

## Why

Integration onboarding previously lived in the experimental fallback skill. The dedicated response-driven flow closes the Wave 4 coverage gap while keeping Relay business logic unchanged and avoiding secret material in chat.

## User impact

Users can ask HA NOVA to add an integration or continue an existing reauthentication prompt. Non-secret menu/form steps remain guided; credential, external/OAuth, and progress steps move safely to Home Assistant UI.

## Validation

- `npm run verify`
- pre-push hook: 82 files / 797 tests, build, documentation fact-check
- `git diff --check`

## Risk

Integration schemas remain integration-specific. The skill reads every live step schema and fails closed instead of guessing.