### PR TITLE
chore(release): prepare v0.18.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.18.0"
+    "version": "0.18.1"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,18 +85,12 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## New Features
 
-    - **Pair with one short code.** HA OS and Supervised installs now get NOVA Home Base inside Home Assistant. It shows Relay status and a six-digit, short-lived pairing code, so new setup no longer asks you to copy the Relay token.
-    - **Recover configuration changes.** HA NOVA can capture compact config snapshots before destructive changes and restore supported items through the normal preview, confirmation, and verification flow. Existing update-revert remains the quick undo path.
-    - **More first-class Home Assistant work.** Set up integrations through Home Assistant's own secure UI, create and edit calendar events, fire events and webhooks, and get deeper reviews for scenes, dashboards, YAML sensors, and cross-item conflicts. Alarm and lock actions now use explicit security guidance.
-    - **Clearer updates and diagnostics.** Successful updates tell every supported client when to start a fresh AI session, while Relay health reports why the Home Assistant connection is unavailable and logs request failures more usefully.
+    - **Clean up config snapshots in one safe batch.** Select up to 20 exact snapshot files, approve one manifest-bound confirmation, and HA NOVA deletes them sequentially with per-file verification and fail-fast reporting.
 
     ## Bug Fixes
 
-    - Clean Windows installations without an AI client now finish with clear next-step guidance instead of a setup error.
+    - **Relay App updates no longer stay hidden above the compatibility floor.** When Home Assistant reports a newer exact NOVA Relay App version, `doctor`, `check-update`, and guided update now offer it without marking an otherwise healthy compatible Relay as broken.
 
-    ## What To Watch
-
-    - Update the NOVA Relay App to **0.6.0** to use Home Base and pairing. Relay 0.5.0 already supports config snapshots; older compatible Relay versions keep the legacy token setup and safety-backup fallback.
     Stable install commands are release-pinned for this tag.
 
     **macOS / Linux:**

--- a/docs/work/0.18.1-release-body.md
+++ b/docs/work/0.18.1-release-body.md
@@ -1,0 +1,14 @@
+# 0.18.1 Release Body (draft)
+
+## New Features
+
+- **Clean up config snapshots in one safe batch.** Select up to 20 exact
+  snapshot files, approve one manifest-bound confirmation, and HA NOVA deletes
+  them sequentially with per-file verification and fail-fast reporting.
+
+## Bug Fixes
+
+- **Relay App updates no longer stay hidden above the compatibility floor.**
+  When Home Assistant reports a newer exact NOVA Relay App version, `doctor`,
+  `check-update`, and guided update now offer it without marking an otherwise
+  healthy compatible Relay as broken.

--- a/docs/work/2026-07-16-v0.18.1-release-prep-spec.md
+++ b/docs/work/2026-07-16-v0.18.1-release-prep-spec.md
@@ -1,0 +1,44 @@
+# v0.18.1 Release Prep Spec
+
+Status: active
+Date: 2026-07-16
+
+## Scope
+
+Publish the two user-facing fixes found during the v0.18.0 live acceptance:
+
+- offer an exact pending NOVA Relay App update even when the installed Relay
+  already satisfies the compatibility floor;
+- allow up to 20 explicitly selected config snapshot blobs to be deleted with
+  one manifest-bound confirmation and per-file verification.
+
+## Release shape
+
+- Bump the HA NOVA skill/CLI version from 0.18.0 to 0.18.1.
+- Keep the Relay App at 0.6.0 and `min_relay_version` at 0.4.0; neither fix
+  requires a new Relay endpoint or a higher compatibility floor.
+- Keep `README.md` unchanged; its stable claims remain accurate.
+- Replace the stable GoReleaser body with short 0.18.1 user-facing notes.
+- Do not include unrelated maintenance or backlog work.
+
+## Gates
+
+- Complete the mandatory PR merge checklist, including the manifest approval
+  label and a real Codex result on the final PR SHA.
+- On the reviewed merge commit, run the strict release-pipeline audit and a
+  dispatched disposable-HA E2E workflow.
+- Publish an RC before the final tag because the release includes Go CLI and
+  update-flow changes.
+- Verify the RC through the public installer path, restore any reused test VM
+  to its named clean snapshot, and stop it afterward.
+- Tag the final release only from the reviewed release-prep merge commit, wait
+  for the full release workflow, and verify a public stable install.
+
+## Acceptance
+
+- All release metadata reports 0.18.1 and remains internally consistent.
+- Release notes describe only the two shipped user-facing changes.
+- RC and final tags point to the same reviewed merge commit.
+- All automated release gates and public-install smoke checks pass.
+- No disposable Home Assistant artifact or obsolete running test machine
+  remains after verification.

--- a/nova/version.json
+++ b/nova/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.18.0",
+  "skill_version": "0.18.1",
   "min_relay_version": "0.4.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "home-assistant-js-websocket": "^9.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -54,15 +54,14 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("dist/winget");
   });
 
-  it("keeps v0.18.0 release-facing wording user-centric", () => {
+  it("keeps v0.18.1 release-facing wording user-centric", () => {
     // Shipped release-note bodies are archived (docs/archive/work/) and
     // non-normative per documentation governance; only the active GoReleaser
     // template is contract-checked here.
-    expect(goreleaser).toContain("Pair with one short code");
-    expect(goreleaser).toContain("Recover configuration changes");
-    expect(goreleaser).toContain("More first-class Home Assistant work");
-    expect(goreleaser).toContain("Clearer updates and diagnostics");
-    expect(goreleaser).toContain("Update the NOVA Relay App to **0.6.0**");
+    expect(goreleaser).toContain("Clean up config snapshots in one safe batch");
+    expect(goreleaser).toContain("up to 20 exact snapshot files");
+    expect(goreleaser).toContain("Relay App updates no longer stay hidden above the compatibility floor");
+    expect(goreleaser).toContain("without marking an otherwise healthy compatible Relay as broken");
     expect(goreleaser).not.toContain("Use `v0.7.1` or the latest release command");
   });
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.18.0",
+  "skill_version": "0.18.1",
   "min_relay_version": "0.4.0"
 }


### PR DESCRIPTION
## Summary
- bump HA NOVA skill/CLI metadata from 0.18.0 to 0.18.1
- keep Relay App 0.6.0 and the 0.4.0 compatibility floor unchanged
- publish short notes for safe config-snapshot batch cleanup and above-floor Relay update detection
- pin the active release wording with the release contract

## Verification
- `npm run verify:next-release-version -- v0.18.1-rc1`
- `npm run verify:next-release-version -- v0.18.1`
- `goreleaser check`
- `npm run verify`
- pre-push gate: typecheck, 846 tests, build, docs fact-check

## Release gates after merge
- strict release-pipeline audit with bypass verification
- dispatched disposable-HA E2E on the reviewed merge commit
- tag-first v0.18.1-rc1 rehearsal and public installer verification
- final v0.18.1 tag on the same merge commit and public stable verification

## Preflight
- no open pull requests
- no Dependabot, workflow, installer, or release blocker to pull into this train