### PR TITLE
feat(skills): add runtime event and security guidance

### DIFF
--- a/docs/reference/ha-api-matrix.md
+++ b/docs/reference/ha-api-matrix.md
@@ -14,8 +14,8 @@ Which HA operations require REST, WS, or filesystem?
 | `/api/config` | GET | HA Core configuration |
 | `/api/config/core/check_config` | POST | Validate YAML configuration |
 | `/api/template` | POST | Render Jinja2 template (body: `{"template": "..."}`) |
-| `/api/events/{event_type}` | POST | Fire custom event |
-| `/api/webhook/{webhook_id}` | POST | Invoke webhook |
+| `/api/events/{event_type}` | POST | Fire a custom event (admin; JSON object; asynchronous listener execution) |
+| `/api/webhook/{webhook_id}` | POST | Invoke a known JSON webhook (opaque HTTP 200; effect verification required) |
 | `/api/history/period/{start_iso}` | GET | State history (with `?filter_entity_id=...&end_time=...`) |
 | `/api/logbook/{timestamp}` | GET | Logbook entries |
 | `/api/error_log` | GET | Error log of the current session — **404 on HA OS/Supervised since 2025.11** (log file moved to journald; official docs are stale). Re-enable: `ha core options --duplicate-log-file=true` + `ha core rebuild` + `ha core restart` (2026.1+). Prefer WS `system_log/list` |
@@ -34,7 +34,14 @@ Which HA operations require REST, WS, or filesystem?
 | `/api/config/config_entries/flow` | POST | Start an integration/helper config flow |
 | `/api/config/config_entries/flow/{flow_id}` | GET / POST / DELETE | Read, submit, or cancel one config flow |
 
-**Auth header:** `Authorization: Bearer {LONG_LIVED_TOKEN}`
+**Auth header:** `Authorization: Bearer {LONG_LIVED_TOKEN}`. The webhook endpoint itself is unauthenticated and treats its ID as the bearer secret; calls through HA NOVA still require Relay authentication.
+
+### Runtime event and security notes
+
+- Custom events use an exact user-defined event type. `GET /api/events` supplies total listener counts; automation-config scans identify only readable automation listeners.
+- Automation webhooks default to POST/PUT and `local_only: true`. IDs are secrets, multiple triggers may share one ID, and HTTP 200 does not prove registration, locality, or handler success.
+- Alarm-panel feature bits are home `1`, away `2`, night `4`, trigger `8`, custom bypass `16`, vacation `32`; disarm has no feature bit.
+- `lock.open` requires feature bit `1`; `lock.lock` and `lock.unlock` have no feature bit. Code-bearing alarm/lock actions stay in the Home Assistant UI.
 
 ## WebSocket API (requires Relay as proxy)
 
@@ -145,6 +152,7 @@ Recurring instances add `recurrence_id`; `recurrence_range` is `""` for only tha
 | WS Type | Purpose |
 |---------|-----|
 | `config/automation/list` | Automations with metadata |
+| `webhook/list` | Registered webhook IDs plus domain/name, locality, and allowed methods (secret-bearing; internal use only) |
 | `repairs/list_issues` | Repairs/Deprecation Issues |
 | `config_entries/get` | Config-entry metadata; health uses not-loaded entries as integration status |
 | `system_health/info` | System health finite event response (Skill opts into Relay `collect_events` until `finish`) |

--- a/docs/reference/ha-api-matrix.md
+++ b/docs/reference/ha-api-matrix.md
@@ -152,7 +152,7 @@ Recurring instances add `recurrence_id`; `recurrence_range` is `""` for only tha
 | WS Type | Purpose |
 |---------|-----|
 | `config/automation/list` | Automations with metadata |
-| `webhook/list` | Registered webhook IDs plus domain/name, locality, and allowed methods (secret-bearing; internal use only) |
+| `webhook/list` | Registered webhook IDs plus domain/name, locality, and allowed methods (secret-bearing; private `--out` file only, never stdout) |
 | `repairs/list_issues` | Repairs/Deprecation Issues |
 | `config_entries/get` | Config-entry metadata; health uses not-loaded entries as integration status |
 | `system_health/info` | System health finite event response (Skill opts into Relay `collect_events` until `finish`) |

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -315,7 +315,7 @@ Event/webhook rules:
 
 Alarm/lock rules:
 - inspect the exact state and `supported_features` immediately before preview
-- codes/PINs never enter chat or Relay payloads; alarm arming hands off when both `code_arm_required` and `code_format` are set, while other code-bearing actions use `code_format`
+- codes/PINs never enter chat or Relay payloads; alarm arming hands off whenever `code_arm_required` is true, while other code-bearing actions use `code_format`
 - unlocking/opening a lock and disarming an alarm use the typed high-consequence confirmation
 - security-state verification is transition-aware and never auto-retries
 

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -37,7 +37,7 @@ skills/
   organize/SKILL.md                     (ha-nova:organize — areas/floors/labels/categories/entity+device metadata)
   history/SKILL.md                      (ha-nova:history — bounded history/logbook/statistics reads)
   health/SKILL.md                       (ha-nova:health — read-only home status, repairs, system health)
-  calendar/SKILL.md                     (ha-nova:calendar — read-only calendar lists and bounded event windows)
+  calendar/SKILL.md                     (ha-nova:calendar — bounded calendar reads and single-event writes)
   todo/SKILL.md                         (ha-nova:todo — to-do list items + Local To-do lifecycle)
   backup/SKILL.md                       (ha-nova:backup — backup status/create/inspect/delete; restore stays in HA UI)
   updates/SKILL.md                      (ha-nova:updates — pending updates, release notes, feature-gated installs)
@@ -47,7 +47,7 @@ skills/
   maintenance/maintenance-reference.md  (reference doc — issue matrix, repair payloads, orphan gates)
   review/SKILL.md                       (ha-nova:review — config quality review + collision scan)
   entity-discovery/SKILL.md             (ha-nova:entity-discovery — entity lookup)
-  service-call/SKILL.md                 (ha-nova:service-call — service calls + runtime control)
+  service-call/SKILL.md                 (ha-nova:service-call — services, events/webhooks, alarm/lock runtime control)
   fallback/SKILL.md                     (ha-nova:fallback — mandatory fallback for relay-ready features)
   onboarding/SKILL.md                   (ha-nova:onboarding — onboarding + diagnostics)
   diagnose/SKILL.md                     (ha-nova:diagnose — failure root-cause: traces, logs, bounded windows)
@@ -106,7 +106,7 @@ Current mapping:
 | organize | inline | field-level registry mutations with direct preview/readback |
 | history | inline | read-only bounded timeline lookups |
 | health | inline | read-only status aggregation, best-effort diagnostics |
-| calendar | inline | REST-only bounded calendar event reads |
+| calendar | inline | bounded REST reads plus feature-gated service/WS event writes |
 | todo | inline | service-based item CRUD with feature gate, single-step list flow |
 | backup | inline | WS status/generate/delete with initiation-vs-completion polling |
 | updates | inline | entity-based overview, feature-gated install with entity-poll verification |
@@ -114,7 +114,7 @@ Current mapping:
 | maintenance | inline | grouped issue triage, token-gated destructive repairs with per-item verification |
 | review | inline | analysis is client-side, relay calls are reads only |
 | entity-discovery | inline | 1-2 calls, search + return |
-| service-call | inline | 2-3 calls, preview + execute |
+| service-call | inline | direct preview/confirm; any listener scan stays read-only and user-facing |
 | fallback | inline | research + web search + experimental relay calls (write-guarded) |
 | onboarding | inline | diagnostics only |
 | diagnose | inline | evidence gathering + reasoning, one gated debug escalation |
@@ -296,6 +296,28 @@ Rules:
 - credential-bearing, external/OAuth, or progress steps on pre-existing reauth flows hand off to the matching Home Assistant UI card; secrets never enter chat and the reauth flow stays preserved
 - config-entry existence/state is primary verification evidence; linked devices/entities are secondary
 - agent-created canceled add flows are deleted; Home Assistant-created reauth flows are preserved
+
+## Service Call Architecture
+
+`ha-nova:service-call` owns ordinary HA service calls plus four guarded runtime families:
+- custom event firing through `POST /api/events/{event_type}`
+- known JSON-webhook triggering through `POST /api/webhook/{webhook_id}`
+- alarm-panel runtime services with feature bits 1/2/4/8/16/32
+- lock runtime services, with `lock.open` gated by feature bit 1
+
+Event/webhook rules:
+- resolve an exact event type or an exact automation with a static webhook ID; never probe either endpoint
+- scan readable automation configs for every matching current/legacy trigger and classify literal event-data filters; compare with `GET /api/events` for unclassified event listeners
+- use WS `webhook/list` internally to check registration, POST support, and `local_only`; the ID never appears in user output or persistent storage
+- preview payload fields, known listeners, unknown-listener limits, and inherited action risk before bound confirmation
+- event success proves bus acceptance only; webhook HTTP 200 is deliberately opaque and does not prove registration, locality, or handler success
+- verify known automation runs against pre-call `last_triggered`/trace baselines; never auto-retry either runtime action
+
+Alarm/lock rules:
+- inspect the exact state and `supported_features` immediately before preview
+- codes/PINs never enter chat or Relay payloads; alarm arming hands off when both `code_arm_required` and `code_format` are set, while other code-bearing actions use `code_format`
+- unlocking/opening a lock and disarming an alarm use the typed high-consequence confirmation
+- security-state verification is transition-aware and never auto-retries
 
 ## Review Architecture
 

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -308,7 +308,7 @@ Rules:
 Event/webhook rules:
 - resolve an exact event type or an exact automation with a static webhook ID; never probe either endpoint
 - scan readable automation configs for every matching current/legacy trigger and classify literal event-data filters; compare with `GET /api/events` for unclassified event listeners
-- use WS `webhook/list` internally to check registration, POST support, and `local_only`; the ID never appears in user output or persistent storage
+- use WS `webhook/list` with `--out` into client-private scratch storage to check registration, POST support, and `local_only`; the full response never reaches stdout, user output, or persistent storage
 - preview payload fields, known listeners, unknown-listener limits, and inherited action risk before bound confirmation
 - event success proves bus acceptance only; webhook HTTP 200 is deliberately opaque and does not prove registration, locality, or handler success
 - verify known automation runs against pre-call `last_triggered`/trace baselines; never auto-retry either runtime action

--- a/docs/work/2026-07-15-wave-4-coverage-spec.md
+++ b/docs/work/2026-07-15-wave-4-coverage-spec.md
@@ -1,6 +1,6 @@
 # Wave 4 Coverage Spec
 
-Status: active
+Status: complete
 Date: 2026-07-15
 Sequencing SSOT: `docs/work/masterplan-2026-h2.md` → Wave 4
 
@@ -38,7 +38,8 @@ Each PR completes the repository PR merge checklist independently. No release/ve
 - Home Assistant config flows are response-driven data-entry flows with form, menu, external, progress, create-entry, and abort results.
 - The current frontend starts/fetches/submits/deletes config flows through `/api/config/config_entries/flow`, lists handlers through `/flow_handlers`, and discovers pending flows through WS `config_entries/flow/progress`.
 - Current Home Assistant Core registers calendar create as a service and calendar update/delete as feature-gated WebSocket commands.
-- Webhook IDs are authentication secrets; a webhook is owned by one automation and should remain local-only unless remote access is required.
+- Webhook IDs are authentication secrets. One registered handler can dispatch multiple automation triggers sharing the same ID; automation webhooks default to local-only.
+- Home Assistant deliberately returns HTTP 200 for unknown webhook IDs, blocked non-local calls, and handler failures, so only fresh listener evidence can verify an effect.
 
 ## Acceptance
 

--- a/docs/work/masterplan-2026-h2.md
+++ b/docs/work/masterplan-2026-h2.md
@@ -93,6 +93,8 @@ Already specced as "Phase 2" in `docs/reference/bridge-architecture.md` (`POST /
 
 ## Wave 3 — Review expansion: deliver "deeper audits rolling out" (skill-only)
 
+Status: **DONE** — #352
+
 The README already promises it; `skills/review/checks.md` covers only automations/scripts/storage-helpers. New rule families (candidates from the audit, IDs in checks.md style):
 
 - **SC-01…07 scenes**: dead entity refs, mixed color attributes, group capture, read-only domains captured, orphaned scenes.
@@ -106,10 +108,12 @@ The README already promises it; `skills/review/checks.md` covers only automation
 
 ## Wave 4 — Coverage gaps (skill-only)
 
-- **NEW `integration-setup` skill**: add/re-auth integrations via `config_entries/flow` (reuse the proven flow-loop machinery from `helper` Family 2). The largest remaining domain gap — exactly the moment non-technical users need help.
-- **Calendar writes**: `calendar.create_event`/update/delete with preview/confirm (calendar is read-only today).
-- **Events/webhooks**: decide ownership (`service-call` vs `fallback`) + payload examples for `POST /api/events/{type}` and `/api/webhook/{id}`.
-- **Alarm/lock guidance** in `service-call`: arm modes, code handling (codes never in chat) — builds on the Wave-0 high-consequence tier.
+Status: **DONE** — #353, #354, #355
+
+- **`integration-setup` skill**: add/re-auth integrations via `config_entries/flow`, reusing the proven response-driven flow loop from `helper` Family 2.
+- **Calendar writes**: create through `calendar.create_event`; update/delete through feature-gated calendar WS commands, all with preview/confirm and read-back verification.
+- **Events/webhooks**: owned by `service-call`, with listener-impact scans and payload contracts for `POST /api/events/{type}` and `/api/webhook/{id}`.
+- **Alarm/lock guidance** in `service-call`: feature-gated arm/open modes and code handling (codes never in chat), building on the Wave-0 high-consequence tier.
 
 ---
 
@@ -167,8 +171,8 @@ All waves land on `main` first; releases batch per the release-worthiness rule. 
 | 0 | Safety seams (3 PRs) | — | **DONE** — #340, #341, #342 |
 | 1 | Skill intelligence hardening (3 PRs) | — | **DONE** — #344, #345, #346 |
 | 2 | Config Snapshots | 0.5.0 | **DONE** — #347, #348, #349, #350 |
-| 3 | Review expansion (SC/D/TS/HX families, test-offer) | — | in progress |
-| 4 | Coverage (integration-setup, calendar writes, events, alarm/lock) | — | planned |
+| 3 | Review expansion (SC/D/TS/HX families, test-offer) | — | **DONE** — #352 |
+| 4 | Coverage (integration-setup, calendar writes, events, alarm/lock) | — | **DONE** — #353, #354, #355 |
 | 5 | Relay diagnosability | 0.5.0 (with Wave 2) | **DONE** — #351 |
 | 6 | Pairing Code + Home Base | 0.6.0 | planned (spec first) |
 | 7 | Update UX parity | — | planned |

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -64,6 +64,8 @@ For every Relay-Ready call in this skill:
 | External data stores (InfluxDB long-term history, Prometheus, ...) | Covered | external-sources |
 | Weather forecasts (`weather.get_forecasts`) | Covered | service-call |
 | Calendar Events (read / create / update / delete) | Covered | calendar |
+| Custom events / known JSON webhooks | Covered | service-call |
+| Alarm / lock runtime control | Covered | service-call |
 | To-do Lists (items + Local To-do lifecycle) | Covered | todo |
 | Area / Floor CRUD | Covered | organize |
 | Label CRUD / Rich label metadata | Covered | organize |
@@ -83,7 +85,7 @@ For every Relay-Ready call in this skill:
 | Apps / Supervisor | External | -- |
 | HACS | External | -- |
 | Zigbee / Z-Wave Config | External | -- (MQTT-level inspection of a Zigbee2MQTT setup: `mqtt`) |
-| Alarm / lock code management (lock user codes, alarm PINs) | External | -- (arming/disarming/locking itself: `service-call`, high-consequence confirmation) |
+| Alarm / lock code management (lock user codes, alarm PINs) | External | -- (Home Assistant UI; codes never enter chat) |
 
 ## Flow
 
@@ -189,23 +191,6 @@ ha-nova relay ws --data-file <payload-file>
 ```
 
 **Risks:** Device detach depends on integration support (`supports_remove_device`) and can sever the current device/config-entry relationship. Preview impact first.
-
-### Events / Webhooks -- RELAY-READY
-
-Fire a custom event on the HA event bus or trigger an inbound webhook.
-
-**Search:** `home assistant fire event REST api webhook 2026`
-
-**Experimental relay calls (no skill guardrails):**
-```text
-# Fire event: POST /api/events/{event_type}, body = event data JSON
-ha-nova relay core --method POST --path /api/events/<event_type> --body-file <payload-file>
-
-# Trigger webhook: POST /api/webhook/{webhook_id} (body as the webhook expects)
-ha-nova relay core --method POST --path /api/webhook/<webhook_id> --body-file <payload-file>
-```
-
-**Risks:** Every automation listening to that event/webhook fires. `search/related` does NOT index event listeners — scan automation configs for the same `event_type`/webhook trigger before previewing, or state in the preview that other listeners cannot be ruled out (pattern: `skills/ha-nova/test-run.md`). Webhook IDs are secrets; never print full IDs in output.
 
 ## Roadmap Features
 

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -98,7 +98,7 @@ Skills reference this section as "context skill → Active Preview Confirmation"
 ### Confirmation Tiers
 
 - `create`/`update`: natural confirmation bound to active preview.
-- high-consequence runtime action (grants physical access or is physically irreversible): token confirmation `confirm:<token>`, same enforcement as destructive writes. Canonical set: unlocking locks, disarming alarm panels, opening garage/gate/entry-door covers — `device_class` and what the entity controls decide, never the domain alone. Owning-skill escalations (e.g. retained MQTT publishes) sit on this same rung.
+- high-consequence runtime action (grants physical access or is physically irreversible): token confirmation `confirm:<token>`, same enforcement as destructive writes. Canonical set: unlocking or opening locks, disarming alarm panels, opening garage/gate/entry-door covers — `device_class` and what the entity controls decide, never the domain alone. Owning-skill escalations (e.g. retained MQTT publishes) sit on this same rung.
 - `delete`/destructive: token confirmation `confirm:<token>`.
   **Strict token enforcement:** User MUST reply with the exact token string (e.g., `confirm:del-main-lights`). Any other response — including "yes", "sure, delete it", "do it", or any natural-language confirmation — is NOT valid. Reject and re-prompt with the exact code required. In user-facing output call it the "confirmation code" (localized), never a "token" (see `skills/ha-nova/output-rules.md` → Localization).
   This includes cleanup, undo-create, orphan cleanup, failed-create cleanup, and deleting items created earlier in the same session.
@@ -199,6 +199,8 @@ Match user intent to exactly one skill:
 | repair statistics (orphans, unit mismatches, sum spikes), purge recorder history, clean up dead registry entries | `ha-nova:maintenance` |
 | turn on/off, toggle, set, call a service | `ha-nova:service-call` |
 | enable/disable/trigger an automation | `ha-nova:service-call` |
+| fire a custom event or trigger a known JSON webhook | `ha-nova:service-call` |
+| arm/disarm/trigger an alarm panel; lock/unlock/open a lock | `ha-nova:service-call` |
 | find entities by name, room, area | `ha-nova:entity-discovery` |
 | fix relay/auth/connectivity errors | `ha-nova:onboarding` |
 | undo, revert, or restore the last automation/script/helper change | the skill that wrote it — `ha-nova:write` (automation/script) or `ha-nova:helper` (helper). `revert` applies only to supported verified updates. Creates clean up through the normal delete flow; a DELETED automation/script/scene/dashboard/STORAGE helper restores from its auto config snapshot in the owning skill (`skills/ha-nova/config-snapshots.md`); config-entry helpers are not snapshot-covered — their recovery stays Backup/recreate. Run `ha-nova snapshot show` to see the saved update target if unsure |
@@ -216,6 +218,9 @@ Match user intent to exactly one skill:
 **"Create a scene called Movie Night"** → `ha-nova:scene`
 **"Activate the scene Movie Night"** → `ha-nova:service-call` (runtime action, not a config change)
 **"Unlock the front door"** → `ha-nova:service-call` (high-consequence: typed confirmation code)
+**"Arm the alarm in night mode"** → `ha-nova:service-call` (feature/code gate before preview)
+**"Fire the movie_night event"** → `ha-nova:service-call` (listener-impact scan before preview)
+**"Trigger the delivery webhook"** → `ha-nova:service-call` (webhook ID stays secret)
 **"Install the firmware update for my kitchen light"** → `ha-nova:updates` (never raw `update.install` through service-call)
 **"Publish an MQTT message"** → `ha-nova:mqtt` (never raw `mqtt.publish` through service-call)
 **"Test the automation I just created"** → `ha-nova:write` Phase 5 test offer (plan per `skills/ha-nova/test-run.md`); a plain manual trigger stays `ha-nova:service-call`

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -389,6 +389,35 @@ Call with response data:
 
 Supported target fields: `entity_id` (string or array), `area_id`, `device_id`.
 
+## Runtime Events And Webhooks
+
+Fire a custom event with an event-data JSON object:
+
+```json
+{"method":"POST","path":"/api/events/example_event","body":{"source":"ha_nova"}}
+```
+
+Inspect registered webhook metadata through WS without exposing the returned IDs:
+
+```json
+{"type":"webhook/list"}
+```
+
+Trigger a known JSON webhook only after the owning skill resolves the exact ID internally:
+
+```json
+{"method":"POST","path":"/api/webhook/<webhook_id>","body":{"example":"value"}}
+```
+
+Rules:
+
+- `/api/events/{event_type}` requires an exact custom event name and an object body; a successful response proves bus acceptance, not listener completion
+- automation webhook triggers default to POST/PUT and `local_only: true`; inspect the registered `allowed_methods` and locality before calling
+- multiple automation triggers can share one webhook ID and all will run
+- webhook IDs are authentication secrets; keep them in client-private scratch storage and out of previews, results, and logs
+- Home Assistant intentionally answers unknown IDs, blocked non-local requests, and handler failures with HTTP 200; verify matched automation runs instead
+- events and webhooks may already have fired when transport evidence is ambiguous; never retry automatically
+
 ## Calendar Event Writes
 
 `ha-nova:calendar` creates events through the service API and updates/deletes them through WS:

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -403,6 +403,8 @@ Inspect registered webhook metadata through WS without exposing the returned IDs
 {"type":"webhook/list"}
 ```
 
+Run that payload only with `ha-nova relay ws --data-file <payload-file> --out <result-file>`, with both files in client-private scratch storage. Never print the full response to stdout; inspect the saved result internally and expose only redacted metadata.
+
 Trigger a known JSON webhook only after the owning skill resolves the exact ID internally:
 
 ```json
@@ -414,7 +416,7 @@ Rules:
 - `/api/events/{event_type}` requires an exact custom event name and an object body; a successful response proves bus acceptance, not listener completion
 - automation webhook triggers default to POST/PUT and `local_only: true`; inspect the registered `allowed_methods` and locality before calling
 - multiple automation triggers can share one webhook ID and all will run
-- webhook IDs are authentication secrets; keep them in client-private scratch storage and out of previews, results, and logs
+- webhook IDs are authentication secrets; keep them in client-private scratch storage and out of previews, stdout, user-facing results, and logs
 - Home Assistant intentionally answers unknown IDs, blocked non-local requests, and handler failures with HTTP 200; verify matched automation runs instead
 - events and webhooks may already have fired when transport evidence is ambiguous; never retry automatically
 

--- a/skills/service-call/SKILL.md
+++ b/skills/service-call/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: service-call
-description: Use when the user wants to call Home Assistant services (turn on lights, set temperature, toggle switches) through HA NOVA Relay.
+description: Use when the user wants to call Home Assistant services, fire custom events, trigger known webhooks, or control alarm panels and locks through HA NOVA Relay.
 license: MIT
 compatibility: Requires the ha-nova CLI (run 'ha-nova setup' first) and the HA NOVA Relay in Home Assistant (App, or standalone container on Container/Core).
 ---
@@ -14,6 +14,8 @@ Direct device/service control:
 - call any HA service (`light.turn_on`, `climate.set_temperature`, etc.)
 - list available services
 - target by entity_id, area_id, or device_id
+- fire a named custom event or trigger a known JSON webhook
+- control alarm panels and locks with capability and secret-code gates
 
 No config mutations (use `ha-nova:write` for automation/script changes).
 
@@ -26,6 +28,10 @@ If this fails: `ha-nova setup`
 
 Use file-based payloads for service writes:
 - `ha-nova relay core --method POST --path /api/services/... --body-file <payload-file>`
+- `ha-nova relay core --method GET --path /api/events`
+- `ha-nova relay core --method POST --path /api/events/<event_type> --body-file <payload-file>`
+- `ha-nova relay ws --data-file <payload-file>` for internal `webhook/list` metadata
+- `ha-nova relay core --method POST --path /api/webhook/<webhook_id> --body-file <payload-file>`
 - `ha-nova relay core --method GET --path /api/states/<entity_id>`
 - `--out <result-file>` when the response is large
 
@@ -42,7 +48,7 @@ Use file-based payloads for service writes:
 | `notify.*` / `persistent_notification.*` | `ha-nova:notify` |
 | `logger.set_level` | `ha-nova:diagnose` |
 
-Runtime calls that stay here: `scene.turn_on`, `automation.trigger`, direct `script.*` (see Automation And Script Runtime Calls), and plain `lock`/`alarm_control_panel`/`cover` control under the high-consequence rule (see Safety).
+Runtime calls that stay here: `scene.turn_on`, `automation.trigger`, direct `script.*` (see Automation And Script Runtime Calls), custom events, known JSON webhooks, and `lock`/`alarm_control_panel`/`cover` control under the gates below.
 
 ## Response services
 
@@ -138,6 +144,49 @@ Rules:
 - Post-write test runs: plan structure, real-path recipes, and the post-run follow-up live in `skills/ha-nova/test-run.md`.
 - When a Test Plan Card already showed the concrete preview (service, target, payload, `skip_condition`), the user's option choice on that card IS the bound confirmation — do not ask again.
 
+## Custom Events And Webhooks
+
+Both paths are runtime actions that can start every matching automation. Never use either endpoint to probe or discover whether a listener exists.
+
+### Custom events
+
+1. Require the exact user-defined `event_type` and a JSON-object payload. Never normalize or invent the name, and never fire core lifecycle/state events through this flow.
+2. Read `GET /api/events` for the total listener count. Scan readable automation configs for current event triggers (`trigger: event`) and legacy triggers (`platform: event`) with the same static `event_type`; apply any literal `event_data` filters to classify known matches. Templated event types and non-automation listeners are not safely enumerable — disclose that limit.
+3. Inspect known matching automations for high-consequence actions. Preview the exact event type, payload fields, known matching automations, total listener count, unclassified-listener warning, and risk tier. Use natural bound confirmation unless the known impact reaches the high-consequence tier; then require `confirm:<token>`.
+4. Execute `POST /api/events/<event_type>` with the JSON object. A success response proves only that Home Assistant accepted the bus fire.
+5. For known matching automations, compare `last_triggered` or a new trace with the pre-call baseline using up to three reads over ten seconds. Never claim that every listener completed, and never repeat an event automatically after any timeout or transport error.
+
+### Webhooks
+
+1. Resolve the target automation by exact identity, then extract its static `webhook_id` internally from the stored trigger config. Scan all readable automation configs for that exact ID because multiple triggers can share one webhook. A templated ID is not safe to resolve here.
+2. Call WS `webhook/list` internally and confirm that the ID is registered and `POST` is allowed; retain the reported `local_only` setting. The current Relay sends JSON; if the automation expects form/query data or another method, stop and use an explicitly authorized local caller outside this JSON-only flow.
+3. Treat the webhook ID as an authentication secret: never ask the user to paste it, echo it, put it in a preview/result, or persist it outside client-private scratch storage. Only the internal request path may contain it.
+4. Preview the JSON payload fields, every known matching automation, local-only status, and risk tier — never the ID. Shared IDs mean every match runs. Use the same bound/high-consequence confirmation rule as custom events.
+5. Execute one `POST /api/webhook/<webhook_id>`. Home Assistant intentionally returns HTTP 200 for unknown IDs, blocked remote calls, and handler errors, so status alone is not verification.
+6. Compare every known match's `last_triggered` or trace baseline with up to three reads over ten seconds. If no fresh run appears, report the outcome as unverified; never retry automatically and never weaken `local_only` to make the call work.
+
+## Alarm Panels And Locks
+
+Read the exact entity state immediately before preview. Never include a `code` field in a Relay payload and never ask for, accept, repeat, or store a PIN/code in chat.
+
+Alarm panel services and feature bits:
+
+| Service | Required `supported_features` bit | Expected terminal state |
+|---|---:|---|
+| `alarm_arm_home` | 1 | `armed_home` |
+| `alarm_arm_away` | 2 | `armed_away` |
+| `alarm_arm_night` | 4 | `armed_night` |
+| `alarm_trigger` | 8 | `triggered` |
+| `alarm_arm_custom_bypass` | 16 | `armed_custom_bypass` |
+| `alarm_arm_vacation` | 32 | `armed_vacation` |
+| `alarm_disarm` | none | `disarmed` |
+
+For an arm action, hand off to the Home Assistant UI when `code_arm_required` is true and `code_format` is present. For disarm/trigger, hand off when `code_format` indicates a code. `alarm_disarm` takes the typed high-consequence confirmation; `alarm_trigger` is disruptive, so warn explicitly and require bound confirmation even when no code is needed.
+
+`lock.lock` and `lock.unlock` have no feature bit. `lock.open` requires `supported_features & 1`. If `code_format` is present, finish the action in the Home Assistant UI. `lock.unlock` and `lock.open` take the typed high-consequence confirmation; `lock.lock` uses normal bound confirmation.
+
+Verify terminal states transition-aware: alarm panels can pass through `arming`, `pending`, or `disarming`; locks can pass through `locking`, `unlocking`, or `opening`. A service response is not proof of the physical result. Report `jammed`, `unavailable`, timeouts, or an unchanged terminal state as a discrepancy; never auto-retry a security action.
+
 ## Error Handling
 
 Full relay/upstream error taxonomy (codes, HTTP-status split, retry rules): `skills/ha-nova/relay-api.md` → Error Handling.
@@ -164,7 +213,7 @@ Previews are the runtime-action Preview Card (`apply · cancel`); results are th
 - For any HA write this skill does not cover, STOP and invoke `ha-nova:fallback` first — never probe unfamiliar write endpoints.
 
 - No token confirmation needed for ordinary service calls; confirmation is still bound to the active preview.
-- **High-consequence runtime actions take the typed `confirm:<token>`** like a destructive write: unlocking a lock, disarming an alarm panel, opening a garage door, gate, or entry-door cover. Check `device_class` and what the entity controls — a garage door exposed as `cover.*` belongs here, a living-room blind does not. These actions grant physical access; calling the opposite service afterwards does not undo the exposure window.
+- **High-consequence runtime actions take the typed `confirm:<token>`** like a destructive write: unlocking or opening a lock, disarming an alarm panel, opening a garage door, gate, or entry-door cover. Check `device_class` and what the entity controls — a garage door exposed as `cover.*` belongs here, a living-room blind does not. These actions grant physical access; calling the opposite service afterwards does not undo the exposure window.
 - For potentially disruptive services (`homeassistant.restart`, `homeassistant.stop`), warn and ask for explicit post-preview confirmation.
 
 ## Guardrails

--- a/skills/service-call/SKILL.md
+++ b/skills/service-call/SKILL.md
@@ -30,7 +30,7 @@ Use file-based payloads for service writes:
 - `ha-nova relay core --method POST --path /api/services/... --body-file <payload-file>`
 - `ha-nova relay core --method GET --path /api/events`
 - `ha-nova relay core --method POST --path /api/events/<event_type> --body-file <payload-file>`
-- `ha-nova relay ws --data-file <payload-file>` for internal `webhook/list` metadata
+- `ha-nova relay ws --data-file <payload-file> --out <result-file>` for internal `webhook/list` metadata; both files stay in client-private scratch storage and the response never goes to stdout
 - `ha-nova relay core --method POST --path /api/webhook/<webhook_id> --body-file <payload-file>`
 - `ha-nova relay core --method GET --path /api/states/<entity_id>`
 - `--out <result-file>` when the response is large
@@ -159,7 +159,7 @@ Both paths are runtime actions that can start every matching automation. Never u
 ### Webhooks
 
 1. Resolve the target automation by exact identity, then extract its static `webhook_id` internally from the stored trigger config. Scan all readable automation configs for that exact ID because multiple triggers can share one webhook. A templated ID is not safe to resolve here.
-2. Call WS `webhook/list` internally and confirm that the ID is registered and `POST` is allowed; retain the reported `local_only` setting. The current Relay sends JSON; if the automation expects form/query data or another method, stop and use an explicitly authorized local caller outside this JSON-only flow.
+2. Call WS `webhook/list` internally with `--out <result-file>` in client-private scratch storage; never allow its secret-bearing response on stdout. Read the saved result internally, confirm that the ID is registered and `POST` is allowed, and retain only redacted metadata such as `local_only` for preview. The current Relay sends JSON; if the automation expects form/query data or another method, stop and use an explicitly authorized local caller outside this JSON-only flow.
 3. Treat the webhook ID as an authentication secret: never ask the user to paste it, echo it, put it in a preview/result, or persist it outside client-private scratch storage. Only the internal request path may contain it.
 4. Preview the JSON payload fields, every known matching automation, local-only status, and risk tier — never the ID. Shared IDs mean every match runs. Use the same bound/high-consequence confirmation rule as custom events.
 5. Execute one `POST /api/webhook/<webhook_id>`. Home Assistant intentionally returns HTTP 200 for unknown IDs, blocked remote calls, and handler errors, so status alone is not verification.

--- a/skills/service-call/SKILL.md
+++ b/skills/service-call/SKILL.md
@@ -181,7 +181,7 @@ Alarm panel services and feature bits:
 | `alarm_arm_vacation` | 32 | `armed_vacation` |
 | `alarm_disarm` | none | `disarmed` |
 
-For an arm action, hand off to the Home Assistant UI when `code_arm_required` is true and `code_format` is present. For disarm/trigger, hand off when `code_format` indicates a code. `alarm_disarm` takes the typed high-consequence confirmation; `alarm_trigger` is disruptive, so warn explicitly and require bound confirmation even when no code is needed.
+For an arm action, hand off to the Home Assistant UI whenever `code_arm_required` is true, even when `code_format` is absent. For disarm/trigger, hand off when `code_format` indicates a code. `alarm_disarm` takes the typed high-consequence confirmation; `alarm_trigger` is disruptive, so warn explicitly and require bound confirmation even when no code is needed.
 
 `lock.lock` and `lock.unlock` have no feature bit. `lock.open` requires `supported_features & 1`. If `code_format` is present, finish the action in the Home Assistant UI. `lock.unlock` and `lock.open` take the typed high-consequence confirmation; `lock.lock` uses normal bound confirmation.
 

--- a/tests/skills/ha-nova-contract.test.ts
+++ b/tests/skills/ha-nova-contract.test.ts
@@ -598,8 +598,11 @@ describe("ha-nova contract", () => {
     const fallback = readFileSync("skills/fallback/SKILL.md", "utf8");
     expect(fallback).toContain("| System Health / Repairs | Covered | health |");
     expect(fallback).toContain("| Calendar Events (read / create / update / delete) | Covered | calendar |");
+    expect(fallback).toContain("| Custom events / known JSON webhooks | Covered | service-call |");
+    expect(fallback).toContain("| Alarm / lock runtime control | Covered | service-call |");
     expect(fallback).not.toContain("### System Health / Repairs -- RELAY-READY");
     expect(fallback).not.toContain("### Calendar Queries -- RELAY-READY");
+    expect(fallback).not.toContain("### Events / Webhooks -- RELAY-READY");
     expect(fallback).not.toContain("<calendar-events-path>");
     expect(fallback).not.toContain("--path '/api/calendars/");
     expect(fallback).toContain("| Dashboard / Lovelace (storage lifecycle, cards, resources) | Covered | dashboard |");

--- a/tests/skills/service-call-contract.test.ts
+++ b/tests/skills/service-call-contract.test.ts
@@ -172,12 +172,15 @@ describe("service call contract", () => {
 
     it("keeps webhook IDs secret and rejects opaque HTTP 200 as proof", () => {
       expect(skillDoc).toContain("WS `webhook/list`");
+      expect(skillDoc).toContain("never allow its secret-bearing response on stdout");
+      expect(skillDoc).toContain("`--out <result-file>` in client-private scratch storage");
       expect(skillDoc).toContain("multiple triggers can share one webhook");
       expect(skillDoc).toContain("never ask the user to paste it");
       expect(skillDoc).toContain("persist it outside client-private scratch storage");
       expect(skillDoc).toContain("unknown IDs, blocked remote calls, and handler errors");
       expect(skillDoc).toContain("never weaken `local_only`");
       expect(relayApi).toContain('{"type":"webhook/list"}');
+      expect(relayApi).toContain("Never print the full response to stdout");
       expect(relayApi).toContain("multiple automation triggers can share one webhook ID");
       expect(apiMatrix).toContain("opaque HTTP 200; effect verification required");
       expect(waveSpec).toContain("only fresh listener evidence can verify an effect");

--- a/tests/skills/service-call-contract.test.ts
+++ b/tests/skills/service-call-contract.test.ts
@@ -11,6 +11,26 @@ const skillDoc = readFileSync(
   resolve(__dirname, "../../skills/service-call/SKILL.md"),
   "utf-8",
 );
+const contextSkill = readFileSync(
+  resolve(__dirname, "../../skills/ha-nova/SKILL.md"),
+  "utf-8",
+);
+const fallbackSkill = readFileSync(
+  resolve(__dirname, "../../skills/fallback/SKILL.md"),
+  "utf-8",
+);
+const architecture = readFileSync(
+  resolve(__dirname, "../../docs/reference/skill-architecture.md"),
+  "utf-8",
+);
+const apiMatrix = readFileSync(
+  resolve(__dirname, "../../docs/reference/ha-api-matrix.md"),
+  "utf-8",
+);
+const waveSpec = readFileSync(
+  resolve(__dirname, "../../docs/work/2026-07-15-wave-4-coverage-spec.md"),
+  "utf-8",
+);
 
 describe("service call contract", () => {
   describe("relay-api.md documents service call paths", () => {
@@ -132,6 +152,73 @@ describe("service call contract", () => {
       expect(skillDoc).toContain("before using `area_id`");
       expect(skillDoc).toContain("second blocking ambiguity question");
       expect(skillDoc).toContain("narrower confirmed target");
+    });
+  });
+
+  describe("custom event and webhook runtime actions", () => {
+    it("pins event listener impact, confirmation, and bounded verification", () => {
+      expect(skillDoc).toContain("## Custom Events And Webhooks");
+      expect(skillDoc).toContain("GET /api/events");
+      expect(skillDoc).toContain("`webhook/list` metadata");
+      expect(skillDoc).toContain("`trigger: event`");
+      expect(skillDoc).toContain("`platform: event`");
+      expect(skillDoc).toContain("literal `event_data` filters");
+      expect(skillDoc).toContain("unclassified-listener warning");
+      expect(skillDoc).toContain("up to three reads over ten seconds");
+      expect(skillDoc).toContain("never repeat an event automatically");
+      expect(relayApi).toContain('"path":"/api/events/example_event"');
+      expect(apiMatrix).toContain("Custom events use an exact user-defined event type");
+    });
+
+    it("keeps webhook IDs secret and rejects opaque HTTP 200 as proof", () => {
+      expect(skillDoc).toContain("WS `webhook/list`");
+      expect(skillDoc).toContain("multiple triggers can share one webhook");
+      expect(skillDoc).toContain("never ask the user to paste it");
+      expect(skillDoc).toContain("persist it outside client-private scratch storage");
+      expect(skillDoc).toContain("unknown IDs, blocked remote calls, and handler errors");
+      expect(skillDoc).toContain("never weaken `local_only`");
+      expect(relayApi).toContain('{"type":"webhook/list"}');
+      expect(relayApi).toContain("multiple automation triggers can share one webhook ID");
+      expect(apiMatrix).toContain("opaque HTTP 200; effect verification required");
+      expect(waveSpec).toContain("only fresh listener evidence can verify an effect");
+    });
+
+    it("moves ownership out of mandatory fallback", () => {
+      expect(contextSkill).toContain("fire a custom event or trigger a known JSON webhook");
+      expect(contextSkill).toContain('**"Fire the movie_night event"** → `ha-nova:service-call`');
+      expect(fallbackSkill).toContain("| Custom events / known JSON webhooks | Covered | service-call |");
+      expect(fallbackSkill).not.toContain("### Events / Webhooks -- RELAY-READY");
+      expect(architecture).toContain("## Service Call Architecture");
+      expect(architecture).toContain("webhook HTTP 200 is deliberately opaque");
+    });
+  });
+
+  describe("alarm and lock security gates", () => {
+    it("pins alarm modes, feature bits, code handoff, and terminal states", () => {
+      for (const [service, bit, state] of [
+        ["alarm_arm_home", "1", "armed_home"],
+        ["alarm_arm_away", "2", "armed_away"],
+        ["alarm_arm_night", "4", "armed_night"],
+        ["alarm_trigger", "8", "triggered"],
+        ["alarm_arm_custom_bypass", "16", "armed_custom_bypass"],
+        ["alarm_arm_vacation", "32", "armed_vacation"],
+      ]) {
+        expect(skillDoc).toContain(`| \`${service}\` | ${bit} | \`${state}\` |`);
+      }
+      expect(skillDoc).toContain("`code_arm_required` is true and `code_format` is present");
+      expect(skillDoc).toContain("`code_format` indicates a code");
+      expect(skillDoc).toContain("Never include a `code` field in a Relay payload");
+      expect(skillDoc).toContain("finish the action in the Home Assistant UI");
+    });
+
+    it("feature-gates lock.open and elevates access-granting actions", () => {
+      expect(skillDoc).toContain("`lock.open` requires `supported_features & 1`");
+      expect(skillDoc).toContain("`lock.unlock` and `lock.open` take the typed high-consequence confirmation");
+      expect(skillDoc).toContain("never auto-retry a security action");
+      expect(contextSkill).toContain("unlocking or opening locks");
+      expect(fallbackSkill).toContain("| Alarm / lock runtime control | Covered | service-call |");
+      expect(fallbackSkill).toContain("Home Assistant UI; codes never enter chat");
+      expect(architecture).toContain("feature bits 1/2/4/8/16/32");
     });
   });
 });

--- a/tests/skills/service-call-contract.test.ts
+++ b/tests/skills/service-call-contract.test.ts
@@ -205,7 +205,8 @@ describe("service call contract", () => {
       ]) {
         expect(skillDoc).toContain(`| \`${service}\` | ${bit} | \`${state}\` |`);
       }
-      expect(skillDoc).toContain("`code_arm_required` is true and `code_format` is present");
+      expect(skillDoc).toContain("whenever `code_arm_required` is true");
+      expect(skillDoc).toContain("even when `code_format` is absent");
       expect(skillDoc).toContain("`code_format` indicates a code");
       expect(skillDoc).toContain("Never include a `code` field in a Relay payload");
       expect(skillDoc).toContain("finish the action in the Home Assistant UI");

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -133,8 +133,9 @@ const WORD_BUDGETS: Record<string, number> = {
   // ratcheted for the owning-skill deferral table + high-consequence
   // confirmation rule (Wave 0), and again for the differentiated verify
   // block (transitions, stateless targets, canonical area expansion,
-  // scene-timestamp verify) + capability gate (2026-h2 Wave 1a).
-  "service-call": 1800,
+  // scene-timestamp verify) + capability gate (2026-h2 Wave 1a); runtime
+  // event/webhook and alarm/lock contracts (2026-h2 Wave 4).
+  "service-call": 2600,
   // Carries the canonical File-Change Preview example — the only layout
   // source for file edits; concrete examples are what make a card renderable.
   // Sibling-survival verification (Wave 1b) + yaml snapshot capture with
@@ -150,9 +151,9 @@ const WORD_BUDGETS: Record<string, number> = {
   // purge quantification, glob expansion, apply_filter semantics
   // (2026-h2 Wave 1b).
   maintenance: 1400,
-  // events/webhooks Relay-Ready section and the blueprint payload examples
-  // (integration onboarding moved to its own skill in Wave 4).
-  fallback: 2450,
+  // blueprint payload examples; integration onboarding and runtime
+  // events/webhooks moved to owning skills in Wave 4.
+  fallback: 2300,
   // semantic-slot note on the read templates (Wave 0); pre-write cross-field
   // constraint checks + drift-check step (Wave 1); pre-delete snapshot
   // capture (Wave 2).


### PR DESCRIPTION
## Summary
- move custom events and known JSON webhooks from fallback to service-call
- add listener-impact, opaque-webhook-response, secret-ID, and bounded verification gates
- add alarm/lock feature-bit, code-handoff, high-consequence, and transition-aware guidance
- mark Wave 3 and Wave 4 complete in the active H2 masterplan

## Verification
- npm run verify
- npm run test:safe (82 files, 802 tests)
- npx vitest run tests/skills/service-call-contract.test.ts tests/skills/ha-nova-contract.test.ts tests/skills/skill-template-contract.test.ts (71 tests)
- git diff --check

## Risk
- no live writes: event, webhook, alarm, and lock calls can have real side effects; contracts pin conservative verification and no-auto-retry behavior