### PR TITLE
test(onboarding): make the shared-tools dev-sync test hermetic against ambient Go

### DIFF
--- a/tests/onboarding/dev-sync-behavior.test.ts
+++ b/tests/onboarding/dev-sync-behavior.test.ts
@@ -152,7 +152,7 @@ describe("dev-sync behavior", () => {
     // that satisfies the build-to-temp-and-move contract deterministically.
     writeFileSync(
       join(binDir, "go"),
-      '#!/usr/bin/env bash\nif [ "$1" = "build" ]; then shift; out=""; while [ "$#" -gt 0 ]; do if [ "$1" = "-o" ]; then out="$2"; shift 2; else shift; fi; done; [ -n "$out" ] && : > "$out"; fi\nexit 0\n',
+      '#!/usr/bin/env bash\nif [ "$1" = "build" ]; then shift; out=""; while [ "$#" -gt 0 ]; do if [ "$1" = "-o" ]; then out="$2"; shift 2; else shift; fi; done; [ -n "$out" ] && printf "#!/usr/bin/env bash\\n# mock-go-artifact\\nexit 0\\n" > "$out"; fi\nexit 0\n',
       { mode: 0o755 },
     );
 
@@ -170,6 +170,9 @@ describe("dev-sync behavior", () => {
     expect(result.stdout).toContain("Shared tools refreshed");
     expect(existsSync(join(configDir, "version-check"))).toBe(true);
     expect(existsSync(join(configDir, "version.json"))).toBe(true);
+    // The refreshed relay must be the runnable artifact the mock build
+    // produced — not a clobbered or zero-byte leftover.
+    expect(readFileSync(join(configDir, "relay"), "utf8")).toContain("mock-go-artifact");
   });
 
   it("copies the current client registry next to the dev-synced CLI runtime", { timeout: 90000 }, () => {

--- a/tests/onboarding/dev-sync-behavior.test.ts
+++ b/tests/onboarding/dev-sync-behavior.test.ts
@@ -146,6 +146,16 @@ describe("dev-sync behavior", () => {
     const binDir = createMockBinaries();
     const configDir = join(home, ".config", "ha-nova");
 
+    // Hermetic go: the harness may leak a real toolchain (PATH go + foreign
+    // GOROOT from release-workflow setup), which made this test fail only in
+    // release.yml. Go availability is incidental here — pin it to a fast mock
+    // that satisfies the build-to-temp-and-move contract deterministically.
+    writeFileSync(
+      join(binDir, "go"),
+      '#!/usr/bin/env bash\nif [ "$1" = "build" ]; then shift; out=""; while [ "$#" -gt 0 ]; do if [ "$1" = "-o" ]; then out="$2"; shift 2; else shift; fi; done; [ -n "$out" ] && : > "$out"; fi\nexit 0\n',
+      { mode: 0o755 },
+    );
+
     mkdirSync(configDir, { recursive: true });
     writeFileSync(join(configDir, "relay"), "#!/usr/bin/env bash\n", { mode: 0o755 });
 


### PR DESCRIPTION
## Summary
The v0.19.0-rc1 rehearsal failed exactly as designed: `release.yml`'s Go setup (for GoReleaser) leaks `GOROOT`/toolchain env through `mockEnv`'s `process.env` spread, and with the test's trimmed `PATH` an image-provided `go` plus a foreign `GOROOT` aborts `dev-sync.sh` instantly — reproducible on rerun, green in PR ci (which sets up no Go). Go availability is incidental to this test's purpose (shared-tools refresh), so it now pins a deterministic first-in-PATH mock `go` honoring the build-to-temp-and-move contract.

## Test plan
- `dev-sync-behavior.test.ts`: 16/16 green.
- Poisoned-env proof: `GOROOT=/nonexistent-goroot GOTOOLCHAIN=local` → target test still green.
- Unblocks `v0.19.0-rc2` (rc1 tag stays as the honest failed-rehearsal artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tzZA5RAsH8e6CZhBoPMt8