### PR TITLE
chore(release): prepare 0.18.0 and relay 0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.17.0"
+    "version": "0.18.0"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,8 +85,14 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## New Features
 
-    - **Test it right after saving.** Every new or changed automation and script now ends with a test offer matched to its risk: a zero-impact logic check, an actions-only run, or a full real test that fires the actual trigger — always naming exactly which devices will switch, with one confirmation; every real run gets an automatic trace check afterwards and cleanup of any test state. High-consequence targets such as locks, garage doors, alarms, and heating are never presented as consequence-free.
-    - **One consistent look everywhere.** Suggestions, reports, lists, and status answers now follow the same recognizable shapes as the preview cards: improvement suggestions render as a compact 💡 block, read answers lead with the answer and close with a clear next step, and lists state their counts and caps honestly.
+    - **Pair with one short code.** HA OS and Supervised installs now get NOVA Home Base inside Home Assistant. It shows Relay status and a six-digit, short-lived pairing code, so new setup no longer asks you to copy the Relay token.
+    - **Recover configuration changes.** HA NOVA can capture compact config snapshots before destructive changes and restore supported items through the normal preview, confirmation, and verification flow. Existing update-revert remains the quick undo path.
+    - **More first-class Home Assistant work.** Set up integrations through Home Assistant's own secure UI, create and edit calendar events, fire events and webhooks, and get deeper reviews for scenes, dashboards, YAML sensors, and cross-item conflicts. Alarm and lock actions now use explicit security guidance.
+    - **Clearer updates and diagnostics.** Successful updates tell every supported client when to start a fresh AI session, while Relay health reports why the Home Assistant connection is unavailable and logs request failures more usefully.
+
+    ## What To Watch
+
+    - Update the NOVA Relay App to **0.6.0** to use Home Base and pairing. Relay 0.5.0 already supports config snapshots; older compatible Relay versions keep the legacy token setup and safety-backup fallback.
     Stable install commands are release-pinned for this tag.
 
     **macOS / Linux:**
@@ -107,7 +113,7 @@ release:
     ## Upgrade Notes
 
     - Already installed? Run `ha-nova check-update` or `ha-nova update`.
-    - Claude shipped installs use the local staged HA NOVA release payload on disk. When HA NOVA shows an update notice, run `ha-nova update` and then restart Claude.
+    - Shipped installs use the local staged HA NOVA release payload on disk. When HA NOVA shows an update notice, run `ha-nova update`, then start a new AI client session.
     - Default `ha-nova uninstall` is standard remove. Use `ha-nova uninstall --purge` for a full local wipe.
     - Windows now uses `%APPDATA%\ha-nova` and `%LOCALAPPDATA%\ha-nova\cache` as the canonical config and cache paths.
     - Home Assistant Relay setup and token steps remain guided in the browser after local install completes.

--- a/README.md
+++ b/README.md
@@ -77,9 +77,19 @@ One installer. One wizard. Done. It even finds your Home Assistant automatically
 
 > **You need:** Home Assistant — any install type. HA OS and Supervised get the NOVA Relay App, and the wizard below walks you through it. Container and Core run the same relay as a [standalone container](docs/reference/relay-container.md) — skip the steps below and follow that guide end to end instead (it installs the CLI without the wizard and attaches it non-interactively).
 
-1. Open the [latest release](https://github.com/markusleben/ha-nova/releases/latest)
-2. Copy the one-liner for your OS
-3. Run it — the wizard discovers your HA, sets up the connection, and configures your AI client
+**macOS / Linux:**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/main/install.sh | bash
+```
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://raw.githubusercontent.com/markusleben/ha-nova/main/install.ps1 | iex
+```
+
+The installer selects the latest stable release. Run the command for your OS; the wizard discovers your HA, sets up the connection, and configures your AI client.
 
 Once it finishes, try: *"Show me all my automations."*
 

--- a/docs/work/0.18.0-release-body.md
+++ b/docs/work/0.18.0-release-body.md
@@ -1,0 +1,12 @@
+# 0.18.0 Release Body (draft — collects unreleased user-facing claims)
+
+## New Features
+
+- **Pair with one short code.** HA OS and Supervised installs now get NOVA Home Base inside Home Assistant. It shows Relay status and a six-digit, short-lived pairing code, so new setup no longer asks you to copy the Relay token. (#357–#360)
+- **Recover configuration changes.** HA NOVA can capture compact config snapshots before destructive changes and restore supported items through the normal preview, confirmation, and verification flow. Existing update-revert remains the quick undo path. (#348–#350)
+- **More first-class Home Assistant work.** Set up integrations through Home Assistant's own secure UI, create and edit calendar events, fire events and webhooks, and get deeper reviews for scenes, dashboards, YAML sensors, and cross-item conflicts. Alarm and lock actions now use explicit security guidance. (#352–#355)
+- **Clearer updates and diagnostics.** Successful updates tell every supported client when to start a fresh AI session, while Relay health reports why the Home Assistant connection is unavailable and logs request failures more usefully. (#351, #363)
+
+## What To Watch
+
+- Update the NOVA Relay App to **0.6.0** to use Home Base and pairing. Relay 0.5.0 already supports config snapshots; older compatible Relay versions keep the legacy token setup and safety-backup fallback.

--- a/docs/work/masterplan-2026-h2.md
+++ b/docs/work/masterplan-2026-h2.md
@@ -117,7 +117,7 @@ Status: **DONE** — #353, #354, #355
 
 ---
 
-## Wave 5 — Relay diagnosability & robustness (bundled with Wave 2 into Relay 0.5.0)
+## Wave 5 — Relay diagnosability & robustness (ships with Relay 0.6.0)
 
 - `/health`: WS-disconnect reason (auth vs network), `file_access` mode, HA version — so the onboarding skill can classify failures instead of prematurely sending users into `ha-nova setup`.
 - Wire up `LOG_LEVEL` (validated but never consumed today); log the cause on the 500 path (`nova/src/http/errors.ts` swallows it); log 401s; fix the `constantTimeEqual` length leak (`nova/src/security/auth.ts`); server request/headers timeouts; make the 256 MiB response ceiling configurable for constrained hosts.
@@ -168,7 +168,7 @@ From the ideation pass; each needs its own decision before entering a wave:
 
 ## Release sequencing
 
-All waves land on `main` first; releases batch per the release-worthiness rule. Relay changes bundle into exactly two releases: **0.5.0** (`/backups` + diagnosability) and **0.6.0** (`/pair` + Home Base). Skill-only waves (0, 1, 3, 4) batch freely between them.
+All waves land on `main` first; releases batch per the release-worthiness rule. Relay 0.5.0 published the `/backups` foundation. Its immutable image tag existed before Wave 5 merged, so diagnosability ships with Pairing Code + Home Base in Relay **0.6.0**. Skill-only waves (0, 1, 3, 4) batch freely between them.
 
 | Wave | Theme | Relay release | Status |
 |------|-------|---------------|--------|
@@ -177,7 +177,7 @@ All waves land on `main` first; releases batch per the release-worthiness rule. 
 | 2 | Config Snapshots | 0.5.0 | **DONE** — #347, #348, #349, #350 |
 | 3 | Review expansion (SC/D/TS/HX families, test-offer) | — | **DONE** — #352 |
 | 4 | Coverage (integration-setup, calendar writes, events, alarm/lock) | — | **DONE** — #353, #354, #355 |
-| 5 | Relay diagnosability | 0.5.0 (with Wave 2) | **DONE** — #351 |
+| 5 | Relay diagnosability | 0.6.0 (with Wave 6) | **DONE** — #351 |
 | 6 | Pairing Code + Home Base | 0.6.0 | **DONE** — #357, #358, #359, #360; unreleased |
 | 7 | Update UX parity | — | **IN PROGRESS** — spec written |
 

--- a/nova/CHANGELOG.md
+++ b/nova/CHANGELOG.md
@@ -9,6 +9,29 @@ The format follows [Keep a Changelog](https://keepachangelog.com/) and [Semantic
 Recent changes are tracked in [GitHub releases](https://github.com/markusleben/ha-nova/releases)
 and merged PRs. This changelog will be updated with the next tagged relay version.
 
+## [Relay 0.6.0] - 2026-07-15
+
+### Added
+- Home Base: an admin-only Home Assistant sidebar page with Relay status, the current pairing code, and install guidance.
+- `POST /pair`: exchange a short-lived, single-use six-digit code for the Relay token during local setup.
+- App-managed persistent Relay tokens when the advanced `relay_auth_token` option is left empty. Existing configured tokens remain compatible.
+
+### Changed
+- `/health` now reports the Home Assistant WebSocket disconnect reason (`auth`, `network`, or `never_connected`) and snapshot-store status.
+- `LOG_LEVEL` is applied at runtime; rejected auth requests and unexpected request failures now produce useful logs without exposing secrets.
+- HTTP request, header, keep-alive, and upstream response limits are explicit and configurable where appropriate.
+
+### Security
+- Pairing is peer- and globally rate-limited, returns generic failures, rotates codes after success or expiry, and marks every response `no-store`.
+- Home Base requires the real Supervisor ingress peer plus authenticated user headers; direct-port header spoofing is rejected.
+- Secret comparisons no longer reveal length through an early return.
+
+## [Relay 0.5.0] - 2026-07-14
+
+### Added
+- `POST /backups`: a bearer-authenticated, generic gzip JSON store for named and automatic config snapshots, with bounded save/load/list/delete/prune actions and no Home Assistant business logic.
+- Snapshot storage persists in the App data directory and can use a mounted `SNAPSHOT_DIR` in the standalone container.
+
 ## [Relay 0.4.1] - 2026-07-12
 
 - The App info page now explains what the NOVA Relay is, what it deliberately does not do, and where the security model lives — instead of a one-line stub. No functional changes.

--- a/nova/config.yaml
+++ b/nova/config.yaml
@@ -1,5 +1,5 @@
 name: NOVA Relay
-version: "0.5.0"
+version: "0.6.0"
 slug: ha_nova_relay
 description: Thin Home Assistant relay for WS proxy and skill workflows
 url: https://github.com/markusleben/ha-nova

--- a/nova/version.json
+++ b/nova/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.17.0",
+  "skill_version": "0.18.0",
   "min_relay_version": "0.4.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "home-assistant-js-websocket": "^9.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/client-install-docs-contract.test.ts
+++ b/tests/onboarding/client-install-docs-contract.test.ts
@@ -28,8 +28,13 @@ describe("client install docs contract", () => {
     expect(readme).not.toContain("npm.cmd");
     expect(readme).not.toContain("5 tested clients");
     expect(readme).toContain("ha-nova uninstall --purge");
-    expect(readme).toContain("Copy the one-liner for your OS");
-    expect(readme).toContain("https://github.com/markusleben/ha-nova/releases/latest");
+    expect(readme).toContain(
+      "curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/main/install.sh | bash"
+    );
+    expect(readme).toContain(
+      "irm https://raw.githubusercontent.com/markusleben/ha-nova/main/install.ps1 | iex"
+    );
+    expect(readme).toContain("The installer selects the latest stable release.");
     expect(readme).toContain("Git for Windows / Git Bash");
     expect(readme).toContain("Google Antigravity Desktop or CLI must be installed");
     expect(readme).toContain("Google Antigravity is the current Google client path");
@@ -37,8 +42,6 @@ describe("client install docs contract", () => {
     expect(readme).not.toContain("%LOCALAPPDATA%\\Programs\\antigravity\\Antigravity.exe");
     // Hermes is now a listed (preview) client like the others; the gate is resolved.
     expect(readme).not.toContain("docs/reference/hermes-platform-validation.md");
-    expect(readme).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.sh");
-    expect(readme).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.ps1");
   });
 
   it("keeps client overlays scoped to client-specific deltas", () => {

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -9,6 +9,7 @@ describe("release contract", () => {
   const releaseWorkflow = readFileSync(".github/workflows/release.yml", "utf8");
   const rcWorkflow = readFileSync(".github/workflows/release-candidate.yml", "utf8");
   const releasing = readFileSync("docs/releasing.md", "utf8");
+  const readme = readFileSync("README.md", "utf8");
   const linuxHeadlessHelper = readFileSync("scripts/smoke/linux-headless-setup-check.sh", "utf8");
   const pkg = JSON.parse(readFileSync("package.json", "utf8")) as {
     scripts?: Record<string, string>;
@@ -53,15 +54,28 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
-  it("keeps v0.17.0 release-facing wording user-centric", () => {
+  it("keeps v0.18.0 release-facing wording user-centric", () => {
     // Shipped release-note bodies are archived (docs/archive/work/) and
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
-    expect(goreleaser).toContain("Test it right after saving");
-    expect(goreleaser).toContain("naming exactly which devices will switch");
-    expect(goreleaser).toContain("never presented as consequence-free");
-    expect(goreleaser).toContain("One consistent look everywhere");
+    expect(goreleaser).toContain("Pair with one short code");
+    expect(goreleaser).toContain("Recover configuration changes");
+    expect(goreleaser).toContain("More first-class Home Assistant work");
+    expect(goreleaser).toContain("Clearer updates and diagnostics");
+    expect(goreleaser).toContain("Update the NOVA Relay App to **0.6.0**");
     expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");
+  });
+
+  it("keeps README install commands visible and versionless", () => {
+    expect(readme).toContain(
+      "curl -fsSL https://raw.githubusercontent.com/markusleben/ha-nova/main/install.sh | bash"
+    );
+    expect(readme).toContain(
+      "irm https://raw.githubusercontent.com/markusleben/ha-nova/main/install.ps1 | iex"
+    );
+    expect(readme).toContain("The installer selects the latest stable release.");
+    expect(readme).not.toMatch(/HA_NOVA_VERSION=v\d/);
+    expect(readme).not.toMatch(/\$env:HA_NOVA_VERSION\s*=\s*['\"]v\d/);
   });
 
   it("pins the GoReleaser release tag to the triggering workflow ref", () => {

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.17.0",
+  "skill_version": "0.18.0",
   "min_relay_version": "0.4.0"
 }


### PR DESCRIPTION
## Summary
- bump HA NOVA to 0.18.0 and Relay App to 0.6.0
- publish concise user-facing notes for pairing, config snapshots, wider coverage, and clearer update diagnostics
- expose versionless macOS/Linux and Windows install commands in README
- backfill Relay 0.5.0/0.6.0 changelog truth and align the H2 masterplan with the immutable 0.5.0 image

## Verification
- npm run verify
- npm run verify:next-release-version -- v0.18.0
- goreleaser check
- git diff --check

## Release gates after merge
- strict release-pipeline audit on the merge commit
- dispatched disposable-HA E2E on the merge commit
- required v0.18.0-rc1 tag-first rehearsal, then final v0.18.0 publish and public-install verification