### PR TITLE
fix(app): fresh install could not start — null relay_auth_token default marked the option required

### DIFF
--- a/nova/config.yaml
+++ b/nova/config.yaml
@@ -46,7 +46,11 @@ map:
     path: /config
 
 options:
-  relay_auth_token: null
+  # A null default marks an option as REQUIRED in Supervisor (the App refuses to
+  # start until the user fills it) — the opposite of passwordless onboarding. An
+  # empty string keeps the field optional and matches what the legacy-migration
+  # clear writes back after importing a token.
+  relay_auth_token: ""
   ha_llat: ""
   file_access: "off"
 

--- a/tests/app/config-contract.test.ts
+++ b/tests/app/config-contract.test.ts
@@ -35,7 +35,11 @@ describe("app config contract", () => {
     });
 
     expect(parsed.options).toEqual({
-      relay_auth_token: null,
+      // MUST stay "" and never null: a null default marks the option as
+      // REQUIRED in Supervisor, so a fresh install refuses to start until the
+      // user fills a token — breaking passwordless onboarding (proven live:
+      // "Missing required option 'relay_auth_token'").
+      relay_auth_token: "",
       ha_llat: "",
       // File access is a capability, not a default: the App ships it OFF.
       file_access: "off"


### PR DESCRIPTION
## Problem
A fresh install of the App (pure config defaults, no user input) refuses to start:

```
Error: App local_ha_nova_relay_test has invalid options: Missing required option 'relay_auth_token' in NOVA Relay TEST … Got {'relay_auth_token': None, 'ha_llat': '', 'file_access': 'off'}
```

Supervisor treats a `null` default in `options:` as **required-to-be-filled-by-the-user** (documented add-on config convention) — the `password?` schema suffix does not override that. This is the exact opposite of the passwordless onboarding shipped in #374: every fresh 0.7.0 install would be dead on arrival until the user manually enters a token they no longer need.

Found during the pre-release real-world validation of `ad37baf` on a live HAOS box (fresh install from zero).

## Fix
Default `relay_auth_token: ""` — consistent with `ha_llat` and with what `clearLegacyOptions` writes back after a successful legacy import. All runtime readers already guard with `typeof === "string" && length > 0`, so `""` is uniformly treated as absent.

**Proven live**: with this default the same fresh cycle (uninstall → install → start) comes up passwordless: 3 listeners up, `/pair/v1/info` answering, TLS 1.3 on the secure port.

## Tests
- `tests/app/config-contract.test.ts` now pins `relay_auth_token: ""` with a comment explaining why `null` must never come back (regression lock in the correct direction).
- Targeted suites green: config-contract, run-contract, legacy-migration, app-mode, deploy-bootstrap-script-contract (20/20).

No release: no version bump, README untouched.