### PR TITLE
feat(onboarding): complete Wave 6 setup flank

### DIFF
--- a/cli/prompt_reader.go
+++ b/cli/prompt_reader.go
@@ -25,6 +25,17 @@ func clearSetupNextPromptSkipsStaleBlankInput() {
 	setupNextPromptSkipsStaleBlankInput = false
 }
 
+func beginSetupStaleBlankInputWindow() time.Time {
+	if consumeSetupNextPromptSkipsStaleBlankInput() {
+		return time.Now().Add(setupStaleBlankInputWindow)
+	}
+	return time.Time{}
+}
+
+func setupInputIsStaleBlank(deadline time.Time, blank bool) bool {
+	return !deadline.IsZero() && blank && !time.Now().After(deadline)
+}
+
 func rerenderSetupPromptAfterStaleBlank(out io.Writer) {
 	if resolveSetupUISession(out).enhanced() {
 		fmt.Fprint(out, "\r\033[2K")
@@ -34,10 +45,7 @@ func rerenderSetupPromptAfterStaleBlank(out io.Writer) {
 }
 
 func promptLineWithOptions(reader *bufio.Reader, out io.Writer, label, defaultValue string, allowWizardNav bool) (string, error) {
-	var staleBlankDeadline time.Time
-	if consumeSetupNextPromptSkipsStaleBlankInput() {
-		staleBlankDeadline = time.Now().Add(setupStaleBlankInputWindow)
-	}
+	staleBlankDeadline := beginSetupStaleBlankInputWindow()
 
 	for {
 		fmt.Fprint(out, "  ")
@@ -52,7 +60,7 @@ func promptLineWithOptions(reader *bufio.Reader, out io.Writer, label, defaultVa
 			return "", err
 		}
 		line = strings.TrimSpace(line)
-		if !staleBlankDeadline.IsZero() && line == "" && !time.Now().After(staleBlankDeadline) {
+		if setupInputIsStaleBlank(staleBlankDeadline, line == "") {
 			rerenderSetupPromptAfterStaleBlank(out)
 			continue
 		}

--- a/cli/setup_discovery.go
+++ b/cli/setup_discovery.go
@@ -23,53 +23,115 @@ var resolveHostToIPv4ForDiscovery = resolveHostToIPv4
 var setupDiscoveryIPResolveTimeout = 2 * time.Second
 var setupDiscoveryIPProbeTimeout = 3 * time.Second
 
+const setupDiscoveryMaxCandidateCount = 12
+
+var setupDiscoveryMaxProbeTimeout = 3 * time.Second
+
+type setupDiscoveryCandidate struct {
+	Host   string
+	HAURL  string
+	Via    string
+	Source string
+}
+
+type setupDiscoveryProbe struct {
+	Host   string
+	Source string
+}
+
 func detectDefaultHAHost(cfg runtimeConfig) string {
 	host, _, _ := detectDefaultHAHostChoice(cfg)
 	return host
 }
 
-// detectDefaultHAHostChoice returns the best default Home Assistant host, the
-// mDNS name it was discovered through (empty unless the result was normalized
-// to an IP), and whether the host was confirmed reachable. mDNS names like
-// "homeassistant.local" are only used to FIND the instance — the offered and
-// later persisted default is the resolved IP whenever possible, because those
-// names can stop resolving mid-setup (notably on Windows).
+// detectDefaultHAHostChoice preserves the single-result helper used by focused
+// discovery tests while sharing the production all-candidate implementation.
 func detectDefaultHAHostChoice(cfg runtimeConfig) (string, string, bool) {
+	found, fallback := discoverReachableHAHosts(cfg)
+	if len(found) == 0 {
+		return fallback, "", false
+	}
+	return found[0].Host, found[0].Via, true
+}
+
+// discoverReachableHAHosts probes every bounded candidate instead of silently
+// stopping at the first reachable Home Assistant. Results retain candidate
+// priority and are deduplicated after .local names are resolved to a confirmed
+// IP address.
+func discoverReachableHAHosts(cfg runtimeConfig) ([]setupDiscoveryCandidate, string) {
 	deadline := time.Now().Add(setupDiscoveryOverallTimeout)
-	for _, candidate := range collectCandidateHosts(cfg) {
-		if candidate == "" {
-			continue
-		}
+	probes := collectDiscoveryProbes(cfg)
+	found := make([]setupDiscoveryCandidate, 0, len(probes))
+	seen := map[string]struct{}{}
+
+	for idx, probe := range probes {
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
 			break
 		}
-		if _, err := resolveHAURLBaseWithinTimeoutForDiscovery(candidate, remaining); err == nil {
-			if ip := confirmedIPv4ForMDNSHost(candidate, time.Until(deadline)); ip != "" {
-				return ip, candidate, true
-			}
-			return candidate, "", true
+		probesLeft := len(probes) - idx
+		probeTimeout := remaining / time.Duration(probesLeft)
+		if probeTimeout > setupDiscoveryMaxProbeTimeout {
+			probeTimeout = setupDiscoveryMaxProbeTimeout
 		}
+		if probeTimeout <= 0 {
+			break
+		}
+		probeDeadline := time.Now().Add(probeTimeout)
+
+		resolved, err := resolveHAURLBaseWithinTimeoutForDiscovery(probe.Host, probeTimeout)
+		if err != nil {
+			continue
+		}
+		candidate := setupDiscoveryCandidate{
+			Host:   normalizeHostInput(resolved),
+			HAURL:  strings.TrimRight(resolved, "/"),
+			Source: probe.Source,
+		}
+		if probeDeadline.After(deadline) {
+			probeDeadline = deadline
+		}
+		if host, haURL := confirmedDiscoveryIPv4(probe.Host, probeDeadline); host != "" {
+			candidate.Host = host
+			candidate.HAURL = haURL
+			candidate.Via = probe.Host
+		}
+		key := strings.ToLower(normalizeHostInput(candidate.Host))
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		found = append(found, candidate)
 	}
-	return preferredUnverifiedHAHost(cfg), "", false
+
+	return found, preferredUnverifiedHAHost(cfg)
 }
 
-func confirmedIPv4ForMDNSHost(host string, remaining time.Duration) string {
+func confirmedDiscoveryIPv4(host string, deadline time.Time) (string, string) {
+	remaining := time.Until(deadline)
 	if remaining <= 0 {
-		return ""
+		return "", ""
 	}
 	trimmed := strings.TrimSuffix(strings.ToLower(host), ".")
 	if !strings.HasSuffix(trimmed, ".local") {
-		return ""
+		return "", ""
 	}
 	ip := resolveHostToIPv4ForDiscovery(host, min(setupDiscoveryIPResolveTimeout, remaining))
 	if ip == "" || ip == host {
-		return ""
+		return "", ""
 	}
-	if _, err := resolveHAURLBaseWithinTimeoutForDiscovery(ip, min(setupDiscoveryIPProbeTimeout, remaining)); err != nil {
-		return ""
+	remaining = time.Until(deadline)
+	if remaining <= 0 {
+		return "", ""
 	}
-	return ip
+	resolved, err := resolveHAURLBaseWithinTimeoutForDiscovery(ip, min(setupDiscoveryIPProbeTimeout, remaining))
+	if err != nil {
+		return "", ""
+	}
+	return ip, strings.TrimRight(resolved, "/")
 }
 
 func resolveHostToIPv4(host string, timeout time.Duration) string {
@@ -87,30 +149,30 @@ func resolveHostToIPv4(host string, timeout time.Duration) string {
 	return ""
 }
 
-func collectCandidateHosts(cfg runtimeConfig) []string {
-	candidates := []string{}
-	appendUnique := func(value string) {
+func collectDiscoveryProbes(cfg runtimeConfig) []setupDiscoveryProbe {
+	candidates := []setupDiscoveryProbe{}
+	appendUnique := func(value, source string) {
 		host := normalizeHostInput(value)
-		if host == "" {
+		if host == "" || len(candidates) >= setupDiscoveryMaxCandidateCount {
 			return
 		}
 		for _, existing := range candidates {
-			if existing == host {
+			if strings.EqualFold(existing.Host, host) {
 				return
 			}
 		}
-		candidates = append(candidates, host)
+		candidates = append(candidates, setupDiscoveryProbe{Host: host, Source: source})
 	}
 
-	appendUnique(cfg.HAHost)
-	appendUnique(cfg.HAURL)
-	appendUnique(cfg.RelayBaseURL)
-	appendUnique(discoverHAViaMDNSForDiscovery())
-	appendUnique("homeassistant.local")
-	appendUnique("home-assistant.local")
-	appendUnique("hass.local")
+	appendUnique(cfg.HAHost, "saved Home Assistant address")
+	appendUnique(cfg.HAURL, "saved Home Assistant address")
+	appendUnique(cfg.RelayBaseURL, "saved Relay address")
+	appendUnique(discoverHAViaMDNSForDiscovery(), "mDNS")
+	appendUnique("homeassistant.local", "common network name")
+	appendUnique("home-assistant.local", "common network name")
+	appendUnique("hass.local", "common network name")
 	for _, candidate := range collectARPHostsForDiscovery() {
-		appendUnique(candidate)
+		appendUnique(candidate, "local network cache")
 	}
 
 	return candidates

--- a/cli/setup_discovery_multi_test.go
+++ b/cli/setup_discovery_multi_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestDiscoverReachableHAHostsReturnsAllInPriorityOrderAndDeduplicatesResolvedHosts(t *testing.T) {
+	originalResolve := resolveHAURLBaseWithinTimeoutForDiscovery
+	originalMDNS := discoverHAViaMDNSForDiscovery
+	originalARP := collectARPHostsForDiscovery
+	originalIPResolve := resolveHostToIPv4ForDiscovery
+	t.Cleanup(func() {
+		resolveHAURLBaseWithinTimeoutForDiscovery = originalResolve
+		discoverHAViaMDNSForDiscovery = originalMDNS
+		collectARPHostsForDiscovery = originalARP
+		resolveHostToIPv4ForDiscovery = originalIPResolve
+	})
+
+	resolveHAURLBaseWithinTimeoutForDiscovery = func(input string, _ time.Duration) (string, error) {
+		switch input {
+		case "saved.local":
+			return "http://saved.local:8123", nil
+		case "other.local":
+			return "https://other.local", nil
+		case "10.0.0.1":
+			return "http://10.0.0.1:8123", nil
+		case "10.0.0.2":
+			return "https://10.0.0.2", nil
+		case "10.0.0.3":
+			return "http://10.0.0.3:8123", nil
+		default:
+			return "", assertDiscoveryFailure{}
+		}
+	}
+	discoverHAViaMDNSForDiscovery = func() string { return "other.local" }
+	collectARPHostsForDiscovery = func() []string { return []string{"10.0.0.3"} }
+	resolveHostToIPv4ForDiscovery = func(host string, _ time.Duration) string {
+		switch host {
+		case "saved.local", "other.local":
+			return "10.0.0.1"
+		default:
+			return ""
+		}
+	}
+
+	found, fallback := discoverReachableHAHosts(runtimeConfig{
+		HAHost:       "saved.local",
+		RelayBaseURL: "http://10.0.0.2:8791",
+	})
+	if fallback != "saved.local" {
+		t.Fatalf("fallback = %q, want saved.local", fallback)
+	}
+	want := []setupDiscoveryCandidate{
+		{Host: "10.0.0.1", HAURL: "http://10.0.0.1:8123", Via: "saved.local", Source: "saved Home Assistant address"},
+		{Host: "10.0.0.2", HAURL: "https://10.0.0.2", Source: "saved Relay address"},
+		{Host: "10.0.0.3", HAURL: "http://10.0.0.3:8123", Source: "local network cache"},
+	}
+	if len(found) != len(want) {
+		t.Fatalf("found = %+v, want %d candidates", found, len(want))
+	}
+	for idx := range want {
+		if found[idx] != want[idx] {
+			t.Fatalf("found[%d] = %+v, want %+v", idx, found[idx], want[idx])
+		}
+	}
+}
+
+func TestCollectDiscoveryProbesCapsCandidateCount(t *testing.T) {
+	originalMDNS := discoverHAViaMDNSForDiscovery
+	originalARP := collectARPHostsForDiscovery
+	t.Cleanup(func() {
+		discoverHAViaMDNSForDiscovery = originalMDNS
+		collectARPHostsForDiscovery = originalARP
+	})
+	discoverHAViaMDNSForDiscovery = func() string { return "discovered.local" }
+	collectARPHostsForDiscovery = func() []string {
+		hosts := make([]string, 20)
+		for idx := range hosts {
+			hosts[idx] = fmt.Sprintf("10.0.0.%d", idx+1)
+		}
+		return hosts
+	}
+
+	probes := collectDiscoveryProbes(runtimeConfig{
+		HAHost:       "saved.local",
+		HAURL:        "https://saved-url.example",
+		RelayBaseURL: "http://relay.example:8791",
+	})
+	if len(probes) != setupDiscoveryMaxCandidateCount {
+		t.Fatalf("candidate count = %d, want cap %d", len(probes), setupDiscoveryMaxCandidateCount)
+	}
+	if probes[0].Host != "saved.local" || probes[len(probes)-1].Host != "10.0.0.5" {
+		t.Fatalf("bounded probe priority = %+v", probes)
+	}
+}
+
+func TestDiscoverReachableHAHostsSharesOverallDeadlineAcrossCandidates(t *testing.T) {
+	originalResolve := resolveHAURLBaseWithinTimeoutForDiscovery
+	originalMDNS := discoverHAViaMDNSForDiscovery
+	originalARP := collectARPHostsForDiscovery
+	originalOverall := setupDiscoveryOverallTimeout
+	originalProbe := setupDiscoveryMaxProbeTimeout
+	t.Cleanup(func() {
+		resolveHAURLBaseWithinTimeoutForDiscovery = originalResolve
+		discoverHAViaMDNSForDiscovery = originalMDNS
+		collectARPHostsForDiscovery = originalARP
+		setupDiscoveryOverallTimeout = originalOverall
+		setupDiscoveryMaxProbeTimeout = originalProbe
+	})
+
+	setupDiscoveryOverallTimeout = 50 * time.Millisecond
+	setupDiscoveryMaxProbeTimeout = time.Second
+	discoverHAViaMDNSForDiscovery = func() string { return "" }
+	collectARPHostsForDiscovery = func() []string { return nil }
+	calls := 0
+	resolveHAURLBaseWithinTimeoutForDiscovery = func(string, time.Duration) (string, error) {
+		calls++
+		time.Sleep(10 * time.Millisecond)
+		return "", assertDiscoveryFailure{}
+	}
+
+	started := time.Now()
+	found, _ := discoverReachableHAHosts(runtimeConfig{})
+	elapsed := time.Since(started)
+	if len(found) != 0 {
+		t.Fatalf("found = %+v, want none", found)
+	}
+	if calls < 2 {
+		t.Fatalf("calls = %d, want fair probing beyond the first candidate", calls)
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Fatalf("elapsed = %s, want bounded near %s", elapsed, setupDiscoveryOverallTimeout)
+	}
+}

--- a/cli/setup_discovery_test.go
+++ b/cli/setup_discovery_test.go
@@ -253,7 +253,7 @@ func TestDetectDefaultHAHostIncludesARPFallbackCandidates(t *testing.T) {
 	}
 }
 
-func TestDetectDefaultHAHostChoiceStopsAfterOverallTimeout(t *testing.T) {
+func TestDetectDefaultHAHostChoiceSharesOverallTimeoutAcrossCandidates(t *testing.T) {
 	originalResolve := resolveHAURLBaseWithinTimeoutForDiscovery
 	originalMDNS := discoverHAViaMDNSForDiscovery
 	originalARP := collectARPHostsForDiscovery
@@ -280,8 +280,8 @@ func TestDetectDefaultHAHostChoiceStopsAfterOverallTimeout(t *testing.T) {
 	if host != "" || discovered {
 		t.Fatalf("detectDefaultHAHostChoice() = (%q, %v), want blank false result", host, discovered)
 	}
-	if calls != 1 {
-		t.Fatalf("calls = %d, want 1", calls)
+	if calls < 2 {
+		t.Fatalf("calls = %d, want fair probing beyond the first candidate", calls)
 	}
 }
 

--- a/cli/setup_discovery_ui.go
+++ b/cli/setup_discovery_ui.go
@@ -25,7 +25,8 @@ func selectDefaultHAHostWithFeedback(reader *bufio.Reader, out io.Writer, cfg ru
 	case 1:
 		candidate := result.candidates[0]
 		renderSetupDiscoveryResult(out, candidate.Host, candidate.Via, true)
-		return candidate, true, nil
+		needsAddressConfirmation := isLocalDiscoveryHost(candidate.Host)
+		return candidate, !needsAddressConfirmation, nil
 	default:
 		fmt.Fprintf(out, "  Found %d reachable Home Assistant instances. Choose the one to set up.\n", len(result.candidates))
 		return promptSetupDiscoveryCandidateInteractive(reader, out, result.candidates)
@@ -128,6 +129,11 @@ func promptSetupDiscoveryCandidateFromReader(reader *bufio.Reader, out io.Writer
 			return strconv.Itoa(choice - 1), nil
 		}
 	}
+}
+
+func isLocalDiscoveryHost(host string) bool {
+	normalized := strings.TrimSuffix(strings.ToLower(normalizeHostInput(host)), ".")
+	return strings.HasSuffix(normalized, ".local")
 }
 
 func setupDiscoveryCandidateLabel(candidate setupDiscoveryCandidate) string {

--- a/cli/setup_discovery_ui.go
+++ b/cli/setup_discovery_ui.go
@@ -1,37 +1,133 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 	"time"
 )
 
-var detectDefaultHAHostChoiceForSetup = detectDefaultHAHostChoice
+var discoverReachableHAHostsForSetup = discoverReachableHAHosts
 
-func detectDefaultHAHostWithFeedback(out io.Writer, cfg runtimeConfig) (string, bool) {
+type setupDiscoveryResult struct {
+	candidates []setupDiscoveryCandidate
+	fallback   string
+}
+
+func selectDefaultHAHostWithFeedback(reader *bufio.Reader, out io.Writer, cfg runtimeConfig) (setupDiscoveryCandidate, bool, error) {
+	result := runSetupDiscoveryWithFeedback(out, cfg)
+	switch len(result.candidates) {
+	case 0:
+		renderSetupDiscoveryResult(out, result.fallback, "", false)
+		return setupDiscoveryCandidate{Host: result.fallback}, false, nil
+	case 1:
+		candidate := result.candidates[0]
+		renderSetupDiscoveryResult(out, candidate.Host, candidate.Via, true)
+		return candidate, true, nil
+	default:
+		fmt.Fprintf(out, "  Found %d reachable Home Assistant instances. Choose the one to set up.\n", len(result.candidates))
+		return promptSetupDiscoveryCandidateInteractive(reader, out, result.candidates)
+	}
+}
+
+func runSetupDiscoveryWithFeedback(out io.Writer, cfg runtimeConfig) setupDiscoveryResult {
 	if !resolveSetupUISession(out).animatesSpinner() {
 		fmt.Fprintln(out)
 		fmt.Fprintf(out, "  Discovering Home Assistant on your network... (up to %ds)\n", int((setupDiscoveryOverallTimeout+time.Second-1)/time.Second))
 		fmt.Fprintln(out)
-		host, via, discovered := detectDefaultHAHostChoiceForSetup(cfg)
-		renderSetupDiscoveryResult(out, host, via, discovered)
-		return host, discovered
+		candidates, fallback := discoverReachableHAHostsForSetup(cfg)
+		return setupDiscoveryResult{candidates: candidates, fallback: fallback}
 	}
 
 	found, err := runSetupCountdownSpinnerWithResult(out, "Discovering Home Assistant on your network...", setupDiscoveryOverallTimeout, setupDiscoveryMinimumVisibleDuration, func() (setupDiscoveryResult, error) {
-		host, via, discovered := detectDefaultHAHostChoiceForSetup(cfg)
-		return setupDiscoveryResult{host: host, via: via, discovered: discovered}, nil
+		candidates, fallback := discoverReachableHAHostsForSetup(cfg)
+		return setupDiscoveryResult{candidates: candidates, fallback: fallback}, nil
 	})
 	armSetupNextPromptSkipsStaleBlankInput()
 	if err != nil {
-		return preferredUnverifiedHAHost(cfg), false
+		return setupDiscoveryResult{fallback: preferredUnverifiedHAHost(cfg)}
 	}
-	renderSetupDiscoveryResult(out, found.host, found.via, found.discovered)
-	return found.host, found.discovered
+	return found
 }
 
-type setupDiscoveryResult struct {
-	host       string
-	via        string
-	discovered bool
+func promptSetupDiscoveryCandidateInteractive(reader *bufio.Reader, out io.Writer, candidates []setupDiscoveryCandidate) (setupDiscoveryCandidate, bool, error) {
+	spec := setupMenuSpec{
+		Title:        "Choose your Home Assistant:",
+		Prompt:       "Use ↑/↓ or j/k, Enter to select, Esc to go back, Ctrl+C to exit",
+		AllowBack:    true,
+		DefaultValue: "0",
+	}
+	for idx, candidate := range candidates {
+		spec.Options = append(spec.Options, setupMenuOption{
+			Value: strconv.Itoa(idx),
+			Label: setupDiscoveryCandidateLabel(candidate),
+		})
+	}
+	spec.Options = append(spec.Options, setupMenuOption{Value: "manual", Label: "Enter a different address"})
+
+	answer, err := promptSetupMenu(reader, out, spec, func() (string, error) {
+		return promptSetupDiscoveryCandidateFromReader(reader, out, candidates)
+	})
+	if err != nil {
+		return setupDiscoveryCandidate{}, false, err
+	}
+	if answer == "manual" {
+		return setupDiscoveryCandidate{}, false, nil
+	}
+	idx, err := strconv.Atoi(answer)
+	if err != nil || idx < 0 || idx >= len(candidates) {
+		return setupDiscoveryCandidate{}, false, fmt.Errorf("invalid Home Assistant discovery choice")
+	}
+	return candidates[idx], true, nil
+}
+
+func promptSetupDiscoveryCandidateFromReader(reader *bufio.Reader, out io.Writer, candidates []setupDiscoveryCandidate) (string, error) {
+	for {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "  Choose your Home Assistant:")
+		fmt.Fprintln(out)
+		for idx, candidate := range candidates {
+			fmt.Fprintf(out, "    %d) %s\n", idx+1, setupDiscoveryCandidateLabel(candidate))
+		}
+		manualNumber := len(candidates) + 1
+		fmt.Fprintf(out, "    %d) Enter a different address\n", manualNumber)
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "  Enter [1-%d] (default 1, or type 'back'/'exit'): ", manualNumber)
+
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		line = strings.ToLower(strings.TrimSpace(line))
+		switch line {
+		case "":
+			return "0", nil
+		case "back":
+			return "", errSetupBack
+		case "exit":
+			return "", errSetupExit
+		case "manual":
+			return "manual", nil
+		}
+
+		choice, err := strconv.Atoi(line)
+		switch {
+		case err != nil || choice < 1 || choice > manualNumber:
+			renderSetupErrorLine(out, "Invalid choice. Please enter one of the listed options.")
+		case choice == manualNumber:
+			return "manual", nil
+		default:
+			return strconv.Itoa(choice - 1), nil
+		}
+	}
+}
+
+func setupDiscoveryCandidateLabel(candidate setupDiscoveryCandidate) string {
+	source := candidate.Source
+	if candidate.Via != "" {
+		source += " via " + candidate.Via
+	}
+	return fmt.Sprintf("%s (%s)", candidate.Host, source)
 }

--- a/cli/setup_discovery_ui.go
+++ b/cli/setup_discovery_ui.go
@@ -84,6 +84,7 @@ func promptSetupDiscoveryCandidateInteractive(reader *bufio.Reader, out io.Write
 }
 
 func promptSetupDiscoveryCandidateFromReader(reader *bufio.Reader, out io.Writer, candidates []setupDiscoveryCandidate) (string, error) {
+	staleBlankDeadline := beginSetupStaleBlankInputWindow()
 	for {
 		fmt.Fprintln(out)
 		fmt.Fprintln(out, "  Choose your Home Assistant:")
@@ -101,6 +102,11 @@ func promptSetupDiscoveryCandidateFromReader(reader *bufio.Reader, out io.Writer
 			return "", err
 		}
 		line = strings.ToLower(strings.TrimSpace(line))
+		if setupInputIsStaleBlank(staleBlankDeadline, line == "") {
+			rerenderSetupPromptAfterStaleBlank(out)
+			continue
+		}
+		staleBlankDeadline = time.Time{}
 		switch line {
 		case "":
 			return "0", nil

--- a/cli/setup_discovery_ui_test.go
+++ b/cli/setup_discovery_ui_test.go
@@ -1,98 +1,117 @@
 package main
 
 import (
+	"bufio"
 	"io"
 	"strings"
 	"testing"
 	"time"
 )
 
-func TestDetectDefaultHAHostWithFeedbackReportsResultWithoutTTYSpinner(t *testing.T) {
-	originalDetect := detectDefaultHAHostChoiceForSetup
-	defer func() {
-		detectDefaultHAHostChoiceForSetup = originalDetect
-	}()
-
-	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
-		return "ha-box.local", "", true
+func TestSelectDefaultHAHostWithFeedbackAutoSelectsSingleResultWithoutTTYSpinner(t *testing.T) {
+	originalDiscover := discoverReachableHAHostsForSetup
+	t.Cleanup(func() { discoverReachableHAHostsForSetup = originalDiscover })
+	discoverReachableHAHostsForSetup = func(runtimeConfig) ([]setupDiscoveryCandidate, string) {
+		return []setupDiscoveryCandidate{{
+			Host:   "ha-box.local",
+			HAURL:  "http://ha-box.local:8123",
+			Source: "mDNS",
+		}}, ""
 	}
 
 	output := &strings.Builder{}
-	host, discovered := detectDefaultHAHostWithFeedback(output, runtimeConfig{})
-
-	if host != "ha-box.local" {
-		t.Fatalf("host = %q, want %q", host, "ha-box.local")
+	candidate, selected, err := selectDefaultHAHostWithFeedback(bufio.NewReader(strings.NewReader("")), output, runtimeConfig{})
+	if err != nil {
+		t.Fatalf("selectDefaultHAHostWithFeedback() error = %v", err)
 	}
-	if !discovered {
-		t.Fatal("expected discovered=true")
+	if !selected || candidate.Host != "ha-box.local" || candidate.HAURL != "http://ha-box.local:8123" {
+		t.Fatalf("selection = (%+v, %v), want single discovered host", candidate, selected)
 	}
-	rendered := output.String()
 	for _, want := range []string{
 		"Discovering Home Assistant on your network...",
 		"Found Home Assistant via the network name ha-box.local",
 		"this name can stop working",
 	} {
-		if !strings.Contains(rendered, want) {
-			t.Fatalf("discovery output missing %q:\n%s", want, rendered)
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("discovery output missing %q:\n%s", want, output.String())
 		}
 	}
 }
 
-func TestDetectDefaultHAHostWithFeedbackAsksForManualAddressWhenNothingWasConfirmed(t *testing.T) {
-	originalDetect := detectDefaultHAHostChoiceForSetup
-	defer func() {
-		detectDefaultHAHostChoiceForSetup = originalDetect
-	}()
-
-	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
-		return "", "", false
+func TestSelectDefaultHAHostWithFeedbackKeepsManualPathWhenNothingWasConfirmed(t *testing.T) {
+	originalDiscover := discoverReachableHAHostsForSetup
+	t.Cleanup(func() { discoverReachableHAHostsForSetup = originalDiscover })
+	discoverReachableHAHostsForSetup = func(runtimeConfig) ([]setupDiscoveryCandidate, string) {
+		return nil, "saved-ha.local"
 	}
 
 	output := &strings.Builder{}
-	host, discovered := detectDefaultHAHostWithFeedback(output, runtimeConfig{})
-
-	if host != "" {
-		t.Fatalf("host = %q, want blank", host)
+	candidate, selected, err := selectDefaultHAHostWithFeedback(bufio.NewReader(strings.NewReader("")), output, runtimeConfig{})
+	if err != nil {
+		t.Fatalf("selectDefaultHAHostWithFeedback() error = %v", err)
 	}
-	if discovered {
-		t.Fatal("expected discovered=false")
+	if selected || candidate.Host != "saved-ha.local" {
+		t.Fatalf("selection = (%+v, %v), want saved manual default", candidate, selected)
 	}
-	if !strings.Contains(output.String(), "enter the Home Assistant address manually") {
+	if !strings.Contains(output.String(), "using your saved address as a starting point: saved-ha.local") {
 		t.Fatalf("missing manual entry guidance:\n%s", output.String())
 	}
 }
 
-func TestDetectDefaultHAHostWithFeedbackDoesNotDelayFastTTYDiscovery(t *testing.T) {
-	originalDetect := detectDefaultHAHostChoiceForSetup
+func TestSelectDefaultHAHostWithFeedbackListsEveryReachableInstanceAndSource(t *testing.T) {
+	originalDiscover := discoverReachableHAHostsForSetup
+	t.Cleanup(func() { discoverReachableHAHostsForSetup = originalDiscover })
+	discoverReachableHAHostsForSetup = func(runtimeConfig) ([]setupDiscoveryCandidate, string) {
+		return []setupDiscoveryCandidate{
+			{Host: "192.168.1.20", HAURL: "http://192.168.1.20:8123", Via: "homeassistant.local", Source: "mDNS"},
+			{Host: "192.168.1.30", HAURL: "https://192.168.1.30", Source: "local network cache"},
+		}, ""
+	}
+
+	output := &strings.Builder{}
+	candidate, selected, err := selectDefaultHAHostWithFeedback(bufio.NewReader(strings.NewReader("2\n")), output, runtimeConfig{})
+	if err != nil {
+		t.Fatalf("selectDefaultHAHostWithFeedback() error = %v", err)
+	}
+	if !selected || candidate.Host != "192.168.1.30" || candidate.HAURL != "https://192.168.1.30" {
+		t.Fatalf("selection = (%+v, %v), want second discovered host", candidate, selected)
+	}
+	for _, want := range []string{
+		"Found 2 reachable Home Assistant instances",
+		"192.168.1.20 (mDNS via homeassistant.local)",
+		"192.168.1.30 (local network cache)",
+		"Enter a different address",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("pick list missing %q:\n%s", want, output.String())
+		}
+	}
+}
+
+func TestSelectDefaultHAHostWithFeedbackDoesNotDelayFastTTYDiscovery(t *testing.T) {
+	originalDiscover := discoverReachableHAHostsForSetup
 	originalTTY := writerSupportsTTYForSetup
 	originalInput := uiInputSupportsTTY
 	originalMin := setupDiscoveryMinimumVisibleDuration
-	defer func() {
-		detectDefaultHAHostChoiceForSetup = originalDetect
+	t.Cleanup(func() {
+		discoverReachableHAHostsForSetup = originalDiscover
 		writerSupportsTTYForSetup = originalTTY
 		uiInputSupportsTTY = originalInput
 		setupDiscoveryMinimumVisibleDuration = originalMin
-	}()
-
-	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
-		return "192.168.1.123", "homeassistant.local", true
+	})
+	discoverReachableHAHostsForSetup = func(runtimeConfig) ([]setupDiscoveryCandidate, string) {
+		return []setupDiscoveryCandidate{{Host: "192.168.1.123", HAURL: "http://192.168.1.123:8123", Via: "homeassistant.local", Source: "mDNS"}}, ""
 	}
-	writerSupportsTTYForSetup = func(out io.Writer) bool {
-		return true
-	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
 	uiInputSupportsTTY = func() bool { return true }
 	setupDiscoveryMinimumVisibleDuration = 40 * time.Millisecond
 
 	output := &strings.Builder{}
 	start := time.Now()
-	host, discovered := detectDefaultHAHostWithFeedback(output, runtimeConfig{})
+	candidate, selected, err := selectDefaultHAHostWithFeedback(bufio.NewReader(strings.NewReader("")), output, runtimeConfig{})
 	elapsed := time.Since(start)
-
-	if host != "192.168.1.123" {
-		t.Fatalf("host = %q, want %q", host, "192.168.1.123")
-	}
-	if !discovered {
-		t.Fatal("expected discovered=true")
+	if err != nil || !selected || candidate.Host != "192.168.1.123" {
+		t.Fatalf("selection = (%+v, %v), err = %v", candidate, selected, err)
 	}
 	if elapsed >= 40*time.Millisecond {
 		t.Fatalf("elapsed = %s, want less than %s for a fast task", elapsed, 40*time.Millisecond)
@@ -102,31 +121,28 @@ func TestDetectDefaultHAHostWithFeedbackDoesNotDelayFastTTYDiscovery(t *testing.
 	}
 }
 
-func TestDetectDefaultHAHostWithFeedbackShowsSpinnerAfterDebounceForSlowTTYDiscovery(t *testing.T) {
-	originalDetect := detectDefaultHAHostChoiceForSetup
+func TestSelectDefaultHAHostWithFeedbackShowsSpinnerAfterDebounceForSlowTTYDiscovery(t *testing.T) {
+	originalDiscover := discoverReachableHAHostsForSetup
 	originalTTY := writerSupportsTTYForSetup
 	originalInput := uiInputSupportsTTY
 	originalANSI := uiOutputSupportsANSI
 	originalEnv := uiEnvLookup
 	originalMin := setupDiscoveryMinimumVisibleDuration
 	originalTimeout := setupDiscoveryOverallTimeout
-	defer func() {
-		detectDefaultHAHostChoiceForSetup = originalDetect
+	t.Cleanup(func() {
+		discoverReachableHAHostsForSetup = originalDiscover
 		writerSupportsTTYForSetup = originalTTY
 		uiInputSupportsTTY = originalInput
 		uiOutputSupportsANSI = originalANSI
 		uiEnvLookup = originalEnv
 		setupDiscoveryMinimumVisibleDuration = originalMin
 		setupDiscoveryOverallTimeout = originalTimeout
-	}()
-
-	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
+	})
+	discoverReachableHAHostsForSetup = func(runtimeConfig) ([]setupDiscoveryCandidate, string) {
 		time.Sleep(1200 * time.Millisecond)
-		return "192.168.1.124", "", true
+		return []setupDiscoveryCandidate{{Host: "192.168.1.124", HAURL: "http://192.168.1.124:8123", Source: "local network cache"}}, ""
 	}
-	writerSupportsTTYForSetup = func(out io.Writer) bool {
-		return true
-	}
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
 	uiInputSupportsTTY = func() bool { return true }
 	uiOutputSupportsANSI = func(io.Writer) bool { return true }
 	uiEnvLookup = func(string) string { return "" }
@@ -134,13 +150,9 @@ func TestDetectDefaultHAHostWithFeedbackShowsSpinnerAfterDebounceForSlowTTYDisco
 	setupDiscoveryOverallTimeout = 2 * time.Second
 
 	output := &strings.Builder{}
-	host, discovered := detectDefaultHAHostWithFeedback(output, runtimeConfig{})
-
-	if host != "192.168.1.124" {
-		t.Fatalf("host = %q, want %q", host, "192.168.1.124")
-	}
-	if !discovered {
-		t.Fatal("expected discovered=true")
+	candidate, selected, err := selectDefaultHAHostWithFeedback(bufio.NewReader(strings.NewReader("")), output, runtimeConfig{})
+	if err != nil || !selected || candidate.Host != "192.168.1.124" {
+		t.Fatalf("selection = (%+v, %v), err = %v", candidate, selected, err)
 	}
 	rendered := output.String()
 	if !strings.Contains(rendered, "Discovering Home Assistant on your network...") {

--- a/cli/setup_discovery_ui_test.go
+++ b/cli/setup_discovery_ui_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestSelectDefaultHAHostWithFeedbackAutoSelectsSingleResultWithoutTTYSpinner(t *testing.T) {
+func TestSelectDefaultHAHostWithFeedbackKeepsOverridePromptForSingleLocalResult(t *testing.T) {
 	originalDiscover := discoverReachableHAHostsForSetup
 	t.Cleanup(func() { discoverReachableHAHostsForSetup = originalDiscover })
 	discoverReachableHAHostsForSetup = func(runtimeConfig) ([]setupDiscoveryCandidate, string) {
@@ -24,8 +24,8 @@ func TestSelectDefaultHAHostWithFeedbackAutoSelectsSingleResultWithoutTTYSpinner
 	if err != nil {
 		t.Fatalf("selectDefaultHAHostWithFeedback() error = %v", err)
 	}
-	if !selected || candidate.Host != "ha-box.local" || candidate.HAURL != "http://ha-box.local:8123" {
-		t.Fatalf("selection = (%+v, %v), want single discovered host", candidate, selected)
+	if selected || candidate.Host != "ha-box.local" || candidate.HAURL != "http://ha-box.local:8123" {
+		t.Fatalf("selection = (%+v, %v), want unconfirmed .local default", candidate, selected)
 	}
 	for _, want := range []string{
 		"Discovering Home Assistant on your network...",

--- a/cli/setup_discovery_ui_test.go
+++ b/cli/setup_discovery_ui_test.go
@@ -88,6 +88,32 @@ func TestSelectDefaultHAHostWithFeedbackListsEveryReachableInstanceAndSource(t *
 	}
 }
 
+func TestPromptSetupDiscoveryCandidateSkipsStaleEnterBeforeDefault(t *testing.T) {
+	clearSetupNextPromptSkipsStaleBlankInput()
+	t.Cleanup(clearSetupNextPromptSkipsStaleBlankInput)
+	armSetupNextPromptSkipsStaleBlankInput()
+
+	candidates := []setupDiscoveryCandidate{
+		{Host: "192.168.1.20", Source: "mDNS"},
+		{Host: "192.168.1.30", Source: "local network cache"},
+	}
+	output := &strings.Builder{}
+	answer, err := promptSetupDiscoveryCandidateFromReader(
+		bufio.NewReader(strings.NewReader("\n2\n")),
+		output,
+		candidates,
+	)
+	if err != nil {
+		t.Fatalf("promptSetupDiscoveryCandidateFromReader() error = %v", err)
+	}
+	if answer != "1" {
+		t.Fatalf("answer = %q, want second candidate", answer)
+	}
+	if strings.Count(output.String(), "Choose your Home Assistant:") != 2 {
+		t.Fatalf("expected picker to be re-rendered after stale Enter:\n%s", output.String())
+	}
+}
+
 func TestSelectDefaultHAHostWithFeedbackDoesNotDelayFastTTYDiscovery(t *testing.T) {
 	originalDiscover := discoverReachableHAHostsForSetup
 	originalTTY := writerSupportsTTYForSetup

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -13,7 +13,6 @@ import (
 var resolveHAURLBaseForSetup = resolveHomeAssistantURLBase
 var probeHTTPForSetup = probeHTTP
 var fetchRelayHealthForSetup = fetchRelayHealth
-var detectDefaultHAHostForSetup = detectDefaultHAHost
 var probeRelayWSPingForSetup = probeRelayWSPing
 var readRelayAuthTokenForSetup = readRelayAuthToken
 
@@ -417,16 +416,27 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			continue
 
 		case setupStageHost:
-			defaultHost := ""
+			var host string
+			var haURL string
+			var err error
 			if hostChangeRetry {
 				// The user just rejected the saved address — don't spend the
 				// discovery window re-confirming it or offer it back as the
 				// press-Enter default.
 				renderSetupParagraph(os.Stdout, fmt.Sprintf("The saved address %s could not be used. Enter a new one.", cfg.HAURL))
+				host, haURL, err = promptValidHAHostFromReader(reader, os.Stdout, "")
 			} else {
-				defaultHost, _ = detectDefaultHAHostWithFeedback(os.Stdout, cfg)
+				candidate, selected, discoveryErr := selectDefaultHAHostWithFeedback(reader, os.Stdout, cfg)
+				switch {
+				case discoveryErr != nil:
+					err = discoveryErr
+				case selected:
+					host = candidate.Host
+					haURL = candidate.HAURL
+				default:
+					host, haURL, err = promptValidHAHostFromReader(reader, os.Stdout, candidate.Host)
+				}
 			}
-			host, haURL, err := promptValidHAHostFromReader(reader, os.Stdout, defaultHost)
 			if err == errSetupBack {
 				if hostChangeRetry {
 					hostChangeRetry = false

--- a/cli/setup_interactive_test.go
+++ b/cli/setup_interactive_test.go
@@ -934,12 +934,6 @@ func TestInteractiveSetupResumeCanChangeHostFromRepairMenuWithoutTokenRePrompt(t
 	// be handed the freed port, silently resurrecting the "dead" address.
 	deadHAURL := newDeadServerURL()
 
-	originalDetect := detectDefaultHAHostChoiceForSetup
-	t.Cleanup(func() { detectDefaultHAHostChoiceForSetup = originalDetect })
-	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
-		return "", "", false
-	}
-
 	paths, err := detectPaths()
 	if err != nil {
 		t.Fatalf("detectPaths() error: %v", err)
@@ -1024,12 +1018,6 @@ func TestInteractiveSetupHostChangePersistsNewHostEvenWhenUserExitsBeforeVerifyS
 	defer failingRelayServer.Close()
 
 	deadHAURL := newDeadServerURL()
-
-	originalDetect := detectDefaultHAHostChoiceForSetup
-	t.Cleanup(func() { detectDefaultHAHostChoiceForSetup = originalDetect })
-	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
-		return "", "", false
-	}
 
 	paths, err := detectPaths()
 	if err != nil {
@@ -1127,10 +1115,10 @@ func TestInteractiveSetupExitAtTokenChoiceCancelsCleanly(t *testing.T) {
 }
 
 func TestInteractiveSetupInitialClientPageAllowsRepeatedBack(t *testing.T) {
-	originalDetect := detectDefaultHAHostChoiceForSetup
-	t.Cleanup(func() { detectDefaultHAHostChoiceForSetup = originalDetect })
-	detectDefaultHAHostChoiceForSetup = func(cfg runtimeConfig) (string, string, bool) {
-		return "", "", false
+	originalDiscover := discoverReachableHAHostsForSetup
+	t.Cleanup(func() { discoverReachableHAHostsForSetup = originalDiscover })
+	discoverReachableHAHostsForSetup = func(runtimeConfig) ([]setupDiscoveryCandidate, string) {
+		return nil, ""
 	}
 
 	home := t.TempDir()
@@ -2209,6 +2197,11 @@ func TestInteractiveSetupCompletedResumePersistsHostOnlyOverride(t *testing.T) {
 func captureInteractiveSetupIO(t *testing.T, input string, fn func() int) (string, string) {
 	t.Helper()
 	withAllClientRuntimesAvailable(t)
+	originalDiscovery := discoverReachableHAHostsForSetup
+	discoverReachableHAHostsForSetup = func(cfg runtimeConfig) ([]setupDiscoveryCandidate, string) {
+		return nil, preferredUnverifiedHAHost(cfg)
+	}
+	defer func() { discoverReachableHAHostsForSetup = originalDiscovery }()
 
 	home, err := os.UserHomeDir()
 	if err == nil {

--- a/cli/setup_ui.go
+++ b/cli/setup_ui.go
@@ -171,7 +171,7 @@ func renderSetupDiscoveryResult(out io.Writer, host, via string, discovered bool
 	session := resolveSetupUISession(out)
 	if discovered && via != "" {
 		fmt.Fprintf(out, "  %s Found Home Assistant at %s (discovered via %s)\n", session.style("success", session.successMarker()), host, via)
-	} else if discovered && strings.HasSuffix(strings.ToLower(host), ".local") {
+	} else if discovered && isLocalDiscoveryHost(host) {
 		fmt.Fprintf(out, "  %s Found Home Assistant via the network name %s\n", session.style("warning", session.warningMarker()), host)
 		fmt.Fprintln(out, "    Heads-up: this name can stop working (especially on Windows).")
 		fmt.Fprintln(out, "    If you know the IP address, enter it below instead — you can find it in your")

--- a/cli/ui_menu.go
+++ b/cli/ui_menu.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"golang.org/x/term"
 )
@@ -136,6 +137,7 @@ func (terminalSetupMenuRunner) Run(out io.Writer, spec setupMenuSpec) (string, e
 	if index < 0 {
 		return "", errSetupMenuUnavailable
 	}
+	staleBlankDeadline := beginSetupStaleBlankInputWindow()
 
 	lines := renderSetupMenuBlock(out, session, spec, index)
 	for {
@@ -149,6 +151,9 @@ func (terminalSetupMenuRunner) Run(out io.Writer, spec setupMenuSpec) (string, e
 		case "down":
 			index = moveSetupMenuIndex(spec.Options, index, 1)
 		case "enter":
+			if setupInputIsStaleBlank(staleBlankDeadline, true) {
+				continue
+			}
 			return spec.Options[index].Value, nil
 		case "back":
 			if spec.AllowBack {
@@ -159,6 +164,7 @@ func (terminalSetupMenuRunner) Run(out io.Writer, spec setupMenuSpec) (string, e
 		default:
 			continue
 		}
+		staleBlankDeadline = time.Time{}
 		fmt.Fprintf(out, "\033[%dA\033[J", lines)
 		lines = renderSetupMenuBlock(out, session, spec, index)
 	}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -307,10 +307,12 @@ Windows uninstall contract:
 
 Rules:
 - Windows uses a single supported install path: `install.ps1`
+- before downloading, the Windows installer requires Windows 10 / Server 2016 or later, PowerShell 5.1 or later, an amd64 process (including x64 emulation on ARM64), a writable per-user install root, and working TLS access to GitHub
 - supported public Windows onboarding means one `irm .../install.ps1 | iex` command in a local PowerShell console or Windows Terminal session
 - if at least one supported client is already runnable, the supported public Windows path must not end with `Next step: ha-nova setup`
 - if at least one supported client is already runnable, the supported public Windows path must positively prove that setup started automatically in the same session
 - if no supported client is ready yet, the same public installer path is still valid when it installs HA NOVA locally, explains the missing client prerequisite, and exits cleanly
+- when an installer cannot start the interactive wizard, it must print `ha-nova setup` as the exact next command and explain that setup asks for the six-digit NOVA Home Base pairing code
 - `scripts/dev/windows-desktop-setup.ps1` proves same-version update smoke plus standard/purge uninstall semantics; the cross-version background replace path is still covered by the manual RC/stable matrix above
 - do not present any package-manager alternative as an equal public path
 - keep the matrix small but explicit; do not replace the commands above with vague "relevant tests" wording

--- a/install.ps1
+++ b/install.ps1
@@ -8,6 +8,7 @@ $ErrorActionPreference = "Stop"
 $RepoOwner = "markusleben"
 $RepoName = "ha-nova"
 $LatestReleaseUrl = "https://api.github.com/repos/markusleben/ha-nova/releases/latest"
+$GitHubPreflightUrl = "https://github.com"
 $ReleaseBaseUrl = "https://github.com/$RepoOwner/$RepoName/releases/download"
 $LocalAppDataDir = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { Join-Path $HOME "AppData\Local" }
 $AppDataDir = if ($env:APPDATA) { $env:APPDATA } else { Join-Path $HOME "AppData\Roaming" }
@@ -194,6 +195,89 @@ function Invoke-GitHubJson {
   Fail "Could not read the latest HA NOVA release from GitHub: $Uri`nAttempts:`n- $($errors -join "`n- ")`nSet HA_NOVA_VERSION to an exact version or check that this Windows session can reach api.github.com."
 }
 
+function Get-InstallerWindowsVersion {
+  return [Environment]::OSVersion.Version
+}
+
+function Get-InstallerPowerShellVersion {
+  return $PSVersionTable.PSVersion
+}
+
+function Assert-InstallRootWritable {
+  $installParent = Split-Path -Parent $InstallDir
+  $probePath = Join-Path $installParent (".ha-nova-write-test-" + [guid]::NewGuid().ToString("N"))
+  try {
+    New-Item -ItemType Directory -Force -Path $installParent | Out-Null
+    [System.IO.File]::WriteAllText($probePath, "preflight")
+  }
+  catch {
+    Fail "Cannot write to the per-user HA NOVA install location '$installParent'. Fix LOCALAPPDATA permissions for this user, then rerun the installer."
+  }
+  finally {
+    Remove-PathQuiet -Path $probePath
+  }
+}
+
+function Assert-GitHubTlsAccess {
+  $handler = $null
+  $client = $null
+  $response = $null
+  try {
+    Add-Type -AssemblyName System.Net.Http
+    $handler = [System.Net.Http.HttpClientHandler]::new()
+    $handler.AllowAutoRedirect = $true
+    $handler.UseProxy = $true
+    $defaultProxy = [System.Net.WebRequest]::DefaultWebProxy
+    if ($defaultProxy) {
+      $defaultProxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials
+      $handler.Proxy = $defaultProxy
+    }
+    try {
+      $handler.DefaultProxyCredentials = [System.Net.CredentialCache]::DefaultCredentials
+    }
+    catch {
+    }
+    $client = [System.Net.Http.HttpClient]::new($handler)
+    $client.Timeout = [TimeSpan]::FromSeconds(15)
+    $client.DefaultRequestHeaders.UserAgent.ParseAdd("ha-nova-installer")
+    $response = $client.GetAsync(
+      $GitHubPreflightUrl,
+      [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead
+    ).GetAwaiter().GetResult()
+  }
+  catch {
+    Fail "Could not establish a TLS connection to GitHub. Check the Windows date/time, proxy or firewall, and pending Windows updates, then rerun the installer."
+  }
+  finally {
+    if ($null -ne $response) {
+      $response.Dispose()
+    }
+    if ($null -ne $client) {
+      $client.Dispose()
+    }
+    if ($null -ne $handler) {
+      $handler.Dispose()
+    }
+  }
+}
+
+function Invoke-WindowsInstallerPreflight {
+  $windowsVersion = Get-InstallerWindowsVersion
+  if ($windowsVersion.Major -lt 10) {
+    Fail "Windows 10 or Windows Server 2016 or later is required. Update Windows before installing HA NOVA."
+  }
+
+  $powerShellVersion = Get-InstallerPowerShellVersion
+  if ($powerShellVersion -lt [version]"5.1") {
+    Fail "PowerShell 5.1 or later is required. Install Windows PowerShell 5.1 or PowerShell 7, then rerun the installer."
+  }
+
+  $null = Get-PlatformArch
+  Assert-InstallRootWritable
+  Assert-GitHubTlsAccess
+  Write-Info "Windows prerequisites passed"
+}
+
 function Test-InteractiveSession {
   try {
     return -not [Console]::IsInputRedirected
@@ -213,7 +297,11 @@ function Get-PlatformArch {
     Fail "HA NOVA currently ships a Windows amd64 bundle only. On Windows ARM64, use x64 emulation."
   }
 
-  Fail "Unsupported Windows architecture '$arch'. HA NOVA currently ships a Windows amd64 bundle only."
+  if ($arch -eq "x86") {
+    Fail "HA NOVA requires a 64-bit PowerShell process. Open 64-bit PowerShell or Windows Terminal, then rerun the installer."
+  }
+
+  Fail "Unsupported Windows architecture '$arch'. Use 64-bit PowerShell on Windows amd64, or x64 emulation on Windows ARM64."
 }
 
 function Get-ExpectedInstallVersion {
@@ -857,6 +945,7 @@ function Start-Setup {
   if ($env:HA_NOVA_NO_SETUP -eq "1") {
     Write-Info "Installed HA NOVA without setup."
     Write-Note "Next step: ha-nova setup"
+    Write-Note "Setup will ask for the six-digit pairing code shown in NOVA Home Base."
     Write-Note "Need help later? Run: ha-nova doctor"
     return
   }
@@ -864,6 +953,7 @@ function Start-Setup {
   if (-not (Test-InteractiveSession)) {
     Write-Warn "No interactive terminal detected; setup was not started automatically."
     Write-Note "Next step: ha-nova setup"
+    Write-Note "Setup will ask for the six-digit pairing code shown in NOVA Home Base."
     Write-Note "Need help later? Run: ha-nova doctor"
     return
   }
@@ -879,8 +969,6 @@ $UsePlainUi = Test-PlainUi
 Write-Banner
 Initialize-WebSecurity
 
-$expectedVersion = Get-ExpectedInstallVersion
-$version = Get-DownloadInstallVersion
 if (-not (Test-CurrentInstall) -and (Test-LegacyInstall)) {
   Stop-ForLegacyInstall
 }
@@ -888,6 +976,9 @@ $uninstallRecovery = Get-UninstallRecoveryState
 if ($null -ne $uninstallRecovery) {
   Stop-ForUninstallRecovery -Recovery $uninstallRecovery
 }
+Invoke-WindowsInstallerPreflight
+$expectedVersion = Get-ExpectedInstallVersion
+$version = Get-DownloadInstallVersion
 $bundleResult = Install-Bundle -Version $version
 Ensure-InstallDirOnPath | Out-Null
 if ($expectedVersion -and $bundleResult.Version -ne $expectedVersion) {

--- a/install.sh
+++ b/install.sh
@@ -454,6 +454,7 @@ run_setup() {
 
   if [[ "${HA_NOVA_NO_SETUP:-0}" == "1" ]]; then
     note "Next step: ha-nova setup"
+    note "Setup will ask for the six-digit pairing code shown in NOVA Home Base."
     note "Need help later? Run: ha-nova doctor"
     return 0
   fi
@@ -466,6 +467,7 @@ run_setup() {
 
   warn "No interactive terminal detected; setup was not started automatically."
   note "Next step: ha-nova setup"
+  note "Setup will ask for the six-digit pairing code shown in NOVA Home Base."
   note "Need help later? Run: ha-nova doctor"
 }
 

--- a/nova/DOCS.md
+++ b/nova/DOCS.md
@@ -59,7 +59,7 @@ Or if you already have the repo:
 ha-nova setup
 ```
 
-The setup wizard handles relay configuration and skill installation. Its normal App flow asks for the six-digit Home Base code, stores the returned relay token in the client's OS credential store, and verifies both Relay health and WebSocket access without displaying the private relay token. Existing saved tokens, `--relay-token`, service token files, and standalone Container/Core setups keep their explicit-token paths.
+The setup wizard handles relay configuration and skill installation. It automatically uses one reachable Home Assistant instance, shows a source-labeled pick list when it finds several, and keeps manual address entry when discovery finds none. Its normal App flow asks for the six-digit Home Base code, stores the returned relay token in the client's OS credential store, and verifies both Relay health and WebSocket access without displaying the private relay token. Existing saved tokens, `--relay-token`, service token files, and standalone Container/Core setups keep their explicit-token paths.
 
 ## Checking Status
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "preverify:docs": "node scripts/test/assert-vitest-files-exist.mjs verify:docs",
     "verify:docs": "bash scripts/check-docs.sh && npx vitest run tests/onboarding/project-docs-contract.test.ts tests/onboarding/client-install-docs-contract.test.ts",
     "preverify:installers": "node scripts/test/assert-vitest-files-exist.mjs verify:installers",
-    "verify:installers": "npx vitest run tests/onboarding/installer-contract.test.ts tests/onboarding/windows-installer-contract.test.ts",
+    "verify:installers": "npx vitest run tests/onboarding/installer-contract.test.ts tests/onboarding/windows-installer-contract.test.ts tests/onboarding/windows-installer-preflight.test.ts",
     "preverify:onboarding": "node scripts/test/assert-vitest-files-exist.mjs verify:onboarding",
     "verify:onboarding": "npm run verify:installers && npx vitest run tests/onboarding/install-skills-per-client.test.ts tests/onboarding/dev-sync-contract.test.ts tests/onboarding/dev-sync-behavior.test.ts tests/onboarding/claude-plugin-state-helper.test.ts tests/onboarding/installer-contract.test.ts tests/onboarding/relay-cli-contract.test.ts tests/onboarding/self-update-contract.test.ts tests/onboarding/platform-dispatch.test.ts tests/onboarding/linux-keyring-contract.test.ts tests/onboarding/macos-keyring-contract.test.ts tests/onboarding/windows-keyring-interop-contract.test.ts tests/onboarding/legacy-cleanup-contract.test.ts tests/onboarding/onboarding-skill-contract.test.ts tests/onboarding/go-runtime-contract.test.ts tests/onboarding/safe-test-system-contract.test.ts tests/onboarding/bump-version.test.ts",
     "preverify:release-contracts": "node scripts/test/assert-vitest-files-exist.mjs verify:release-contracts",

--- a/tests/e2e/codex-skill-live-contract.test.ts
+++ b/tests/e2e/codex-skill-live-contract.test.ts
@@ -91,7 +91,7 @@ describe("codex live skill e2e contract", () => {
     expect(pkg.scripts?.test).toBe("npm run test:safe");
     expect(pkg.scripts?.["test:safe:core"]).toBe("node scripts/test/run-safe-core.mjs");
     expect(pkg.scripts?.["verify:installers"]).toBe(
-      "npx vitest run tests/onboarding/installer-contract.test.ts tests/onboarding/windows-installer-contract.test.ts",
+      "npx vitest run tests/onboarding/installer-contract.test.ts tests/onboarding/windows-installer-contract.test.ts tests/onboarding/windows-installer-preflight.test.ts",
     );
     expect(pkg.scripts?.["e2e:skill:codex"]).toBeDefined();
   });

--- a/tests/onboarding/installer-contract.test.ts
+++ b/tests/onboarding/installer-contract.test.ts
@@ -28,11 +28,12 @@ async function listen(server: Server): Promise<number> {
   return address.port;
 }
 
-async function runInstallerFunctions(script: string): Promise<void> {
-  await execFileAsync("bash", [
+async function runInstallerFunctions(script: string): Promise<string> {
+  const result = await execFileAsync("bash", [
     "-c",
     `set -euo pipefail; export HA_NOVA_INSTALLER_TEST_EXPORT=1 HA_NOVA_PLAIN_UI=1; source install.sh; ${script}`,
   ]);
+  return `${result.stdout}${result.stderr}`;
 }
 
 describe("install.sh contract", () => {
@@ -134,7 +135,24 @@ describe("install.sh contract", () => {
     expect(content).toContain("HA_NOVA_NO_SETUP");
     expect(content).toContain('run_setup "${BIN_LINK}"');
     expect(content).toContain("Next step: ha-nova setup");
+    expect(content).toContain(
+      "Setup will ask for the six-digit pairing code shown in NOVA Home Base.",
+    );
     expect(content).toContain("Need help later? Run: ha-nova doctor");
+  });
+
+  it("prints the exact pairing-aware continuation without reading hidden input", async () => {
+    if (!hasBash()) return;
+    const output = await runInstallerFunctions(
+      'has_interactive_tty() { return 1; }; run_setup "/bin/false"',
+    );
+    expect(output).toContain(
+      "No interactive terminal detected; setup was not started automatically.",
+    );
+    expect(output).toContain("Next step: ha-nova setup");
+    expect(output).toContain(
+      "Setup will ask for the six-digit pairing code shown in NOVA Home Base.",
+    );
   });
 
   it("uses resilient curl downloads with checksum-first verification", () => {

--- a/tests/onboarding/safe-test-system-contract.test.ts
+++ b/tests/onboarding/safe-test-system-contract.test.ts
@@ -80,7 +80,7 @@ describe("safe test system contract", () => {
     expect(pkg.scripts?.["verify:docs"]).toContain("scripts/check-docs.sh");
     expect(pkg.scripts?.["preverify:installers"]).toBe("node scripts/test/assert-vitest-files-exist.mjs verify:installers");
     expect(pkg.scripts?.["verify:installers"]).toBe(
-      "npx vitest run tests/onboarding/installer-contract.test.ts tests/onboarding/windows-installer-contract.test.ts",
+      "npx vitest run tests/onboarding/installer-contract.test.ts tests/onboarding/windows-installer-contract.test.ts tests/onboarding/windows-installer-preflight.test.ts",
     );
     expect(pkg.scripts?.["preverify:onboarding"]).toBe("node scripts/test/assert-vitest-files-exist.mjs verify:onboarding");
     expect(pkg.scripts?.["verify:onboarding"]).toContain("tests/onboarding/install-skills-per-client.test.ts");

--- a/tests/onboarding/windows-installer-contract.test.ts
+++ b/tests/onboarding/windows-installer-contract.test.ts
@@ -91,8 +91,27 @@ describe("install.ps1 contract", () => {
     expect(content).toContain("Could not read the latest HA NOVA release from GitHub");
     expect(content).toContain("github.com release downloads");
     expect(content).toContain("$release = Invoke-GitHubJson -Uri $LatestReleaseUrl");
-    expect(content).toContain("Initialize-WebSecurity\n\n$expectedVersion");
+    expect(content).toContain("Initialize-WebSecurity\n\nif (-not (Test-CurrentInstall)");
+    expect(content).toContain("Invoke-WindowsInstallerPreflight\n$expectedVersion");
     expect(content).toContain("HA_NOVA_INSTALLER_TEST_EXPORT");
+  });
+
+  it("checks Windows prerequisites before resolving or downloading a release", () => {
+    expect(content).toContain("function Invoke-WindowsInstallerPreflight");
+    expect(content).toContain("Windows 10 or Windows Server 2016 or later is required");
+    expect(content).toContain("PowerShell 5.1 or later is required");
+    expect(content).toContain("Get-PlatformArch");
+    expect(content).toContain("function Assert-InstallRootWritable");
+    expect(content).toContain("function Assert-GitHubTlsAccess");
+    expect(content).toContain('$GitHubPreflightUrl = "https://github.com"');
+    expect(content).toContain("HttpCompletionOption]::ResponseHeadersRead");
+
+    const preflight = content.indexOf("Invoke-WindowsInstallerPreflight\n$expectedVersion");
+    const versionResolution = content.indexOf("$version = Get-DownloadInstallVersion", preflight);
+    const bundleInstall = content.indexOf("$bundleResult = Install-Bundle", preflight);
+    expect(preflight).toBeGreaterThan(-1);
+    expect(preflight).toBeLessThan(versionResolution);
+    expect(versionResolution).toBeLessThan(bundleInstall);
   });
 
   it("retries a hash-mismatched primary download with the next transport", async () => {
@@ -267,6 +286,10 @@ if (($script:methods -join ",") -ne "Invoke-WebRequest,HttpClient") {
     expect(content).toContain("HA_NOVA_NO_SETUP");
     expect(content).toContain("Start-Setup");
     expect(content).toContain("& $BinaryPath setup");
+    expect(content).toContain("Next step: ha-nova setup");
+    expect(content).toContain(
+      "Setup will ask for the six-digit pairing code shown in NOVA Home Base.",
+    );
     expect(content).not.toContain("ha-nova.cmd");
   });
 

--- a/tests/onboarding/windows-installer-preflight.test.ts
+++ b/tests/onboarding/windows-installer-preflight.test.ts
@@ -1,0 +1,154 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+function hasPowerShell(): boolean {
+  return spawnSync("pwsh", ["-NoProfile", "-Command", "exit 0"]).status === 0;
+}
+
+function runPreflightProbe(body: string): { status: number | null; output: string } {
+  const tempDir = mkdtempSync(join(tmpdir(), "ha-nova-windows-preflight-"));
+  const probe = join(tempDir, "probe.ps1");
+  const installScript = join(process.cwd(), "install.ps1").replaceAll("'", "''");
+  writeFileSync(
+    probe,
+    `$ErrorActionPreference = "Stop"
+$env:HA_NOVA_INSTALLER_TEST_EXPORT = "1"
+$env:HA_NOVA_PLAIN_UI = "1"
+. '${installScript}'
+${body}
+`,
+    "utf8",
+  );
+  const result = spawnSync(
+    "pwsh",
+    ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", probe],
+    { encoding: "utf8" },
+  );
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+const supportedRuntime = `
+function Get-InstallerWindowsVersion { return [version]"10.0" }
+function Get-InstallerPowerShellVersion { return [version]"5.1" }
+$env:PROCESSOR_ARCHITECTURE = "AMD64"
+`;
+
+describe("Windows installer preflight behavior", () => {
+  it("prints the exact pairing-aware continuation in a non-interactive session", () => {
+    if (!hasPowerShell()) return;
+    const result = runPreflightProbe(`
+function Test-InteractiveSession { return $false }
+Start-Setup -BinaryPath "never-run.exe"
+`);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(
+      "No interactive terminal detected; setup was not started automatically.",
+    );
+    expect(result.output).toContain("Next step: ha-nova setup");
+    expect(result.output).toContain(
+      "Setup will ask for the six-digit pairing code shown in NOVA Home Base.",
+    );
+  });
+
+  it("passes supported prerequisites in write-then-TLS order", () => {
+    if (!hasPowerShell()) return;
+    const result = runPreflightProbe(`${supportedRuntime}
+$script:checks = @()
+function Assert-InstallRootWritable { $script:checks += "write" }
+function Assert-GitHubTlsAccess { $script:checks += "tls" }
+Invoke-WindowsInstallerPreflight
+Write-Output ($script:checks -join ",")
+`);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("Windows prerequisites passed");
+    expect(result.output).toContain("write,tls");
+  });
+
+  it("fails unsupported Windows before later preflight work", () => {
+    if (!hasPowerShell()) return;
+    const result = runPreflightProbe(`
+function Get-InstallerWindowsVersion { return [version]"6.3" }
+function Get-InstallerPowerShellVersion { throw "PowerShell check must not run" }
+Invoke-WindowsInstallerPreflight
+`);
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain(
+      "Windows 10 or Windows Server 2016 or later is required",
+    );
+    expect(result.output).not.toContain("PowerShell check must not run");
+  });
+
+  it("fails PowerShell below 5.1 before architecture or network work", () => {
+    if (!hasPowerShell()) return;
+    const result = runPreflightProbe(`
+function Get-InstallerWindowsVersion { return [version]"10.0" }
+function Get-InstallerPowerShellVersion { return [version]"5.0" }
+function Get-PlatformArch { throw "Architecture check must not run" }
+Invoke-WindowsInstallerPreflight
+`);
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("PowerShell 5.1 or later is required");
+    expect(result.output).not.toContain("Architecture check must not run");
+  });
+
+  it("fails a native ARM64 process with the x64-emulation recovery", () => {
+    if (!hasPowerShell()) return;
+    const result = runPreflightProbe(`${supportedRuntime}
+$env:PROCESSOR_ARCHITECTURE = "ARM64"
+Invoke-WindowsInstallerPreflight
+`);
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("Windows amd64 bundle only");
+    expect(result.output).toContain("use x64 emulation");
+  });
+
+  it("fails a 32-bit process with a 64-bit PowerShell recovery", () => {
+    if (!hasPowerShell()) return;
+    const result = runPreflightProbe(`${supportedRuntime}
+$env:PROCESSOR_ARCHITECTURE = "x86"
+Invoke-WindowsInstallerPreflight
+`);
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("requires a 64-bit PowerShell process");
+    expect(result.output).toContain("Open 64-bit PowerShell or Windows Terminal");
+  });
+
+  it("fails an unwritable per-user install root before the TLS probe", () => {
+    if (!hasPowerShell()) return;
+    const tempDir = mkdtempSync(join(tmpdir(), "ha-nova-unwritable-root-"));
+    const blocker = join(tempDir, "not-a-directory");
+    writeFileSync(blocker, "blocked", "utf8");
+    const escapedBlocker = blocker.replaceAll("'", "''");
+    const result = runPreflightProbe(`${supportedRuntime}
+$script:InstallDir = Join-Path '${escapedBlocker}' "ha-nova"
+function Assert-GitHubTlsAccess { throw "TLS probe must not run" }
+Invoke-WindowsInstallerPreflight
+`);
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("Cannot write to the per-user HA NOVA install location");
+    expect(result.output).toContain("Fix LOCALAPPDATA permissions");
+    expect(result.output).not.toContain("TLS probe must not run");
+  });
+
+  it("surfaces actionable GitHub TLS recovery before downloads", () => {
+    if (!hasPowerShell()) return;
+    const result = runPreflightProbe(`${supportedRuntime}
+function Assert-InstallRootWritable { }
+function Assert-GitHubTlsAccess {
+  Fail "Could not establish a TLS connection to GitHub. Check the Windows date/time, proxy or firewall, and pending Windows updates, then rerun the installer."
+}
+Invoke-WindowsInstallerPreflight
+`);
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("Could not establish a TLS connection to GitHub");
+    expect(result.output).toContain("proxy or firewall");
+    expect(result.output).toContain("pending Windows updates");
+  });
+});


### PR DESCRIPTION
## Summary
- list every reachable Home Assistant instance in stable, source-labeled discovery order
- auto-select one instance and retain manual entry when none are confirmed
- add pairing-aware non-TTY installer continuation
- preflight Windows, PowerShell, architecture, install-root writes, and GitHub TLS before downloads

## Verification
- npm run verify
- go vet ./...
- bash -n install.sh

## Risk
- no live Windows host or live Home Assistant browser smoke in this local run; platform behavior is covered by executable PowerShell and Go tests