### PR TITLE
feat(skills): add calendar event writes

### DIFF
--- a/docs/reference/ha-api-matrix.md
+++ b/docs/reference/ha-api-matrix.md
@@ -21,6 +21,7 @@ Which HA operations require REST, WS, or filesystem?
 | `/api/error_log` | GET | Error log of the current session — **404 on HA OS/Supervised since 2025.11** (log file moved to journald; official docs are stale). Re-enable: `ha core options --duplicate-log-file=true` + `ha core rebuild` + `ha core restart` (2026.1+). Prefer WS `system_log/list` |
 | `/api/calendars` | GET | All calendars |
 | `/api/calendars/{entity_id}` | GET | Calendar events |
+| `/api/services/calendar/create_event` | POST | Create a calendar event (feature bit 1; no recurrence field) |
 | `/api/components` | GET | Loaded components |
 | `/api/config/automation/config/{id}` | GET | Read automation config |
 | `/api/config/automation/config/{id}` | POST | Create/update automation |
@@ -125,6 +126,14 @@ Observed locally on a real HA instance on 2026-03-19: raw WS `config_entries/flo
 | `energy/validate` | Validate energy config |
 | `energy/solar_forecast` | Solar forecast data |
 | `energy/fossil_energy_consumption` | Fossil consumption calculation |
+
+### Calendar event writes
+| WS Type | Purpose |
+|---------|---------|
+| `calendar/event/update` | Full-object event update by `entity_id` + `uid` (feature bit 4) |
+| `calendar/event/delete` | Event delete by `entity_id` + `uid` (feature bit 2) |
+
+Recurring instances add `recurrence_id`; `recurrence_range` is `""` for only that occurrence or `THISANDFUTURE` for that occurrence and later ones.
 
 ### Traces
 | WS Type | Purpose |

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -270,15 +270,21 @@ Rules:
 
 ## Calendar Architecture
 
-`ha-nova:calendar` is a REST-only read skill:
+`ha-nova:calendar` owns bounded calendar reads and single-event writes:
 - list calendars through `/api/calendars`
 - read events through `/api/calendars/{entity_id}?start=<timestamp>&end=<timestamp>`
+- create through `calendar.create_event`; update/delete through WS `calendar/event/update|delete`
+- capability gates use `supported_features` bits 1/2/4 before create/delete/update
+- update/delete identity is `(uid, recurrence_id)`; recurring scope is one occurrence (`""`) or this-and-future (`THISANDFUTURE`)
+- update sends a full merged event object, never a partial patch
 
 Rules:
 - default to the next 7 days
 - always use a bounded event window
 - resolve ambiguous calendar names before querying events
-- no event create/update/delete actions
+- create/update use natural bound confirmation; delete uses the typed token
+- drift-check immediately before the write; verify through bounded REST read-back and never auto-retry a write
+- recurring creation stays in the Home Assistant UI because `calendar.create_event` has no recurrence field
 
 ## Integration Setup Architecture
 

--- a/skills/calendar/SKILL.md
+++ b/skills/calendar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: calendar
-description: Use when listing Home Assistant calendars or reading bounded calendar event windows through HA NOVA Relay.
+description: Use when listing, reading, creating, updating, or deleting Home Assistant calendar events through HA NOVA Relay.
 license: MIT
 compatibility: Requires the ha-nova CLI (run 'ha-nova setup' first) and the HA NOVA Relay in Home Assistant (App, or standalone container on Container/Core).
 ---
@@ -9,16 +9,17 @@ compatibility: Requires the ha-nova CLI (run 'ha-nova setup' first) and the HA N
 
 ## Scope
 
-Read-only calendar work:
+Calendar event work:
 - list calendar entities
 - read events for one calendar over a bounded window
 - summarize upcoming events across selected calendars
+- create, update, or delete one event
 
 Not in scope:
-- create, update, delete, or edit calendar events
-- recurring-event management
+- recurring-event creation (finish in the Home Assistant UI; `calendar.create_event` has no recurrence field)
 - calendar dashboard edits
 - automation writes that use calendar triggers
+- calendar sharing, permissions, or provider-account settings
 
 ## Bootstrap (once per session)
 
@@ -27,9 +28,12 @@ If this fails: `ha-nova setup`
 
 ## Relay Contract
 
-Use REST through relay core only:
+Use REST reads, one create service, and feature-gated WebSocket writes:
 - `ha-nova relay core --method GET --path /api/calendars --out <result-file>`
+- `ha-nova relay core --method GET --path /api/states/<calendar_entity_id> --out <result-file>`
 - `ha-nova relay core --method GET --path <calendar-events-path> --out <result-file>`
+- `ha-nova relay core --method POST --path /api/services/calendar/create_event --body-file <payload-file> --out <result-file>`
+- `ha-nova relay ws --data-file <payload-file> --out <result-file>` for `calendar/event/update` and `calendar/event/delete`
 - `ha-nova relay jq --file <result-file> --jq-file <filter-file>`
 
 `<calendar-events-path>` is:
@@ -47,7 +51,7 @@ Relay-core response body is under `.data.body` (envelope contract: `skills/ha-no
    - otherwise default to now through the next 7 days
    - if the user asks for an unbounded or very broad range, narrow it before querying
 5. Query events with `/api/calendars/<entity_id>?start=<start>&end=<end>`.
-6. Summarize events:
+6. Summarize read results:
    - title/summary
    - start and end
    - all-day vs timed; all-day events carry date-only values with an EXCLUSIVE end — a one-day event on the 14th returns end = the 15th; report it as "on the 14th", never as "ends the 15th"
@@ -55,6 +59,35 @@ Relay-core response body is under `.data.body` (envelope contract: `skills/ha-no
    - recurring events arrive pre-expanded as individual instances within the window — count and report them as such, not as one series
    - location only when useful
    - omit private descriptions unless the user explicitly asks
+
+### Create, update, or delete
+
+1. Resolve one exact calendar and read `/api/states/<entity_id>`. Gate create on `supported_features & 1`, delete on `& 2`, and update on `& 4`; stop when the required bit is absent.
+2. Read a bounded event window covering the target. Update/delete require an exact event with `uid`; use `(uid, recurrence_id)` as the instance identity. If several events match the user's description, ask one blocking question. Never guess.
+3. Normalize event fields:
+   - timed events use `start_date_time`/`end_date_time` for create and `dtstart`/`dtend` inside the WS `event` object; both values use the Home Assistant timezone and end must be after start
+   - all-day events use `start_date`/`end_date` for create and date-only `dtstart`/`dtend` for update; end is exclusive
+   - create requires `summary`; optional `description` and `location` are included only when set
+   - update is a full event replacement: merge requested changes into the current summary/start/end/description/location/rrule instead of sending a patch; omit absent optional fields, use an empty string only to clear description/location, and omit `rrule` to clear recurrence
+4. For an occurrence with `recurrence_id`, ask whether the scope is **this occurrence** (`recurrence_range:""`) or **this and future occurrences** (`"THISANDFUTURE"`). Bind that scope to the preview. For a single-occurrence update, omit `rrule` from the replacement event. Do not invent an entire-series mode.
+5. Show the Preview Card with operation, calendar, exact event identity, summary, start/end, timezone or all-day range, changed fields, and recurrence scope. Create/update use natural bound confirmation; delete uses the typed `confirm:<token>` from the core rule.
+6. Immediately before execution, re-read the target window and calendar state; this event set is the create baseline. Abort and rebuild the preview if capability, identity, current fields, or recurrence scope drifted.
+7. Execute exactly one write:
+   - create: POST `{"entity_id":"calendar.example","summary":"Event","start_date_time":"<start>","end_date_time":"<end>"}` to `/api/services/calendar/create_event`
+   - update: WS `{"type":"calendar/event/update","entity_id":"calendar.example","uid":"<uid>","recurrence_id":"<instance>","recurrence_range":"<range>","event":{"summary":"Event","dtstart":"<start>","dtend":"<end>"}}`; omit recurrence keys for a non-recurring event
+   - delete: WS `{"type":"calendar/event/delete","entity_id":"calendar.example","uid":"<uid>","recurrence_id":"<instance>","recurrence_range":"<range>"}`; omit recurrence keys for a non-recurring event
+8. Verify through bounded REST read-back, up to three reads over ten seconds:
+   - create: compared with the baseline, exactly one new event must match the requested normalized fields; the service response alone is not identity evidence
+   - update: the same `(uid, recurrence_id)` must contain the full requested fields; for `THISANDFUTURE`, also check the first later occurrence when one exists in the window and state that later events outside the window were not verified
+   - delete: the target identity must be absent; for `THISANDFUTURE`, all occurrences with that `uid` from the selected instance onward must be absent within the window
+   - ambiguous, stale, or delayed results are reported as not verified; never repeat a write automatically
+
+## Error Handling
+
+- Relay/upstream failures follow `skills/ha-nova/relay-api.md` → Error Handling.
+- Unsupported feature or missing `uid`: stop and name the limitation; do not try another endpoint.
+- Timeout/`502`: verify first. Create may already have produced an event, so automatic retry risks a duplicate.
+- Provider rejection: surface the Home Assistant reason without guessing a corrected payload.
 
 ## Output Format
 
@@ -65,13 +98,25 @@ Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 - `Events`
 - `Next step`
 
-These slots render the Report shape (output-rules.md); event groups follow the List Frame. For multiple calendars, group by calendar and keep each group short.
+These slots render the Report shape (output-rules.md); event groups follow the List Frame. For multiple calendars, group by calendar and keep each group short. Writes use the Preview Card and Result Card; report the exact bounded verification scope.
 
 ## Safety
 
-- Read-only skill: never issue mutating relay or service calls.
-- For write intent, hand off to the owning skill; unfamiliar writes go through `ha-nova:fallback` first.
+- Preview before write: nothing is saved until the user confirms the shown preview.
+- Confirmation binds to the displayed preview and expires on any change to target, payload, endpoint, or scope (context skill → Active Preview Confirmation).
+- Pre-preview phrases ("do it", "go ahead", "implement the plan") authorize drafting and preview only — never the write itself.
+- Delete and destructive operations require the typed token `confirm:<token>` verbatim; "yes" or any natural-language reply is invalid.
+- Never guess entity, service, or config IDs — resolve them or ask.
+- Home Assistant is reached exclusively through `ha-nova relay`.
+- For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
 
-- Read-only skill. No event writes.
+- Create and update require natural confirmation; delete retains the core typed-token gate.
+- Calendar event writes have no HA NOVA revert. A provider recycle bin may exist but is not guaranteed; recreate only from a user-approved preview.
 - Always use bounded windows.
 - Never guess a calendar id from a partial name when multiple matches exist.
+- One event write at a time; no batch mutation.
+
+## References
+
+- Relay API: `skills/ha-nova/relay-api.md`
+- Shared write safety: `skills/ha-nova/write-safety.md`

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -63,7 +63,7 @@ For every Relay-Ready call in this skill:
 | Frontend themes | Covered | yaml-config |
 | External data stores (InfluxDB long-term history, Prometheus, ...) | Covered | external-sources |
 | Weather forecasts (`weather.get_forecasts`) | Covered | service-call |
-| Calendar Queries | Covered | calendar |
+| Calendar Events (read / create / update / delete) | Covered | calendar |
 | To-do Lists (items + Local To-do lifecycle) | Covered | todo |
 | Area / Floor CRUD | Covered | organize |
 | Label CRUD / Rich label metadata | Covered | organize |

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -191,7 +191,7 @@ Match user intent to exactly one skill:
 | manage persons, zones, tags, or user accounts | `ha-nova:admin` |
 | create or edit configuration that only exists as YAML (template/REST/command-line sensors, packages, themes) | `ha-nova:yaml-config` |
 | query long-term history from InfluxDB or another external store Home Assistant writes to but cannot read back | `ha-nova:external-sources` |
-| list calendars or show calendar events | `ha-nova:calendar` |
+| list calendars; read, create, update, or delete calendar events | `ha-nova:calendar` |
 | show, add, complete, update, remove to-do or shopping-list items; create/delete to-do lists | `ha-nova:todo` |
 | check backup status, create a backup (also as a safety net before risky changes), inspect a backup's contents, delete backups | `ha-nova:backup` |
 | check pending updates, read release notes, install updates, skip/unskip versions | `ha-nova:updates` |
@@ -257,6 +257,9 @@ Match user intent to exactly one skill:
 **"What's on my to-do list?"** → `ha-nova:todo`
 **"Show my calendars"** → `ha-nova:calendar`
 **"What's on my calendar this week?"** → `ha-nova:calendar`
+**"Add a dentist appointment tomorrow"** → `ha-nova:calendar`
+**"Move this calendar event to Friday"** → `ha-nova:calendar`
+**"Delete this calendar event"** → `ha-nova:calendar` (typed confirmation token)
 **"Review all automations in area Area Alpha"** → `ha-nova:review` (area-first aggregate review when more than one target resolves)
 **"Create a timer"** → ambiguous! Ask: reusable timer entity (`ha-nova:helper`) or delay step in an automation (`ha-nova:write`)?
 **"How much energy did the dryer use last month?"** → `ha-nova:energy`

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -389,6 +389,24 @@ Call with response data:
 
 Supported target fields: `entity_id` (string or array), `area_id`, `device_id`.
 
+## Calendar Event Writes
+
+`ha-nova:calendar` creates events through the service API and updates/deletes them through WS:
+
+```json
+{"method":"POST","path":"/api/services/calendar/create_event","body":{"entity_id":"calendar.example","summary":"Event","start_date_time":"2026-07-15T14:00:00+02:00","end_date_time":"2026-07-15T15:00:00+02:00"}}
+{"type":"calendar/event/update","entity_id":"calendar.example","uid":"<uid>","event":{"summary":"Event","dtstart":"2026-07-15T14:00:00+02:00","dtend":"2026-07-15T15:00:00+02:00"}}
+{"type":"calendar/event/delete","entity_id":"calendar.example","uid":"<uid>"}
+```
+
+Rules:
+
+- read the calendar entity state first; feature bits are create `1`, delete `2`, update `4`
+- REST event reads return `uid` and optional `recurrence_id`; update/delete require exact identity
+- update's `event` is a full replacement object with `summary`, `dtstart`, `dtend`, and any retained optional `description`, `location`, or `rrule`
+- recurring instances add `recurrence_id` and `recurrence_range`: `""` for one occurrence, `THISANDFUTURE` for that occurrence and later ones
+- the create service has no recurrence field; use the Home Assistant UI for recurring creation
+
 ## Registry Queries (via /ws)
 
 List areas:

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -299,6 +299,7 @@ operations and for relays whose `/backups` answers 404.
 | `helper` storage family | yes | yes (verified updates, last 5 targets) | config snapshot (auto before delete; recreate mints a new id); HA Backups |
 | `helper` config-entry family | diff only | no (multi-step options flow) | HA Backups |
 | `integration-setup` | flow-step preview + config-entry read-back | no (multi-step add/reauth flow) | cancel only an unfinished add flow started in this session; after entry creation, manage or remove it in Home Assistant UI |
+| `calendar` | event-field preview + bounded event read-back | no (provider event mutation) | provider recycle bin when available; otherwise recreate from the approved preview |
 | `dashboard` | preview + read-back verify | no | config snapshot (auto before delete / content-dropping save); HA Backups |
 | `scene` | preview + read-back verify | no | config snapshot (auto before delete, identity-preserving restore); HA Backups |
 | `todo` | preview + read-back verify | no (list delete irreversible) | re-add items; HA Backups for lists |

--- a/tests/skills/ha-nova-contract.test.ts
+++ b/tests/skills/ha-nova-contract.test.ts
@@ -35,7 +35,7 @@ describe("ha-nova contract", () => {
     expect(context).toContain('| assign or remove entity categories | `ha-nova:organize` |');
     expect(context).toContain('| show history, logbook timelines, or long-term statistics | `ha-nova:history` |');
     expect(context).toContain('| check home status, repairs, system health, integration issues, unavailable entities, or low batteries | `ha-nova:health` |');
-    expect(context).toContain('| list calendars or show calendar events | `ha-nova:calendar` |');
+    expect(context).toContain('| list calendars; read, create, update, or delete calendar events | `ha-nova:calendar` |');
     expect(context).toContain('"Show my main dashboard"** → `ha-nova:dashboard`');
     expect(context).toContain('"Create a dashboard called Test Board"** → `ha-nova:dashboard`');
     expect(context).toContain('"Delete the Test dashboard"** → `ha-nova:dashboard`');
@@ -335,7 +335,7 @@ describe("ha-nova contract", () => {
     expect(architecture).toContain("every `config/category_registry/*` call includes the exact `scope`");
     expect(architecture).toContain("`ha-nova:history` is a bounded read-only timeline skill");
     expect(architecture).toContain("`ha-nova:health` is a read-only home-status skill");
-    expect(architecture).toContain("`ha-nova:calendar` is a REST-only read skill");
+    expect(architecture).toContain("`ha-nova:calendar` owns bounded calendar reads and single-event writes");
     expect(architecture).toContain("long-term trends via `recorder/statistics_during_period`");
     expect(architecture).toContain("room/area bulk resolution is area-first");
     expect(architecture).toContain("materialize and trim the current workset before any per-item reads");
@@ -597,7 +597,7 @@ describe("ha-nova contract", () => {
 
     const fallback = readFileSync("skills/fallback/SKILL.md", "utf8");
     expect(fallback).toContain("| System Health / Repairs | Covered | health |");
-    expect(fallback).toContain("| Calendar Queries | Covered | calendar |");
+    expect(fallback).toContain("| Calendar Events (read / create / update / delete) | Covered | calendar |");
     expect(fallback).not.toContain("### System Health / Repairs -- RELAY-READY");
     expect(fallback).not.toContain("### Calendar Queries -- RELAY-READY");
     expect(fallback).not.toContain("<calendar-events-path>");

--- a/tests/skills/health-calendar-contract.test.ts
+++ b/tests/skills/health-calendar-contract.test.ts
@@ -74,23 +74,44 @@ describe("health and calendar skill contracts", () => {
     expect(health).toContain("--jq-file");
   });
 
-  it("defines a REST-only calendar skill with bounded event windows", () => {
+  it("defines bounded calendar reads and feature-gated event writes", () => {
     const calendar = readFileSync("skills/calendar/SKILL.md", "utf8");
+    const apiMatrix = readFileSync("docs/reference/ha-api-matrix.md", "utf8");
+    const relayApi = readFileSync("skills/ha-nova/relay-api.md", "utf8");
+    const writeSafety = readFileSync("skills/ha-nova/write-safety.md", "utf8");
 
     expect(calendar).toContain("name: calendar");
-    expect(calendar).toContain("description: Use when listing Home Assistant calendars");
+    expect(calendar).toContain("description: Use when listing, reading, creating, updating, or deleting Home Assistant calendar events");
     expect(calendar).toContain("/api/calendars");
     expect(calendar).toContain("/api/calendars/<entity_id>?start=<start>&end=<end>");
     expect(calendar).toContain("default to now through the next 7 days");
     expect(calendar).toContain("Always use bounded windows.");
-    expect(calendar).toContain("No event writes.");
     expect(calendar).toContain("Never guess a calendar id from a partial name");
-    expect(calendar).toContain("REST through relay core only");
     expect(calendar).toContain("--out <result-file>");
     expect(calendar).toContain("--jq-file");
-    expect(calendar).not.toContain("relay ws");
-    expect(calendar).not.toContain("POST");
-    expect(calendar).not.toContain("DELETE");
+    expect(calendar).toContain("/api/services/calendar/create_event");
+    expect(calendar).toContain('`calendar/event/update`');
+    expect(calendar).toContain('`calendar/event/delete`');
+    expect(calendar).toContain("`supported_features & 1`");
+    expect(calendar).toContain("`& 2`");
+    expect(calendar).toContain("`& 4`");
+    expect(calendar).toContain("(uid, recurrence_id)");
+    expect(calendar).toContain('`recurrence_range:""`');
+    expect(calendar).toContain('`"THISANDFUTURE"`');
+    expect(calendar).toContain("update is a full event replacement");
+    expect(calendar).toContain("omit `rrule` to clear recurrence");
+    expect(calendar).toContain("Immediately before execution, re-read");
+    expect(calendar).toContain("this event set is the create baseline");
+    expect(calendar).toContain("up to three reads over ten seconds");
+    expect(calendar).toContain("never repeat a write automatically");
+    expect(calendar).toContain("delete uses the typed `confirm:<token>`");
+    expect(calendar).toContain("no HA NOVA revert");
+    expect(apiMatrix).toContain("### Calendar event writes");
+    expect(apiMatrix).toContain("`calendar/event/update`");
+    expect(apiMatrix).toContain("`calendar/event/delete`");
+    expect(relayApi).toContain("## Calendar Event Writes");
+    expect(relayApi).toContain("feature bits are create `1`, delete `2`, update `4`");
+    expect(writeSafety).toContain("| `calendar` | event-field preview + bounded event read-back |");
   });
 
   it("updates architecture and fallback ownership for the new dedicated skills", () => {
@@ -108,11 +129,11 @@ describe("health and calendar skill contracts", () => {
     expect(architecture).toContain("capped examples, sanitized integration reasons");
     expect(architecture).toContain("deprioritize noisy/stateless domains");
     expect(architecture).not.toContain("current-session error log");
-    expect(architecture).toContain("`ha-nova:calendar` is a REST-only read skill");
+    expect(architecture).toContain("`ha-nova:calendar` owns bounded calendar reads and single-event writes");
     expect(architecture).not.toContain("energy, calendars, system health");
 
     expect(fallback).toContain("| System Health / Repairs | Covered | health |");
-    expect(fallback).toContain("| Calendar Queries | Covered | calendar |");
+    expect(fallback).toContain("| Calendar Events (read / create / update / delete) | Covered | calendar |");
     expect(fallback).not.toContain("### System Health / Repairs -- RELAY-READY");
     expect(fallback).not.toContain("### Calendar Queries -- RELAY-READY");
 

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -80,6 +80,7 @@ const MUTATION_SKILLS = new Set([
   "maintenance",
   "service-call",
   "integration-setup",
+  "calendar",
   "fallback",
   "review",
 ]);
@@ -89,7 +90,6 @@ const READ_ONLY_SKILLS = new Set([
   "entity-discovery",
   "history",
   "health",
-  "calendar",
   "onboarding",
 ]);
 


### PR DESCRIPTION
## Summary

- extend the calendar skill from bounded reads to single-event create, update, and delete
- gate writes by calendar feature bits and exact `(uid, recurrence_id)` identity
- add recurrence-scope selection, pre-write drift checks, bounded read-back verification, and honest recovery limits
- update dispatch, fallback ownership, API references, safety matrix, and contracts

## Why

Calendar events were the second Wave 4 coverage gap. Home Assistant exposes create as `calendar.create_event`, while update/delete use feature-gated WebSocket commands and full event objects.

## User impact

Users can create, move/edit, and delete calendar events through the same preview-confirm-verify UX as other HA NOVA writes. Recurring-instance scope is explicit; recurring creation stays in the Home Assistant UI because the create service has no recurrence field.

## Validation

- `npm run verify`
- targeted calendar/template/routing contracts: 50 tests
- pre-push hook: 82 files / 797 tests, build, documentation fact-check
- `git diff --check`

## Risk

Calendar providers can synchronize asynchronously. Verification is bounded to three reads over ten seconds; ambiguous or delayed results remain not verified and no write is retried automatically.