### PR TITLE
feat(app): enable the NOVA sidebar entry by default on first App boot

### DIFF
--- a/nova/src/ha/supervisor-client.ts
+++ b/nova/src/ha/supervisor-client.ts
@@ -15,6 +15,8 @@ export interface SelfInfo {
   version: string;
   versionLatest: string | null;
   updateAvailable: boolean;
+  // Whether the App's ingress sidebar entry is currently enabled.
+  ingressPanel: boolean;
   // Container port ("8792/tcp") -> mapped host port, or null when unmapped.
   network: Record<string, number | null>;
 }
@@ -28,6 +30,10 @@ export interface SupervisorClient {
   // Replace the App options (used to clear a migrated legacy token). The caller
   // passes the full desired options object.
   setOptions(options: Record<string, unknown>): Promise<void>;
+  // Toggle the App's sidebar entry. `ingress_panel` is a sibling field of
+  // `options` on the same Supervisor endpoint, so this must not be merged into
+  // setOptions payloads.
+  setIngressPanel(enabled: boolean): Promise<void>;
 }
 
 export function createSupervisorClient(token: string, base: string = SUPERVISOR_BASE): SupervisorClient {
@@ -57,6 +63,7 @@ export function createSupervisorClient(token: string, base: string = SUPERVISOR_
       version: asString(data.version, ""),
       versionLatest: typeof data.version_latest === "string" ? data.version_latest : null,
       updateAvailable: data.update_available === true,
+      ingressPanel: data.ingress_panel === true,
       network: parseNetwork(data.network),
     };
   }
@@ -73,6 +80,13 @@ export function createSupervisorClient(token: string, base: string = SUPERVISOR_
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ options }),
+      });
+    },
+    async setIngressPanel(enabled) {
+      await request("/addons/self/options", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ingress_panel: enabled }),
       });
     },
   };

--- a/nova/src/runtime/app-mode.ts
+++ b/nova/src/runtime/app-mode.ts
@@ -23,6 +23,7 @@ import { createFileResponseStore } from "../security/pairing-response-store.js";
 import { createPairingV1Manager, type PairingV1Manager } from "../security/pairing-v1.js";
 import { loadOrCreateTlsIdentity } from "../security/tls-identity.js";
 import { clearLegacyOptions, importLegacyToken } from "./legacy-migration.js";
+import { ensureSidebarPanel } from "./sidebar-panel.js";
 import { createBootstrapListener, createDeviceListener, type FunctionalHandlers } from "./listeners.js";
 
 // App-mode assembly: three listeners over one shared pipeline. Constructed only
@@ -113,6 +114,10 @@ export async function buildAppMode(input: AppModeInput): Promise<AppModeRuntime>
   // is healthy enough to have migrated it; ha_llat always). A corrupt registry
   // keeps the shared token recoverable until the owner resets.
   await clearLegacyOptions({ supervisor, appOptionsPath: input.appOptionsPath, logger: input.logger }, !registryCorrupt);
+  // First-boot default: make the NOVA sidebar entry appear without a manual
+  // "Add to sidebar" toggle. Once-ever via marker; never overrides an owner
+  // who hides the panel later.
+  await ensureSidebarPanel({ supervisor, dataDir, logger: input.logger });
 
   // OPAQUE runs on WASM that must finish initializing before the first pairing
   // operation. Await it once here, before any listener accepts traffic, so the

--- a/nova/src/runtime/sidebar-panel.ts
+++ b/nova/src/runtime/sidebar-panel.ts
@@ -9,6 +9,14 @@ import type { RelayLogger } from "../http/server.js";
 // The marker makes this once-ever — an owner who later hides the panel is never
 // overridden. On Supervisor failure no marker is written, so the default is
 // retried on the next start.
+//
+// Deliberate (maintainer decision 2026-07-20): the one-time enable also applies
+// to UPGRADES from pre-marker versions. `ingress_panel: false` cannot
+// distinguish "never enabled" from "deliberately hidden", and the 0.19
+// migration sends every upgrader to the NOVA page (re-pair, revoke legacy) —
+// without the sidebar entry they hit exactly the wall this removes. The cost is
+// capped: an owner who had hidden the panel sees it restored at most once,
+// ever; hiding it again is permanent. Announced in the 0.19.0 release notes.
 
 const MARKER_FILE = "sidebar_default_applied";
 

--- a/nova/src/runtime/sidebar-panel.ts
+++ b/nova/src/runtime/sidebar-panel.ts
@@ -1,0 +1,38 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { createSupervisorClient } from "../ha/supervisor-client.js";
+import type { RelayLogger } from "../http/server.js";
+
+// One-time App default: enable the NOVA sidebar entry (`ingress_panel`) on the
+// first App-mode boot, so "open NOVA in the sidebar" is true out of the box.
+// The marker makes this once-ever — an owner who later hides the panel is never
+// overridden. On Supervisor failure no marker is written, so the default is
+// retried on the next start.
+
+const MARKER_FILE = "sidebar_default_applied";
+
+export interface SidebarPanelDeps {
+  supervisor: ReturnType<typeof createSupervisorClient>;
+  dataDir: string;
+  logger: RelayLogger;
+}
+
+export async function ensureSidebarPanel(deps: SidebarPanelDeps): Promise<void> {
+  const marker = join(deps.dataDir, MARKER_FILE);
+  if (existsSync(marker)) {
+    return;
+  }
+  try {
+    const info = await deps.supervisor.getSelfInfo();
+    if (!info.ingressPanel) {
+      await deps.supervisor.setIngressPanel(true);
+      deps.logger.info?.("Enabled the NOVA sidebar entry (ingress_panel) as the App default");
+    }
+    writeFileSync(marker, "");
+  } catch (error) {
+    deps.logger.warn("Could not apply the sidebar default; retrying on next start", {
+      error: String((error as Error).message),
+    });
+  }
+}

--- a/scripts/test/safe-core-files.json
+++ b/scripts/test/safe-core-files.json
@@ -11,6 +11,7 @@
   "tests/bootstrap/app-wiring.test.ts",
   "tests/bootstrap/legacy-migration.test.ts",
   "tests/bootstrap/runtime-start.test.ts",
+  "tests/bootstrap/sidebar-panel.test.ts",
   "tests/bootstrap/startup.test.ts",
   "tests/config/app-options.test.ts",
   "tests/e2e/codex-skill-bulk-live-validator.test.ts",

--- a/tests/bootstrap/sidebar-panel.test.ts
+++ b/tests/bootstrap/sidebar-panel.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ensureSidebarPanel } from "../../nova/src/runtime/sidebar-panel.js";
+
+const MARKER = "sidebar_default_applied";
+
+function fakeSupervisor(overrides: { ingressPanel?: boolean; infoError?: Error; setError?: Error } = {}) {
+  const getSelfInfo = vi.fn(async () => {
+    if (overrides.infoError) throw overrides.infoError;
+    return {
+      version: "0.7.0",
+      versionLatest: null,
+      updateAvailable: false,
+      ingressPanel: overrides.ingressPanel ?? false,
+      network: {},
+    };
+  });
+  const setIngressPanel = vi.fn(async () => {
+    if (overrides.setError) throw overrides.setError;
+  });
+  return {
+    getSelfInfo,
+    getMappedHostPort: vi.fn(),
+    setOptions: vi.fn(),
+    setIngressPanel,
+  } as unknown as Parameters<typeof ensureSidebarPanel>[0]["supervisor"] & {
+    getSelfInfo: ReturnType<typeof vi.fn>;
+    setIngressPanel: ReturnType<typeof vi.fn>;
+  };
+}
+
+function fakeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe("ensureSidebarPanel", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "nova-sidebar-"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("enables the panel once and stamps the marker when it is off", async () => {
+    const supervisor = fakeSupervisor({ ingressPanel: false });
+    const logger = fakeLogger();
+    await ensureSidebarPanel({ supervisor, dataDir, logger });
+    expect(supervisor.setIngressPanel).toHaveBeenCalledWith(true);
+    expect(existsSync(join(dataDir, MARKER))).toBe(true);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("stamps the marker without a write when the panel is already on", async () => {
+    const supervisor = fakeSupervisor({ ingressPanel: true });
+    await ensureSidebarPanel({ supervisor, dataDir, logger: fakeLogger() });
+    expect(supervisor.setIngressPanel).not.toHaveBeenCalled();
+    expect(existsSync(join(dataDir, MARKER))).toBe(true);
+  });
+
+  it("does nothing when the marker exists — an owner who hides the panel is never overridden", async () => {
+    writeFileSync(join(dataDir, MARKER), "");
+    const supervisor = fakeSupervisor({ ingressPanel: false });
+    await ensureSidebarPanel({ supervisor, dataDir, logger: fakeLogger() });
+    expect(supervisor.getSelfInfo).not.toHaveBeenCalled();
+    expect(supervisor.setIngressPanel).not.toHaveBeenCalled();
+  });
+
+  it("warns without a marker on Supervisor failure, so the default retries next boot", async () => {
+    const supervisor = fakeSupervisor({ setError: new Error("supervisor down") });
+    const logger = fakeLogger();
+    await ensureSidebarPanel({ supervisor, dataDir, logger });
+    expect(logger.warn).toHaveBeenCalled();
+    expect(existsSync(join(dataDir, MARKER))).toBe(false);
+  });
+});

--- a/tests/ha/supervisor-client.test.ts
+++ b/tests/ha/supervisor-client.test.ts
@@ -35,6 +35,29 @@ describe("supervisor-client", () => {
     expect(info.updateAvailable).toBe(true);
   });
 
+  it("parses ingress_panel from self/info and defaults it to false when absent", async () => {
+    const withPanel = infoBody({ "8791/tcp": 8791 });
+    (withPanel.data as Record<string, unknown>).ingress_panel = true;
+    mockFetch(() => ({ body: withPanel }));
+    expect((await createSupervisorClient("tok").getSelfInfo()).ingressPanel).toBe(true);
+    // The captured live shape has no ingress_panel field — that must read as false.
+    mockFetch(() => ({ body: infoBody({ "8791/tcp": 8791 }) }));
+    expect((await createSupervisorClient("tok").getSelfInfo()).ingressPanel).toBe(false);
+  });
+
+  it("posts ingress_panel as a sibling field, not inside options", async () => {
+    const calls: Array<{ url: string; body: string }> = [];
+    mockFetch((url, init) => {
+      calls.push({ url, body: String(init?.body ?? "") });
+      return { body: null };
+    });
+    await createSupervisorClient("tok").setIngressPanel(true);
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    expect(call.url).toContain("/addons/self/options");
+    expect(JSON.parse(call.body)).toEqual({ ingress_panel: true });
+  });
+
   it("returns the mapped host port for the secure container port", async () => {
     mockFetch(() => ({ body: infoBody({ "8791/tcp": 8791, "8792/tcp": 18792 }) }));
     expect(await createSupervisorClient("tok").getMappedHostPort("8792/tcp")).toBe(18792);


### PR DESCRIPTION
## Summary
- The onboarding says "open NOVA in the sidebar", but the sidebar entry (`ingress_panel`) is a manual per-user toggle — this closes that hidden step: App mode enables its own sidebar entry on first boot via the Supervisor self API.
- Once-ever semantics: a marker in `/data` guarantees we never override an owner who deliberately hides the panel later. Supervisor failures warn (fail-soft) and retry on the next start.
- `supervisor-client` gains `setIngressPanel` — `ingress_panel` is a sibling field of `options` on `POST /addons/self/options`, so it must not be merged into `setOptions` payloads — and `SelfInfo` now parses `ingress_panel`.

## Test plan
- `tests/bootstrap/sidebar-panel.test.ts` (new, registered in `safe-core-files.json`): enables+stamps when off; stamps without write when already on; marker short-circuits everything; Supervisor failure warns without marker (retry next boot).
- `tests/ha/supervisor-client.test.ts`: `ingress_panel` parsing (incl. absent → false against the captured live shape) and the sibling-field payload contract.
- Full pre-push suite: 977/977 green after registration, `tsc --noEmit` clean, `scripts/check-docs.sh` all green.
- Live proof on a real Supervisor happens with the next App deploy; the path is fail-soft by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tzZA5RAsH8e6CZhBoPMt8