### PR TITLE
fix(cli): offer above-floor Relay updates

### DIFF
--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -110,6 +110,16 @@ func runDoctor(paths runtimePaths, args []string) int {
 				// that is running NOW.
 				readiness = checkRelayReadiness(cfg.RelayBaseURL, token)
 			}
+		} else if !*quiet {
+			// A newer App may be available even while the running Relay remains
+			// compatible with min_relay_version. That is an optional update, not
+			// a failed doctor check; decline/non-TTY keeps status unchanged.
+			if notice := relayAvailableUpdateNotice(cfg, token); !notice.empty() {
+				printHumanNotice(notice)
+				if maybeOfferGuidedRelayUpdate(paths, notice) {
+					readiness = checkRelayReadiness(cfg.RelayBaseURL, token)
+				}
+			}
 		}
 		if haReachable {
 			switch {
@@ -253,13 +263,13 @@ func runCheckUpdate(paths runtimePaths, args []string) int {
 	}
 	// CLI/skills freshness is only half the answer: the relay in Home
 	// Assistant has its own version, and "up to date" would be misleading
-	// while it sits below min_relay_version. Human path only: --quiet is the
-	// skill self-update channel whose contract is "UPDATE AVAILABLE or
+	// below min_relay_version or while an App update is pending. Human path
+	// only: --quiet is the skill self-update channel whose contract is "UPDATE AVAILABLE or
 	// silence" — skill sessions already get the relay warning through the
 	// proxy version header. Stderr-only, exit code unchanged, --json above
 	// stays machine-clean.
 	if !*quiet {
-		if relayNotice := relayFloorNotice(paths); !relayNotice.empty() {
+		if relayNotice := relayUpdateNotice(paths); !relayNotice.empty() {
 			printHumanNotice(relayNotice)
 		}
 	}

--- a/cli/command_update.go
+++ b/cli/command_update.go
@@ -138,10 +138,10 @@ func runUpdate(paths runtimePaths, args []string) int {
 	// may be the OLD (dev) binary whose compiled-in version predates the
 	// update (issue #245 showed "Updated to v0.7.1" while installing 0.8.0).
 	printHumanInfo("Updated to v%s", targetVersion)
-	// The freshly installed version.json may raise min_relay_version — the
-	// update moment is where the user can still act on it, instead of being
-	// interrupted mid-session by the proxy warning later.
-	if notice := relayFloorNotice(paths); !notice.empty() {
+	// The freshly installed version.json may raise min_relay_version, and Home
+	// Assistant may expose a newer compatible App update. The update moment is
+	// where the user can still act instead of being interrupted later.
+	if notice := relayUpdateNotice(paths); !notice.empty() {
 		printHumanNotice(notice)
 		maybeOfferGuidedRelayUpdate(paths, notice)
 	}
@@ -190,14 +190,14 @@ func runInternalReplace(paths runtimePaths, args []string) int {
 	}
 	printHumanInfo("Updated to v%s", localVersion(paths))
 	// Windows finishes the update in this replacement process — the freshly
-	// installed version.json is live here, so the relay-floor warning belongs
-	// here too (the staging branch in runUpdate exits before it). No guided
-	// prompt here on purpose: this helper runs in the background with stdin
+	// installed version.json and Relay App-update state are live here, so the
+	// notice belongs here too (the staging branch in runUpdate exits before it).
+	// No guided prompt here: this helper runs in the background with stdin
 	// unwired (windowsHelperLaunchProfile attaches output only) and the
 	// console is already back at the shell — the documented Windows contract
 	// is background-complete, never same-console-interactive. Point at the
 	// interactive path instead.
-	if notice := relayFloorNotice(paths); !notice.empty() {
+	if notice := relayUpdateNotice(paths); !notice.empty() {
 		printHumanNotice(notice)
 		printHumanInfo("Run `ha-nova doctor` in a terminal to be offered the guided relay update.")
 	}
@@ -228,9 +228,10 @@ func syncInstalledClientsForCurrentVersion(paths runtimePaths, currentVersion, t
 	} else {
 		printHumanInfo("Already up to date: v%s", currentVersion)
 	}
-	// "Up to date" is misleading while the relay sits below the floor the
-	// installed skills need — say so here, where the user is looking.
-	if notice := relayFloorNotice(paths); !notice.empty() {
+	// "Up to date" is misleading while the relay is below the required floor
+	// or Home Assistant exposes a newer App update — say so where the user is
+	// looking.
+	if notice := relayUpdateNotice(paths); !notice.empty() {
 		printHumanNotice(notice)
 		maybeOfferGuidedRelayUpdate(paths, notice)
 	}

--- a/cli/relay_above_floor_update_test.go
+++ b/cli/relay_above_floor_update_test.go
@@ -137,6 +137,32 @@ func TestGuidedRelayUpdateWaitsForOfferedAboveFloorVersion(t *testing.T) {
 	}
 }
 
+func TestWaitForRelayVersionKeepsFloorForStaleTarget(t *testing.T) {
+	paths := guidedUpdatePaths(t)
+	shrinkGuidedUpdatePolling(t, time.Second)
+	var healthPolls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		version := "0.3.0" // Offered target, but still below the 0.4.0 floor.
+		if healthPolls.Add(1) >= 3 {
+			version = "0.4.0"
+		}
+		fmt.Fprintf(w, `{"ok":true,"data":{"version":%q}}`, version)
+	}))
+	defer server.Close()
+
+	version, ok := waitForRelayVersion(paths, config{RelayBaseURL: server.URL}, "token", "0.3.0")
+	if !ok || version != "0.4.0" {
+		t.Fatalf("verification = (%q, %v), want floor-compatible v0.4.0", version, ok)
+	}
+	if healthPolls.Load() < 3 {
+		t.Fatalf("verification accepted the stale below-floor target after %d poll(s)", healthPolls.Load())
+	}
+}
+
 func TestRunDoctorReportsAboveFloorRelayUpdateWithoutFailing(t *testing.T) {
 	paths, cfg := doctorTestSetup(t)
 	relay := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/relay_above_floor_update_test.go
+++ b/cli/relay_above_floor_update_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func pendingRelayUpdateEntity(id, installed, latest string) map[string]interface{} {
+	return map[string]interface{}{
+		"entity_id": id,
+		"state":     "on",
+		"attributes": map[string]interface{}{
+			"title":             relayUpdateEntityTitle,
+			"installed_version": installed,
+			"latest_version":    latest,
+		},
+	}
+}
+
+func TestRelayAvailableUpdateNoticeRequiresExactPendingEvidence(t *testing.T) {
+	cases := []struct {
+		name       string
+		states     []map[string]interface{}
+		wantNotice bool
+	}{
+		{
+			name:       "pending exact App update",
+			states:     []map[string]interface{}{pendingRelayUpdateEntity("update.nova_relay_update", "0.4.1", "0.6.0")},
+			wantNotice: true,
+		},
+		{
+			name: "current update entity",
+			states: []map[string]interface{}{{
+				"entity_id": "update.nova_relay_update",
+				"state":     "off",
+				"attributes": map[string]interface{}{
+					"title":             relayUpdateEntityTitle,
+					"installed_version": "0.6.0",
+					"latest_version":    "0.6.0",
+				},
+			}},
+		},
+		{
+			name: "malformed versions",
+			states: []map[string]interface{}{
+				pendingRelayUpdateEntity("update.nova_relay_update", "unknown", "0.6.0"),
+			},
+		},
+		{
+			name: "ambiguous exact title",
+			states: []map[string]interface{}{
+				pendingRelayUpdateEntity("update.nova_relay_update", "0.4.1", "0.6.0"),
+				pendingRelayUpdateEntity("update.nova_relay_update_2", "0.4.1", "0.6.0"),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Write(statesEnvelope(t, tc.states))
+			}))
+			defer server.Close()
+
+			notice := relayAvailableUpdateNotice(config{RelayBaseURL: server.URL}, "token")
+			if tc.wantNotice {
+				if notice.kind != humanNoticeKindRelayUpdateAvailable {
+					t.Fatalf("notice kind = %q, want %q", notice.kind, humanNoticeKindRelayUpdateAvailable)
+				}
+				if !strings.Contains(notice.message, "v0.4.1 → v0.6.0") {
+					t.Fatalf("notice does not name installed and latest versions: %q", notice.message)
+				}
+			} else if !notice.empty() {
+				t.Fatalf("unexpected notice: %q", notice.message)
+			}
+		})
+	}
+}
+
+func TestGuidedRelayUpdateWaitsForOfferedAboveFloorVersion(t *testing.T) {
+	paths := guidedUpdatePaths(t)
+	shrinkGuidedUpdatePolling(t, time.Second)
+	var installed atomic.Bool
+	var healthPolls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			poll := healthPolls.Add(1)
+			version := "0.4.1" // Already above the 0.4.0 compatibility floor.
+			if installed.Load() && poll >= 3 {
+				version = "0.6.0"
+			}
+			fmt.Fprintf(w, `{"ok":true,"data":{"version":%q}}`, version)
+		case "/core":
+			var req struct {
+				Path string `json:"path"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode core payload: %v", err)
+			}
+			if req.Path == "/api/states" {
+				w.Write(statesEnvelope(t, []map[string]interface{}{
+					pendingRelayUpdateEntity("update.nova_relay_update", "0.4.1", "0.6.0"),
+				}))
+				return
+			}
+			if req.Path != "/api/services/update/install" {
+				t.Errorf("unexpected core path %q", req.Path)
+				return
+			}
+			installed.Store(true)
+			fmt.Fprint(w, `{"ok":true,"data":{"status":200}}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	if !runGuidedRelayUpdate(paths, config{RelayBaseURL: server.URL}, "token", bufio.NewReader(strings.NewReader("y\n")), &out) {
+		t.Fatalf("above-floor update must verify the offered target; output: %s", out.String())
+	}
+	if healthPolls.Load() < 3 {
+		t.Fatalf("guided update accepted the old above-floor relay after %d poll(s)", healthPolls.Load())
+	}
+	if !strings.Contains(out.String(), "Relay updated and verified: v0.6.0 is running.") {
+		t.Fatalf("missing target-version verification: %s", out.String())
+	}
+}
+
+func TestRunDoctorReportsAboveFloorRelayUpdateWithoutFailing(t *testing.T) {
+	paths, cfg := doctorTestSetup(t)
+	relay := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/core" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Write(statesEnvelope(t, []map[string]interface{}{
+			pendingRelayUpdateEntity("update.nova_relay_update", "0.4.1", "0.6.0"),
+		}))
+	}))
+	defer relay.Close()
+	cfg.RelayBaseURL = relay.URL
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.VersionFile), 0o755); err != nil {
+		t.Fatalf("mkdir version dir: %v", err)
+	}
+	if err := os.WriteFile(paths.VersionFile, []byte(`{"skill_version":"0.18.0","min_relay_version":"0.4.0"}`), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+
+	originalHealth := fetchRelayHealthForReadiness
+	originalWSPing := probeRelayWSPingForReadiness
+	defer func() {
+		fetchRelayHealthForReadiness = originalHealth
+		probeRelayWSPingForReadiness = originalWSPing
+	}()
+	fetchRelayHealthForReadiness = func(relayBaseURL, token string) ([]byte, error) {
+		return []byte(`{"ok":true,"data":{"status":"ok","ha_ws_connected":true,"version":"0.4.1"}}`), nil
+	}
+	probeRelayWSPingForReadiness = func(relayBaseURL, token string) (relayWSPingResponse, error) {
+		return relayWSPingResponse{StatusCode: http.StatusOK, Body: []byte(`{"type":"pong"}`)}, nil
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runDoctor(paths, nil)
+	})
+	if exitCode != 0 {
+		t.Fatalf("compatible pending Relay update must not fail doctor: exit %d\n%s", exitCode, output)
+	}
+	if !strings.Contains(output, "Relay update available: v0.4.1 → v0.6.0") {
+		t.Fatalf("doctor did not surface the pending Relay update:\n%s", output)
+	}
+	if !strings.Contains(output, "Doctor checks passed") {
+		t.Fatalf("doctor did not preserve compatible-health success:\n%s", output)
+	}
+}

--- a/cli/relay_guided_update.go
+++ b/cli/relay_guided_update.go
@@ -32,16 +32,17 @@ var (
 
 const relayUpdateManualPath = "Manual path: open Home Assistant > Settings > Apps > NOVA Relay (older HA calls it Add-ons) and install the update there; a standalone container needs a manual image pull."
 
-// maybeOfferGuidedRelayUpdate follows a printed relay-outdated notice and
+// maybeOfferGuidedRelayUpdate follows a printed relay update notice and
 // reports whether the relay ended up updated AND verified — doctor uses that
-// to not fail a run whose only problem the user just fixed. It is
+// to not fail a run whose below-floor problem the user just fixed. It is
 // deliberately best-effort: a non-TTY session, a "no", a missing update
 // entity (standalone container), or any transport problem falls back to the
 // manual path without touching the caller's exit code.
 func maybeOfferGuidedRelayUpdate(paths runtimePaths, notice humanNotice) bool {
 	// Both ends must be a terminal: with stdout redirected the question would
 	// land in a file while the command silently blocks on stdin.
-	if notice.kind != humanNoticeKindRelayOutdated || !isInteractiveTTY() || !stdoutIsInteractiveTTY() {
+	if (notice.kind != humanNoticeKindRelayOutdated && notice.kind != humanNoticeKindRelayUpdateAvailable) ||
+		!isInteractiveTTY() || !stdoutIsInteractiveTTY() {
 		return false
 	}
 	cfg, err := loadConfig(paths)
@@ -60,12 +61,12 @@ func runGuidedRelayUpdate(paths runtimePaths, cfg config, token string, in *bufi
 	if err != nil || !yes {
 		return false
 	}
-	entityID, reason := resolveRelayUpdateEntity(cfg, token)
-	if entityID == "" {
+	candidate, reason := resolveRelayUpdateCandidate(cfg, token)
+	if candidate.EntityID == "" {
 		fmt.Fprintf(out, "Cannot start the App update from here: %s\n%s\n", reason, relayUpdateManualPath)
 		return false
 	}
-	fmt.Fprintf(out, "Installing the NOVA Relay App update (%s) with a partial backup — the relay restarts during the install.\n", entityID)
+	fmt.Fprintf(out, "Installing the NOVA Relay App update (%s) with a partial backup — the relay restarts during the install.\n", candidate.EntityID)
 	// The relay dies mid-call when the install lands, so a dropped response
 	// is the EXPECTED shape of success here; polling decides the outcome.
 	// An ok:false envelope is a relay-side transport problem (the relay's
@@ -73,7 +74,7 @@ func runGuidedRelayUpdate(paths runtimePaths, cfg config, token string, in *bufi
 	// polls too. Only Home Assistant itself answering >= 400 (ok:true) is an
 	// explicit rejection that skips the three-minute wait.
 	body, err := relayCoreRequest(cfg, token, "POST", "/api/services/update/install",
-		[]byte(fmt.Sprintf(`{"entity_id":%q,"backup":true}`, entityID)))
+		[]byte(fmt.Sprintf(`{"entity_id":%q,"backup":true}`, candidate.EntityID)))
 	if err == nil {
 		var envelope struct {
 			OK   bool `json:"ok"`
@@ -86,7 +87,7 @@ func runGuidedRelayUpdate(paths runtimePaths, cfg config, token string, in *bufi
 			return false
 		}
 	}
-	version, ok := waitForRelayFloor(paths, cfg, token)
+	version, ok := waitForRelayVersion(paths, cfg, token, candidate.LatestVersion)
 	if !ok {
 		fmt.Fprintf(out, "The relay did not report a new version within %s.\n%s\n", relayUpdatePollTimeout, relayUpdateManualPath)
 		return false
@@ -95,13 +96,28 @@ func runGuidedRelayUpdate(paths runtimePaths, cfg config, token string, in *bufi
 	return true
 }
 
-// resolveRelayUpdateEntity finds the NOVA Relay App's update.* entity via
-// GET /api/states. It returns the entity id, or "" plus the human reason
-// (no entity → container/manual install; several → ambiguous, never guess).
-func resolveRelayUpdateEntity(cfg config, token string) (string, string) {
+type relayUpdateCandidate struct {
+	EntityID         string
+	State            string
+	InstalledVersion string
+	LatestVersion    string
+}
+
+func (candidate relayUpdateCandidate) updateAvailable() bool {
+	if candidate.State != "on" || candidate.InstalledVersion == "" || candidate.LatestVersion == "" {
+		return false
+	}
+	cmp, err := compareReleaseVersions(candidate.InstalledVersion, candidate.LatestVersion)
+	return err == nil && cmp < 0
+}
+
+// resolveRelayUpdateCandidate finds the NOVA Relay App's update.* entity via
+// GET /api/states. It returns the candidate, or an empty candidate plus the
+// human reason (no entity → container/manual install; several → never guess).
+func resolveRelayUpdateCandidate(cfg config, token string) (relayUpdateCandidate, string) {
 	body, err := relayCoreRequest(cfg, token, "GET", "/api/states", nil)
 	if err != nil {
-		return "", fmt.Sprintf("could not read Home Assistant states (%s)", err)
+		return relayUpdateCandidate{}, fmt.Sprintf("could not read Home Assistant states (%s)", err)
 	}
 	var envelope struct {
 		OK   bool `json:"ok"`
@@ -111,44 +127,61 @@ func resolveRelayUpdateEntity(cfg config, token string) (string, string) {
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(body, &envelope); err != nil || !envelope.OK || envelope.Data.Status != http.StatusOK {
-		return "", "could not read Home Assistant states"
+		return relayUpdateCandidate{}, "could not read Home Assistant states"
 	}
 	var states []struct {
 		EntityID   string `json:"entity_id"`
+		State      string `json:"state"`
 		Attributes struct {
-			Title string `json:"title"`
+			Title            string `json:"title"`
+			InstalledVersion string `json:"installed_version"`
+			LatestVersion    string `json:"latest_version"`
 		} `json:"attributes"`
 	}
 	if err := json.Unmarshal(envelope.Data.Body, &states); err != nil {
-		return "", "could not read Home Assistant states"
+		return relayUpdateCandidate{}, "could not read Home Assistant states"
 	}
-	var matches []string
+	var matches []relayUpdateCandidate
 	for _, s := range states {
 		if strings.HasPrefix(s.EntityID, "update.") && s.Attributes.Title == relayUpdateEntityTitle {
-			matches = append(matches, s.EntityID)
+			matches = append(matches, relayUpdateCandidate{
+				EntityID:         s.EntityID,
+				State:            s.State,
+				InstalledVersion: s.Attributes.InstalledVersion,
+				LatestVersion:    s.Attributes.LatestVersion,
+			})
 		}
 	}
 	switch len(matches) {
 	case 1:
 		return matches[0], ""
 	case 0:
-		return "", "no NOVA Relay App update entity found (standalone container, or the App is not installed)"
+		return relayUpdateCandidate{}, "no NOVA Relay App update entity found (standalone container, or the App is not installed)"
 	default:
-		return "", fmt.Sprintf("several update entities carry the title %q — not guessing", relayUpdateEntityTitle)
+		return relayUpdateCandidate{}, fmt.Sprintf("several update entities carry the title %q — not guessing", relayUpdateEntityTitle)
 	}
 }
 
-// waitForRelayFloor polls GET /health until the reported version satisfies
-// min_relay_version, then returns it. Connection errors are the normal
-// restart window and just keep the loop going.
-func waitForRelayFloor(paths runtimePaths, cfg config, token string) (string, bool) {
+// waitForRelayVersion polls GET /health until the reported version reaches the
+// update entity's offered target. Older update entities without version
+// metadata retain the floor-based verification used before above-floor update
+// offers existed. Connection errors are the normal restart window.
+func waitForRelayVersion(paths runtimePaths, cfg config, token, targetVersion string) (string, bool) {
 	deadline := time.Now().Add(relayUpdatePollTimeout)
 	for {
 		body, err := fetchRelayHealth(cfg.RelayBaseURL, token)
 		if err == nil {
 			version := parseRelayHealthVersion(body)
-			if version != "" && checkRelayVersionValue(paths, version).empty() {
-				return version, true
+			if version != "" {
+				if targetVersion == "" && checkRelayVersionValue(paths, version).empty() {
+					return version, true
+				}
+				if targetVersion != "" {
+					cmp, compareErr := compareReleaseVersions(version, targetVersion)
+					if compareErr == nil && cmp >= 0 {
+						return version, true
+					}
+				}
 			}
 		}
 		if time.Now().After(deadline) {

--- a/cli/relay_guided_update.go
+++ b/cli/relay_guided_update.go
@@ -173,10 +173,13 @@ func waitForRelayVersion(paths runtimePaths, cfg config, token, targetVersion st
 		if err == nil {
 			version := parseRelayHealthVersion(body)
 			if version != "" {
-				if targetVersion == "" && checkRelayVersionValue(paths, version).empty() {
-					return version, true
-				}
-				if targetVersion != "" {
+				// Every successful update must still satisfy the installed skill
+				// floor. The App update entity can lag behind version.json and
+				// advertise a target that remains incompatible.
+				if checkRelayVersionValue(paths, version).empty() {
+					if targetVersion == "" {
+						return version, true
+					}
 					cmp, compareErr := compareReleaseVersions(version, targetVersion)
 					if compareErr == nil && cmp >= 0 {
 						return version, true

--- a/cli/relay_guided_update_test.go
+++ b/cli/relay_guided_update_test.go
@@ -93,7 +93,8 @@ func TestResolveRelayUpdateEntity(t *testing.T) {
 				w.Write(statesEnvelope(t, tc.states))
 			}))
 			defer server.Close()
-			entity, reason := resolveRelayUpdateEntity(config{RelayBaseURL: server.URL}, "token")
+			candidate, reason := resolveRelayUpdateCandidate(config{RelayBaseURL: server.URL}, "token")
+			entity := candidate.EntityID
 			if entity != tc.wantEntity {
 				t.Fatalf("entity = %q, want %q (reason %q)", entity, tc.wantEntity, reason)
 			}
@@ -324,7 +325,8 @@ func TestGuidedRelayUpdateContainerFallsBackToManualPath(t *testing.T) {
 func TestMaybeOfferGuidedRelayUpdateIgnoresOtherNoticeKinds(t *testing.T) {
 	paths := guidedUpdatePaths(t)
 	// Wrong kind returns before any prompt or network use; under `go test`
-	// stdin is a pipe, so the TTY gate also holds the relay-outdated kind.
+	// stdin is a pipe, so the TTY gate also holds both Relay notice kinds.
 	maybeOfferGuidedRelayUpdate(paths, humanNotice{kind: humanNoticeKindUpdateAvailable, level: humanNoticeWarning})
 	maybeOfferGuidedRelayUpdate(paths, humanNotice{kind: humanNoticeKindRelayOutdated, level: humanNoticeWarning})
+	maybeOfferGuidedRelayUpdate(paths, humanNotice{kind: humanNoticeKindRelayUpdateAvailable, level: humanNoticeWarning})
 }

--- a/cli/ui_mode.go
+++ b/cli/ui_mode.go
@@ -30,11 +30,12 @@ const (
 type humanNoticeKind string
 
 const (
-	humanNoticeKindNone              humanNoticeKind = ""
-	humanNoticeKindUpToDate          humanNoticeKind = "up_to_date"
-	humanNoticeKindUpdateAvailable   humanNoticeKind = "update_available"
-	humanNoticeKindUpdateCheckFailed humanNoticeKind = "update_check_failed"
-	humanNoticeKindRelayOutdated     humanNoticeKind = "relay_outdated"
+	humanNoticeKindNone                 humanNoticeKind = ""
+	humanNoticeKindUpToDate             humanNoticeKind = "up_to_date"
+	humanNoticeKindUpdateAvailable      humanNoticeKind = "update_available"
+	humanNoticeKindUpdateCheckFailed    humanNoticeKind = "update_check_failed"
+	humanNoticeKindRelayOutdated        humanNoticeKind = "relay_outdated"
+	humanNoticeKindRelayUpdateAvailable humanNoticeKind = "relay_update_available"
 )
 
 type humanNotice struct {

--- a/cli/version.go
+++ b/cli/version.go
@@ -261,6 +261,41 @@ func relayFloorNotice(paths runtimePaths) humanNotice {
 	return checkRelayVersion(paths, body)
 }
 
+// relayUpdateNotice preserves the compatibility-floor warning and, when the
+// floor is satisfied, also surfaces an exact pending NOVA Relay App update
+// reported by Home Assistant. Missing or ambiguous update-entity evidence is
+// best-effort silence so standalone Container/Core installs stay unchanged.
+func relayUpdateNotice(paths runtimePaths) humanNotice {
+	if notice := relayFloorNotice(paths); !notice.empty() {
+		return notice
+	}
+	cfg, err := loadConfig(paths)
+	if err != nil || cfg.RelayBaseURL == "" {
+		return humanNotice{}
+	}
+	token, err := readRelayAuthTokenForDoctor()
+	if err != nil || token == "" {
+		return humanNotice{}
+	}
+	return relayAvailableUpdateNotice(cfg, token)
+}
+
+func relayAvailableUpdateNotice(cfg config, token string) humanNotice {
+	candidate, _ := resolveRelayUpdateCandidate(cfg, token)
+	if !candidate.updateAvailable() {
+		return humanNotice{}
+	}
+	return humanNotice{
+		level: humanNoticeWarning,
+		kind:  humanNoticeKindRelayUpdateAvailable,
+		message: fmt.Sprintf(
+			"Relay update available: v%s → v%s. Inform the user, then ask whether to install the relay update now — the updates skill (ha-nova:updates) handles the App update.",
+			candidate.InstalledVersion,
+			candidate.LatestVersion,
+		),
+	}
+}
+
 // checkRelayVersionValue compares a bare relay version (from the /health body
 // or the relay's version response header on /ws and /core) against
 // min_relay_version.

--- a/docs/work/2026-07-16-relay-above-floor-update-spec.md
+++ b/docs/work/2026-07-16-relay-above-floor-update-spec.md
@@ -1,0 +1,26 @@
+# Spec: Above-Floor Relay Update Offer
+
+Status: active
+Date: 2026-07-16
+
+## Problem
+
+`ha-nova doctor`, `ha-nova update`, and human `ha-nova check-update` only compare the running Relay with `min_relay_version`. A compatible but stale Relay therefore looks current even when Home Assistant's exact `NOVA Relay` update entity reports a newer App version. Live acceptance reproduced this with client 0.18.0, Relay 0.4.1, floor 0.4.0, and App update 0.6.0.
+
+## Decision
+
+- Keep `min_relay_version` as the compatibility floor.
+- After the floor check passes, resolve exactly one `update.*` entity whose title is `NOVA Relay`.
+- Report an available update only when the entity is on and its valid `latest_version` is newer than its valid `installed_version`.
+- Interactive `doctor` and `update` offer the existing guided App install. Non-interactive commands report the update without blocking. Quiet and JSON contracts remain unchanged.
+- Missing, duplicate, malformed, or unreachable update-entity evidence stays silent; standalone Container/Core remains manual.
+- After install, verify the Relay health version reached the offered target version. Satisfying only the lower compatibility floor is not sufficient.
+
+## Acceptance
+
+- Above-floor pending update: notice and interactive offer.
+- Current update entity: no notice.
+- Duplicate/malformed/missing update entity: no guess and no notice.
+- Below-floor Relay: existing outdated warning and failure semantics remain.
+- Guided install waits for the offered target version and does not claim success while the old above-floor version still runs.
+- Existing TTY, quiet, JSON, Windows-background, and standalone behavior remains covered.

--- a/docs/work/2026-07-16-relay-above-floor-update-spec.md
+++ b/docs/work/2026-07-16-relay-above-floor-update-spec.md
@@ -14,7 +14,7 @@ Date: 2026-07-16
 - Report an available update only when the entity is on and its valid `latest_version` is newer than its valid `installed_version`.
 - Interactive `doctor` and `update` offer the existing guided App install. Non-interactive commands report the update without blocking. Quiet and JSON contracts remain unchanged.
 - Missing, duplicate, malformed, or unreachable update-entity evidence stays silent; standalone Container/Core remains manual.
-- After install, verify the Relay health version reached the offered target version. Satisfying only the lower compatibility floor is not sufficient.
+- After install, verify the Relay health version reached the offered target version and still satisfies the compatibility floor. Neither condition alone is sufficient.
 
 ## Acceptance
 
@@ -23,4 +23,5 @@ Date: 2026-07-16
 - Duplicate/malformed/missing update entity: no guess and no notice.
 - Below-floor Relay: existing outdated warning and failure semantics remain.
 - Guided install waits for the offered target version and does not claim success while the old above-floor version still runs.
+- Guided install does not accept a stale offered target that remains below the compatibility floor.
 - Existing TTY, quiet, JSON, Windows-background, and standalone behavior remains covered.


### PR DESCRIPTION
## Summary
- detect an exact pending NOVA Relay App update even when the running Relay satisfies the compatibility floor
- surface the update in doctor, update, and human check-update flows without failing compatible doctor runs
- verify guided installs against the offered target version

## Verification
- npm run verify
- cd cli && go test ./...
- cd cli && go vet ./...
- pre-push: 87 Vitest files / 845 tests, build, docs fact-check

## Live acceptance context
Live acceptance observed Relay 0.4.1, floor 0.4.0, and pending App 0.6.0. The live Relay is now current at 0.6.0; positive pending behavior is covered hermetically without an unsafe downgrade.