### PR TITLE
docs: archive v0.19.0 release work

### DIFF
--- a/docs/archive/work/0.19.0-release-body.md
+++ b/docs/archive/work/0.19.0-release-body.md
@@ -1,8 +1,4 @@
-# 0.19.0 Release Body (draft — collects unreleased user-facing claims)
-
-> Draft for the v0.19.0 release-prep PR. Verify at release time: the App/Relay
-> version this ships as (expected **0.7.0** — `nova/config.yaml` bump happens in
-> the release-prep PR) and the final PR reference list.
+# 0.19.0 Release Body
 
 ## New Features
 

--- a/docs/archive/work/2026-07-17-supervisor-token-onboarding-spec.md
+++ b/docs/archive/work/2026-07-17-supervisor-token-onboarding-spec.md
@@ -1,6 +1,6 @@
 # Supervisor-Token Onboarding Spec
 
-Status: active
+Status: archived (shipped in v0.19.0)
 Date: 2026-07-17
 Trigger: live macOS first-install acceptance exposed that the Wave 6 wizard still requires a manually created Home Assistant Long-Lived Access Token (LLAT)
 


### PR DESCRIPTION
Move the released 0.19.0 release body and the supervisor-token onboarding spec to `docs/archive/work/`, following the v0.18.1 convention (#371). One-line status/title cleanup in each file; no active-doc references point at the old paths (`scripts/check-docs.sh` green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tzZA5RAsH8e6CZhBoPMt8