### PR TITLE
fix(skills): support config snapshot batch delete

### DIFF
--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -165,6 +165,16 @@ Current mapping:
 Fallback:
 - if agent dispatch unavailable, execute same phases inline serially.
 
+## Config Snapshot Architecture
+
+The `ha-nova` context skill owns generic config snapshot listing and deletion
+through `skills/ha-nova/config-snapshots.md`; restore delegates to the skill
+that owns the captured Home Assistant item because restore fidelity and write
+verification are family-specific. Exact multi-file deletion is the sole
+context-owned destructive batch family: `config-snapshots`, capped at 20,
+sequential, fail-fast, and verified per blob. The Relay remains an opaque blob
+store and gains no Home Assistant business logic.
+
 ## Read Architecture
 
 `ha-nova:read` is intentionally direct/low-overhead:

--- a/docs/work/2026-07-16-config-snapshot-batch-delete-spec.md
+++ b/docs/work/2026-07-16-config-snapshot-batch-delete-spec.md
@@ -1,0 +1,25 @@
+# Spec: Config Snapshot Batch Delete
+
+Status: active
+Date: 2026-07-16
+
+## Problem
+
+Config snapshot deletion supports only one typed confirmation per blob. Cleaning several obsolete snapshots therefore repeats the same preview/confirmation cycle even though every target uses the same generic Relay blob-store operation.
+
+## Decision
+
+- The `ha-nova` context skill owns listing and deleting config snapshot blobs; restoring a snapshot still routes to the skill that owns the captured Home Assistant item.
+- Explicitly opt exact config snapshot blob deletion into `skills/ha-nova/batch-safety.md` as the `config-snapshots` resource family with the config-item cap of 20.
+- Snapshot categories may share one manifest because category is blob metadata, not a different mutation family. The manifest may contain only literal snapshot files from a fresh list and only `action:delete` operations.
+- Execute one `POST /backups` delete per file in deterministic order, fail fast, and verify each deleted file is absent from a fresh list before continuing.
+- Preserve one unselected snapshot as an unrelated-resource invariant when available. A deleted snapshot has no rollback, but deleting it never changes the underlying Home Assistant config.
+- Keep prune separate: never turn a category, age, prefix, or `keep_named:false` selector into a post-confirmation batch expansion.
+
+## Acceptance
+
+- One manifest and one `confirm:batch-delete-config-snapshots-<count>-<digest>` code can authorize up to 20 exact snapshot files across categories.
+- Missing, changed, or newly selected files invalidate the preview; no wildcard or late selector expansion is allowed.
+- Execution is sequential, per-file verified, fail-fast, and reports succeeded / failed / not attempted.
+- Single-snapshot delete and prune behavior remain unchanged.
+- Context dispatch, capability matrix, and contract tests pin the opt-in.

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -103,6 +103,7 @@ Skills reference this section as "context skill → Active Preview Confirmation"
   **Strict token enforcement:** User MUST reply with the exact token string (e.g., `confirm:del-main-lights`). Any other response — including "yes", "sure, delete it", "do it", or any natural-language confirmation — is NOT valid. Reject and re-prompt with the exact code required. In user-facing output call it the "confirmation code" (localized), never a "token" (see `skills/ha-nova/output-rules.md` → Localization).
   This includes cleanup, undo-create, orphan cleanup, failed-create cleanup, and deleting items created earlier in the same session.
 - destructive multi-target batch: manifest-bound code `confirm:batch-<operation>-<family>-<count>-<digest>` per `skills/ha-nova/batch-safety.md` — only where the owning skill declares batch support, never inferred.
+- This context skill explicitly owns batch deletion only for exact config snapshot blobs in the `config-snapshots` family (`skills/ha-nova/config-snapshots.md`).
 
 ### Write Routing Gate
 
@@ -204,7 +205,8 @@ Match user intent to exactly one skill:
 | find entities by name, room, area | `ha-nova:entity-discovery` |
 | fix relay/auth/connectivity errors | `ha-nova:onboarding` |
 | undo, revert, or restore the last automation/script/helper change | the skill that wrote it — `ha-nova:write` (automation/script) or `ha-nova:helper` (helper). `revert` applies only to supported verified updates. Creates clean up through the normal delete flow; a DELETED automation/script/scene/dashboard/STORAGE helper restores from its auto config snapshot in the owning skill (`skills/ha-nova/config-snapshots.md`); config-entry helpers are not snapshot-covered — their recovery stays Backup/recreate. Run `ha-nova snapshot show` to see the saved update target if unsure |
-| list or restore config snapshots ("restore X from a snapshot", "what snapshots do I have?") | the skill that owns the item family — `ha-nova:write` (automations/scripts), `ha-nova:scene`, `ha-nova:dashboard`, `ha-nova:helper`, `ha-nova:energy` (prefs), `ha-nova:yaml-config` (files), `ha-nova:organize` (metadata); mechanics: `skills/ha-nova/config-snapshots.md` |
+| list or delete config snapshots ("what snapshots do I have?", "delete these obsolete snapshots") | `ha-nova` (this context skill); mechanics: `skills/ha-nova/config-snapshots.md` |
+| restore a config snapshot ("restore X from a snapshot") | the skill that owns the item family — `ha-nova:write` (automations/scripts), `ha-nova:scene`, `ha-nova:dashboard`, `ha-nova:helper`, `ha-nova:energy` (prefs), `ha-nova:yaml-config` (files), `ha-nova:organize` (metadata); mechanics: `skills/ha-nova/config-snapshots.md` |
 | **any HA task not matched above** — blueprints, unsupported admin writes, any unfamiliar raw relay/ws/core write | `ha-nova:fallback` **(mandatory fallback — never skip)** |
 
 **"Analyze my automation"** → `ha-nova:review` (NOT read + review)
@@ -215,6 +217,7 @@ Match user intent to exactly one skill:
 **"Create an input_boolean"** → `ha-nova:helper` (NOT write)
 **"Show my helpers"** → `ha-nova:helper` (NOT read)
 **"Revert that"** / **"Undo the last change"** → re-invoke the skill that made it: `ha-nova:write` (automation/script) or `ha-nova:helper` (helper). `revert` is update-only and lives there (see `write-safety.md` → Update-Revert), never `ha-nova:fallback`; create cleanup uses delete flow, and a deleted item in a snapshot-covered family restores from its auto config snapshot in the owning skill (`config-snapshots.md`); config-entry helpers stay Backup/recreate.
+**"Delete these obsolete config snapshots"** → `ha-nova` context skill using `config-snapshots.md`; exact multi-file cleanup may use its declared `config-snapshots` batch family.
 **"Create a scene called Movie Night"** → `ha-nova:scene`
 **"Activate the scene Movie Night"** → `ha-nova:service-call` (runtime action, not a config change)
 **"Unlock the front door"** → `ha-nova:service-call` (high-consequence: typed confirmation code)

--- a/skills/ha-nova/batch-safety.md
+++ b/skills/ha-nova/batch-safety.md
@@ -83,7 +83,7 @@ separate manifests, each with its own preview and confirmation code:
 
 - config-item families (automations, scripts, helpers, scenes, dashboards,
   resources, cards within one dashboard, to-do lists, registry
-  categories/labels/areas/floors): **20**
+  categories/labels/areas/floors, config snapshot blobs): **20**
 - evidence-derived cleanup families (retained discovery topics, orphaned
   statistics IDs, orphan registry entries per config entry): **100**
 
@@ -153,6 +153,7 @@ the offer of a remaining-targets manifest).
 
 | Skill | Batch support | Families / rationale |
 |---|---|---|
+| `ha-nova` | yes | exact config snapshot blobs only (`config-snapshots` family); categories may mix because they remain one generic blob resource family |
 | `write` | yes | automations OR scripts (never mixed); per-item consumer check; YAML export before delete when feasible |
 | `helper` | yes | one helper family per manifest; storage and config-entry families never mixed |
 | `mqtt` | yes | retained discovery cleanup for ONE resolved device (topics only from `mqtt/device/debug_info`); command/`set` topics excluded |

--- a/skills/ha-nova/config-snapshots.md
+++ b/skills/ha-nova/config-snapshots.md
@@ -1,9 +1,9 @@
 # Config Snapshots (shared reference)
 
 SSOT for the targeted, lightweight snapshot layer on top of the relay's generic
-blob store (`POST /backups`). Load this file only when capturing
-or restoring a snapshot. The relay stores opaque gzip'd JSON — everything smart
-(what to capture, how to restore, what to promise) lives here.
+blob store (`POST /backups`). Load this file only when capturing, listing,
+deleting, or restoring a snapshot. The relay stores opaque gzip'd JSON —
+everything smart (what to capture, how to restore, what to promise) lives here.
 
 ## Relay contract
 
@@ -16,6 +16,40 @@ the payload sits under `.data`, errors under `.error`.
 - List: `{"action":"list"}` (optional `"category"`) → `.data[]` newest first (`file`, `category`, `bytes`, `created_at`)
 - Delete: `{"action":"delete","file":...}` — typed confirmation code like any destructive op
 - Prune: `{"action":"prune"}` (defaults: 30 days / 100 files, named snapshots exempt) → `.data.deleted[]`. Offer prune when a save fails `SNAPSHOT_STORE_FULL` or the user asks; preview count + age range of the affected auto-snapshots, natural confirmation (they are expendable copies), `keep_named` stays true unless the user explicitly says otherwise.
+
+## Batch delete (explicit opt-in)
+
+The `ha-nova` context skill explicitly supports destructive batch deletion for
+the `config-snapshots` resource family through
+`skills/ha-nova/batch-safety.md`. Single-file delete stays the default.
+
+- Run an unfiltered `list` immediately before building the manifest. Every
+  target must be a literal `.data[].file` value with its category, bytes, and
+  created time; never expand a category, age, prefix, wildcard, or other
+  selector after the preview.
+- Snapshot categories may share one manifest: they are metadata on the same
+  generic blob resource, with the same endpoint, delete semantics, and
+  recovery limits. Never mix another resource type or a prune action into the
+  manifest.
+- Cap the manifest at **20** files. Use deterministic bytewise file-path order
+  and the confirmation code
+  `confirm:batch-delete-config-snapshots-<count>-<digest>`.
+- Record the dependency result per target as not applicable: deleting a
+  snapshot copy cannot change the underlying Home Assistant config. State
+  plainly that the deleted copy itself has no rollback.
+- Immediately before execution, run another unfiltered `list` and require
+  every selected file and its listed metadata to still match the manifest.
+  Missing or changed target evidence expires the confirmation; a new
+  unselected file does not.
+- Execute one `{"action":"delete","file":"<literal-file>"}` request at a
+  time in manifest order. After each response, `list` again and verify that
+  exact file is absent before continuing. On timeout, verify first and never
+  retry blindly. Fail fast and report succeeded, failed, and not attempted.
+- When an unselected snapshot exists, pin one in the manifest and verify it is
+  still present at the end as the unrelated-resource invariant.
+
+Prune remains a separate retention flow with its own preview and confirmation.
+Never use batch delete to emulate prune or to widen `keep_named`.
 
 Names: auto-snapshots MUST use the `auto-` prefix (prune eats them); snapshots
 the user asked for by name use a plain slug and survive prune. A `404/NOT_FOUND`

--- a/tests/skills/batch-safety-contract.test.ts
+++ b/tests/skills/batch-safety-contract.test.ts
@@ -9,6 +9,7 @@ const outputRules = readFileSync("skills/ha-nova/output-rules.md", "utf8");
 
 // Every skill that declares batch support must point at the shared contract.
 const OPTED_IN_SKILLS = [
+  "ha-nova",
   "write",
   "helper",
   "mqtt",
@@ -130,6 +131,8 @@ describe("batch safety contract (issue #327)", () => {
   });
 
   it("keeps the domain guards of the opted-in skills", () => {
+    expect(contextSkill).toContain("exact config snapshot blobs in the `config-snapshots` family");
+    expect(batchSafety).toContain("exact config snapshot blobs only (`config-snapshots` family)");
     const mqtt = readFileSync("skills/mqtt/SKILL.md", "utf8");
     expect(mqtt).toContain("topics taken only from `mqtt/device/debug_info`");
     expect(mqtt).toContain("command/`set` topics always stay single-target");

--- a/tests/skills/config-snapshots-contract.test.ts
+++ b/tests/skills/config-snapshots-contract.test.ts
@@ -62,6 +62,22 @@ describe("config snapshots contract", () => {
   it("updates the safety matrix and dispatch", () => {
     expect(writeSafety).toContain("`skills/ha-nova/config-snapshots.md` is the SSOT");
     expect(writeSafety).toContain("config snapshot (auto before delete, identity-preserving restore); HA Backups");
-    expect(contextSkill).toContain("list or restore config snapshots");
+    expect(contextSkill).toContain("list or delete config snapshots");
+    expect(contextSkill).toContain("restore a config snapshot");
+  });
+
+  it("supports exact manifest-bound batch deletion without widening prune", () => {
+    expect(reference).toContain("## Batch delete (explicit opt-in)");
+    expect(reference).toContain("`config-snapshots` resource family");
+    expect(reference).toContain("Snapshot categories may share one manifest");
+    expect(reference).toContain("Cap the manifest at **20** files");
+    expect(reference).toContain("confirm:batch-delete-config-snapshots-<count>-<digest>");
+    expect(reference).toContain("Run an unfiltered `list` immediately before building the manifest");
+    expect(reference).toContain("never expand a category, age, prefix, wildcard, or other\n  selector after the preview");
+    expect(reference).toContain('Execute one `{"action":"delete","file":"<literal-file>"}` request at a\n  time');
+    expect(reference).toContain("After each response, `list` again and verify that\n  exact file is absent before continuing");
+    expect(reference).toContain("succeeded, failed, and not attempted");
+    expect(reference).toContain("the deleted copy itself has no rollback");
+    expect(reference).toContain("Never use batch delete to emulate prune or to widen `keep_named`");
   });
 });


### PR DESCRIPTION
## Summary
- route config snapshot listing/deletion through the context skill while preserving family-owned restore
- opt exact snapshot blobs into manifest-bound batch deletion with a 20-item cap
- require sequential fail-fast execution, fresh evidence, per-file verification, and separate prune semantics
- pin dispatch and safety behavior with contract tests

## Verification
- `npx vitest run tests/skills/batch-safety-contract.test.ts tests/skills/config-snapshots-contract.test.ts tests/skills/ha-nova-contract.test.ts tests/skills/skill-template-contract.test.ts` (64 passed)
- `npm run verify:docs`
- `npm run verify`
- pre-push gate: typecheck, 846 tests, build, docs fact-check

## Risk
- Skill-contract change only; no Relay/runtime endpoint changes
- Existing single-file delete remains the execution primitive
- Destructive execution still requires an exact manifest-bound confirmation code