### PR TITLE
docs: close Wave 6

### DIFF
--- a/docs/work/2026-07-15-wave-6-onboarding-spec.md
+++ b/docs/work/2026-07-15-wave-6-onboarding-spec.md
@@ -1,9 +1,10 @@
 # Wave 6 Onboarding Spec
 
-Status: active
+Status: complete
 Date: 2026-07-15
 Sequencing SSOT: `docs/work/masterplan-2026-h2.md` -> Wave 6
 Release train: Relay 0.6.0; version/tag changes stay in release prep
+Implementation PRs: #357, #358, #359, #360
 
 ## Goal
 
@@ -85,7 +86,7 @@ Official Supervisor behavior used by this design: ingress authenticates the Home
 
 - Return all reachable candidates in stable priority order instead of stopping at the first success.
 - Deduplicate candidates by normalized resolved host.
-- One candidate selects automatically. Multiple candidates show a pick list with address and discovery source. No candidate keeps the existing manual-address path.
+- One candidate selects automatically unless its only confirmed address is an unresolved `.local` name; that case remains an editable default so the user can enter an IP. Multiple candidates show a pick list with address and discovery source. No candidate keeps the existing manual-address path.
 - Bound the total discovery time and candidate count; no unbounded subnet scan.
 
 ### Non-TTY and Windows
@@ -114,6 +115,15 @@ Each PR completes the repository merge checklist independently. No README featur
 - Token-revoked and LLAT-revoked failures route to different, correct recovery surfaces.
 - Targeted Relay/CLI suites and full `npm run verify` pass.
 - Every PR receives a real clean Codex result on its final SHA, all threads are resolved, and merge uses squash/delete-branch only after the mandatory checklist is complete.
+
+## Completion record
+
+- #357 added the persistent App token, pairing-code manager, `/pair`, rate limits, security contracts, and compatibility coverage.
+- #358 added the Supervisor-ingress Home Base, authenticated peer/header gate, read-only status rendering, and charter contracts.
+- #359 moved the normal CLI flow to Home Base pairing while retaining saved-token, explicit-token, service, legacy-relay, and LLAT-repair paths.
+- #360 completed bounded multi-instance discovery, non-TTY guidance, Windows preflight, and the `.local` correction path.
+- All four behavior PRs passed the full repository checklist with a real clean Codex result on the final SHA and all review threads resolved.
+- No release, README claim, version bump, tag, or publish action is part of this closeout. Those remain release-prep work.
 
 ## Research basis
 

--- a/docs/work/masterplan-2026-h2.md
+++ b/docs/work/masterplan-2026-h2.md
@@ -127,7 +127,7 @@ Status: **DONE** — #353, #354, #355
 
 ## Wave 6 — Onboarding flagship: Pairing Code + Home Base (Relay 0.6.0, committed)
 
-Status: **IN PROGRESS** — implementation spec: `docs/work/2026-07-15-wave-6-onboarding-spec.md`
+Status: **DONE** — #357, #358, #359, #360; implementation spec: `docs/work/2026-07-15-wave-6-onboarding-spec.md`. Unreleased until the separate release-prep gate.
 
 - **`/pair` endpoint**: a 6-digit short-lived pairing code (visible in the App log/panel) exchanges for the relay token over LAN. The wizard asks for exactly one thing: the code. The two-token model disappears from the user's world (the relay token becomes invisible; the LLAT stays in the App's own config UI where it belongs). Charter-clean: pure auth handshake, rate-limited, zero HA semantics. Natural future home for token rotation.
 - **Home Base**: a minimal ingress status page in the HA sidebar (one HTML file rendering `/health` data): connection status, version floor, pairing code, install one-liner. When something breaks, non-terminal users look *here* — inside the UI they know — instead of running `ha-nova doctor`. A charter test pins that no HA business logic creeps in.
@@ -176,7 +176,7 @@ All waves land on `main` first; releases batch per the release-worthiness rule. 
 | 3 | Review expansion (SC/D/TS/HX families, test-offer) | — | **DONE** — #352 |
 | 4 | Coverage (integration-setup, calendar writes, events, alarm/lock) | — | **DONE** — #353, #354, #355 |
 | 5 | Relay diagnosability | 0.5.0 (with Wave 2) | **DONE** — #351 |
-| 6 | Pairing Code + Home Base | 0.6.0 | **IN PROGRESS** — spec written |
+| 6 | Pairing Code + Home Base | 0.6.0 | **DONE** — #357, #358, #359, #360; unreleased |
 | 7 | Update UX parity | — | planned |
 
 ## Opinionated defaults (documented instead of asked)
@@ -188,5 +188,5 @@ All waves land on `main` first; releases batch per the release-worthiness rule. 
 ## Known risks
 - Wave 1's settle-window and drift-check changes touch the hottest skill paths — each needs targeted live verification (`npm run dev:sync` + fresh session) before PR.
 - The snapshot matrix's PARTIAL families need per-family honesty wording; overpromising restore fidelity would damage exactly the trust the feature is meant to build.
-- `/pair` changes the auth surface — needs the same adversarial review depth as the original dual-token design and a rate-limit test.
+- `/pair` changes the auth surface. Adversarial and rate-limit coverage landed in #357; the eventual release still requires the delivery-machinery RC path.
 - 29+ skills after Wave 4: dispatch sharpness pressure keeps rising; the linter and context-skill examples remain the backstop.


### PR DESCRIPTION
## Summary
- mark the Wave 6 onboarding spec complete
- record behavior PRs #357 through #360 and the unreleased state
- advance the masterplan to Wave 7

## Verification
- npm run verify:docs

No README, version, manifest, tag, or release change.