### PR TITLE
fix: capture Windows onboarding validator output

### DIFF
--- a/scripts/dev/windows-public-onboarding.ps1
+++ b/scripts/dev/windows-public-onboarding.ps1
@@ -112,12 +112,6 @@ function Set-InstallEnv {
   Remove-Item Env:HA_NOVA_BUNDLE_SHA256_URL -ErrorAction SilentlyContinue
   Remove-Item Env:HA_NOVA_NO_SETUP -ErrorAction SilentlyContinue
   Remove-Item Env:HA_NOVA_NO_BROWSER -ErrorAction SilentlyContinue
-  Remove-Item Env:HA_NOVA_PLAIN_UI -ErrorAction SilentlyContinue
-
-  # Windows 10 PowerShell 5.1 transcripts can omit Write-Host output emitted by
-  # a nested Invoke-Expression. Plain UI keeps installer messages on the success
-  # stream so the validator can capture them without redirecting the console.
-  $env:HA_NOVA_PLAIN_UI = "1"
 
   if ($Source -eq "rc") {
     if (-not $BundleUrl -or -not $BundleSha256Url) {
@@ -175,16 +169,75 @@ function Invoke-PublicInstaller {
   $exitCode = 0
   $caught = $null
   $transcriptStarted = $false
-  $installerOutput = New-Object System.Collections.Generic.List[string]
+  $installerOutput = New-Object System.Text.StringBuilder
+
+  function Add-InstallerOutput {
+    param(
+      [AllowEmptyString()][string]$Text,
+      [switch]$NoNewline
+    )
+
+    $installerOutput.Append($Text) | Out-Null
+    if (-not $NoNewline) {
+      $installerOutput.AppendLine() | Out-Null
+    }
+  }
+
+  # Windows 10 PowerShell 5.1 transcripts can omit nested host output. Mirror
+  # explicit installer UI writes into memory while the installer and its native
+  # interactive child stay attached directly to the console.
+  function Write-Host {
+    [CmdletBinding()]
+    param(
+      [Parameter(Position = 0, ValueFromPipeline = $true, ValueFromRemainingArguments = $true)]
+      [object[]]$Object,
+      [string]$Separator = " ",
+      [switch]$NoNewline,
+      [ConsoleColor]$ForegroundColor,
+      [ConsoleColor]$BackgroundColor
+    )
+
+    process {
+      $parts = New-Object System.Collections.Generic.List[string]
+      foreach ($item in $Object) {
+        $parts.Add([string]$item)
+      }
+      $line = [string]::Join($Separator, $parts)
+      Add-InstallerOutput -Text $line -NoNewline:$NoNewline
+
+      $hostParameters = @{
+        Object = $Object
+        Separator = $Separator
+        NoNewline = $NoNewline
+      }
+      if ($PSBoundParameters.ContainsKey("ForegroundColor")) {
+        $hostParameters.ForegroundColor = $ForegroundColor
+      }
+      if ($PSBoundParameters.ContainsKey("BackgroundColor")) {
+        $hostParameters.BackgroundColor = $BackgroundColor
+      }
+      Microsoft.PowerShell.Utility\Write-Host @hostParameters
+    }
+  }
+
+  function Write-Output {
+    [CmdletBinding()]
+    param(
+      [Parameter(Position = 0, ValueFromPipeline = $true, ValueFromRemainingArguments = $true)]
+      [AllowNull()][object]$InputObject,
+      [switch]$NoEnumerate
+    )
+
+    process {
+      Add-InstallerOutput -Text ([string]$InputObject)
+      Microsoft.PowerShell.Utility\Write-Output -InputObject $InputObject -NoEnumerate:$NoEnumerate
+    }
+  }
 
   try {
     Start-Transcript -Path $TranscriptPath -Force | Out-Null
     $transcriptStarted = $true
-    Invoke-Expression (Get-Content -LiteralPath $InstallScript -Raw) | ForEach-Object {
-      $line = [string]$_
-      $installerOutput.Add($line)
-      Write-Host $line
-    }
+    Invoke-Expression (Get-Content -LiteralPath $InstallScript -Raw)
     if ($LASTEXITCODE) {
       $exitCode = $LASTEXITCODE
     }
@@ -204,10 +257,10 @@ function Invoke-PublicInstaller {
     }
   }
 
-  return @{
+  $script:PublicInstallerResult = @{
     ExitCode = $exitCode
     Error = $caught
-    InstallerOutput = [string]::Join([Environment]::NewLine, $installerOutput)
+    InstallerOutput = $installerOutput.ToString()
   }
 }
 
@@ -217,7 +270,12 @@ $readyClients = @(Get-ReadyClients)
 $agyAvailable = Test-CommandAvailable "agy"
 $antigravityDesktopAvailable = Test-AntigravityDesktopAvailable
 
-$result = Invoke-PublicInstaller
+$script:PublicInstallerResult = $null
+Invoke-PublicInstaller
+$result = $script:PublicInstallerResult
+if ($null -eq $result) {
+  throw "public Windows installer did not return a validation result"
+}
 $transcript = if (Test-Path -LiteralPath $TranscriptPath) {
   Get-Content -LiteralPath $TranscriptPath -Raw
 }

--- a/scripts/dev/windows-public-onboarding.ps1
+++ b/scripts/dev/windows-public-onboarding.ps1
@@ -112,6 +112,12 @@ function Set-InstallEnv {
   Remove-Item Env:HA_NOVA_BUNDLE_SHA256_URL -ErrorAction SilentlyContinue
   Remove-Item Env:HA_NOVA_NO_SETUP -ErrorAction SilentlyContinue
   Remove-Item Env:HA_NOVA_NO_BROWSER -ErrorAction SilentlyContinue
+  Remove-Item Env:HA_NOVA_PLAIN_UI -ErrorAction SilentlyContinue
+
+  # Windows 10 PowerShell 5.1 transcripts can omit Write-Host output emitted by
+  # a nested Invoke-Expression. Plain UI keeps installer messages on the success
+  # stream so the validator can capture them without redirecting the console.
+  $env:HA_NOVA_PLAIN_UI = "1"
 
   if ($Source -eq "rc") {
     if (-not $BundleUrl -or -not $BundleSha256Url) {
@@ -169,11 +175,16 @@ function Invoke-PublicInstaller {
   $exitCode = 0
   $caught = $null
   $transcriptStarted = $false
+  $installerOutput = New-Object System.Collections.Generic.List[string]
 
   try {
     Start-Transcript -Path $TranscriptPath -Force | Out-Null
     $transcriptStarted = $true
-    Invoke-Expression (Get-Content -LiteralPath $InstallScript -Raw)
+    Invoke-Expression (Get-Content -LiteralPath $InstallScript -Raw) | ForEach-Object {
+      $line = [string]$_
+      $installerOutput.Add($line)
+      Write-Host $line
+    }
     if ($LASTEXITCODE) {
       $exitCode = $LASTEXITCODE
     }
@@ -196,6 +207,7 @@ function Invoke-PublicInstaller {
   return @{
     ExitCode = $exitCode
     Error = $caught
+    InstallerOutput = [string]::Join([Environment]::NewLine, $installerOutput)
   }
 }
 
@@ -212,21 +224,22 @@ $transcript = if (Test-Path -LiteralPath $TranscriptPath) {
 else {
   ""
 }
+$installerLog = @($transcript, $result.InstallerOutput) -join [Environment]::NewLine
 
 $setupAutoStarted = (
-  $transcript -match "Press Enter to continue setup" -or
-  $transcript -match "Install NOVA Relay in Home Assistant" -or
-  $transcript -match "Set up Relay Auth Token" -or
-  $transcript -match "Setup complete!" -or
-  $transcript -match "Setup cancelled"
+  $installerLog -match "Press Enter to continue setup" -or
+  $installerLog -match "Install NOVA Relay in Home Assistant" -or
+  $installerLog -match "Set up Relay Auth Token" -or
+  $installerLog -match "Setup complete!" -or
+  $installerLog -match "Setup cancelled"
 )
 $manualFallbackDisplayed = (
-  $transcript -match [regex]::Escape("Next step: ha-nova setup") -or
-  $transcript -match [regex]::Escape("Finish setup later from a local PowerShell or Windows Terminal session:")
+  $installerLog -match [regex]::Escape("Next step: ha-nova setup") -or
+  $installerLog -match [regex]::Escape("Finish setup later from a local PowerShell or Windows Terminal session:")
 )
 $missingClientGuidanceDisplayed = (
-  $transcript -match [regex]::Escape("No supported AI client is ready on this machine yet.") -and
-  $transcript -match [regex]::Escape("Install one supported client first, then rerun: ha-nova setup")
+  $installerLog -match [regex]::Escape("No supported AI client is ready on this machine yet.") -and
+  $installerLog -match [regex]::Escape("Install one supported client first, then rerun: ha-nova setup")
 )
 $localInstallCompleted = Test-Path -LiteralPath $InstallDir
 $expectedPublicResult = if ($RequireAntigravityDesktopOnly) {

--- a/tests/onboarding/desktop-validation-behavior.test.ts
+++ b/tests/onboarding/desktop-validation-behavior.test.ts
@@ -31,13 +31,19 @@ describe("desktop validation helper behavior", () => {
     expect(windowsPublic).not.toContain('second_terminal_command_needed -eq $true');
   });
 
-  it("captures installer guidance when legacy PowerShell transcripts omit nested host output", () => {
-    expect(windowsPublic).toContain('$env:HA_NOVA_PLAIN_UI = "1"');
-    expect(windowsPublic).toContain("$installerOutput = New-Object System.Collections.Generic.List[string]");
-    expect(windowsPublic).toContain("$installerOutput.Add($line)");
-    expect(windowsPublic).toContain("InstallerOutput = [string]::Join([Environment]::NewLine, $installerOutput)");
+  it("captures legacy host output without piping the interactive installer", () => {
+    expect(windowsPublic).toContain("$installerOutput = New-Object System.Text.StringBuilder");
+    expect(windowsPublic).toContain("function Write-Host {");
+    expect(windowsPublic).toContain("function Write-Output {");
+    expect(windowsPublic).toContain("Add-InstallerOutput -Text $line");
+    expect(windowsPublic).toContain("Microsoft.PowerShell.Utility\\Write-Host @hostParameters");
+    expect(windowsPublic).toContain("Microsoft.PowerShell.Utility\\Write-Output -InputObject $InputObject");
+    expect(windowsPublic).toContain("$script:PublicInstallerResult = @{");
+    expect(windowsPublic).toContain("Invoke-PublicInstaller\n$result = $script:PublicInstallerResult");
+    expect(windowsPublic).not.toContain("$result = Invoke-PublicInstaller");
     expect(windowsPublic).toContain("$installerLog = @($transcript, $result.InstallerOutput) -join [Environment]::NewLine");
     expect(windowsPublic).toMatch(/\$missingClientGuidanceDisplayed = \([\s\S]+\$installerLog -match/);
+    expect(windowsPublic).not.toMatch(/Invoke-Expression \([^\n]+\)\s*\|\s*ForEach-Object/);
   });
 
   it("keeps Antigravity Desktop-only proof from passing through agy or missing-client fallback", () => {

--- a/tests/onboarding/desktop-validation-behavior.test.ts
+++ b/tests/onboarding/desktop-validation-behavior.test.ts
@@ -31,6 +31,15 @@ describe("desktop validation helper behavior", () => {
     expect(windowsPublic).not.toContain('second_terminal_command_needed -eq $true');
   });
 
+  it("captures installer guidance when legacy PowerShell transcripts omit nested host output", () => {
+    expect(windowsPublic).toContain('$env:HA_NOVA_PLAIN_UI = "1"');
+    expect(windowsPublic).toContain("$installerOutput = New-Object System.Collections.Generic.List[string]");
+    expect(windowsPublic).toContain("$installerOutput.Add($line)");
+    expect(windowsPublic).toContain("InstallerOutput = [string]::Join([Environment]::NewLine, $installerOutput)");
+    expect(windowsPublic).toContain("$installerLog = @($transcript, $result.InstallerOutput) -join [Environment]::NewLine");
+    expect(windowsPublic).toMatch(/\$missingClientGuidanceDisplayed = \([\s\S]+\$installerLog -match/);
+  });
+
   it("keeps Antigravity Desktop-only proof from passing through agy or missing-client fallback", () => {
     expect(windowsPublic).toContain("$desktopOnlyProofPassed = (");
     expect(windowsPublic).toContain("$RequireAntigravityDesktopOnly -and");

--- a/tests/onboarding/desktop-validation-contract.test.ts
+++ b/tests/onboarding/desktop-validation-contract.test.ts
@@ -337,7 +337,6 @@ describe("desktop validation helpers contract", () => {
     expect(windowsPublic).toContain("Install one supported client first, then rerun: ha-nova setup");
     expect(windowsPublic).toContain("Invoke-Expression (Get-Content -LiteralPath $InstallScript -Raw)");
     expect(windowsPublic).toContain("Start-Transcript");
-    expect(windowsPublic).toContain("HA_NOVA_PLAIN_UI");
     expect(windowsPublic).toContain("InstallerOutput");
     expect(windowsPublic).not.toContain("Tee-Object");
     expect(windowsPublic).not.toContain("cmd.exe /d /s /c");

--- a/tests/onboarding/desktop-validation-contract.test.ts
+++ b/tests/onboarding/desktop-validation-contract.test.ts
@@ -337,6 +337,8 @@ describe("desktop validation helpers contract", () => {
     expect(windowsPublic).toContain("Install one supported client first, then rerun: ha-nova setup");
     expect(windowsPublic).toContain("Invoke-Expression (Get-Content -LiteralPath $InstallScript -Raw)");
     expect(windowsPublic).toContain("Start-Transcript");
+    expect(windowsPublic).toContain("HA_NOVA_PLAIN_UI");
+    expect(windowsPublic).toContain("InstallerOutput");
     expect(windowsPublic).not.toContain("Tee-Object");
     expect(windowsPublic).not.toContain("cmd.exe /d /s /c");
     expect(windowsPublic).not.toContain("*>&1");


### PR DESCRIPTION
## Summary
- force the public Windows validator onto its plain output stream
- combine captured installer output with transcript evidence
- cover Windows PowerShell 5.1 transcript omissions with regression contracts

## Verification
- PowerShell parser
- release contracts: 43/43
- full pre-push: 87 files, 845 tests
- real RC2 matrix: Windows 10/11 × PowerShell 5.1/7.6.3, all pass