### PR TITLE
fix(cli): headless device pairing (private-file fallback) + keyring-safe tests

### DIFF
--- a/cli/claude_paths_test.go
+++ b/cli/claude_paths_test.go
@@ -26,6 +26,19 @@ func TestMain(m *testing.M) {
 	// override on top (e.g. keyring_linux_test.go stubs keyringGetWithService, or
 	// device-storage tests stub deviceStorageKeyringCanary).
 	keyring.MockInit()
+	// Same protection for the device-credential storage probe: on Linux its
+	// keyring canary preflights the REAL DBus Secret Service before go-keyring is
+	// even consulted, so MockInit alone does not isolate it. A package-wide test
+	// secret dir short-circuits the probe and every device-slot read/write into
+	// per-file storage. Tests that exercise the real selection logic clear this
+	// env and stub the canaries instead (device_credential_storage_test.go).
+	testSecretDirRoot := ""
+	if os.Getenv("HA_NOVA_TEST_SECRET_DIR") == "" {
+		if secretDir, err := os.MkdirTemp("", "ha-nova-test-secrets"); err == nil {
+			os.Setenv("HA_NOVA_TEST_SECRET_DIR", secretDir)
+			testSecretDirRoot = secretDir
+		}
+	}
 	os.Unsetenv("CLAUDE_CONFIG_DIR")
 	// Same protection class for the update-nudge background refresh: under
 	// `go test`, os.Executable() is the generated test binary, so the real
@@ -43,6 +56,9 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	if stubDir != "" {
 		os.RemoveAll(stubDir)
+	}
+	if testSecretDirRoot != "" {
+		os.RemoveAll(testSecretDirRoot)
 	}
 	os.Exit(code)
 }

--- a/cli/claude_paths_test.go
+++ b/cli/claude_paths_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/zalando/go-keyring"
 )
 
 // Tests across this package build Claude state under temp HOMEs; a
@@ -17,6 +19,13 @@ import (
 // fallback paths behave like on claude-less CI. Tests that need claude
 // behavior prepend their own mock in front of it.
 func TestMain(m *testing.M) {
+	// Route ALL go-keyring access to an in-memory mock for the whole package, so
+	// no test ever touches the developer's real OS keyring (on macOS a raw
+	// keyring.Set/Get pops the native "Schlüsselbund" unlock dialog and can hang
+	// CI/headless runs). Tests that need a keyring FAILURE install their own
+	// override on top (e.g. keyring_linux_test.go stubs keyringGetWithService, or
+	// device-storage tests stub deviceStorageKeyringCanary).
+	keyring.MockInit()
 	os.Unsetenv("CLAUDE_CONFIG_DIR")
 	// Same protection class for the update-nudge background refresh: under
 	// `go test`, os.Executable() is the generated test binary, so the real

--- a/cli/cmd_pair.go
+++ b/cli/cmd_pair.go
@@ -63,6 +63,19 @@ func runPairCommand(paths runtimePaths, args []string) int {
 		cfg.RelayBaseURL = bootstrapURL
 	}
 
+	// Verify credential storage BEFORE asking for (or spending) a code: a broken
+	// backend must not burn the owner's one-time code. On headless systems this
+	// engages the private-file fallback and says so.
+	probe, probeErr := probeDeviceCredentialStorage()
+	if probeErr != nil {
+		printErr("This system cannot store the device credential yet: %s", probeErr)
+		printErr("Nothing was paired — no code was used.")
+		return 1
+	}
+	if probe.note != "" {
+		fmt.Println(probe.note)
+	}
+
 	if code == "" {
 		entered, promptErr := promptWizardLineFromReader(bufio.NewReader(os.Stdin), os.Stdout, "Six-digit code from the NOVA page", "")
 		if promptErr != nil {

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -138,8 +138,23 @@ func runSetup(paths runtimePaths, args []string) int {
 	// on the token path; a silently reused stored token must never retire a
 	// working device pairing below.
 	explicitTokenIntent := token != ""
+	// A passwordless-paired install has no legacy token; its device credential in
+	// the separate slot is the usable credential.
+	pairedDeviceAvailable := func() bool {
+		if explicitTokenIntent || cfg.RelaySecureBaseURL == "" || cfg.RelaySpkiPin == "" {
+			return false
+		}
+		_, ok, credErr := readDeviceCredential()
+		return credErr == nil && ok
+	}
 	if token == "" {
 		if tokenStoragePreflightErr != nil {
+			// Headless (no Secret Service): honor an existing device pairing —
+			// whose credential is file-backed, no keyring — BEFORE failing on the
+			// legacy-token store, so a paired box still installs/syncs clients.
+			if pairedDeviceAvailable() {
+				return completeNonInteractivePairedSetup(paths, cfg, state, selectedClients)
+			}
 			printHumanErr("%s", relayAuthTokenProblemMessage(tokenStoragePreflightErr))
 			if hint := setupSecureStorageRecoveryHint(tokenStoragePreflightErr); hint != "" {
 				printHumanWarn("%s", hint)
@@ -160,13 +175,10 @@ func runSetup(paths runtimePaths, args []string) int {
 			return 1
 		}
 	}
-	// A passwordless-paired install has no legacy token; its device credential in
-	// the separate slot is the usable credential. Honor the pairing instead of
-	// requiring or prompting for a token.
-	if token == "" && !explicitTokenIntent && cfg.RelaySecureBaseURL != "" && cfg.RelaySpkiPin != "" {
-		if _, ok, credErr := readDeviceCredential(); credErr == nil && ok {
-			return completeNonInteractivePairedSetup(paths, cfg, state, selectedClients)
-		}
+	// No legacy token (stored or flag) but a device pairing exists: honor it
+	// instead of prompting/requiring a token.
+	if token == "" && pairedDeviceAvailable() {
+		return completeNonInteractivePairedSetup(paths, cfg, state, selectedClients)
 	}
 	if token == "" && !*nonInteractive {
 		answer, err := promptLine("Relay auth token", "")

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -171,13 +171,13 @@ func deviceSecretFileSet(service, value string) error {
 	if service == deviceCredentialService {
 		path := testSecretPath(dir, service)
 		if deviceFileBackendMarkerExists() {
-			return os.WriteFile(path, []byte(value), 0o600)
+			return writeSecretFile0600(path, value)
 		}
 		// First commit: keep the invariant "current credential file exists IFF
 		// marker exists" by writing the file, then the marker, and rolling the
 		// file back if the marker cannot be created. Nothing valuable is lost —
 		// there is no prior committed file credential on a first commit.
-		if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+		if err := writeSecretFile0600(path, value); err != nil {
 			return err
 		}
 		if err := writeDeviceFileBackendMarker(); err != nil {
@@ -186,7 +186,18 @@ func deviceSecretFileSet(service, value string) error {
 		}
 		return nil
 	}
-	return os.WriteFile(testSecretPath(dir, service), []byte(value), 0o600)
+	return writeSecretFile0600(testSecretPath(dir, service), value)
+}
+
+// writeSecretFile0600 writes a device secret and ENFORCES 0600, even when the
+// file already existed with looser permissions: os.WriteFile's mode applies only
+// on create, so a re-pair overwriting a manually-repaired credential file could
+// otherwise leave it readable by other local users.
+func writeSecretFile0600(path, value string) error {
+	if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
 }
 
 func deviceSecretFileDelete(service string) error {
@@ -205,11 +216,17 @@ func deviceSecretFileDelete(service string) error {
 // marker would otherwise make a fresh reinstall inherit file mode without
 // re-probing. Also drops the in-process forced flag so the same run re-decides.
 func removeDeviceFileStorageResidue() {
+	// Delete the file-backed credential slots DIRECTLY (by path), not through the
+	// marker-routed deleters: a headless pairing interrupted before promotion
+	// leaves a pending FILE with no marker, so routed deletes would go to the
+	// keyring and leave the orphan file (and a non-empty secrets dir) behind.
+	_ = deviceSecretFileDelete(deviceCredentialService)
+	_ = deviceSecretFileDelete(deviceCredentialPendingService)
 	if path, err := deviceFileBackendMarkerPath(); err == nil {
 		_ = os.Remove(path)
 	}
 	if dir, err := deviceSecretFileDir(); err == nil {
-		_ = os.Remove(dir) // removes only when empty
+		_ = os.Remove(dir) // removes only when now empty
 	}
 	deviceCredentialFileModeForced = false
 }

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/zalando/go-keyring"
+)
+
+// Storage-mode handling for the device-credential slots.
+//
+// Desktop systems keep device credentials in the OS keyring. Headless systems
+// (containers, servers, LXCs — a core Home Assistant audience) have no Secret
+// Service session at all; for them the credential lives in a private 0600 file
+// under the config directory, mirroring the relay token's service-file mode.
+//
+// The mode is decided ONCE per pairing by probeDeviceCredentialStorage — BEFORE
+// the one-time code is consumed — and is self-describing afterwards: reads use
+// the file whenever it exists, so an install paired headless keeps working
+// without any marker or config plumbing.
+
+const deviceCredentialProbeService = "ha-nova.device-credential.probe"
+
+// Process-local decision from the probe: route new writes to the file backend.
+var deviceCredentialFileModeForced = false
+
+type deviceStorageProbe struct {
+	// mode is "keyring" or "file" — informational for callers/tests.
+	mode string
+	// note is a user-facing sentence to print when the fallback engaged.
+	note string
+}
+
+func deviceSecretFileDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if runtime.GOOS == "windows" {
+		return filepath.Join(windowsAppDataDir(home), "ha-nova", "secrets"), nil
+	}
+	return filepath.Join(home, ".config", "ha-nova", "secrets"), nil
+}
+
+func deviceSecretFilePath(service string) (string, error) {
+	dir, err := deviceSecretFileDir()
+	if err != nil {
+		return "", err
+	}
+	return testSecretPath(dir, service), nil
+}
+
+func deviceSecretFileExists(service string) bool {
+	path, err := deviceSecretFilePath(service)
+	if err != nil {
+		return false
+	}
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+// deviceSecretFileModeActive reports whether this install stores device
+// credentials in files: either the probe forced it in this process, or a
+// previous headless pairing left a credential file behind (self-describing
+// state — the probe service never counts).
+func deviceSecretFileModeActive() bool {
+	if deviceCredentialFileModeForced {
+		return true
+	}
+	return deviceSecretFileExists(deviceCredentialService) || deviceSecretFileExists(deviceCredentialPendingService)
+}
+
+func deviceSecretFileGet(service string) (string, error) {
+	path, err := deviceSecretFilePath(service)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", errSecretNotFound
+		}
+		return "", err
+	}
+	return string(data), nil
+}
+
+func deviceSecretFileSet(service, value string) error {
+	dir, err := deviceSecretFileDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(testSecretPath(dir, service), []byte(value), 0o600)
+}
+
+func deviceSecretFileDelete(service string) error {
+	path, err := deviceSecretFilePath(service)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// Test seams: the canaries hit the real OS keyring / filesystem by default.
+var deviceStorageKeyringCanary = keyringStorageCanary
+var deviceStorageFileCanary = fileStorageCanary
+
+// probeDeviceCredentialStorage verifies that a device credential CAN be stored
+// before any pairing starts, so a broken backend never burns the owner's
+// one-time code. On a headless system (no Secret Service session at all) it
+// switches this install to the private-file backend and says so; a PRESENT but
+// locked/uninitialized desktop keyring is a hard error — no silent downgrade.
+func probeDeviceCredentialStorage() (deviceStorageProbe, error) {
+	if _, ok := testSecretDir(); ok {
+		return deviceStorageProbe{mode: "file"}, nil
+	}
+	if deviceSecretFileModeActive() {
+		return deviceStorageProbe{mode: "file"}, nil
+	}
+
+	keyringErr := deviceStorageKeyringCanary()
+	if keyringErr == nil {
+		return deviceStorageProbe{mode: "keyring"}, nil
+	}
+	if errors.Is(keyringErr, errDesktopKeyringSessionUnavailable) {
+		// No desktop session at all — there is no keyring this could protect.
+		if fileErr := deviceStorageFileCanary(); fileErr != nil {
+			return deviceStorageProbe{}, fmt.Errorf("no desktop keyring (%v) and the file fallback failed: %w", keyringErr, fileErr)
+		}
+		deviceCredentialFileModeForced = true
+		dir, _ := deviceSecretFileDir()
+		return deviceStorageProbe{
+			mode: "file",
+			note: fmt.Sprintf("No desktop keyring on this system — the device credential will be stored in a private file (0600) under %s.", dir),
+		}, nil
+	}
+	// Locked or uninitialized desktop keyring, permission problems, …: guide the
+	// user instead of silently weakening storage on a desktop system.
+	return deviceStorageProbe{}, keyringErr
+}
+
+func keyringStorageCanary() error {
+	if err := deviceCredentialPreflight(); err != nil {
+		return err
+	}
+	user := secretUser()
+	if err := keyring.Set(deviceCredentialProbeService, user, "probe"); err != nil {
+		return err
+	}
+	if _, err := keyring.Get(deviceCredentialProbeService, user); err != nil {
+		return err
+	}
+	if err := keyring.Delete(deviceCredentialProbeService, user); err != nil && !errors.Is(err, keyring.ErrNotFound) {
+		return err
+	}
+	return nil
+}
+
+func fileStorageCanary() error {
+	if err := deviceSecretFileSet(deviceCredentialProbeService, "probe"); err != nil {
+		return err
+	}
+	if _, err := deviceSecretFileGet(deviceCredentialProbeService); err != nil {
+		return err
+	}
+	return deviceSecretFileDelete(deviceCredentialProbeService)
+}

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -131,6 +131,24 @@ func deviceSecretFileSet(service, value string) error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
+	// Persisting the CURRENT (active) credential to a file is the moment this
+	// install commits to the file backend, so the marker is written with it — and
+	// ONLY here (pending writes are provisional and never commit the mode). The
+	// invariant "a current credential file exists IFF its marker exists" must
+	// hold, or a marker-less credential file would be masked by keyring reads and
+	// a credential-less marker would mask a keyring credential. Write the file,
+	// then the marker; if the marker fails, roll the file back.
+	if service == deviceCredentialService {
+		path := testSecretPath(dir, service)
+		if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+			return err
+		}
+		if err := writeDeviceFileBackendMarker(); err != nil {
+			_ = os.Remove(path)
+			return err
+		}
+		return nil
+	}
 	return os.WriteFile(testSecretPath(dir, service), []byte(value), 0o600)
 }
 
@@ -192,22 +210,21 @@ func probeDeviceCredentialStorage() (deviceStorageProbe, error) {
 		return deviceStorageProbe{mode: "keyring"}, nil
 	}
 	if errors.Is(keyringErr, errDesktopKeyringSessionUnavailable) || errors.Is(keyringErr, errDesktopKeyringUnavailable) {
-		// No usable keyring EXISTS on this system (no session bus, or no Secret
-		// Service provider installed — typical for containers/servers/LXCs).
-		// There is nothing a keyring could protect here, so fall back to a
-		// private file and say so. A keyring that exists but needs the user
-		// (locked / uninitialized) is handled below and never downgrades.
+		// No keyring is reachable here (no session bus, or no Secret Service
+		// provider — typical for containers/servers/LXCs, but ALSO for SSH into a
+		// desktop whose keyring still holds a credential). So force file mode for
+		// THIS process only and do NOT persist the marker yet: the install-wide
+		// switch happens only when a current credential is actually promoted to a
+		// file (deviceSecretFileSet). A canceled pair/setup then leaves nothing
+		// behind and can never mask or downgrade an existing keyring credential.
 		if fileErr := deviceStorageFileCanary(); fileErr != nil {
 			return deviceStorageProbe{}, fmt.Errorf("no desktop keyring (%v) and the file fallback failed: %w", keyringErr, fileErr)
-		}
-		if markerErr := writeDeviceFileBackendMarker(); markerErr != nil {
-			return deviceStorageProbe{}, fmt.Errorf("no desktop keyring and could not record file-backend mode: %w", markerErr)
 		}
 		deviceCredentialFileModeForced = true
 		dir, _ := deviceSecretFileDir()
 		return deviceStorageProbe{
 			mode: "file",
-			note: fmt.Sprintf("No desktop keyring on this system — the device credential will be stored in a private file (0600) under %s.", dir),
+			note: fmt.Sprintf("No desktop keyring reachable — the device credential will be stored in a private file (0600) under %s.", dir),
 		}, nil
 	}
 	// Locked or uninitialized desktop keyring, permission problems, …: guide the

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -188,6 +188,15 @@ func removeDeviceFileStorageResidue() {
 var deviceStorageKeyringCanary = keyringStorageCanary
 var deviceStorageFileCanary = fileStorageCanary
 
+// deviceCredentialStorageViable reports whether a device credential can be
+// stored here (OS keyring, or the headless file fallback). Used by the setup
+// wizard to decide that a missing relay-token keyring must not abort the
+// pairing path, which does not need the legacy token store.
+func deviceCredentialStorageViable() bool {
+	_, err := probeDeviceCredentialStorage()
+	return err == nil
+}
+
 // probeDeviceCredentialStorage verifies that a device credential CAN be stored
 // before any pairing starts, so a broken backend never burns the owner's
 // one-time code. On a headless system (no Secret Service at all) it switches

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -314,8 +314,12 @@ func fileStorageCanary() error {
 		if err != nil {
 			return err
 		}
-		if !deviceSecretFileExists(service) {
-			continue
+		regular, err := canaryPathRegularOrAbsent(path)
+		if err != nil {
+			return err
+		}
+		if !regular {
+			continue // absent: will be created at write time
 		}
 		// O_WRONLY (no O_TRUNC) proves write permission without corrupting the
 		// stored credential; close immediately.
@@ -326,16 +330,40 @@ func fileStorageCanary() error {
 		_ = f.Close()
 	}
 	// The marker is written at first promotion. Prove its path is writable NOW so
-	// a non-regular residue there (e.g. a leftover directory named .file-backend)
-	// fails the probe BEFORE a one-time code is spent, not at promotion. Only test
-	// when no regular marker exists yet; create-then-remove leaves none behind.
-	if !deviceFileBackendMarkerExists() {
+	// non-regular residue there (a leftover directory/FIFO/symlink) fails the probe
+	// BEFORE a one-time code is spent, not at promotion. Only test when no regular
+	// marker exists yet; create-then-remove leaves none behind.
+	markerPath, err := deviceFileBackendMarkerPath()
+	if err != nil {
+		return err
+	}
+	regular, err := canaryPathRegularOrAbsent(markerPath)
+	if err != nil {
+		return err
+	}
+	if !regular {
 		if err := writeDeviceFileBackendMarker(); err != nil {
 			return fmt.Errorf("file-backend marker path is not writable: %w", err)
 		}
-		if markerPath, perr := deviceFileBackendMarkerPath(); perr == nil {
-			_ = os.Remove(markerPath)
-		}
+		_ = os.Remove(markerPath)
 	}
 	return nil
+}
+
+// canaryPathRegularOrAbsent reports whether path is a regular file (true) or
+// absent (false), and errors when it exists as a NON-regular file (directory,
+// FIFO, socket, symlink) — such residue would make a later os.WriteFile fail
+// after a one-time code was already spent.
+func canaryPathRegularOrAbsent(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !info.Mode().IsRegular() {
+		return false, fmt.Errorf("%s is not a regular file", filepath.Base(path))
+	}
+	return true, nil
 }

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -325,5 +325,17 @@ func fileStorageCanary() error {
 		}
 		_ = f.Close()
 	}
+	// The marker is written at first promotion. Prove its path is writable NOW so
+	// a non-regular residue there (e.g. a leftover directory named .file-backend)
+	// fails the probe BEFORE a one-time code is spent, not at promotion. Only test
+	// when no regular marker exists yet; create-then-remove leaves none behind.
+	if !deviceFileBackendMarkerExists() {
+		if err := writeDeviceFileBackendMarker(); err != nil {
+			return fmt.Errorf("file-backend marker path is not writable: %w", err)
+		}
+		if markerPath, perr := deviceFileBackendMarkerPath(); perr == nil {
+			_ = os.Remove(markerPath)
+		}
+	}
 	return nil
 }

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -62,14 +62,18 @@ func deviceSecretFileExists(service string) bool {
 	return err == nil && info.Mode().IsRegular()
 }
 
-// deviceSecretFileModeActive reports whether this install stores device
-// credentials in files: either the probe forced it in this process, or a
-// previous headless pairing left a credential file behind (self-describing
-// state — the probe service never counts).
-func deviceSecretFileModeActive() bool {
-	if deviceCredentialFileModeForced {
-		return true
-	}
+// deviceSecretFileBacked reports whether THIS slot lives in the file backend:
+// its own file exists, or the probe forced file mode for this process. The
+// decision is strictly per slot — a stale pending file left by an interrupted
+// headless re-pair (e.g. pairing over SSH into a desktop machine) must never
+// redirect reads of the CURRENT slot away from a valid keyring credential.
+func deviceSecretFileBacked(service string) bool {
+	return deviceCredentialFileModeForced || deviceSecretFileExists(service)
+}
+
+// anyDeviceSecretFileExists reports whether any real credential slot already
+// lives in the file backend (the probe service never counts).
+func anyDeviceSecretFileExists() bool {
 	return deviceSecretFileExists(deviceCredentialService) || deviceSecretFileExists(deviceCredentialPendingService)
 }
 
@@ -123,7 +127,13 @@ func probeDeviceCredentialStorage() (deviceStorageProbe, error) {
 	if _, ok := testSecretDir(); ok {
 		return deviceStorageProbe{mode: "file"}, nil
 	}
-	if deviceSecretFileModeActive() {
+	if deviceCredentialFileModeForced || anyDeviceSecretFileExists() {
+		// Existing file-mode install: still prove the files are writable NOW —
+		// a read-only volume or chmod-ed directory discovered after the fact
+		// would consume the one-time code with nothing storable.
+		if fileErr := deviceStorageFileCanary(); fileErr != nil {
+			return deviceStorageProbe{}, fmt.Errorf("this install keeps its device credential in a file, but the file store is not writable: %w", fileErr)
+		}
 		return deviceStorageProbe{mode: "file"}, nil
 	}
 
@@ -131,8 +141,12 @@ func probeDeviceCredentialStorage() (deviceStorageProbe, error) {
 	if keyringErr == nil {
 		return deviceStorageProbe{mode: "keyring"}, nil
 	}
-	if errors.Is(keyringErr, errDesktopKeyringSessionUnavailable) {
-		// No desktop session at all — there is no keyring this could protect.
+	if errors.Is(keyringErr, errDesktopKeyringSessionUnavailable) || errors.Is(keyringErr, errDesktopKeyringUnavailable) {
+		// No usable keyring EXISTS on this system (no session bus, or no Secret
+		// Service provider installed — typical for containers/servers/LXCs).
+		// There is nothing a keyring could protect here, so fall back to a
+		// private file and say so. A keyring that exists but needs the user
+		// (locked / uninitialized) is handled below and never downgrades.
 		if fileErr := deviceStorageFileCanary(); fileErr != nil {
 			return deviceStorageProbe{}, fmt.Errorf("no desktop keyring (%v) and the file fallback failed: %w", keyringErr, fileErr)
 		}

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -17,14 +17,20 @@ import (
 // Service session at all; for them the credential lives in a private 0600 file
 // under the config directory, mirroring the relay token's service-file mode.
 //
-// The mode is decided ONCE per pairing by probeDeviceCredentialStorage — BEFORE
-// the one-time code is consumed — and is self-describing afterwards: reads use
-// the file whenever it exists, so an install paired headless keeps working
-// without any marker or config plumbing.
+// The backend is a SINGLE per-install decision recorded by an explicit marker
+// file, NOT inferred from whether a credential file happens to exist. Inferring
+// from credential files is fragile: a stale `.pending` file left by an aborted
+// headless re-pair on a desktop must never flip the install to file mode (which
+// would mask the real keyring credential and silently downgrade storage). The
+// marker is written only when the probe commits to file mode, so every slot on
+// an install resolves to the same backend.
 
 const deviceCredentialProbeService = "ha-nova.device-credential.probe"
+const deviceCredentialFileBackendMarker = ".file-backend"
 
-// Process-local decision from the probe: route new writes to the file backend.
+// Process-local decision from the probe: route this run to the file backend even
+// before the on-disk marker is consulted (belt-and-suspenders for the first run
+// on a headless system, before the marker write).
 var deviceCredentialFileModeForced = false
 
 type deviceStorageProbe struct {
@@ -53,8 +59,16 @@ func deviceSecretFilePath(service string) (string, error) {
 	return testSecretPath(dir, service), nil
 }
 
-func deviceSecretFileExists(service string) bool {
-	path, err := deviceSecretFilePath(service)
+func deviceFileBackendMarkerPath() (string, error) {
+	dir, err := deviceSecretFileDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, deviceCredentialFileBackendMarker), nil
+}
+
+func deviceFileBackendMarkerExists() bool {
+	path, err := deviceFileBackendMarkerPath()
 	if err != nil {
 		return false
 	}
@@ -62,19 +76,36 @@ func deviceSecretFileExists(service string) bool {
 	return err == nil && info.Mode().IsRegular()
 }
 
-// deviceSecretFileBacked reports whether THIS slot lives in the file backend:
-// its own file exists, or the probe forced file mode for this process. The
-// decision is strictly per slot — a stale pending file left by an interrupted
-// headless re-pair (e.g. pairing over SSH into a desktop machine) must never
-// redirect reads of the CURRENT slot away from a valid keyring credential.
-func deviceSecretFileBacked(service string) bool {
-	return deviceCredentialFileModeForced || deviceSecretFileExists(service)
+func writeDeviceFileBackendMarker() error {
+	dir, err := deviceSecretFileDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	path, err := deviceFileBackendMarkerPath()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte("file\n"), 0o600)
 }
 
-// anyDeviceSecretFileExists reports whether any real credential slot already
-// lives in the file backend (the probe service never counts).
-func anyDeviceSecretFileExists() bool {
-	return deviceSecretFileExists(deviceCredentialService) || deviceSecretFileExists(deviceCredentialPendingService)
+// deviceSecretFileBacked reports whether THIS install stores device credentials
+// in files. It is a single install-wide decision (marker or process-forced) so
+// every slot resolves to the same backend — a leftover credential file for one
+// slot can never redirect another slot.
+func deviceSecretFileBacked() bool {
+	return deviceCredentialFileModeForced || deviceFileBackendMarkerExists()
+}
+
+func deviceSecretFileExists(service string) bool {
+	path, err := deviceSecretFilePath(service)
+	if err != nil {
+		return false
+	}
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode().IsRegular()
 }
 
 func deviceSecretFileGet(service string) (string, error) {
@@ -114,31 +145,50 @@ func deviceSecretFileDelete(service string) error {
 	return nil
 }
 
+// removeDeviceFileStorageResidue clears the file-backend marker and removes the
+// secrets directory if it is now empty. Best-effort, purge-only: a leftover
+// marker would otherwise make a fresh reinstall inherit file mode without
+// re-probing. Also drops the in-process forced flag so the same run re-decides.
+func removeDeviceFileStorageResidue() {
+	if path, err := deviceFileBackendMarkerPath(); err == nil {
+		_ = os.Remove(path)
+	}
+	if dir, err := deviceSecretFileDir(); err == nil {
+		_ = os.Remove(dir) // removes only when empty
+	}
+	deviceCredentialFileModeForced = false
+}
+
 // Test seams: the canaries hit the real OS keyring / filesystem by default.
 var deviceStorageKeyringCanary = keyringStorageCanary
 var deviceStorageFileCanary = fileStorageCanary
 
 // probeDeviceCredentialStorage verifies that a device credential CAN be stored
 // before any pairing starts, so a broken backend never burns the owner's
-// one-time code. On a headless system (no Secret Service session at all) it
-// switches this install to the private-file backend and says so; a PRESENT but
-// locked/uninitialized desktop keyring is a hard error — no silent downgrade.
+// one-time code. On a headless system (no Secret Service at all) it switches
+// this install to the private-file backend, records the marker, and says so; a
+// PRESENT-but-locked/uninitialized desktop keyring is a hard error — no silent
+// downgrade.
 func probeDeviceCredentialStorage() (deviceStorageProbe, error) {
 	if _, ok := testSecretDir(); ok {
 		return deviceStorageProbe{mode: "file"}, nil
 	}
-	if deviceCredentialFileModeForced || anyDeviceSecretFileExists() {
-		// Existing file-mode install: still prove the files are writable NOW —
-		// a read-only volume or chmod-ed directory discovered after the fact
-		// would consume the one-time code with nothing storable.
-		if fileErr := deviceStorageFileCanary(); fileErr != nil {
-			return deviceStorageProbe{}, fmt.Errorf("this install keeps its device credential in a file, but the file store is not writable: %w", fileErr)
+	if deviceSecretFileBacked() {
+		// Established file-mode install: prove the slots are writable NOW —
+		// a read-only volume or a root-owned/0400 credential file discovered
+		// after the fact would consume the one-time code with nothing storable.
+		if err := deviceStorageFileCanary(); err != nil {
+			return deviceStorageProbe{}, fmt.Errorf("this install keeps its device credential in a file, but the file store is not writable: %w", err)
 		}
 		return deviceStorageProbe{mode: "file"}, nil
 	}
 
 	keyringErr := deviceStorageKeyringCanary()
 	if keyringErr == nil {
+		// Committed to the keyring: drop any orphan credential files from an
+		// aborted earlier file attempt so they can never be mistaken for state.
+		_ = deviceSecretFileDelete(deviceCredentialService)
+		_ = deviceSecretFileDelete(deviceCredentialPendingService)
 		return deviceStorageProbe{mode: "keyring"}, nil
 	}
 	if errors.Is(keyringErr, errDesktopKeyringSessionUnavailable) || errors.Is(keyringErr, errDesktopKeyringUnavailable) {
@@ -149,6 +199,9 @@ func probeDeviceCredentialStorage() (deviceStorageProbe, error) {
 		// (locked / uninitialized) is handled below and never downgrades.
 		if fileErr := deviceStorageFileCanary(); fileErr != nil {
 			return deviceStorageProbe{}, fmt.Errorf("no desktop keyring (%v) and the file fallback failed: %w", keyringErr, fileErr)
+		}
+		if markerErr := writeDeviceFileBackendMarker(); markerErr != nil {
+			return deviceStorageProbe{}, fmt.Errorf("no desktop keyring and could not record file-backend mode: %w", markerErr)
 		}
 		deviceCredentialFileModeForced = true
 		dir, _ := deviceSecretFileDir()
@@ -179,6 +232,10 @@ func keyringStorageCanary() error {
 	return nil
 }
 
+// fileStorageCanary proves the file backend can actually store credentials: the
+// secrets directory accepts a new file, AND every existing credential slot is
+// overwritable (a root-owned or 0400 credential file would otherwise only fail
+// at promotion, after the one-time code was already spent).
 func fileStorageCanary() error {
 	if err := deviceSecretFileSet(deviceCredentialProbeService, "probe"); err != nil {
 		return err
@@ -186,5 +243,24 @@ func fileStorageCanary() error {
 	if _, err := deviceSecretFileGet(deviceCredentialProbeService); err != nil {
 		return err
 	}
-	return deviceSecretFileDelete(deviceCredentialProbeService)
+	if err := deviceSecretFileDelete(deviceCredentialProbeService); err != nil {
+		return err
+	}
+	for _, service := range []string{deviceCredentialService, deviceCredentialPendingService} {
+		path, err := deviceSecretFilePath(service)
+		if err != nil {
+			return err
+		}
+		if !deviceSecretFileExists(service) {
+			continue
+		}
+		// O_WRONLY (no O_TRUNC) proves write permission without corrupting the
+		// stored credential; close immediately.
+		f, err := os.OpenFile(path, os.O_WRONLY, 0o600)
+		if err != nil {
+			return fmt.Errorf("existing credential file %s is not overwritable: %w", filepath.Base(path), err)
+		}
+		_ = f.Close()
+	}
+	return nil
 }

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -132,14 +132,21 @@ func deviceSecretFileSet(service, value string) error {
 		return err
 	}
 	// Persisting the CURRENT (active) credential to a file is the moment this
-	// install commits to the file backend, so the marker is written with it — and
-	// ONLY here (pending writes are provisional and never commit the mode). The
-	// invariant "a current credential file exists IFF its marker exists" must
-	// hold, or a marker-less credential file would be masked by keyring reads and
-	// a credential-less marker would mask a keyring credential. Write the file,
-	// then the marker; if the marker fails, roll the file back.
+	// install commits to the file backend, so the marker is written with it — but
+	// ONLY on the FIRST commit (pending writes are provisional and never commit
+	// the mode). On an already-committed file install the marker exists, so a
+	// re-pair/resume just overwrites the credential: never rewrite the marker
+	// there (a marker gone 0400 would otherwise fail and trigger a rollback that
+	// deletes the freshly promoted, already-activated credential).
 	if service == deviceCredentialService {
 		path := testSecretPath(dir, service)
+		if deviceFileBackendMarkerExists() {
+			return os.WriteFile(path, []byte(value), 0o600)
+		}
+		// First commit: keep the invariant "current credential file exists IFF
+		// marker exists" by writing the file, then the marker, and rolling the
+		// file back if the marker cannot be created. Nothing valuable is lost —
+		// there is no prior committed file credential on a first commit.
 		if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
 			return err
 		}

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -219,10 +219,10 @@ func probeDeviceCredentialStorage() (deviceStorageProbe, error) {
 
 	keyringErr := deviceStorageKeyringCanary()
 	if keyringErr == nil {
-		// Committed to the keyring: drop any orphan credential files from an
-		// aborted earlier file attempt so they can never be mistaken for state.
-		_ = deviceSecretFileDelete(deviceCredentialService)
-		_ = deviceSecretFileDelete(deviceCredentialPendingService)
+		// Committed to the keyring. Any leftover credential files are harmless
+		// orphans — reads never consult them without the marker (deviceSecretFileBacked)
+		// — and must NOT be deleted here: a pending file may be an interrupted
+		// headless pairing that resumePendingActivation still needs to finish.
 		return deviceStorageProbe{mode: "keyring"}, nil
 	}
 	if errors.Is(keyringErr, errDesktopKeyringSessionUnavailable) || errors.Is(keyringErr, errDesktopKeyringUnavailable) {

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/zalando/go-keyring"
 )
@@ -106,6 +107,35 @@ func deviceSecretFileExists(service string) bool {
 	}
 	info, err := os.Lstat(path)
 	return err == nil && info.Mode().IsRegular()
+}
+
+// readKeyringDeviceSecret reads a device slot from the OS keyring directly,
+// bypassing the marker/file routing. Returns (value, true, nil) on a hit,
+// ("", false, nil) when the keyring has no such entry, and an error when the
+// keyring is unreachable (headless). Resume uses it to prefer a real keyring
+// pending over an orphan .pending FILE from an aborted earlier headless attempt.
+func readKeyringDeviceSecret(service string) (string, bool, error) {
+	if dir, ok := testSecretDir(); ok {
+		data, err := os.ReadFile(testSecretPath(dir, service))
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", false, nil
+			}
+			return "", false, err
+		}
+		return strings.TrimSpace(string(data)), true, nil
+	}
+	if err := deviceCredentialPreflight(); err != nil {
+		return "", false, err
+	}
+	value, err := keyring.Get(service, secretUser())
+	if err != nil {
+		if errors.Is(err, keyring.ErrNotFound) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return strings.TrimSpace(value), true, nil
 }
 
 func deviceSecretFileGet(service string) (string, error) {

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -362,6 +362,42 @@ func TestResumeFinishesAFileModePendingEvenWhenKeyringNowWorks(t *testing.T) {
 	}
 }
 
+func TestResumePrefersKeyringPendingOverOrphanFile(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// A desktop re-pair was interrupted: its pending lives in the keyring. An
+	// orphan .pending FILE from an aborted earlier headless attempt also exists
+	// (the probe no longer deletes it). Resume must activate the REAL keyring
+	// pending, not the stale file — otherwise it would spend another pairing code.
+	keyringPending := generateTestDeviceCredential(t)
+	if err := keyring.Set(deviceCredentialPendingService, secretUser(), keyringPending); err != nil {
+		t.Fatalf("seed keyring pending: %v", err)
+	}
+	orphanFile := "hanova-dev-v1.IIIIIIIIIIIIIIIIIIIIII.JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ"
+	seedRawSecretFile(t, deviceCredentialPendingService, orphanFile)
+
+	origActivate := activateDeviceV1ForPairing
+	activated := ""
+	activateDeviceV1ForPairing = func(_, _, cred string) error { activated = cred; return nil }
+	t.Cleanup(func() { activateDeviceV1ForPairing = origActivate })
+
+	cfg := runtimeConfig{PendingSecureBaseURL: "https://relay:8792", PendingSpkiPin: "PIN"}
+	resumed, err := resumePendingActivation(&cfg, func(*runtimeConfig) error { return nil })
+	if err != nil || !resumed {
+		t.Fatalf("resume failed: resumed=%v err=%v", resumed, err)
+	}
+	if activated != keyringPending {
+		t.Fatalf("resume activated the stale orphan file instead of the keyring pending: %q", activated)
+	}
+	// Keyring-mode promotion: no file marker; current credential is in the keyring.
+	if deviceFileBackendMarkerExists() {
+		t.Fatal("keyring-mode resume must not write a file-backend marker")
+	}
+	got, ok, err := readDeviceCredential()
+	if err != nil || !ok || got != keyringPending {
+		t.Fatalf("current credential not the promoted keyring pending: got=%q ok=%v err=%v", got, ok, err)
+	}
+}
+
 func generateTestDeviceCredential(t *testing.T) string {
 	t.Helper()
 	const cred = "hanova-dev-v1.AAAAAAAAAAAAAAAAAAAAAA.BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -189,10 +189,9 @@ func TestOrphanCredentialFileWithoutMarkerStaysOnKeyring(t *testing.T) {
 	if err != nil || probe.mode != "keyring" {
 		t.Fatalf("expected keyring mode (no downgrade), got mode=%q err=%v", probe.mode, err)
 	}
-	// The orphan file is cleaned, and the current slot resolves to the keyring.
-	if deviceSecretFileExists(deviceCredentialService) {
-		t.Fatal("expected the probe to clear the orphan credential file on the keyring path")
-	}
+	// The orphan file is harmless (never read without a marker) and must NOT be
+	// deleted — a pending file could be an interrupted headless pairing awaiting
+	// resume. The current slot still resolves to the keyring credential.
 	got, ok, err := readDeviceCredential()
 	if err != nil || !ok || got != keyringCred {
 		t.Fatalf("keyring credential masked by orphan file: got=%q ok=%v err=%v", got, ok, err)
@@ -317,6 +316,49 @@ func TestSecurePairingAbortsBeforeConsumingTheCodeWhenStorageIsBroken(t *testing
 	}
 	if pairCalled {
 		t.Fatal("pairing reached the relay although storage was broken — the one-time code would have been consumed")
+	}
+}
+
+func TestResumeFinishesAFileModePendingEvenWhenKeyringNowWorks(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// A headless pairing was interrupted after writing the pending FILE (no
+	// marker yet) and saving the pending endpoint, but before promotion. Even if
+	// the keyring is now usable, resume must finish it IN FILE MODE — reading its
+	// own pending file, not rerouting to (or being cleaned by) the keyring.
+	pendingCred := generateTestDeviceCredential(t)
+	if err := deviceSecretFileSet(deviceCredentialPendingService, pendingCred); err != nil {
+		t.Fatalf("seed pending file: %v", err)
+	}
+	if deviceFileBackendMarkerExists() {
+		t.Fatal("test setup error: a pending write must not create a marker")
+	}
+
+	origActivate := activateDeviceV1ForPairing
+	activated := ""
+	activateDeviceV1ForPairing = func(_, _, cred string) error { activated = cred; return nil }
+	t.Cleanup(func() { activateDeviceV1ForPairing = origActivate })
+
+	cfg := runtimeConfig{PendingSecureBaseURL: "https://relay:8792", PendingSpkiPin: "PIN"}
+	resumed, err := resumePendingActivation(&cfg, func(*runtimeConfig) error { return nil })
+	if err != nil || !resumed {
+		t.Fatalf("resume failed: resumed=%v err=%v", resumed, err)
+	}
+	if activated != pendingCred {
+		t.Fatalf("resume activated the wrong credential: %q", activated)
+	}
+	// Promotion completed in file mode: current file + marker exist, pending gone.
+	if !deviceFileBackendMarkerExists() {
+		t.Fatal("expected the file-backend marker after file-mode promotion")
+	}
+	if deviceSecretFileExists(deviceCredentialPendingService) {
+		t.Fatal("pending file not cleared after promotion")
+	}
+	got, ok, err := readDeviceCredential()
+	if err != nil || !ok || got != pendingCred {
+		t.Fatalf("current credential not readable from file after resume: got=%q ok=%v err=%v", got, ok, err)
+	}
+	if cfg.RelaySecureBaseURL != "https://relay:8792" || cfg.PendingSecureBaseURL != "" {
+		t.Fatalf("endpoints not finalized: live=%q pending=%q", cfg.RelaySecureBaseURL, cfg.PendingSecureBaseURL)
 	}
 }
 

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -226,6 +226,36 @@ func TestStalePendingFileWithoutMarkerDoesNotMaskKeyringCurrent(t *testing.T) {
 	}
 }
 
+func TestRepairOnFileInstallDoesNotDeleteCredentialWhenMarkerIsReadOnly(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	deviceCredentialFileModeForced = true // headless install: writes go to the file backend
+	// Established file install: marker + current credential present. The marker
+	// has become read-only (0400). A re-pair overwrites the current credential;
+	// it must NOT try to rewrite the marker (which would fail and roll the
+	// freshly promoted, already-activated credential back to nothing).
+	first := generateTestDeviceCredential(t)
+	if err := writeDeviceCredential(first); err != nil { // first commit writes marker + file
+		t.Fatalf("seed file install: %v", err)
+	}
+	if !deviceFileBackendMarkerExists() {
+		t.Fatal("seed did not commit file mode (marker missing)")
+	}
+	markerPath, _ := deviceFileBackendMarkerPath()
+	if err := os.Chmod(markerPath, 0o400); err != nil {
+		t.Fatalf("chmod marker 0400: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(markerPath, 0o600) })
+
+	repaired := "hanova-dev-v1.GGGGGGGGGGGGGGGGGGGGGG.HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH"
+	if err := writeDeviceCredential(repaired); err != nil {
+		t.Fatalf("re-pair overwrite must succeed without touching the marker: %v", err)
+	}
+	got, ok, err := readDeviceCredential()
+	if err != nil || !ok || got != repaired {
+		t.Fatalf("re-paired credential lost: got=%q ok=%v err=%v", got, ok, err)
+	}
+}
+
 func TestFileCanaryRejectsAnUnwritableExistingCredentialFile(t *testing.T) {
 	withDeviceStorageTestHome(t)
 	// Established file install (marker present) whose current credential file has

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -255,6 +255,33 @@ func TestRepairOnFileInstallDoesNotDeleteCredentialWhenMarkerIsReadOnly(t *testi
 	}
 }
 
+func TestFileCredentialWriteEnforces0600OnOverwrite(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	deviceCredentialFileModeForced = true // headless: writes go to the file backend
+	if err := writeDeviceCredential(generateTestDeviceCredential(t)); err != nil {
+		t.Fatalf("seed file credential: %v", err)
+	}
+	path, err := deviceSecretFilePath(deviceCredentialService)
+	if err != nil {
+		t.Fatalf("slot path: %v", err)
+	}
+	// Simulate a manually-repaired credential file left world-readable.
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod 0644: %v", err)
+	}
+	// A re-pair overwrites the credential; it must be re-tightened to 0600.
+	if err := writeDeviceCredential(generateTestDeviceCredential(t)); err != nil {
+		t.Fatalf("re-pair overwrite: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("credential file left permissive after overwrite: %v", info.Mode().Perm())
+	}
+}
+
 func TestFileCanaryRejectsNonRegularCredentialSlot(t *testing.T) {
 	withDeviceStorageTestHome(t)
 	// A leftover DIRECTORY occupies the pending credential slot. deviceSecretFileExists

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -21,11 +21,21 @@ func withDeviceStorageTestHome(t *testing.T) string {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	// The generic slots honor HA_NOVA_TEST_SECRET_DIR first — clear it so these
-	// tests exercise the REAL keyring/file selection logic.
+	// tests exercise the REAL keyring/file selection logic (go-keyring is mocked
+	// package-wide by TestMain, so "keyring" here means the in-memory mock).
 	t.Setenv("HA_NOVA_TEST_SECRET_DIR", "")
 	prevForced := deviceCredentialFileModeForced
 	deviceCredentialFileModeForced = false
-	t.Cleanup(func() { deviceCredentialFileModeForced = prevForced })
+	// Keyring reads run deviceCredentialPreflight first; on Linux that inspects
+	// the REAL DBus Secret Service, which is absent on headless CI. Stub it to a
+	// no-op so keyring-mode reads reach the mock on every platform. Tests that
+	// need a preflight/keyring failure override this again.
+	prevPreflight := deviceCredentialPreflight
+	deviceCredentialPreflight = func() error { return nil }
+	t.Cleanup(func() {
+		deviceCredentialFileModeForced = prevForced
+		deviceCredentialPreflight = prevPreflight
+	})
 	return home
 }
 
@@ -53,6 +63,9 @@ func TestProbeFallsBackToFilesWhenNoDesktopSession(t *testing.T) {
 	}
 	if !deviceCredentialFileModeForced {
 		t.Fatal("expected the probe to force file mode for subsequent writes")
+	}
+	if !deviceFileBackendMarkerExists() {
+		t.Fatal("expected the probe to persist a file-backend marker for future processes")
 	}
 
 	// Writes now land in a 0600 file under the config dir, and reads find them.
@@ -94,16 +107,19 @@ func TestProbeDoesNotDowngradeALockedDesktopKeyring(t *testing.T) {
 	}
 }
 
-func TestProbeShortCircuitsWhenAFileCredentialExists(t *testing.T) {
+func TestProbeShortCircuitsWhenFileBackendMarkerExists(t *testing.T) {
 	withDeviceStorageTestHome(t)
-	// A previous headless pairing left a credential file: the install is in file
-	// mode without any probe/canary — reads must self-select the file.
+	// An established headless install: the file-backend marker records the mode,
+	// so the probe must NOT consult the keyring and reads self-select the file.
 	cred := generateTestDeviceCredential(t)
+	if err := writeDeviceFileBackendMarker(); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
 	if err := deviceSecretFileSet(deviceCredentialService, cred); err != nil {
 		t.Fatalf("seed file credential: %v", err)
 	}
 	stubStorageCanaries(t, fmt.Errorf("canary must not run"))
-	deviceStorageKeyringCanary = func() error { t.Fatal("keyring canary ran despite existing file credential"); return nil }
+	deviceStorageKeyringCanary = func() error { t.Fatal("keyring canary ran despite the file-backend marker"); return nil }
 
 	probe, err := probeDeviceCredentialStorage()
 	if err != nil || probe.mode != "file" {
@@ -115,48 +131,86 @@ func TestProbeShortCircuitsWhenAFileCredentialExists(t *testing.T) {
 	}
 }
 
-func TestStalePendingFileDoesNotMaskKeyringCurrentCredential(t *testing.T) {
+func TestOrphanCredentialFileWithoutMarkerStaysOnKeyring(t *testing.T) {
 	withDeviceStorageTestHome(t)
-	// Desktop-paired install: the CURRENT credential lives in the (mocked) OS
-	// keyring. An interrupted headless re-pair then left only a PENDING file.
+	// A credential file WITHOUT a marker is orphan residue (e.g. an aborted early
+	// file attempt). It must not flip the install to file mode: the current slot
+	// stays on the keyring, and the probe (keyring healthy) cleans the orphan.
 	keyringCred := generateTestDeviceCredential(t)
 	if err := keyring.Set(deviceCredentialService, secretUser(), keyringCred); err != nil {
 		t.Fatalf("seed keyring current credential: %v", err)
 	}
-	pendingCred := "hanova-dev-v1.CCCCCCCCCCCCCCCCCCCCCC.DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
-	if err := deviceSecretFileSet(deviceCredentialPendingService, pendingCred); err != nil {
+	orphan := "hanova-dev-v1.EEEEEEEEEEEEEEEEEEEEEE.FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+	if err := deviceSecretFileSet(deviceCredentialService, orphan); err != nil {
+		t.Fatalf("seed orphan current file: %v", err)
+	}
+	stubStorageCanaries(t, nil) // keyring healthy
+
+	probe, err := probeDeviceCredentialStorage()
+	if err != nil || probe.mode != "keyring" {
+		t.Fatalf("expected keyring mode (no downgrade), got mode=%q err=%v", probe.mode, err)
+	}
+	// The orphan file is cleaned, and the current slot resolves to the keyring.
+	if deviceSecretFileExists(deviceCredentialService) {
+		t.Fatal("expected the probe to clear the orphan credential file on the keyring path")
+	}
+	got, ok, err := readDeviceCredential()
+	if err != nil || !ok || got != keyringCred {
+		t.Fatalf("keyring credential masked by orphan file: got=%q ok=%v err=%v", got, ok, err)
+	}
+}
+
+func TestStalePendingFileWithoutMarkerDoesNotMaskKeyringCurrent(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// Desktop-paired install: the CURRENT credential lives in the (mocked) OS
+	// keyring, with no file-backend marker. An interrupted attempt left a stale
+	// PENDING file. Neither slot may switch to the file backend.
+	keyringCred := generateTestDeviceCredential(t)
+	if err := keyring.Set(deviceCredentialService, secretUser(), keyringCred); err != nil {
+		t.Fatalf("seed keyring current credential: %v", err)
+	}
+	if err := deviceSecretFileSet(deviceCredentialPendingService,
+		"hanova-dev-v1.CCCCCCCCCCCCCCCCCCCCCC.DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"); err != nil {
 		t.Fatalf("seed stale pending file: %v", err)
 	}
 
-	// The current slot must STILL resolve to the keyring credential — the stale
-	// pending file is a different slot and must not switch the current read.
+	// Current resolves to the keyring credential — not masked.
 	got, ok, err := readDeviceCredential()
 	if err != nil || !ok || got != keyringCred {
 		t.Fatalf("current credential masked by stale pending file: got=%q ok=%v err=%v", got, ok, err)
 	}
-	// The pending slot resolves to the file (its own backend), independently.
-	gotP, okP, errP := readPendingDeviceCredential()
-	if errP != nil || !okP || gotP != pendingCred {
-		t.Fatalf("pending slot not readable from file: got=%q ok=%v err=%v", gotP, okP, errP)
+	// Pending resolves to the keyring too (empty) — the stale file is orphan
+	// residue on a keyring install and is ignored, never read.
+	_, okP, errP := readPendingDeviceCredential()
+	if errP != nil || okP {
+		t.Fatalf("stale pending file was read despite keyring backend: ok=%v err=%v", okP, errP)
 	}
 }
 
-func TestProbeRejectsAnExistingFileInstallWithAnUnwritableStore(t *testing.T) {
+func TestFileCanaryRejectsAnUnwritableExistingCredentialFile(t *testing.T) {
 	withDeviceStorageTestHome(t)
-	cred := generateTestDeviceCredential(t)
-	if err := deviceSecretFileSet(deviceCredentialService, cred); err != nil {
-		t.Fatalf("seed file credential: %v", err)
+	// Established file install (marker present) whose current credential file has
+	// become non-writable (root-owned / 0400). The canary must catch the failed
+	// OVERWRITE path, not just a fresh probe file — BEFORE any code is consumed.
+	if err := writeDeviceFileBackendMarker(); err != nil {
+		t.Fatalf("seed marker: %v", err)
 	}
-	// The file store has gone read-only between runs; the canary must catch it
-	// BEFORE a pairing spends the one-time code.
-	prevCanary := deviceStorageFileCanary
-	deviceStorageFileCanary = func() error { return fmt.Errorf("read-only file system") }
-	t.Cleanup(func() { deviceStorageFileCanary = prevCanary })
-	deviceStorageKeyringCanary = func() error { t.Fatal("keyring canary must not run for a file install"); return nil }
+	if err := deviceSecretFileSet(deviceCredentialService, generateTestDeviceCredential(t)); err != nil {
+		t.Fatalf("seed credential file: %v", err)
+	}
+	path, _ := deviceSecretFilePath(deviceCredentialService)
+	if err := os.Chmod(path, 0o400); err != nil {
+		t.Fatalf("chmod 0400: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
 
+	// Real file canary (not stubbed); keyring canary must not run for a file install.
+	prevK := deviceStorageKeyringCanary
+	deviceStorageKeyringCanary = func() error { t.Fatal("keyring canary must not run for a marked file install"); return nil }
+	t.Cleanup(func() { deviceStorageKeyringCanary = prevK })
 	_, err := probeDeviceCredentialStorage()
 	if err == nil || !strings.Contains(err.Error(), "not writable") {
-		t.Fatalf("expected an unwritable-file-store error, got %v", err)
+		t.Fatalf("expected an unwritable-file-store error from the overwrite check, got %v", err)
 	}
 }
 

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -62,16 +62,29 @@ func TestProbeFallsBackToFilesWhenNoDesktopSession(t *testing.T) {
 		t.Fatalf("expected a user-facing note about the file fallback, got %q", probe.note)
 	}
 	if !deviceCredentialFileModeForced {
-		t.Fatal("expected the probe to force file mode for subsequent writes")
+		t.Fatal("expected the probe to force file mode for this process")
 	}
-	if !deviceFileBackendMarkerExists() {
-		t.Fatal("expected the probe to persist a file-backend marker for future processes")
+	// The marker is NOT written at probe time — only when a current credential is
+	// actually promoted to a file. A canceled pairing must leave nothing behind.
+	if deviceFileBackendMarkerExists() {
+		t.Fatal("probe must not persist the file-backend marker before a credential is stored")
 	}
 
-	// Writes now land in a 0600 file under the config dir, and reads find them.
+	// A pending write is provisional and still does not commit the mode.
 	cred := generateTestDeviceCredential(t)
+	if err := writePendingDeviceCredential(cred); err != nil {
+		t.Fatalf("writePendingDeviceCredential in file mode: %v", err)
+	}
+	if deviceFileBackendMarkerExists() {
+		t.Fatal("a pending write must not persist the file-backend marker")
+	}
+
+	// Promotion writes the CURRENT credential to a file — THAT commits the mode.
 	if err := writeDeviceCredential(cred); err != nil {
 		t.Fatalf("writeDeviceCredential in file mode: %v", err)
+	}
+	if !deviceFileBackendMarkerExists() {
+		t.Fatal("expected the file-backend marker after a current credential is stored")
 	}
 	got, ok, err := readDeviceCredential()
 	if err != nil || !ok || got != cred {
@@ -85,11 +98,33 @@ func TestProbeFallsBackToFilesWhenNoDesktopSession(t *testing.T) {
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("expected 0600 file, got %v", info.Mode().Perm())
 	}
-	if err := deleteDeviceCredential(); err != nil {
-		t.Fatalf("deleteDeviceCredential in file mode: %v", err)
+}
+
+func TestCanceledFilePairDoesNotDowngradeAKeyringInstall(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// A desktop-paired install (credential in the keyring) is run from an SSH
+	// shell with no session bus: the probe forces file mode for this process but
+	// must NOT persist the marker. If the pairing is canceled before a current
+	// credential is written, the keyring credential must remain the source of
+	// truth in the next (desktop) process.
+	keyringCred := generateTestDeviceCredential(t)
+	if err := keyring.Set(deviceCredentialService, secretUser(), keyringCred); err != nil {
+		t.Fatalf("seed keyring current credential: %v", err)
 	}
-	if _, ok, _ := readDeviceCredential(); ok {
-		t.Fatal("credential still readable after delete")
+	stubStorageCanaries(t, fmt.Errorf("%w: dbus-launch not found", errDesktopKeyringSessionUnavailable))
+	probe, err := probeDeviceCredentialStorage()
+	if err != nil || probe.mode != "file" {
+		t.Fatalf("expected file mode for this process, got mode=%q err=%v", probe.mode, err)
+	}
+	// Pairing canceled here — no current credential written, so no marker.
+	if deviceFileBackendMarkerExists() {
+		t.Fatal("a canceled file pairing left a marker → a keyring install would be downgraded")
+	}
+	// A fresh process (forced flag reset) still reads the keyring credential.
+	deviceCredentialFileModeForced = false
+	got, ok, err := readDeviceCredential()
+	if err != nil || !ok || got != keyringCred {
+		t.Fatalf("keyring credential lost after a canceled SSH pairing: got=%q ok=%v err=%v", got, ok, err)
 	}
 }
 
@@ -140,9 +175,13 @@ func TestOrphanCredentialFileWithoutMarkerStaysOnKeyring(t *testing.T) {
 	if err := keyring.Set(deviceCredentialService, secretUser(), keyringCred); err != nil {
 		t.Fatalf("seed keyring current credential: %v", err)
 	}
-	orphan := "hanova-dev-v1.EEEEEEEEEEEEEEEEEEEEEE.FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-	if err := deviceSecretFileSet(deviceCredentialService, orphan); err != nil {
-		t.Fatalf("seed orphan current file: %v", err)
+	// Seed a raw orphan credential file WITHOUT a marker (an aborted early file
+	// attempt); deviceSecretFileSet would itself write a marker, which is exactly
+	// what must NOT be present here.
+	seedRawSecretFile(t, deviceCredentialService,
+		"hanova-dev-v1.EEEEEEEEEEEEEEEEEEEEEE.FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+	if deviceFileBackendMarkerExists() {
+		t.Fatal("test setup error: orphan seed must not create a marker")
 	}
 	stubStorageCanaries(t, nil) // keyring healthy
 
@@ -258,4 +297,20 @@ func generateTestDeviceCredential(t *testing.T) string {
 		t.Fatalf("test credential malformed: %q", cred)
 	}
 	return cred
+}
+
+// seedRawSecretFile writes a credential file directly, bypassing the marker
+// side effect of deviceSecretFileSet — used to stage orphan/no-marker residue.
+func seedRawSecretFile(t *testing.T, service, value string) {
+	t.Helper()
+	dir, err := deviceSecretFileDir()
+	if err != nil {
+		t.Fatalf("secret dir: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir secrets: %v", err)
+	}
+	if err := os.WriteFile(testSecretPath(dir, service), []byte(value), 0o600); err != nil {
+		t.Fatalf("seed raw secret file: %v", err)
+	}
 }

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -255,6 +255,27 @@ func TestRepairOnFileInstallDoesNotDeleteCredentialWhenMarkerIsReadOnly(t *testi
 	}
 }
 
+func TestFileCanaryRejectsNonRegularMarkerPath(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// A leftover DIRECTORY occupies the .file-backend marker path. A first-time
+	// file fallback must fail the storage probe (before any code is spent), not
+	// only later when promotion tries to write the marker.
+	dir, err := deviceSecretFileDir()
+	if err != nil {
+		t.Fatalf("secret dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, deviceCredentialFileBackendMarker), 0o700); err != nil {
+		t.Fatalf("seed marker directory: %v", err)
+	}
+	// No desktop keyring → first-time file fallback path in the probe.
+	stubStorageCanaries(t, fmt.Errorf("%w: no session", errDesktopKeyringSessionUnavailable))
+
+	_, perr := probeDeviceCredentialStorage()
+	if perr == nil || !strings.Contains(perr.Error(), "marker path is not writable") {
+		t.Fatalf("expected the probe to reject a non-regular marker path before pairing, got %v", perr)
+	}
+}
+
 func TestFileCanaryRejectsAnUnwritableExistingCredentialFile(t *testing.T) {
 	withDeviceStorageTestHome(t)
 	// Established file install (marker present) whose current credential file has

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -398,6 +398,41 @@ func TestResumePrefersKeyringPendingOverOrphanFile(t *testing.T) {
 	}
 }
 
+func TestResumeRefusesFileFallbackWhenKeyringIsLocked(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// A desktop whose Secret Service is LOCKED: the real keyring pending/current
+	// cannot be checked. An orphan .pending file exists. Resume must NOT activate
+	// and promote that stale file (a silent downgrade) — it surfaces the error.
+	orphanFile := "hanova-dev-v1.KKKKKKKKKKKKKKKKKKKKKK.LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL"
+	seedRawSecretFile(t, deviceCredentialPendingService, orphanFile)
+
+	// Force the keyring read to report a LOCKED backend (present but unreadable),
+	// distinct from the headless "session/provider unavailable" classes.
+	origPreflight := deviceCredentialPreflight
+	deviceCredentialPreflight = func() error { return desktopKeyringLockedError("default collection is locked") }
+	origActivate := activateDeviceV1ForPairing
+	activateDeviceV1ForPairing = func(_, _, _ string) error {
+		t.Fatal("resume must not activate a credential when the keyring is locked")
+		return nil
+	}
+	t.Cleanup(func() {
+		deviceCredentialPreflight = origPreflight
+		activateDeviceV1ForPairing = origActivate
+	})
+
+	cfg := runtimeConfig{PendingSecureBaseURL: "https://relay:8792", PendingSpkiPin: "PIN"}
+	resumed, err := resumePendingActivation(&cfg, func(*runtimeConfig) error { return nil })
+	if resumed || err == nil {
+		t.Fatalf("expected resume to fail-safe on a locked keyring, got resumed=%v err=%v", resumed, err)
+	}
+	if deviceFileBackendMarkerExists() {
+		t.Fatal("a locked-keyring resume must not commit file mode (downgrade)")
+	}
+	if !deviceSecretFileExists(deviceCredentialPendingService) {
+		t.Fatal("the orphan pending file must be left intact, not promoted/removed")
+	}
+}
+
 func generateTestDeviceCredential(t *testing.T) string {
 	t.Helper()
 	const cred = "hanova-dev-v1.AAAAAAAAAAAAAAAAAAAAAA.BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -433,6 +433,33 @@ func TestResumeRefusesFileFallbackWhenKeyringIsLocked(t *testing.T) {
 	}
 }
 
+func TestResumeSurfacesMalformedKeyringPending(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// The keyring pending slot exists but is corrupted/partial. Resume must
+	// surface that, not silently activate/promote an orphan .pending file behind it.
+	if err := keyring.Set(deviceCredentialPendingService, secretUser(), "not-a-valid-credential"); err != nil {
+		t.Fatalf("seed malformed keyring pending: %v", err)
+	}
+	seedRawSecretFile(t, deviceCredentialPendingService,
+		"hanova-dev-v1.MMMMMMMMMMMMMMMMMMMMMM.NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN")
+
+	origActivate := activateDeviceV1ForPairing
+	activateDeviceV1ForPairing = func(_, _, _ string) error {
+		t.Fatal("must not activate anything when the keyring pending is malformed")
+		return nil
+	}
+	t.Cleanup(func() { activateDeviceV1ForPairing = origActivate })
+
+	cfg := runtimeConfig{PendingSecureBaseURL: "https://relay:8792", PendingSpkiPin: "PIN"}
+	resumed, err := resumePendingActivation(&cfg, func(*runtimeConfig) error { return nil })
+	if resumed || err == nil {
+		t.Fatalf("expected resume to surface the malformed keyring pending, got resumed=%v err=%v", resumed, err)
+	}
+	if !strings.Contains(err.Error(), "malformed") {
+		t.Fatalf("expected a malformed-credential error, got: %v", err)
+	}
+}
+
 func generateTestDeviceCredential(t *testing.T) string {
 	t.Helper()
 	const cred = "hanova-dev-v1.AAAAAAAAAAAAAAAAAAAAAA.BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The headless fallback + code-burn guard: a broken keyring must fail BEFORE the
+// one-time code is consumed, and a system with no desktop session at all must
+// fall back to private files instead of dying on a raw dbus error.
+
+func withDeviceStorageTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// The generic slots honor HA_NOVA_TEST_SECRET_DIR first — clear it so these
+	// tests exercise the REAL keyring/file selection logic.
+	t.Setenv("HA_NOVA_TEST_SECRET_DIR", "")
+	prevForced := deviceCredentialFileModeForced
+	deviceCredentialFileModeForced = false
+	t.Cleanup(func() { deviceCredentialFileModeForced = prevForced })
+	return home
+}
+
+func stubStorageCanaries(t *testing.T, keyringErr error) {
+	t.Helper()
+	prevK, prevF := deviceStorageKeyringCanary, deviceStorageFileCanary
+	deviceStorageKeyringCanary = func() error { return keyringErr }
+	deviceStorageFileCanary = fileStorageCanary
+	t.Cleanup(func() { deviceStorageKeyringCanary, deviceStorageFileCanary = prevK, prevF })
+}
+
+func TestProbeFallsBackToFilesWhenNoDesktopSession(t *testing.T) {
+	home := withDeviceStorageTestHome(t)
+	stubStorageCanaries(t, fmt.Errorf("%w: exec dbus-launch not found", errDesktopKeyringSessionUnavailable))
+
+	probe, err := probeDeviceCredentialStorage()
+	if err != nil {
+		t.Fatalf("expected file fallback, got error: %v", err)
+	}
+	if probe.mode != "file" {
+		t.Fatalf("expected file mode, got %q", probe.mode)
+	}
+	if !strings.Contains(probe.note, "private file") {
+		t.Fatalf("expected a user-facing note about the file fallback, got %q", probe.note)
+	}
+	if !deviceCredentialFileModeForced {
+		t.Fatal("expected the probe to force file mode for subsequent writes")
+	}
+
+	// Writes now land in a 0600 file under the config dir, and reads find them.
+	cred := generateTestDeviceCredential(t)
+	if err := writeDeviceCredential(cred); err != nil {
+		t.Fatalf("writeDeviceCredential in file mode: %v", err)
+	}
+	got, ok, err := readDeviceCredential()
+	if err != nil || !ok || got != cred {
+		t.Fatalf("readDeviceCredential in file mode: got=%q ok=%v err=%v", got, ok, err)
+	}
+	path := filepath.Join(home, ".config", "ha-nova", "secrets", "ha-nova.device-credential")
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		t.Fatalf("expected credential file at %s: %v", path, statErr)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected 0600 file, got %v", info.Mode().Perm())
+	}
+	if err := deleteDeviceCredential(); err != nil {
+		t.Fatalf("deleteDeviceCredential in file mode: %v", err)
+	}
+	if _, ok, _ := readDeviceCredential(); ok {
+		t.Fatal("credential still readable after delete")
+	}
+}
+
+func TestProbeDoesNotDowngradeALockedDesktopKeyring(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	locked := fmt.Errorf("%w: default collection is locked", errDesktopKeyringLocked)
+	stubStorageCanaries(t, locked)
+
+	_, err := probeDeviceCredentialStorage()
+	if !errors.Is(err, errDesktopKeyringLocked) {
+		t.Fatalf("expected the locked-keyring error to surface, got %v", err)
+	}
+	if deviceCredentialFileModeForced {
+		t.Fatal("a locked desktop keyring must NOT silently switch to file storage")
+	}
+}
+
+func TestProbeShortCircuitsWhenAFileCredentialExists(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// A previous headless pairing left a credential file: the install is in file
+	// mode without any probe/canary — reads must self-select the file.
+	cred := generateTestDeviceCredential(t)
+	if err := deviceSecretFileSet(deviceCredentialService, cred); err != nil {
+		t.Fatalf("seed file credential: %v", err)
+	}
+	stubStorageCanaries(t, fmt.Errorf("canary must not run"))
+	deviceStorageKeyringCanary = func() error { t.Fatal("keyring canary ran despite existing file credential"); return nil }
+
+	probe, err := probeDeviceCredentialStorage()
+	if err != nil || probe.mode != "file" {
+		t.Fatalf("expected silent file mode, got mode=%q err=%v", probe.mode, err)
+	}
+	got, ok, err := readDeviceCredential()
+	if err != nil || !ok || got != cred {
+		t.Fatalf("file credential not readable: got=%q ok=%v err=%v", got, ok, err)
+	}
+}
+
+func TestSecurePairingAbortsBeforeConsumingTheCodeWhenStorageIsBroken(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	stubStorageCanaries(t, fmt.Errorf("%w: default collection is locked", errDesktopKeyringLocked))
+
+	pairCalled := false
+	prevPair := pairDeviceV1ForPairing
+	pairDeviceV1ForPairing = func(_ *http.Client, _ string, _ string, _ deviceMetadata) (*provisionedCredential, error) {
+		pairCalled = true
+		return nil, fmt.Errorf("must not be reached")
+	}
+	t.Cleanup(func() { pairDeviceV1ForPairing = prevPair })
+
+	cfg := runtimeConfig{RelayBaseURL: "http://relay.test:8791", ClientInstallID: "inst-test"}
+	_, err := runSecurePairing("http://relay.test:8791", "123456", &cfg, func(*runtimeConfig) error { return nil }, defaultPairingClientInfo())
+	if err == nil {
+		t.Fatal("expected pairing to fail on broken storage")
+	}
+	if !strings.Contains(err.Error(), "the code was not used") {
+		t.Fatalf("expected the code-not-used guarantee in the error, got: %v", err)
+	}
+	if pairCalled {
+		t.Fatal("pairing reached the relay although storage was broken — the one-time code would have been consumed")
+	}
+}
+
+func generateTestDeviceCredential(t *testing.T) string {
+	t.Helper()
+	const cred = "hanova-dev-v1.AAAAAAAAAAAAAAAAAAAAAA.BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+	if parseDeviceCredential(cred) == nil {
+		t.Fatalf("test credential malformed: %q", cred)
+	}
+	return cred
+}

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -255,6 +255,27 @@ func TestRepairOnFileInstallDoesNotDeleteCredentialWhenMarkerIsReadOnly(t *testi
 	}
 }
 
+func TestFileCanaryRejectsNonRegularCredentialSlot(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// A leftover DIRECTORY occupies the pending credential slot. deviceSecretFileExists
+	// reports false (not regular), but a later os.WriteFile would fail after the
+	// code was spent — so the probe must reject it up front.
+	dir, err := deviceSecretFileDir()
+	if err != nil {
+		t.Fatalf("secret dir: %v", err)
+	}
+	slot := testSecretPath(dir, deviceCredentialPendingService)
+	if err := os.MkdirAll(slot, 0o700); err != nil {
+		t.Fatalf("seed slot directory: %v", err)
+	}
+	stubStorageCanaries(t, fmt.Errorf("%w: no session", errDesktopKeyringSessionUnavailable))
+
+	_, perr := probeDeviceCredentialStorage()
+	if perr == nil || !strings.Contains(perr.Error(), "not a regular file") {
+		t.Fatalf("expected the probe to reject a non-regular credential slot, got %v", perr)
+	}
+}
+
 func TestFileCanaryRejectsNonRegularMarkerPath(t *testing.T) {
 	withDeviceStorageTestHome(t)
 	// A leftover DIRECTORY occupies the .file-backend marker path. A first-time
@@ -271,7 +292,7 @@ func TestFileCanaryRejectsNonRegularMarkerPath(t *testing.T) {
 	stubStorageCanaries(t, fmt.Errorf("%w: no session", errDesktopKeyringSessionUnavailable))
 
 	_, perr := probeDeviceCredentialStorage()
-	if perr == nil || !strings.Contains(perr.Error(), "marker path is not writable") {
+	if perr == nil || !strings.Contains(perr.Error(), "not a regular file") {
 		t.Fatalf("expected the probe to reject a non-regular marker path before pairing, got %v", perr)
 	}
 }

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/zalando/go-keyring"
 )
 
 // The headless fallback + code-burn guard: a broken keyring must fail BEFORE the
@@ -110,6 +112,63 @@ func TestProbeShortCircuitsWhenAFileCredentialExists(t *testing.T) {
 	got, ok, err := readDeviceCredential()
 	if err != nil || !ok || got != cred {
 		t.Fatalf("file credential not readable: got=%q ok=%v err=%v", got, ok, err)
+	}
+}
+
+func TestStalePendingFileDoesNotMaskKeyringCurrentCredential(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// Desktop-paired install: the CURRENT credential lives in the (mocked) OS
+	// keyring. An interrupted headless re-pair then left only a PENDING file.
+	keyringCred := generateTestDeviceCredential(t)
+	if err := keyring.Set(deviceCredentialService, secretUser(), keyringCred); err != nil {
+		t.Fatalf("seed keyring current credential: %v", err)
+	}
+	pendingCred := "hanova-dev-v1.CCCCCCCCCCCCCCCCCCCCCC.DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
+	if err := deviceSecretFileSet(deviceCredentialPendingService, pendingCred); err != nil {
+		t.Fatalf("seed stale pending file: %v", err)
+	}
+
+	// The current slot must STILL resolve to the keyring credential — the stale
+	// pending file is a different slot and must not switch the current read.
+	got, ok, err := readDeviceCredential()
+	if err != nil || !ok || got != keyringCred {
+		t.Fatalf("current credential masked by stale pending file: got=%q ok=%v err=%v", got, ok, err)
+	}
+	// The pending slot resolves to the file (its own backend), independently.
+	gotP, okP, errP := readPendingDeviceCredential()
+	if errP != nil || !okP || gotP != pendingCred {
+		t.Fatalf("pending slot not readable from file: got=%q ok=%v err=%v", gotP, okP, errP)
+	}
+}
+
+func TestProbeRejectsAnExistingFileInstallWithAnUnwritableStore(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	cred := generateTestDeviceCredential(t)
+	if err := deviceSecretFileSet(deviceCredentialService, cred); err != nil {
+		t.Fatalf("seed file credential: %v", err)
+	}
+	// The file store has gone read-only between runs; the canary must catch it
+	// BEFORE a pairing spends the one-time code.
+	prevCanary := deviceStorageFileCanary
+	deviceStorageFileCanary = func() error { return fmt.Errorf("read-only file system") }
+	t.Cleanup(func() { deviceStorageFileCanary = prevCanary })
+	deviceStorageKeyringCanary = func() error { t.Fatal("keyring canary must not run for a file install"); return nil }
+
+	_, err := probeDeviceCredentialStorage()
+	if err == nil || !strings.Contains(err.Error(), "not writable") {
+		t.Fatalf("expected an unwritable-file-store error, got %v", err)
+	}
+}
+
+func TestProbeFallsBackWhenNoSecretServiceProviderExists(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// "No Secret Service provider installed" (errDesktopKeyringUnavailable) is
+	// the container/LXC signature, distinct from "no session" — both mean no
+	// keyring EXISTS, so both fall back to files rather than erroring.
+	stubStorageCanaries(t, fmt.Errorf("%w: org.freedesktop.secrets not provided", errDesktopKeyringUnavailable))
+	probe, err := probeDeviceCredentialStorage()
+	if err != nil || probe.mode != "file" {
+		t.Fatalf("expected file fallback for a missing Secret Service provider, got mode=%q err=%v", probe.mode, err)
 	}
 }
 

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -433,6 +433,46 @@ func TestResumeRefusesFileFallbackWhenKeyringIsLocked(t *testing.T) {
 	}
 }
 
+func TestResumeFileBackedInstallSkipsKeyringEvenWhenLocked(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// An established file-backed install (marker present) crashed with a pending
+	// file, then runs where Secret Service exists but is LOCKED. Resume must read
+	// the file pending and promote it — the keyring must not be probed at all.
+	if err := writeDeviceFileBackendMarker(); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+	pendingCred := generateTestDeviceCredential(t)
+	if err := deviceSecretFileSet(deviceCredentialPendingService, pendingCred); err != nil {
+		t.Fatalf("seed pending file: %v", err)
+	}
+	// If resume wrongly probed the keyring, this locked preflight would abort it.
+	origPreflight := deviceCredentialPreflight
+	deviceCredentialPreflight = func() error { return desktopKeyringLockedError("locked; must not be consulted") }
+	origActivate := activateDeviceV1ForPairing
+	activated := ""
+	activateDeviceV1ForPairing = func(_, _, cred string) error { activated = cred; return nil }
+	t.Cleanup(func() {
+		deviceCredentialPreflight = origPreflight
+		activateDeviceV1ForPairing = origActivate
+	})
+
+	cfg := runtimeConfig{PendingSecureBaseURL: "https://relay:8792", PendingSpkiPin: "PIN"}
+	resumed, err := resumePendingActivation(&cfg, func(*runtimeConfig) error { return nil })
+	if err != nil || !resumed {
+		t.Fatalf("file-backed resume must ignore a locked keyring: resumed=%v err=%v", resumed, err)
+	}
+	if activated != pendingCred {
+		t.Fatalf("resume activated the wrong credential: %q", activated)
+	}
+	if deviceSecretFileExists(deviceCredentialPendingService) {
+		t.Fatal("pending file not cleared after promotion")
+	}
+	got, ok, err := readDeviceCredential()
+	if err != nil || !ok || got != pendingCred {
+		t.Fatalf("current credential not the promoted file pending: got=%q ok=%v err=%v", got, ok, err)
+	}
+}
+
 func TestResumeSurfacesMalformedKeyringPending(t *testing.T) {
 	withDeviceStorageTestHome(t)
 	// The keyring pending slot exists but is corrupted/partial. Resume must

--- a/cli/device_credential_store.go
+++ b/cli/device_credential_store.go
@@ -67,6 +67,22 @@ func promotePendingDeviceCredential() error {
 	return deletePendingDeviceCredential()
 }
 
+// promotePendingFileCredential finalizes a FILE-backed pending credential
+// explicitly (used by resume): it writes the current credential file — which
+// also lays down the file-backend marker on first commit — and drops the pending
+// file. This finishes a headless-interrupted pairing in file mode without a
+// storage probe or the process-forced flag, so a now-usable keyring can neither
+// reroute nor delete the credential.
+func promotePendingFileCredential(pending string) error {
+	if parseDeviceCredential(pending) == nil {
+		return fmt.Errorf("refusing to store a malformed device credential")
+	}
+	if err := deviceSecretFileSet(deviceCredentialService, pending); err != nil {
+		return err
+	}
+	return deviceSecretFileDelete(deviceCredentialPendingService)
+}
+
 func readCredentialSlot(service string) (string, bool, error) {
 	value, err := secretGet(service)
 	if err != nil {

--- a/cli/device_credential_store.go
+++ b/cli/device_credential_store.go
@@ -58,6 +58,18 @@ func promotePendingDeviceCredential() error {
 	if !ok {
 		return fmt.Errorf("no pending credential to promote")
 	}
+	// The current slot inherits the pending slot's backend: a headless pairing
+	// resumed in a fresh process (probe never ran, so nothing is forced) must
+	// promote file -> file instead of suddenly requiring an OS keyring.
+	if _, testMode := testSecretDir(); !testMode && deviceSecretFileExists(deviceCredentialPendingService) {
+		if parseDeviceCredential(pending) == nil {
+			return fmt.Errorf("refusing to store a malformed device credential")
+		}
+		if err := deviceSecretFileSet(deviceCredentialService, pending); err != nil {
+			return err
+		}
+		return deviceSecretFileDelete(deviceCredentialPendingService)
+	}
 	if err := writeDeviceCredential(pending); err != nil {
 		return err
 	}

--- a/cli/device_credential_store.go
+++ b/cli/device_credential_store.go
@@ -58,18 +58,9 @@ func promotePendingDeviceCredential() error {
 	if !ok {
 		return fmt.Errorf("no pending credential to promote")
 	}
-	// The current slot inherits the pending slot's backend: a headless pairing
-	// resumed in a fresh process (probe never ran, so nothing is forced) must
-	// promote file -> file instead of suddenly requiring an OS keyring.
-	if _, testMode := testSecretDir(); !testMode && deviceSecretFileExists(deviceCredentialPendingService) {
-		if parseDeviceCredential(pending) == nil {
-			return fmt.Errorf("refusing to store a malformed device credential")
-		}
-		if err := deviceSecretFileSet(deviceCredentialService, pending); err != nil {
-			return err
-		}
-		return deviceSecretFileDelete(deviceCredentialPendingService)
-	}
+	// Backend is install-wide (see device_credential_storage.go), so current and
+	// pending always resolve to the same store — a plain write+delete promotes
+	// correctly whether this install uses the keyring or the file backend.
 	if err := writeDeviceCredential(pending); err != nil {
 		return err
 	}

--- a/cli/keyring_generic.go
+++ b/cli/keyring_generic.go
@@ -54,11 +54,11 @@ func secretGet(service string) (string, error) {
 		return strings.TrimSpace(string(data)), nil
 	}
 	// Headless installs keep device credentials in private files (see
-	// device_credential_storage.go). The decision is per slot — THIS slot's file
-	// existing (or probe-forced file mode) routes to the file backend, so a stale
-	// pending file can never mask a valid keyring credential in the current slot,
-	// and no dbus probing happens on the hot read path.
-	if deviceSecretFileBacked(service) {
+	// device_credential_storage.go). This is one install-wide backend decision
+	// (an explicit marker or the process-forced flag), so a leftover credential
+	// file can never redirect a slot on a keyring install, and no dbus probing
+	// happens on the hot read path.
+	if deviceSecretFileBacked() {
 		value, err := deviceSecretFileGet(service)
 		if err != nil {
 			return "", err
@@ -85,7 +85,7 @@ func secretSet(service, value string) error {
 		}
 		return os.WriteFile(testSecretPath(dir, service), []byte(value), 0o600)
 	}
-	if deviceSecretFileBacked(service) {
+	if deviceSecretFileBacked() {
 		return deviceSecretFileSet(service, value)
 	}
 	if err := deviceCredentialPreflight(); err != nil {
@@ -102,7 +102,7 @@ func secretDelete(service string) error {
 		}
 		return nil
 	}
-	if deviceSecretFileBacked(service) {
+	if deviceSecretFileBacked() {
 		return deviceSecretFileDelete(service)
 	}
 	if err := deviceCredentialPreflight(); err != nil {

--- a/cli/keyring_generic.go
+++ b/cli/keyring_generic.go
@@ -53,6 +53,16 @@ func secretGet(service string) (string, error) {
 		}
 		return strings.TrimSpace(string(data)), nil
 	}
+	// Headless installs keep device credentials in private files (see
+	// device_credential_storage.go); the file's existence is the mode marker, so
+	// no dbus probing happens on the hot read path.
+	if deviceSecretFileModeActive() {
+		value, err := deviceSecretFileGet(service)
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(value), nil
+	}
 	if err := deviceCredentialPreflight(); err != nil {
 		return "", err
 	}
@@ -73,6 +83,9 @@ func secretSet(service, value string) error {
 		}
 		return os.WriteFile(testSecretPath(dir, service), []byte(value), 0o600)
 	}
+	if deviceSecretFileModeActive() {
+		return deviceSecretFileSet(service, value)
+	}
 	if err := deviceCredentialPreflight(); err != nil {
 		return err
 	}
@@ -86,6 +99,9 @@ func secretDelete(service string) error {
 			return err
 		}
 		return nil
+	}
+	if deviceSecretFileModeActive() {
+		return deviceSecretFileDelete(service)
 	}
 	if err := deviceCredentialPreflight(); err != nil {
 		return err

--- a/cli/keyring_generic.go
+++ b/cli/keyring_generic.go
@@ -54,9 +54,11 @@ func secretGet(service string) (string, error) {
 		return strings.TrimSpace(string(data)), nil
 	}
 	// Headless installs keep device credentials in private files (see
-	// device_credential_storage.go); the file's existence is the mode marker, so
-	// no dbus probing happens on the hot read path.
-	if deviceSecretFileModeActive() {
+	// device_credential_storage.go). The decision is per slot — THIS slot's file
+	// existing (or probe-forced file mode) routes to the file backend, so a stale
+	// pending file can never mask a valid keyring credential in the current slot,
+	// and no dbus probing happens on the hot read path.
+	if deviceSecretFileBacked(service) {
 		value, err := deviceSecretFileGet(service)
 		if err != nil {
 			return "", err
@@ -83,7 +85,7 @@ func secretSet(service, value string) error {
 		}
 		return os.WriteFile(testSecretPath(dir, service), []byte(value), 0o600)
 	}
-	if deviceSecretFileModeActive() {
+	if deviceSecretFileBacked(service) {
 		return deviceSecretFileSet(service, value)
 	}
 	if err := deviceCredentialPreflight(); err != nil {
@@ -100,7 +102,7 @@ func secretDelete(service string) error {
 		}
 		return nil
 	}
-	if deviceSecretFileModeActive() {
+	if deviceSecretFileBacked(service) {
 		return deviceSecretFileDelete(service)
 	}
 	if err := deviceCredentialPreflight(); err != nil {

--- a/cli/pairing_flow.go
+++ b/cli/pairing_flow.go
@@ -137,24 +137,14 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 	// promotion.
 	var pending string
 	fileMode := false
-	kp, kok, kerr := readKeyringDeviceSecret(deviceCredentialPendingService)
-	switch {
-	case kok && parseDeviceCredential(kp) != nil:
-		// A real keyring pending wins over any orphan .pending file.
-		pending = kp
-	case kok:
-		// The keyring pending slot exists but is malformed (corrupted/partial):
-		// surface it rather than silently resuming an orphan file behind it.
-		return false, fmt.Errorf("keyring pending credential is malformed")
-	case kerr != nil && !isDesktopKeyringSessionUnavailableError(kerr) && !isDesktopKeyringUnavailableError(kerr):
-		// The keyring EXISTS but is unreadable (locked/uninitialized/other): a real
-		// keyring pending may be hidden behind it, so refuse to resume a file and
-		// silently downgrade. Only a genuinely absent keyring (headless) or an
-		// empty-but-readable one (below) may fall back to the file.
-		return false, kerr
-	case deviceSecretFileExists(deviceCredentialPendingService):
-		// Keyring empty (not-found) or genuinely unreachable (headless): the file
-		// holds the interrupted headless pairing.
+	if deviceSecretFileBacked() {
+		// Established file-backed install (marker present, or forced this process):
+		// the pending slot is a file. Do NOT probe the keyring — a locked/present
+		// Secret Service on this box is irrelevant and must not block resuming a
+		// valid file pending.
+		if !deviceSecretFileExists(deviceCredentialPendingService) {
+			return false, nil
+		}
 		raw, err := deviceSecretFileGet(deviceCredentialPendingService)
 		if err != nil {
 			return false, err
@@ -164,8 +154,38 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 		}
 		pending = raw
 		fileMode = true
-	default:
-		return false, kerr
+	} else {
+		// No marker: the install may be keyring-backed (desktop, possibly with an
+		// orphan file) or a headless-interrupted pairing whose marker is not
+		// written until promotion. Prefer a real keyring pending over an orphan
+		// file; only an absent/empty keyring falls back to the file.
+		kp, kok, kerr := readKeyringDeviceSecret(deviceCredentialPendingService)
+		switch {
+		case kok && parseDeviceCredential(kp) != nil:
+			pending = kp
+		case kok:
+			// Keyring pending present but malformed: surface it rather than
+			// silently resuming an orphan file behind it.
+			return false, fmt.Errorf("keyring pending credential is malformed")
+		case kerr != nil && !isDesktopKeyringSessionUnavailableError(kerr) && !isDesktopKeyringUnavailableError(kerr):
+			// Keyring EXISTS but is unreadable (locked/uninitialized): a real
+			// keyring pending may hide behind it — refuse to downgrade to a file.
+			return false, kerr
+		case deviceSecretFileExists(deviceCredentialPendingService):
+			// Keyring empty (not-found) or genuinely unreachable (headless): the
+			// file holds the interrupted headless pairing.
+			raw, err := deviceSecretFileGet(deviceCredentialPendingService)
+			if err != nil {
+				return false, err
+			}
+			if parseDeviceCredential(raw) == nil {
+				return false, nil
+			}
+			pending = raw
+			fileMode = true
+		default:
+			return false, kerr
+		}
 	}
 	if err := activateDeviceV1ForPairing(base, pin, pending); err != nil {
 		return false, err

--- a/cli/pairing_flow.go
+++ b/cli/pairing_flow.go
@@ -52,6 +52,14 @@ func runSecurePairing(bootstrapURL, code string, cfg *runtimeConfig, saveCfg fun
 		return "", fmt.Errorf("could not establish an install id: %w", err)
 	}
 
+	// Prove credential storage works BEFORE talking to the relay: /pair/v1/finish
+	// consumes the owner's one-time code, so a broken keyring discovered after the
+	// fact would burn the code with nothing stored. Callers probe earlier for the
+	// user-facing message; this guard keeps the invariant for every caller.
+	if _, err := probeDeviceCredentialStorage(); err != nil {
+		return "", fmt.Errorf("cannot store a device credential on this system (the code was not used): %w", err)
+	}
+
 	prov, err := pairDeviceV1ForPairing(nil, bootstrapURL, code, deviceMetadata{
 		Name:            info.name,
 		Platform:        info.platform,

--- a/cli/pairing_flow.go
+++ b/cli/pairing_flow.go
@@ -127,15 +127,19 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 		// access): leave any pending slot for a full re-pair rather than guessing.
 		return false, nil
 	}
-	// Resume in the SAME backend that holds the pending credential, chosen without
-	// a storage probe: a headless-interrupted pairing left the pending slot in a
-	// file with no marker yet (the marker is written at promotion), and a probe
-	// here would reroute reads to a now-usable keyring — or clean the file — and
-	// lose the already-activated credential. A desktop-interrupted pairing left it
-	// in the keyring, read via the normal (marker/keyring) path.
-	fileMode := deviceSecretFileExists(deviceCredentialPendingService)
+	// Choose the backend that actually holds the interrupted pairing, without a
+	// storage probe (a probe could reroute reads to a now-usable keyring and lose
+	// a headless file pending). Prefer a real KEYRING pending: a desktop re-pair
+	// stores its pending there, and it must win over any orphan .pending FILE from
+	// an aborted earlier headless attempt. Only when the keyring holds no pending
+	// (or is unreachable, i.e. headless) do we resume from the file — that is the
+	// genuine headless-interrupted pairing whose marker is not written until
+	// promotion.
 	var pending string
-	if fileMode {
+	fileMode := false
+	if kp, ok, _ := readKeyringDeviceSecret(deviceCredentialPendingService); ok && parseDeviceCredential(kp) != nil {
+		pending = kp
+	} else if deviceSecretFileExists(deviceCredentialPendingService) {
 		raw, err := deviceSecretFileGet(deviceCredentialPendingService)
 		if err != nil {
 			return false, err
@@ -144,12 +148,9 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 			return false, nil // malformed residue: leave it for a full re-pair
 		}
 		pending = raw
+		fileMode = true
 	} else {
-		p, ok, err := readPendingDeviceCredential()
-		if err != nil || !ok {
-			return false, err
-		}
-		pending = p
+		return false, nil
 	}
 	if err := activateDeviceV1ForPairing(base, pin, pending); err != nil {
 		return false, err
@@ -166,8 +167,16 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 		if err := promotePendingFileCredential(pending); err != nil {
 			return false, err
 		}
-	} else if err := promotePendingDeviceCredential(); err != nil {
-		return false, err
+	} else {
+		// Keyring-backed: promote the pending we already read and drop the keyring
+		// pending slot. An orphan .pending FILE (if any) is left untouched — it is
+		// harmless residue that marker-based reads never consult.
+		if err := writeDeviceCredential(pending); err != nil {
+			return false, err
+		}
+		if err := deletePendingDeviceCredential(); err != nil {
+			return false, err
+		}
 	}
 	cfg.PendingSecureBaseURL = ""
 	cfg.PendingSpkiPin = ""

--- a/cli/pairing_flow.go
+++ b/cli/pairing_flow.go
@@ -127,18 +127,31 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 		// access): leave any pending slot for a full re-pair rather than guessing.
 		return false, nil
 	}
-	// Re-establish the storage backend for this process before reading the
-	// pending credential: a headless install keeps the pending slot in a file and
-	// the marker is only written at promotion, so without re-probing here a
-	// resume in a fresh process could not find its own pending credential.
-	if _, err := probeDeviceCredentialStorage(); err != nil {
-		return false, err
+	// Resume in the SAME backend that holds the pending credential, chosen without
+	// a storage probe: a headless-interrupted pairing left the pending slot in a
+	// file with no marker yet (the marker is written at promotion), and a probe
+	// here would reroute reads to a now-usable keyring — or clean the file — and
+	// lose the already-activated credential. A desktop-interrupted pairing left it
+	// in the keyring, read via the normal (marker/keyring) path.
+	fileMode := deviceSecretFileExists(deviceCredentialPendingService)
+	var pending string
+	if fileMode {
+		raw, err := deviceSecretFileGet(deviceCredentialPendingService)
+		if err != nil {
+			return false, err
+		}
+		if parseDeviceCredential(raw) == nil {
+			return false, nil // malformed residue: leave it for a full re-pair
+		}
+		pending = raw
+	} else {
+		p, ok, err := readPendingDeviceCredential()
+		if err != nil || !ok {
+			return false, err
+		}
+		pending = p
 	}
-	pending, ok, err := readPendingDeviceCredential()
-	if err != nil || !ok {
-		return false, err
-	}
-	if err := activateDeviceV1(base, pin, pending); err != nil {
+	if err := activateDeviceV1ForPairing(base, pin, pending); err != nil {
 		return false, err
 	}
 	// Same ordering as runSecurePairing: save the live endpoint before promoting
@@ -149,7 +162,11 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 	if err := saveCfg(cfg); err != nil {
 		return false, err
 	}
-	if err := promotePendingDeviceCredential(); err != nil {
+	if fileMode {
+		if err := promotePendingFileCredential(pending); err != nil {
+			return false, err
+		}
+	} else if err := promotePendingDeviceCredential(); err != nil {
 		return false, err
 	}
 	cfg.PendingSecureBaseURL = ""

--- a/cli/pairing_flow.go
+++ b/cli/pairing_flow.go
@@ -137,9 +137,20 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 	// promotion.
 	var pending string
 	fileMode := false
-	if kp, ok, _ := readKeyringDeviceSecret(deviceCredentialPendingService); ok && parseDeviceCredential(kp) != nil {
+	kp, kok, kerr := readKeyringDeviceSecret(deviceCredentialPendingService)
+	switch {
+	case kok && parseDeviceCredential(kp) != nil:
+		// A real keyring pending wins over any orphan .pending file.
 		pending = kp
-	} else if deviceSecretFileExists(deviceCredentialPendingService) {
+	case kerr != nil && !isDesktopKeyringSessionUnavailableError(kerr) && !isDesktopKeyringUnavailableError(kerr):
+		// The keyring EXISTS but is unreadable (locked/uninitialized/other): a real
+		// keyring pending may be hidden behind it, so refuse to resume a file and
+		// silently downgrade. Only a genuinely absent keyring (headless) or an
+		// empty-but-readable one (below) may fall back to the file.
+		return false, kerr
+	case deviceSecretFileExists(deviceCredentialPendingService):
+		// Keyring empty (not-found) or genuinely unreachable (headless): the file
+		// holds the interrupted headless pairing.
 		raw, err := deviceSecretFileGet(deviceCredentialPendingService)
 		if err != nil {
 			return false, err
@@ -149,8 +160,8 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 		}
 		pending = raw
 		fileMode = true
-	} else {
-		return false, nil
+	default:
+		return false, kerr
 	}
 	if err := activateDeviceV1ForPairing(base, pin, pending); err != nil {
 		return false, err

--- a/cli/pairing_flow.go
+++ b/cli/pairing_flow.go
@@ -255,6 +255,11 @@ func retireDeviceCredential(cfg *runtimeConfig) {
 	// live endpoint — cannot be resumed after the user chose the legacy/manual path.
 	_ = deleteDeviceCredential()
 	_ = deletePendingDeviceCredential()
+	// Clear the file-backend marker + empty secrets dir too: otherwise a
+	// credential-less install stays classified as file-backed, and a later desktop
+	// re-pair with a healthy keyring would skip the keyring probe and keep storing
+	// device credentials in files.
+	removeDeviceFileStorageResidue()
 	cfg.RelaySecureBaseURL = ""
 	cfg.RelaySpkiPin = ""
 	cfg.PendingSecureBaseURL = ""

--- a/cli/pairing_flow.go
+++ b/cli/pairing_flow.go
@@ -142,6 +142,10 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 	case kok && parseDeviceCredential(kp) != nil:
 		// A real keyring pending wins over any orphan .pending file.
 		pending = kp
+	case kok:
+		// The keyring pending slot exists but is malformed (corrupted/partial):
+		// surface it rather than silently resuming an orphan file behind it.
+		return false, fmt.Errorf("keyring pending credential is malformed")
 	case kerr != nil && !isDesktopKeyringSessionUnavailableError(kerr) && !isDesktopKeyringUnavailableError(kerr):
 		// The keyring EXISTS but is unreadable (locked/uninitialized/other): a real
 		// keyring pending may be hidden behind it, so refuse to resume a file and

--- a/cli/pairing_flow.go
+++ b/cli/pairing_flow.go
@@ -121,15 +121,22 @@ func runSecurePairing(bootstrapURL, code string, cfg *runtimeConfig, saveCfg fun
 // already stored pending (e.g. a crash between activate and promote). Safe to
 // call at setup/doctor start; a no-op when there is no pending credential.
 func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) error) (bool, error) {
+	base, pin := cfg.PendingSecureBaseURL, cfg.PendingSpkiPin
+	if base == "" || pin == "" {
+		// No interrupted pairing to resume (cheap check first, before any keyring
+		// access): leave any pending slot for a full re-pair rather than guessing.
+		return false, nil
+	}
+	// Re-establish the storage backend for this process before reading the
+	// pending credential: a headless install keeps the pending slot in a file and
+	// the marker is only written at promotion, so without re-probing here a
+	// resume in a fresh process could not find its own pending credential.
+	if _, err := probeDeviceCredentialStorage(); err != nil {
+		return false, err
+	}
 	pending, ok, err := readPendingDeviceCredential()
 	if err != nil || !ok {
 		return false, err
-	}
-	base, pin := cfg.PendingSecureBaseURL, cfg.PendingSpkiPin
-	if base == "" || pin == "" {
-		// No pending endpoint to activate against; leave the pending slot for a
-		// full re-pair rather than guessing.
-		return false, nil
 	}
 	if err := activateDeviceV1(base, pin, pending); err != nil {
 		return false, err

--- a/cli/pairing_flow_test.go
+++ b/cli/pairing_flow_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -123,6 +124,31 @@ func TestRetireDeviceCredentialClearsFileBackendMarker(t *testing.T) {
 	}
 	if deviceSecretFileBacked() {
 		t.Fatal("install still classified as file-backed after retiring the credential")
+	}
+}
+
+// Regression: a headless pairing interrupted before promotion leaves a pending
+// FILE with no marker. Retire/purge must remove that orphan file directly (its
+// routed delete would go to the keyring), not leave it — and the empty secrets
+// dir must go too.
+func TestRetireRemovesOrphanPendingFileWithoutMarker(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	if err := deviceSecretFileSet(deviceCredentialPendingService, generateTestDeviceCredential(t)); err != nil {
+		t.Fatalf("seed orphan pending file: %v", err)
+	}
+	if deviceFileBackendMarkerExists() {
+		t.Fatal("a pending write must not create a marker (test premise)")
+	}
+
+	cfg := runtimeConfig{} // no live endpoint → no revoke attempt
+	retireDeviceCredential(&cfg)
+
+	if deviceSecretFileExists(deviceCredentialPendingService) {
+		t.Fatal("orphan pending credential file left on disk after retire")
+	}
+	dir, _ := deviceSecretFileDir()
+	if _, err := os.Stat(dir); err == nil {
+		t.Fatal("secrets dir left behind after retire (orphan residue not fully cleared)")
 	}
 }
 

--- a/cli/pairing_flow_test.go
+++ b/cli/pairing_flow_test.go
@@ -97,6 +97,35 @@ func TestRetireDeviceCredentialClearsPendingWhenLiveEmpty(t *testing.T) {
 	}
 }
 
+// Regression: retiring the device credential on a file-backed install (switch
+// back to the legacy token path) must also drop the .file-backend marker, or the
+// credential-less install stays classified as file-backed and a later desktop
+// re-pair with a healthy keyring would keep storing credentials in files.
+func TestRetireDeviceCredentialClearsFileBackendMarker(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	deviceCredentialFileModeForced = true // headless: writes go to the file backend
+	cred := generateTestDeviceCredential(t)
+	if err := writeDeviceCredential(cred); err != nil {
+		t.Fatalf("seed file-backed install: %v", err)
+	}
+	if !deviceFileBackendMarkerExists() {
+		t.Fatal("setup: expected a file-backend marker after storing a credential")
+	}
+
+	cfg := runtimeConfig{} // no live endpoint → no revoke attempt
+	retireDeviceCredential(&cfg)
+
+	if deviceFileBackendMarkerExists() {
+		t.Fatal("retire left the file-backend marker behind")
+	}
+	if deviceSecretFileExists(deviceCredentialService) {
+		t.Fatal("retire left the current credential file behind")
+	}
+	if deviceSecretFileBacked() {
+		t.Fatal("install still classified as file-backed after retiring the credential")
+	}
+}
+
 // Regression: an IPv6 relay host must stay bracketed when building the secure
 // endpoint URL, or activation and later functional calls get an invalid host.
 func TestSecureBaseFromBootstrapBracketsIPv6(t *testing.T) {

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -242,14 +242,14 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 		tokenPathRequired := serviceMode || strings.TrimSpace(relayTokenFlag) != ""
 		noKeyringBackend := isDesktopKeyringSessionUnavailableError(tokenStoragePreflightErr) ||
 			isDesktopKeyringUnavailableError(tokenStoragePreflightErr)
-		// Only downgrade the missing-keyring error to a warning when secure v1
-		// pairing is CONFIRMED usable: the v1 device credential lives in a file, so
-		// no keyring is needed. If the relay is still pre-v1, runSetupPairingFlow
-		// falls back to the legacy /pair exchange, which returns a shared token
-		// that must be written to the (unavailable) keyring — after the one-time
-		// code was already consumed. Keeping it fatal there fails safe.
-		if !tokenPathRequired && noKeyringBackend && deviceCredentialStorageViable() &&
-			setupRelaySupportsSecurePairing(relayURLFlag, cfg) {
+		// The default onboarding path is secure device pairing, which brings its
+		// own file-backed credential storage — no keyring needed. So a missing
+		// keyring must not abort here; let the wizard reach the pairing stage,
+		// where the relay URL is known. The legacy /pair fallback (which DOES need
+		// a keyring token store) is guarded there, failing before it consumes a
+		// one-time code — see runSetupPairingFlow. Deciding it here is impossible
+		// for the plain interactive flow, which discovers the relay URL later.
+		if !tokenPathRequired && noKeyringBackend && deviceCredentialStorageViable() {
 			printRelayTokenStorageSetupWarning(tokenStoragePreflightErr)
 			printHumanInfo("No OS keyring is reachable here — this device will pair with secure file-backed storage instead of a shared token.")
 			tokenStoragePreflightErr = nil

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -242,7 +242,14 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 		tokenPathRequired := serviceMode || strings.TrimSpace(relayTokenFlag) != ""
 		noKeyringBackend := isDesktopKeyringSessionUnavailableError(tokenStoragePreflightErr) ||
 			isDesktopKeyringUnavailableError(tokenStoragePreflightErr)
-		if !tokenPathRequired && noKeyringBackend && deviceCredentialStorageViable() {
+		// Only downgrade the missing-keyring error to a warning when secure v1
+		// pairing is CONFIRMED usable: the v1 device credential lives in a file, so
+		// no keyring is needed. If the relay is still pre-v1, runSetupPairingFlow
+		// falls back to the legacy /pair exchange, which returns a shared token
+		// that must be written to the (unavailable) keyring — after the one-time
+		// code was already consumed. Keeping it fatal there fails safe.
+		if !tokenPathRequired && noKeyringBackend && deviceCredentialStorageViable() &&
+			setupRelaySupportsSecurePairing(relayURLFlag, cfg) {
 			printRelayTokenStorageSetupWarning(tokenStoragePreflightErr)
 			printHumanInfo("No OS keyring is reachable here — this device will pair with secure file-backed storage instead of a shared token.")
 			tokenStoragePreflightErr = nil

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -223,6 +223,9 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			}
 		}
 	}
+	// Set when the missing-keyring error is downgraded below: the legacy /pair
+	// token store is unavailable, so the pairing stage must not fall back to it.
+	legacyTokenStoreUnavailable := false
 	if tokenStoragePreflightErr == nil {
 		if savedToken, err := readRelayAuthTokenForSetup(); err == nil && strings.TrimSpace(savedToken) != "" {
 			savedTokenBeforeSetup = strings.TrimSpace(savedToken)
@@ -253,6 +256,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			printRelayTokenStorageSetupWarning(tokenStoragePreflightErr)
 			printHumanInfo("No OS keyring is reachable here — this device will pair with secure file-backed storage instead of a shared token.")
 			tokenStoragePreflightErr = nil
+			legacyTokenStoreUnavailable = true
 		} else {
 			printRelayTokenStorageSetupWarning(tokenStoragePreflightErr)
 			printHumanErr("%s", relayAuthTokenSetupSaveError(tokenStoragePreflightErr))
@@ -748,7 +752,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 		case setupStagePairing:
 			steps := buildSetupPairingWizardSteps()
 			renderSetupStep(os.Stdout, steps.Pairing, steps.Total, "Pair this device")
-			pairedToken, err := runSetupPairingFlow(reader, os.Stdout, paths, &cfg)
+			pairedToken, err := runSetupPairingFlow(reader, os.Stdout, paths, &cfg, legacyTokenStoreUnavailable)
 			if err == errSetupBack {
 				stage = pairingBackStage
 				continue

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -234,9 +234,23 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 			printRelayTokenStorageSetupWarning(err)
 		}
 	} else if !setupSecureStorageRecoveryAvailableNow(tokenStoragePreflightErr) {
-		printRelayTokenStorageSetupWarning(tokenStoragePreflightErr)
-		printHumanErr("%s", relayAuthTokenSetupSaveError(tokenStoragePreflightErr))
-		return 1
+		// A missing OS keyring is only fatal when a relay TOKEN must actually be
+		// stored. The default onboarding path is secure device pairing, which
+		// brings its own file-backed credential storage (device_credential_storage.go),
+		// so a headless box (container/SSH with no Secret Service) must still reach
+		// the pairing stage instead of exiting here on the legacy-token preflight.
+		tokenPathRequired := serviceMode || strings.TrimSpace(relayTokenFlag) != ""
+		noKeyringBackend := isDesktopKeyringSessionUnavailableError(tokenStoragePreflightErr) ||
+			isDesktopKeyringUnavailableError(tokenStoragePreflightErr)
+		if !tokenPathRequired && noKeyringBackend && deviceCredentialStorageViable() {
+			printRelayTokenStorageSetupWarning(tokenStoragePreflightErr)
+			printHumanInfo("No OS keyring is reachable here — this device will pair with secure file-backed storage instead of a shared token.")
+			tokenStoragePreflightErr = nil
+		} else {
+			printRelayTokenStorageSetupWarning(tokenStoragePreflightErr)
+			printHumanErr("%s", relayAuthTokenSetupSaveError(tokenStoragePreflightErr))
+			return 1
+		}
 	}
 	if existingToken == "" {
 		existingToken = savedTokenBeforeSetup

--- a/cli/setup_noninteractive_test.go
+++ b/cli/setup_noninteractive_test.go
@@ -824,3 +824,55 @@ func TestRunSetupNonInteractivePairedInstallHonorsDeviceCredential(t *testing.T)
 		t.Fatalf("expected the device-path verify message:\n%s", output)
 	}
 }
+
+func TestRunSetupNonInteractivePairedInstallHonorsDeviceCredentialWithoutKeyring(t *testing.T) {
+	// Headless parity: a paired install on a box with no Secret Service must still
+	// sync clients over the device transport, not fail on the legacy-token keyring
+	// preflight (the paired-device check runs BEFORE that failure).
+	withClientRuntimeAvailability(t, map[string]bool{"antigravity": true})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_TEST_SECRET_DIR", t.TempDir())
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	origPreflight := relayAuthTokenSetupPreflightForSetup
+	relayAuthTokenSetupPreflightForSetup = func() error {
+		return desktopKeyringSessionUnavailableError("no session bus in this shell")
+	}
+	origVerify := verifyDeviceHealth
+	verifyDeviceHealth = func(runtimeConfig) bool { return false }
+	t.Cleanup(func() {
+		relayAuthTokenSetupPreflightForSetup = origPreflight
+		verifyDeviceHealth = origVerify
+	})
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	const validCred = "hanova-dev-v1.AAAAAAAAAAAAAAAAAAAAAA.BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+	if err := writeDeviceCredential(validCred); err != nil {
+		t.Fatalf("writeDeviceCredential() error: %v", err)
+	}
+	if err := saveConfig(paths, runtimeConfig{
+		HAHost:             "192.168.1.5",
+		HAURL:              "http://192.168.1.5:8123",
+		RelayBaseURL:       "http://192.168.1.5:8791",
+		RelaySecureBaseURL: "https://192.168.1.5:8792",
+		RelaySpkiPin:       "pin",
+	}); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+
+	_, output := captureCommandOutput(t, func() int {
+		return runSetup(paths, []string{"antigravity", "--non-interactive"})
+	})
+	if strings.Contains(output, "missing relay auth token") ||
+		strings.Contains(output, "secure storage unavailable") && strings.Contains(output, "save relay token") {
+		t.Fatalf("headless paired install wrongly hit the legacy-token keyring gate:\n%s", output)
+	}
+	if !strings.Contains(output, "could not be verified") {
+		t.Fatalf("expected the device-path verify message (paired check must precede the token preflight):\n%s", output)
+	}
+}

--- a/cli/setup_pairing.go
+++ b/cli/setup_pairing.go
@@ -159,6 +159,23 @@ func pairingRetryAfterSeconds(header string) int {
 	return seconds
 }
 
+// setupRelaySupportsSecurePairing reports whether the relay at the flag/config
+// URL answers /pair/v1/info — i.e. secure device pairing (file-backed credential,
+// no keyring) is usable. Used to decide that a missing relay-token keyring must
+// not abort setup: only true when the legacy /pair token fallback (which needs
+// the keyring) will NOT be reached. An unknown/unset URL returns false (fail
+// safe: keep the missing-keyring error fatal rather than risk consuming a code).
+func setupRelaySupportsSecurePairing(relayURLFlag string, cfg runtimeConfig) bool {
+	url := strings.TrimSpace(relayURLFlag)
+	if url == "" {
+		url = strings.TrimSpace(cfg.RelayBaseURL)
+	}
+	if url == "" {
+		return false
+	}
+	return probePairingV1(url)
+}
+
 // probePairingV1 reports whether the relay supports secure device pairing
 // (GET /pair/v1/info). Any error or non-v1 answer returns false so the wizard
 // falls back to the legacy code exchange.

--- a/cli/setup_pairing.go
+++ b/cli/setup_pairing.go
@@ -30,7 +30,7 @@ var errSetupDevicePaired = errors.New("device paired securely")
 // /pair/v1 (or a test with no v1 endpoint) transparently uses the old path.
 var probePairingV1ForSetup = probePairingV1
 var securePairForSetup = runSecurePairing
-var relayReachableForSetup = relayReachable
+var probePairingV1DetailedForSetup = probePairingV1Detailed
 
 type relayPairingRateLimitError struct {
 	retryAfterSeconds int
@@ -160,22 +160,30 @@ func pairingRetryAfterSeconds(header string) int {
 	return seconds
 }
 
-// relayReachable reports whether the relay bootstrap endpoint answers at all —
-// ANY HTTP response (even 404 from a pre-v1 relay) counts as reachable; only a
-// connection-level failure (refused/timeout/DNS) is unreachable. Used to tell a
-// genuinely pre-v1 relay apart from one that is merely still starting.
-func relayReachable(relayBaseURL string) bool {
+// probePairingV1Detailed probes GET /pair/v1/info and reports both whether the
+// relay supports secure device pairing (supported) and whether it answered at
+// all (reachable). This tells three cases apart that probePairingV1's bool
+// collapses: v1 supported, reachable-but-pre-v1 (e.g. 404), and unreachable
+// (connection failure). Any HTTP response — even 404 — counts as reachable.
+func probePairingV1Detailed(relayBaseURL string) (supported bool, reachable bool) {
 	req, err := http.NewRequest(http.MethodGet, strings.TrimRight(relayBaseURL, "/")+"/pair/v1/info", nil)
 	if err != nil {
-		return false
+		return false, false
 	}
 	req.URL.User = nil
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return false
+		return false, false
 	}
-	_ = resp.Body.Close()
-	return true
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false, true
+	}
+	body, err := readAllLimited(resp.Body, maxRelayPairingResponseBytes)
+	if err != nil {
+		return false, true
+	}
+	return decodePairInfo(body), true
 }
 
 // probePairingV1 reports whether the relay supports secure device pairing
@@ -226,17 +234,22 @@ func runSetupPairingFlow(reader *bufio.Reader, out io.Writer, paths runtimePaths
 	// one-time code, rather than after the exchange fails to store the token.
 	secure := probePairingV1ForSetup(cfg.RelayBaseURL)
 	if !secure && legacyTokenStoreUnavailable {
-		// probePairingV1 returns false for ANY failure — a genuine pre-v1 relay,
-		// but also a transient one (still starting / momentarily unreachable). Only
-		// a REACHABLE relay that definitively lacks v1 is "too old"; a transient
-		// failure must not strand a headless setup, so surface a retry hint instead
-		// and spend no code either way.
-		if relayReachableForSetup(cfg.RelayBaseURL) {
+		// probePairingV1 returns false for ANY failure — a genuine pre-v1 relay, a
+		// transient one (still starting), OR an unreachable one. Re-probe with a
+		// detailed result so the three cases are distinguished: recovered v1 →
+		// proceed securely; reachable-but-pre-v1 → "too old" (no legacy store);
+		// unreachable → retry hint. No one-time code is spent in any case.
+		supported, reachable := probePairingV1DetailedForSetup(cfg.RelayBaseURL)
+		switch {
+		case supported:
+			secure = true // a transient first probe recovered — v1 is available now
+		case reachable:
 			renderSetupErrorLine(out, "This NOVA Relay is too old for secure device pairing, and this system has no key store for the legacy shared token. Update the NOVA Relay App to enable secure pairing.")
 			return "", fmt.Errorf("relay predates secure pairing and no store is available for the legacy token")
+		default:
+			renderSetupErrorLine(out, "Could not reach NOVA Relay to check secure pairing support. Make sure the NOVA Relay app is running, then run setup again.")
+			return "", fmt.Errorf("relay not reachable to determine secure pairing support")
 		}
-		renderSetupErrorLine(out, "Could not reach NOVA Relay to check secure pairing support. Make sure the NOVA Relay app is running, then run setup again.")
-		return "", fmt.Errorf("relay not reachable to determine secure pairing support")
 	}
 
 	renderSetupParagraph(out,

--- a/cli/setup_pairing.go
+++ b/cli/setup_pairing.go
@@ -183,7 +183,10 @@ func probePairingV1(relayBaseURL string) bool {
 	return decodePairInfo(body)
 }
 
-func runSetupPairingFlow(reader *bufio.Reader, out io.Writer, paths runtimePaths, cfg *runtimeConfig) (string, error) {
+// legacyTokenStoreUnavailable is set by the caller when the OS keyring is
+// missing AND no service-token file is configured, so the legacy /pair token
+// (which needs one of those) cannot be stored on this box.
+func runSetupPairingFlow(reader *bufio.Reader, out io.Writer, paths runtimePaths, cfg *runtimeConfig, legacyTokenStoreUnavailable bool) (string, error) {
 	// Storage first: never send the user to fetch a one-time code that a broken
 	// credential backend would burn. Headless systems switch to the private-file
 	// fallback here, with a visible note.
@@ -199,15 +202,13 @@ func runSetupPairingFlow(reader *bufio.Reader, out io.Writer, paths runtimePaths
 	// Determine the pairing mode up front (the relay URL is known here). Secure v1
 	// pairing stores a file-backed device credential and needs no keyring. The
 	// legacy /pair fallback instead returns a SHARED token that must go into the
-	// OS keyring — so on a keyless box (container/SSH) with a pre-v1 relay, fail
-	// NOW, before the pairing UI prompts for and consumes a one-time code.
+	// OS keyring or a service-token file — so on a keyless box with neither AND a
+	// pre-v1 relay, fail NOW, before the pairing UI prompts for and consumes a
+	// one-time code, rather than after the exchange fails to store the token.
 	secure := probePairingV1ForSetup(cfg.RelayBaseURL)
-	if !secure {
-		if err := relayAuthTokenSetupPreflightForSetup(); err != nil &&
-			(isDesktopKeyringSessionUnavailableError(err) || isDesktopKeyringUnavailableError(err)) {
-			renderSetupErrorLine(out, "This NOVA Relay is too old for secure device pairing, and this system has no key store for the legacy shared token. Update the NOVA Relay App to enable secure pairing.")
-			return "", fmt.Errorf("relay predates secure pairing and no keyring is available for the legacy token: %w", err)
-		}
+	if !secure && legacyTokenStoreUnavailable {
+		renderSetupErrorLine(out, "This NOVA Relay is too old for secure device pairing, and this system has no key store for the legacy shared token. Update the NOVA Relay App to enable secure pairing.")
+		return "", fmt.Errorf("relay predates secure pairing and no store is available for the legacy token")
 	}
 
 	renderSetupParagraph(out,

--- a/cli/setup_pairing.go
+++ b/cli/setup_pairing.go
@@ -30,6 +30,7 @@ var errSetupDevicePaired = errors.New("device paired securely")
 // /pair/v1 (or a test with no v1 endpoint) transparently uses the old path.
 var probePairingV1ForSetup = probePairingV1
 var securePairForSetup = runSecurePairing
+var relayReachableForSetup = relayReachable
 
 type relayPairingRateLimitError struct {
 	retryAfterSeconds int
@@ -159,6 +160,24 @@ func pairingRetryAfterSeconds(header string) int {
 	return seconds
 }
 
+// relayReachable reports whether the relay bootstrap endpoint answers at all —
+// ANY HTTP response (even 404 from a pre-v1 relay) counts as reachable; only a
+// connection-level failure (refused/timeout/DNS) is unreachable. Used to tell a
+// genuinely pre-v1 relay apart from one that is merely still starting.
+func relayReachable(relayBaseURL string) bool {
+	req, err := http.NewRequest(http.MethodGet, strings.TrimRight(relayBaseURL, "/")+"/pair/v1/info", nil)
+	if err != nil {
+		return false
+	}
+	req.URL.User = nil
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return true
+}
+
 // probePairingV1 reports whether the relay supports secure device pairing
 // (GET /pair/v1/info). Any error or non-v1 answer returns false so the wizard
 // falls back to the legacy code exchange.
@@ -207,8 +226,17 @@ func runSetupPairingFlow(reader *bufio.Reader, out io.Writer, paths runtimePaths
 	// one-time code, rather than after the exchange fails to store the token.
 	secure := probePairingV1ForSetup(cfg.RelayBaseURL)
 	if !secure && legacyTokenStoreUnavailable {
-		renderSetupErrorLine(out, "This NOVA Relay is too old for secure device pairing, and this system has no key store for the legacy shared token. Update the NOVA Relay App to enable secure pairing.")
-		return "", fmt.Errorf("relay predates secure pairing and no store is available for the legacy token")
+		// probePairingV1 returns false for ANY failure — a genuine pre-v1 relay,
+		// but also a transient one (still starting / momentarily unreachable). Only
+		// a REACHABLE relay that definitively lacks v1 is "too old"; a transient
+		// failure must not strand a headless setup, so surface a retry hint instead
+		// and spend no code either way.
+		if relayReachableForSetup(cfg.RelayBaseURL) {
+			renderSetupErrorLine(out, "This NOVA Relay is too old for secure device pairing, and this system has no key store for the legacy shared token. Update the NOVA Relay App to enable secure pairing.")
+			return "", fmt.Errorf("relay predates secure pairing and no store is available for the legacy token")
+		}
+		renderSetupErrorLine(out, "Could not reach NOVA Relay to check secure pairing support. Make sure the NOVA Relay app is running, then run setup again.")
+		return "", fmt.Errorf("relay not reachable to determine secure pairing support")
 	}
 
 	renderSetupParagraph(out,

--- a/cli/setup_pairing.go
+++ b/cli/setup_pairing.go
@@ -159,23 +159,6 @@ func pairingRetryAfterSeconds(header string) int {
 	return seconds
 }
 
-// setupRelaySupportsSecurePairing reports whether the relay at the flag/config
-// URL answers /pair/v1/info — i.e. secure device pairing (file-backed credential,
-// no keyring) is usable. Used to decide that a missing relay-token keyring must
-// not abort setup: only true when the legacy /pair token fallback (which needs
-// the keyring) will NOT be reached. An unknown/unset URL returns false (fail
-// safe: keep the missing-keyring error fatal rather than risk consuming a code).
-func setupRelaySupportsSecurePairing(relayURLFlag string, cfg runtimeConfig) bool {
-	url := strings.TrimSpace(relayURLFlag)
-	if url == "" {
-		url = strings.TrimSpace(cfg.RelayBaseURL)
-	}
-	if url == "" {
-		return false
-	}
-	return probePairingV1(url)
-}
-
 // probePairingV1 reports whether the relay supports secure device pairing
 // (GET /pair/v1/info). Any error or non-v1 answer returns false so the wizard
 // falls back to the legacy code exchange.
@@ -213,6 +196,20 @@ func runSetupPairingFlow(reader *bufio.Reader, out io.Writer, paths runtimePaths
 		renderSetupParagraph(out, probe.note)
 	}
 
+	// Determine the pairing mode up front (the relay URL is known here). Secure v1
+	// pairing stores a file-backed device credential and needs no keyring. The
+	// legacy /pair fallback instead returns a SHARED token that must go into the
+	// OS keyring — so on a keyless box (container/SSH) with a pre-v1 relay, fail
+	// NOW, before the pairing UI prompts for and consumes a one-time code.
+	secure := probePairingV1ForSetup(cfg.RelayBaseURL)
+	if !secure {
+		if err := relayAuthTokenSetupPreflightForSetup(); err != nil &&
+			(isDesktopKeyringSessionUnavailableError(err) || isDesktopKeyringUnavailableError(err)) {
+			renderSetupErrorLine(out, "This NOVA Relay is too old for secure device pairing, and this system has no key store for the legacy shared token. Update the NOVA Relay App to enable secure pairing.")
+			return "", fmt.Errorf("relay predates secure pairing and no keyring is available for the legacy token: %w", err)
+		}
+	}
+
 	renderSetupParagraph(out,
 		"Open NOVA in the Home Assistant sidebar and click \"Connect a device\" to get a six-digit code.",
 		`If NOVA is not in the sidebar, open the NOVA Relay app page and choose "Open Web UI".`,
@@ -222,8 +219,6 @@ func runSetupPairingFlow(reader *bufio.Reader, out io.Writer, paths runtimePaths
 		return "", err
 	}
 	openAnnouncedBrowserURL(out, haRelayAppPageURL(cfg.HAURL))
-
-	secure := probePairingV1ForSetup(cfg.RelayBaseURL)
 
 	for {
 		entered, err := promptWizardLineFromReader(reader, out, "Six-digit code from NOVA (or type 'manual')", "")

--- a/cli/setup_pairing.go
+++ b/cli/setup_pairing.go
@@ -252,6 +252,14 @@ func runSetupPairingFlow(reader *bufio.Reader, out io.Writer, paths runtimePaths
 				renderSetupErrorLine(out, "The relay's secure identity did not match. Try again; if it repeats, someone may be intercepting the connection.")
 				continue
 			case errors.Is(perr, errRelayNotV1):
+				// The relay turned out not to support v1 mid-flow. Falling through to
+				// the legacy /pair exchange needs a keyring for its shared token; on a
+				// box without one, fail now (same guard as up front) rather than
+				// consuming another code that could never be persisted.
+				if legacyTokenStoreUnavailable {
+					renderSetupErrorLine(out, "This NOVA Relay is too old for secure device pairing, and this system has no key store for the legacy shared token. Update the NOVA Relay App to enable secure pairing.")
+					return "", fmt.Errorf("relay predates secure pairing mid-flow and no store is available for the legacy token")
+				}
 				secure = false // relay changed under us; fall through to legacy
 			default:
 				var rateLimit *relayPairingRateLimitError

--- a/cli/setup_pairing.go
+++ b/cli/setup_pairing.go
@@ -184,6 +184,18 @@ func probePairingV1(relayBaseURL string) bool {
 }
 
 func runSetupPairingFlow(reader *bufio.Reader, out io.Writer, paths runtimePaths, cfg *runtimeConfig) (string, error) {
+	// Storage first: never send the user to fetch a one-time code that a broken
+	// credential backend would burn. Headless systems switch to the private-file
+	// fallback here, with a visible note.
+	probe, probeErr := probeDeviceCredentialStorage()
+	if probeErr != nil {
+		renderSetupErrorLine(out, "This system cannot store the device credential yet: %s", probeErr)
+		return "", fmt.Errorf("device credential storage unavailable: %w", probeErr)
+	}
+	if probe.note != "" {
+		renderSetupParagraph(out, probe.note)
+	}
+
 	renderSetupParagraph(out,
 		"Open NOVA in the Home Assistant sidebar and click \"Connect a device\" to get a six-digit code.",
 		`If NOVA is not in the sidebar, open the NOVA Relay app page and choose "Open Web UI".`,

--- a/cli/setup_pairing_test.go
+++ b/cli/setup_pairing_test.go
@@ -119,8 +119,17 @@ func TestInteractiveSetupStaysFatalOnHeadlessPreV1Relay(t *testing.T) {
 			normalizeHostInput(haServer.URL), haServer.URL, relayServer.URL, "", false)
 		return exitCode
 	})
+	output := stdout + stderr
 	if exitCode != 1 {
-		t.Fatalf("wizard exit = %d, want 1 (pre-v1 relay + no keyring must fail safe)\n%s", exitCode, stdout+stderr)
+		t.Fatalf("wizard exit = %d, want 1 (pre-v1 relay + no keyring must fail safe)\n%s", exitCode, output)
+	}
+	// It must fail with clear guidance BEFORE prompting for a code (the "exit"
+	// input is never consumed), so no one-time code is ever spent.
+	if !strings.Contains(output, "too old for secure device pairing") {
+		t.Fatalf("expected the pre-v1/no-keyring guidance before the code prompt:\n%s", output)
+	}
+	if strings.Contains(output, "Six-digit code") {
+		t.Fatalf("wizard prompted for a code despite unusable storage (code could be consumed):\n%s", output)
 	}
 }
 

--- a/cli/setup_pairing_test.go
+++ b/cli/setup_pairing_test.go
@@ -75,6 +75,55 @@ func TestInteractiveSetupReachesPairingWhenLegacyKeyringUnavailable(t *testing.T
 	}
 }
 
+func TestInteractiveSetupStaysFatalOnHeadlessPreV1Relay(t *testing.T) {
+	// A pre-v1 relay has no /pair/v1/info, so pairing would fall back to the
+	// legacy /pair exchange whose shared token needs the (unavailable) keyring.
+	// The wizard must NOT clear the token-storage error here — failing before the
+	// one-time code is consumed is the safe outcome.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	originalPreflight := relayAuthTokenSetupPreflightForSetup
+	t.Cleanup(func() { relayAuthTokenSetupPreflightForSetup = originalPreflight })
+	relayAuthTokenSetupPreflightForSetup = func() error {
+		return desktopKeyringSessionUnavailableError("no session bus in this shell")
+	}
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	// Pre-v1 relay: /health only, /pair/v1/info 404.
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer relayServer.Close()
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, "exit\n", func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "codex",
+			normalizeHostInput(haServer.URL), haServer.URL, relayServer.URL, "", false)
+		return exitCode
+	})
+	if exitCode != 1 {
+		t.Fatalf("wizard exit = %d, want 1 (pre-v1 relay + no keyring must fail safe)\n%s", exitCode, stdout+stderr)
+	}
+}
+
 func TestExchangeRelayPairingCodeUsesBodyWithoutBearer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		if request.Method != http.MethodPost || request.URL.Path != "/pair" {

--- a/cli/setup_pairing_test.go
+++ b/cli/setup_pairing_test.go
@@ -12,6 +12,69 @@ import (
 	"testing"
 )
 
+func TestInteractiveSetupReachesPairingWhenLegacyKeyringUnavailable(t *testing.T) {
+	// Regression: on a headless box (container/SSH, no Secret Service) the legacy
+	// relay-token keyring preflight fails, but secure device pairing brings its
+	// own file-backed storage. The wizard must reach the pairing stage instead of
+	// exiting at the token-storage gate.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_DEV_ROOT", repoRootForSetupTest(t))
+
+	originalPreflight := relayAuthTokenSetupPreflightForSetup
+	t.Cleanup(func() { relayAuthTokenSetupPreflightForSetup = originalPreflight })
+	relayAuthTokenSetupPreflightForSetup = func() error {
+		return desktopKeyringSessionUnavailableError("no session bus in this shell")
+	}
+
+	haServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer haServer.Close()
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/pair/v1/info":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"data":{"relay_version":"0.7.0","protocol_version":"v1","available":true}}`))
+		case "/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer relayServer.Close()
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+
+	// Reach the six-digit code prompt, then cancel (avoids driving full OPAQUE).
+	input := joinSetupInputs([]string{"", "", "", "", "exit"})
+	exitCode := 0
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		exitCode = interactiveSetup(paths, runtimeConfig{}, loadStateOrDefault(paths), "codex",
+			normalizeHostInput(haServer.URL), haServer.URL, relayServer.URL, "", false)
+		return exitCode
+	})
+	output := stdout + stderr
+	if exitCode == 1 {
+		t.Fatalf("wizard exited at the token-storage gate on a headless box (want it to reach pairing):\n%s", output)
+	}
+	if strings.Contains(output, "save relay token") {
+		t.Fatalf("wizard surfaced the fatal legacy-token save error instead of pairing:\n%s", output)
+	}
+	for _, want := range []string{"file-backed storage", "Pair this device"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("wizard output missing %q (did not reach the pairing path):\n%s", want, output)
+		}
+	}
+}
+
 func TestExchangeRelayPairingCodeUsesBodyWithoutBearer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		if request.Method != http.MethodPost || request.URL.Path != "/pair" {

--- a/cli/setup_pairing_v1_test.go
+++ b/cli/setup_pairing_v1_test.go
@@ -58,3 +58,32 @@ func TestSetupPairingFallsBackToLegacyExchange(t *testing.T) {
 		t.Fatalf("unexpected legacy token %q", token)
 	}
 }
+
+// A relay that advertises v1 but then rejects it mid-flow must not fall through to
+// the legacy /pair exchange on a box with no legacy token store — that would spend
+// the one-time code and only fail later at token persistence.
+func TestSetupPairingMidFlowRelayNotV1FailsSafeWithoutTokenStore(t *testing.T) {
+	origProbe, origSecure, origExchange := probePairingV1ForSetup, securePairForSetup, exchangeRelayPairingCodeForSetup
+	defer func() {
+		probePairingV1ForSetup, securePairForSetup, exchangeRelayPairingCodeForSetup = origProbe, origSecure, origExchange
+	}()
+	probePairingV1ForSetup = func(string) bool { return true } // v1 at first
+	securePairForSetup = func(_, _ string, _ *runtimeConfig, _ func(*runtimeConfig) error, _ pairingClientInfo) (string, error) {
+		return "", errRelayNotV1 // relay turns out pre-v1 mid-flow
+	}
+	exchangeCalled := false
+	exchangeRelayPairingCodeForSetup = func(_ *http.Client, _, _ string) (string, error) {
+		exchangeCalled = true
+		return "legacy-token", nil
+	}
+
+	reader := bufio.NewReader(strings.NewReader("\n473921\n"))
+	cfg := &runtimeConfig{RelayBaseURL: "http://relay:8791"}
+	_, err := runSetupPairingFlow(reader, io.Discard, runtimePaths{}, cfg, true) // legacyTokenStoreUnavailable
+	if err == nil {
+		t.Fatal("expected a fail-safe error on mid-flow errRelayNotV1 with no legacy token store")
+	}
+	if exchangeCalled {
+		t.Fatal("legacy /pair exchange was reached — a one-time code could be consumed with no store to persist the token")
+	}
+}

--- a/cli/setup_pairing_v1_test.go
+++ b/cli/setup_pairing_v1_test.go
@@ -92,12 +92,12 @@ func TestSetupPairingMidFlowRelayNotV1FailsSafeWithoutTokenStore(t *testing.T) {
 // must NOT be reported as a too-old relay, and must not spend a code — the user
 // should be told to retry once the relay is up.
 func TestSetupPairingTransientV1ProbeFailureDoesNotDeclareOldRelay(t *testing.T) {
-	origProbe, origReach, origExchange := probePairingV1ForSetup, relayReachableForSetup, exchangeRelayPairingCodeForSetup
+	origProbe, origDetailed, origExchange := probePairingV1ForSetup, probePairingV1DetailedForSetup, exchangeRelayPairingCodeForSetup
 	defer func() {
-		probePairingV1ForSetup, relayReachableForSetup, exchangeRelayPairingCodeForSetup = origProbe, origReach, origExchange
+		probePairingV1ForSetup, probePairingV1DetailedForSetup, exchangeRelayPairingCodeForSetup = origProbe, origDetailed, origExchange
 	}()
-	probePairingV1ForSetup = func(string) bool { return false } // probe returns false...
-	relayReachableForSetup = func(string) bool { return false }  // ...because the relay is unreachable
+	probePairingV1ForSetup = func(string) bool { return false }                          // probe returns false...
+	probePairingV1DetailedForSetup = func(string) (bool, bool) { return false, false } // ...and the relay is unreachable
 	exchangeCalled := false
 	exchangeRelayPairingCodeForSetup = func(_ *http.Client, _, _ string) (string, error) {
 		exchangeCalled = true
@@ -115,5 +115,37 @@ func TestSetupPairingTransientV1ProbeFailureDoesNotDeclareOldRelay(t *testing.T)
 	}
 	if exchangeCalled {
 		t.Fatal("legacy /pair exchange reached despite an unreachable relay (a code could be consumed)")
+	}
+}
+
+// If the first v1 probe fails transiently but the second (detailed) probe finds
+// v1 support (relay finished starting), setup proceeds with secure pairing rather
+// than declaring the relay too old.
+func TestSetupPairingRecoversWhenSecondV1ProbeSucceeds(t *testing.T) {
+	origProbe, origDetailed, origSecure, origExchange := probePairingV1ForSetup, probePairingV1DetailedForSetup, securePairForSetup, exchangeRelayPairingCodeForSetup
+	defer func() {
+		probePairingV1ForSetup, probePairingV1DetailedForSetup, securePairForSetup, exchangeRelayPairingCodeForSetup = origProbe, origDetailed, origSecure, origExchange
+	}()
+	probePairingV1ForSetup = func(string) bool { return false }                        // transient miss...
+	probePairingV1DetailedForSetup = func(string) (bool, bool) { return true, true } // ...v1 is up on the retry
+	securePaired := false
+	securePairForSetup = func(_, _ string, cfg *runtimeConfig, _ func(*runtimeConfig) error, _ pairingClientInfo) (string, error) {
+		securePaired = true
+		return "device-id", nil
+	}
+	exchangeCalled := false
+	exchangeRelayPairingCodeForSetup = func(_ *http.Client, _, _ string) (string, error) {
+		exchangeCalled = true
+		return "legacy-token", nil
+	}
+
+	reader := bufio.NewReader(strings.NewReader("\n473921\n"))
+	cfg := &runtimeConfig{RelayBaseURL: "http://relay:8791"}
+	_, err := runSetupPairingFlow(reader, io.Discard, runtimePaths{}, cfg, true)
+	if !errors.Is(err, errSetupDevicePaired) {
+		t.Fatalf("expected secure pairing to proceed after the v1 probe recovered, got %v", err)
+	}
+	if !securePaired || exchangeCalled {
+		t.Fatalf("expected secure pairing, not the legacy exchange; securePaired=%v exchangeCalled=%v", securePaired, exchangeCalled)
 	}
 }

--- a/cli/setup_pairing_v1_test.go
+++ b/cli/setup_pairing_v1_test.go
@@ -87,3 +87,33 @@ func TestSetupPairingMidFlowRelayNotV1FailsSafeWithoutTokenStore(t *testing.T) {
 		t.Fatal("legacy /pair exchange was reached — a one-time code could be consumed with no store to persist the token")
 	}
 }
+
+// A transient v1 probe failure (relay still starting / momentarily unreachable)
+// must NOT be reported as a too-old relay, and must not spend a code — the user
+// should be told to retry once the relay is up.
+func TestSetupPairingTransientV1ProbeFailureDoesNotDeclareOldRelay(t *testing.T) {
+	origProbe, origReach, origExchange := probePairingV1ForSetup, relayReachableForSetup, exchangeRelayPairingCodeForSetup
+	defer func() {
+		probePairingV1ForSetup, relayReachableForSetup, exchangeRelayPairingCodeForSetup = origProbe, origReach, origExchange
+	}()
+	probePairingV1ForSetup = func(string) bool { return false } // probe returns false...
+	relayReachableForSetup = func(string) bool { return false }  // ...because the relay is unreachable
+	exchangeCalled := false
+	exchangeRelayPairingCodeForSetup = func(_ *http.Client, _, _ string) (string, error) {
+		exchangeCalled = true
+		return "legacy-token", nil
+	}
+
+	reader := bufio.NewReader(strings.NewReader("\n473921\n"))
+	cfg := &runtimeConfig{RelayBaseURL: "http://relay:8791"}
+	_, err := runSetupPairingFlow(reader, io.Discard, runtimePaths{}, cfg, true)
+	if err == nil {
+		t.Fatal("expected an error when the relay is unreachable")
+	}
+	if strings.Contains(err.Error(), "predates secure pairing") {
+		t.Fatalf("a transient probe failure must not be reported as a too-old relay: %v", err)
+	}
+	if exchangeCalled {
+		t.Fatal("legacy /pair exchange reached despite an unreachable relay (a code could be consumed)")
+	}
+}

--- a/cli/setup_pairing_v1_test.go
+++ b/cli/setup_pairing_v1_test.go
@@ -29,7 +29,7 @@ func TestSetupPairingPrefersSecureV1(t *testing.T) {
 
 	reader := bufio.NewReader(strings.NewReader("\n473921\n"))
 	cfg := &runtimeConfig{RelayBaseURL: "http://relay:8791"}
-	token, err := runSetupPairingFlow(reader, io.Discard, runtimePaths{}, cfg)
+	token, err := runSetupPairingFlow(reader, io.Discard, runtimePaths{}, cfg, false)
 	if !errors.Is(err, errSetupDevicePaired) {
 		t.Fatalf("expected errSetupDevicePaired, got token=%q err=%v", token, err)
 	}
@@ -50,7 +50,7 @@ func TestSetupPairingFallsBackToLegacyExchange(t *testing.T) {
 
 	reader := bufio.NewReader(strings.NewReader("\n473921\n"))
 	cfg := &runtimeConfig{RelayBaseURL: "http://relay:8791"}
-	token, err := runSetupPairingFlow(reader, io.Discard, runtimePaths{}, cfg)
+	token, err := runSetupPairingFlow(reader, io.Discard, runtimePaths{}, cfg, false)
 	if err != nil {
 		t.Fatalf("legacy exchange should succeed: %v", err)
 	}

--- a/cli/uninstall_device.go
+++ b/cli/uninstall_device.go
@@ -22,6 +22,10 @@ var revokeSelfDeviceV1ForUninstall = revokeSelfDeviceV1
 func purgeDeviceCredentialWithReport(secureBaseURL, spkiPin string, report *uninstallReport, relayExpectedGone bool) {
 	// The pending slot is purely local (never activated): just drop it.
 	_ = deletePendingDeviceCredential()
+	// File-backed installs also leave the storage-mode marker; drop it (and the
+	// now-empty secrets dir) so a later reinstall re-probes cleanly rather than
+	// inheriting a stale file-mode decision.
+	defer removeDeviceFileStorageResidue()
 
 	credential, ok, err := readDeviceCredential()
 	if err != nil {


### PR DESCRIPTION
## Problems

**1. Headless pairing was impossible.** On a system with no desktop keyring session (containers, servers, LXCs — a core Home Assistant audience), `ha-nova pair` / `setup` died:

```
Pairing failed: could not store the new credential securely:
desktop keyring session unavailable: exec: "dbus-launch": executable file not found in $PATH
```

Worse, the failure surfaced AFTER `/pair/v1/finish` had already consumed the owner's one-time code. Found on a real Debian container running the merged `ad37baf` CLI.

**2. `go test` touched the real OS keyring.** The new storage probe runs in the pairing path, and existing pairing tests don't isolate the keyring, so `go test ./...` popped the native macOS keychain unlock dialog (and would hang headless CI).

## Fixes

- **Private-file fallback** (`device_credential_storage.go`): `probeDeviceCredentialStorage()` runs BEFORE any code is spent. No desktop session at all → store the credential in a `0600` file under the config dir and say so; the file's existence is the mode marker, so later reads/doctor/uninstall self-select it with no config plumbing. A PRESENT-but-locked/uninitialized desktop keyring stays a **hard error** — no silent security downgrade. The probe is wired into `cmd_pair`, `setup_pairing`, and `runSecurePairing` (belt-and-suspenders: the code is never consumed if storage can't work).
- **`keyring.MockInit()` in `TestMain`**: the whole package now routes go-keyring to an in-memory mock, so no test can touch a developer's real keyring. Failure-injecting tests override on top as before.

## Proven
- Real Debian container (arm64, no dbus): probe prints the file-fallback note and the relay handshake proceeds cleanly.
- Full `go test ./...` green in 50s **with no keychain dialog**.
- 4 new regression tests: file fallback + 0600 file, no-downgrade on a locked keyring, self-selecting file mode, and the code-not-consumed guarantee on broken storage.
- Cross-compiles clean for windows/linux/darwin.

No release: no version bump, README untouched.