### PR TITLE
fix: guide Windows installs without AI client

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -90,6 +90,10 @@ release:
     - **More first-class Home Assistant work.** Set up integrations through Home Assistant's own secure UI, create and edit calendar events, fire events and webhooks, and get deeper reviews for scenes, dashboards, YAML sensors, and cross-item conflicts. Alarm and lock actions now use explicit security guidance.
     - **Clearer updates and diagnostics.** Successful updates tell every supported client when to start a fresh AI session, while Relay health reports why the Home Assistant connection is unavailable and logs request failures more usefully.
 
+    ## Bug Fixes
+
+    - Clean Windows installations without an AI client now finish with clear next-step guidance instead of a setup error.
+
     ## What To Watch
 
     - Update the NOVA Relay App to **0.6.0** to use Home Base and pairing. Relay 0.5.0 already supports config snapshots; older compatible Relay versions keep the legacy token setup and safety-backup fallback.

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -7,6 +7,24 @@ import (
 	"strings"
 )
 
+const setupReadinessNoClientExitCode = 2
+
+func runInternalSetupReadiness(paths runtimePaths, args []string) int {
+	if len(args) != 0 {
+		printHumanErr("internal-setup-readiness does not accept arguments")
+		return 1
+	}
+	choices, err := buildSetupClientChoices(paths, loadStateOrDefault(paths))
+	if err != nil {
+		printHumanErr("%s", err)
+		return 1
+	}
+	if !hasAvailableSetupClientChoice(choices) {
+		return setupReadinessNoClientExitCode
+	}
+	return 0
+}
+
 func runSetup(paths runtimePaths, args []string) int {
 	fs := flag.NewFlagSet("setup", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)

--- a/cli/main.go
+++ b/cli/main.go
@@ -73,6 +73,8 @@ func dispatch(paths runtimePaths, argv0 string, args []string) int {
 		return runInternalUninstall(paths, args[1:])
 	case "internal-sync-clients":
 		return runInternalSyncClients(paths, args[1:])
+	case "internal-setup-readiness":
+		return runInternalSetupReadiness(paths, args[1:])
 	case "-h", "--help", "help":
 		printUsage()
 		return 0

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -131,6 +131,9 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 	if target == "" {
 		for {
 			answer, err := promptSetupClientInteractive(reader, os.Stdout, choices, "claude")
+			if err == errSetupClientPrerequisite {
+				return 0
+			}
 			if err == errSetupBack {
 				continue
 			}

--- a/cli/setup_interactive_test.go
+++ b/cli/setup_interactive_test.go
@@ -158,6 +158,41 @@ func TestInteractiveSetupFreshInstallShowsWizardAndInstallsAntigravitySkills(t *
 	}
 }
 
+func TestInteractiveSetupWithoutAvailableClientReturnsGuidance(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+	withClientRuntimeAvailability(t, map[string]bool{})
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	exitCode := 1
+	stdout, stderr := captureInteractiveSetupIO(t, "", func() int {
+		clientRuntimeDetectedForStatus = func(string) bool { return false }
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "", "", "", "", "", false)
+		return exitCode
+	})
+	if exitCode != 0 {
+		t.Fatalf("interactiveSetup() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	output := stdout + stderr
+	for _, want := range []string{
+		"No supported AI client is ready on this machine yet.",
+		"Install one supported client first, then rerun: ha-nova setup",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("missing-client guidance missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "[ha-nova] ERROR") {
+		t.Fatalf("missing-client guidance must not render as an error:\n%s", output)
+	}
+}
+
 func TestInteractiveSetupFreshInstallCanTargetHermes(t *testing.T) {
 	withClientRuntimeAvailability(t, map[string]bool{"hermes": true})
 

--- a/cli/setup_ui.go
+++ b/cli/setup_ui.go
@@ -33,7 +33,9 @@ func promptSetupClientFromReader(reader *bufio.Reader, out io.Writer, choices []
 			}
 		}
 		fmt.Fprintln(out)
-		return "", fmt.Errorf("no supported AI clients detected on this machine yet")
+		fmt.Fprintln(out, "  No supported AI client is ready on this machine yet.")
+		fmt.Fprintln(out, "  Install one supported client first, then rerun: ha-nova setup")
+		return "", errSetupClientPrerequisite
 	}
 	defaultChoice := firstAvailableSetupClientChoice(choices)
 	for _, choice := range choices {

--- a/cli/setup_ui_test.go
+++ b/cli/setup_ui_test.go
@@ -62,6 +62,56 @@ func TestPromptSetupClientAcceptsNumberSelection(t *testing.T) {
 	}
 }
 
+func TestPromptSetupClientGuidesMissingClientPrerequisite(t *testing.T) {
+	choices := testSetupClientChoices()
+	for index := range choices {
+		choices[index].Disabled = true
+		choices[index].DisabledReason = "install this client first"
+	}
+	output := &bytes.Buffer{}
+
+	_, err := promptSetupClient(strings.NewReader(""), output, choices, "claude")
+	if err != errSetupClientPrerequisite {
+		t.Fatalf("promptSetupClient() error = %v, want %v", err, errSetupClientPrerequisite)
+	}
+
+	rendered := output.String()
+	for _, want := range []string{
+		"No supported AI client is ready on this machine yet.",
+		"Install one supported client first, then rerun: ha-nova setup",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("prompt output missing %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, "[ha-nova] ERROR") {
+		t.Fatalf("missing-client guidance must not render as an error:\n%s", rendered)
+	}
+}
+
+func TestInternalSetupReadinessDistinguishesMissingAndReadyClients(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	withClientRuntimeAvailability(t, map[string]bool{})
+	if exitCode := runInternalSetupReadiness(paths, nil); exitCode != setupReadinessNoClientExitCode {
+		t.Fatalf("missing-client readiness exit = %d, want %d", exitCode, setupReadinessNoClientExitCode)
+	}
+
+	clientRuntimeDetectedForStatus = func(client string) bool { return client == "antigravity" }
+	if exitCode := runInternalSetupReadiness(paths, nil); exitCode != 0 {
+		t.Fatalf("ready-client readiness exit = %d, want 0", exitCode)
+	}
+	if exitCode := runInternalSetupReadiness(paths, []string{"unexpected"}); exitCode != 1 {
+		t.Fatalf("readiness argument error exit = %d, want 1", exitCode)
+	}
+}
+
 func TestPromptSetupClientAcceptsClientName(t *testing.T) {
 	input := strings.NewReader("opencode\n")
 	output := &bytes.Buffer{}

--- a/cli/setup_wizard_navigation.go
+++ b/cli/setup_wizard_navigation.go
@@ -10,6 +10,7 @@ import (
 
 var errSetupBack = errors.New("setup back")
 var errSetupExit = errors.New("setup exit")
+var errSetupClientPrerequisite = errors.New("setup client prerequisite")
 var errSetupRelayTokenStep = errors.New("setup relay token step")
 var errSetupPairingStep = errors.New("setup pairing step")
 var errSetupHostStep = errors.New("setup host step")

--- a/docs/work/0.18.0-release-body.md
+++ b/docs/work/0.18.0-release-body.md
@@ -7,6 +7,10 @@
 - **More first-class Home Assistant work.** Set up integrations through Home Assistant's own secure UI, create and edit calendar events, fire events and webhooks, and get deeper reviews for scenes, dashboards, YAML sensors, and cross-item conflicts. Alarm and lock actions now use explicit security guidance. (#352–#355)
 - **Clearer updates and diagnostics.** Successful updates tell every supported client when to start a fresh AI session, while Relay health reports why the Home Assistant connection is unavailable and logs request failures more usefully. (#351, #363)
 
+## Bug Fixes
+
+- Clean Windows installations without an AI client now finish with clear next-step guidance instead of a setup error.
+
 ## What To Watch
 
 - Update the NOVA Relay App to **0.6.0** to use Home Base and pairing. Relay 0.5.0 already supports config snapshots; older compatible Relay versions keep the legacy token setup and safety-backup fallback.

--- a/install.ps1
+++ b/install.ps1
@@ -958,8 +958,20 @@ function Start-Setup {
     return
   }
 
-  & $BinaryPath internal-setup-readiness
-  $readinessExitCode = $LASTEXITCODE
+  $nativeErrorPreference = Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue
+  $previousNativeErrorPreference = if ($null -ne $nativeErrorPreference) { [bool]$nativeErrorPreference.Value } else { $false }
+  try {
+    if ($null -ne $nativeErrorPreference) {
+      $PSNativeCommandUseErrorActionPreference = $false
+    }
+    & $BinaryPath internal-setup-readiness
+    $readinessExitCode = $LASTEXITCODE
+  }
+  finally {
+    if ($null -ne $nativeErrorPreference) {
+      $PSNativeCommandUseErrorActionPreference = $previousNativeErrorPreference
+    }
+  }
   if ($readinessExitCode -eq 2) {
     Write-Warn "No supported AI client is ready on this machine yet."
     Write-Note "Install one supported client first, then rerun: ha-nova setup"

--- a/install.ps1
+++ b/install.ps1
@@ -958,6 +958,19 @@ function Start-Setup {
     return
   }
 
+  & $BinaryPath internal-setup-readiness
+  $readinessExitCode = $LASTEXITCODE
+  if ($readinessExitCode -eq 2) {
+    Write-Warn "No supported AI client is ready on this machine yet."
+    Write-Note "Install one supported client first, then rerun: ha-nova setup"
+    Write-Note "Need help later? Run: ha-nova doctor"
+    $global:LASTEXITCODE = 0
+    return
+  }
+  if ($readinessExitCode -ne 0) {
+    Fail "Could not check whether a supported AI client is ready."
+  }
+
   & $BinaryPath setup
 }
 

--- a/tests/onboarding/windows-installer-contract.test.ts
+++ b/tests/onboarding/windows-installer-contract.test.ts
@@ -285,7 +285,14 @@ if (($script:methods -join ",") -ne "Invoke-WebRequest,HttpClient") {
     expect(content).toContain("Ensure-InstallDirOnPath");
     expect(content).toContain("HA_NOVA_NO_SETUP");
     expect(content).toContain("Start-Setup");
+    expect(content).toContain("internal-setup-readiness");
     expect(content).toContain("& $BinaryPath setup");
+    expect(content).toContain(
+      "No supported AI client is ready on this machine yet.",
+    );
+    expect(content).toContain(
+      "Install one supported client first, then rerun: ha-nova setup",
+    );
     expect(content).toContain("Next step: ha-nova setup");
     expect(content).toContain(
       "Setup will ask for the six-digit pairing code shown in NOVA Home Base.",

--- a/tests/onboarding/windows-installer-preflight.test.ts
+++ b/tests/onboarding/windows-installer-preflight.test.ts
@@ -57,6 +57,54 @@ Start-Setup -BinaryPath "never-run.exe"
     );
   });
 
+  it("prints missing-client guidance without launching setup", () => {
+    if (!hasPowerShell()) return;
+    const result = runPreflightProbe(`
+function Test-InteractiveSession { return $true }
+$script:calls = @()
+function Invoke-FakeBinary {
+  param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+  $script:calls += ($Arguments -join " ")
+  if ($Arguments[0] -eq "internal-setup-readiness") {
+    $global:LASTEXITCODE = 2
+  }
+}
+Start-Setup -BinaryPath "Invoke-FakeBinary"
+Write-Output ("CALLS:" + ($script:calls -join ","))
+Write-Output ("LASTEXITCODE:" + $LASTEXITCODE)
+`);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(
+      "No supported AI client is ready on this machine yet.",
+    );
+    expect(result.output).toContain(
+      "Install one supported client first, then rerun: ha-nova setup",
+    );
+    expect(result.output).toContain("CALLS:internal-setup-readiness");
+    expect(result.output).not.toContain("CALLS:internal-setup-readiness,setup");
+    expect(result.output).toContain("LASTEXITCODE:0");
+  });
+
+  it("launches setup after a successful client-readiness check", () => {
+    if (!hasPowerShell()) return;
+    const result = runPreflightProbe(`
+function Test-InteractiveSession { return $true }
+$script:calls = @()
+function Invoke-FakeBinary {
+  param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+  $script:calls += ($Arguments -join " ")
+  $global:LASTEXITCODE = 0
+}
+Start-Setup -BinaryPath "Invoke-FakeBinary"
+Write-Output ("CALLS:" + ($script:calls -join ","))
+`);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("CALLS:internal-setup-readiness,setup");
+    expect(result.output).not.toContain(
+      "No supported AI client is ready on this machine yet.",
+    );
+  });
+
   it("passes supported prerequisites in write-then-TLS order", () => {
     if (!hasPowerShell()) return;
     const result = runPreflightProbe(`${supportedRuntime}

--- a/tests/onboarding/windows-installer-preflight.test.ts
+++ b/tests/onboarding/windows-installer-preflight.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -32,6 +32,19 @@ ${body}
     status: result.status,
     output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
   };
+}
+
+function createNativeExitProbe(exitCode: number): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "ha-nova-native-exit-"));
+  if (process.platform === "win32") {
+    const probe = join(tempDir, "probe.cmd");
+    writeFileSync(probe, `@exit /b ${exitCode}\r\n`, "utf8");
+    return probe;
+  }
+  const probe = join(tempDir, "probe.sh");
+  writeFileSync(probe, `#!/bin/sh\nexit ${exitCode}\n`, "utf8");
+  chmodSync(probe, 0o755);
+  return probe;
 }
 
 const supportedRuntime = `
@@ -82,6 +95,27 @@ Write-Output ("LASTEXITCODE:" + $LASTEXITCODE)
     );
     expect(result.output).toContain("CALLS:internal-setup-readiness");
     expect(result.output).not.toContain("CALLS:internal-setup-readiness,setup");
+    expect(result.output).toContain("LASTEXITCODE:0");
+  });
+
+  it("handles the no-client native exit when PowerShell promotes native errors", () => {
+    if (!hasPowerShell()) return;
+    const fakeBinary = createNativeExitProbe(2).replaceAll("'", "''");
+    const result = runPreflightProbe(`
+function Test-InteractiveSession { return $true }
+$PSNativeCommandUseErrorActionPreference = $true
+Start-Setup -BinaryPath '${fakeBinary}'
+Write-Output ("NATIVE_ERROR_PREFERENCE:" + $PSNativeCommandUseErrorActionPreference)
+Write-Output ("LASTEXITCODE:" + $LASTEXITCODE)
+`);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(
+      "No supported AI client is ready on this machine yet.",
+    );
+    expect(result.output).toContain(
+      "Install one supported client first, then rerun: ha-nova setup",
+    );
+    expect(result.output).toContain("NATIVE_ERROR_PREFERENCE:True");
     expect(result.output).toContain("LASTEXITCODE:0");
   });
 


### PR DESCRIPTION
## Summary
- treat a missing AI client as a successful interactive setup prerequisite handoff
- keep client detection in the Go CLI and expose a hidden readiness exit code to install.ps1
- add Windows installer, CLI, and release-contract regression coverage
- document the user-facing fix in the 0.18.0 release body

## Verification
- real Windows 11 Build 26200 / PowerShell 7.6.3 / standard-user gate: pass
- npm run verify
- pre-push: 843 tests, typecheck, build, docs
- goreleaser check
- npm run verify:next-release-version -- v0.18.0
- git diff --check

## Release impact
Release blocker found by v0.18.0-rc1. Final v0.18.0 remains blocked until this PR merges and a public rc2 Windows onboarding proof passes on the exact merge commit.