### PR TITLE
docs: record the wizard-integration decision in the multi-server spec

### DIFF
--- a/docs/work/2026-07-20-multi-server-spec.md
+++ b/docs/work/2026-07-20-multi-server-spec.md
@@ -15,16 +15,22 @@ Trigger: issue #343 — one client machine should reach more than one Home Assis
 - **Per-server credential slots.** Device-credential slots namespace by server name (keyring service string and secret file name gain a per-server suffix; the `default` profile keeps today's names so nothing re-pairs on upgrade). The credential-store backend decision (`.file-backend` marker) stays machine-wide — it describes the machine, not the server.
 - **Pairing per server:** `ha-nova pair --server <name> [--relay-url …]` reuses the existing bootstrap; `--relay-url` already seeds fresh configs today.
 - **Second-server install docs:** installing the Relay App on another HA instance is independent of the client machine; document that adding a server never touches existing profiles.
+- **Wizard integration — progressive disclosure (decision 2026-07-20).** Adding a server IS a wizard flow, but never a first-run question: the single-server majority must not pay for the multi-server case.
+  - First-run setup stays exactly as it is today.
+  - Re-run entry point: when `ha-nova setup` runs on a completed install, the existing "Setup complete" state screen offers "Add another Home Assistant server". This is also the path the onboarding skill tells AI clients to use.
+  - Discovery assist: when the existing discovery pick list finds MORE than one instance during first-run setup, the wizard may offer a one-line follow-up after the first server is set up ("Found a second instance — connect it too?"). One line, no pressure.
+  - The add flow reuses the existing stages (discovery with already-configured instances filtered out → Relay App install on the new instance → pairing with that instance's code → verify); the only new mechanics is parameterizing which profile the results are written to.
+  - Division of labor: the wizard onboards ("add"), the CLI administers. Profile management (rename, delete, switch default) ships as small CLI commands, not wizard stages; runtime selection stays `--server`/env/default — the wizard sets up, it never routes.
 
 ## Non-goals (first iteration)
 
 - No per-directory config overrides (the issue's alternative idea) — profiles cover the need with less config-resolution magic; revisit only on real demand.
 - No concurrent multi-server fan-out in a single skill call; one call, one server.
 - No profile-aware Home Base UI changes.
+- No new first-run wizard questions, and no profile management (rename/delete/default) inside the wizard — see the wizard-integration decision above.
 
 ## Open questions
 
-- Should `setup` grow an "add another server" wizard entry, or is `pair --server` + a config edit enough for the first cut?
 - How do skills surface which server answered (prefix in output vs. only on ambiguity)?
 
 ## Verification (when implemented)
@@ -32,4 +38,5 @@ Trigger: issue #343 — one client machine should reach more than one Home Assis
 - Migration round-trip tests (flat → profiles, idempotent, rollback-safe).
 - Credential-slot isolation tests (pairing server B never touches server A's slot).
 - Selection-order contract tests (flag > env > default).
+- Wizard contract tests: first-run flow byte-identical for single-server users; completed-install re-run offers the add-server entry; the add flow filters already-configured instances.
 - Live acceptance with two HA instances.


### PR DESCRIPTION
Records the wizard-integration decision (2026-07-20) in `docs/work/2026-07-20-multi-server-spec.md`: adding a server is a wizard flow via progressive disclosure — first-run untouched, completed-install re-run offers "Add another Home Assistant server", optional one-line discovery follow-up, add flow reuses existing stages. Wizard onboards, CLI administers. The corresponding open question is resolved; wizard contract tests added to the verification list. Docs-only; `scripts/check-docs.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tzZA5RAsH8e6CZhBoPMt8