### PR TITLE
fix(skills): anchor the canonical Cards contract in every mutation flow

### DIFF
--- a/skills/admin/SKILL.md
+++ b/skills/admin/SKILL.md
@@ -59,7 +59,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 Render the Report shape (output-rules.md); person/zone/user inventories render the List Frame. For persons: name, device trackers, linked user. For zones: name, radius, and which automations depend on them. For users: name, whether they are owner/active/system-generated — never their tokens or credentials. State what was verified after the write.
 

--- a/skills/assist/SKILL.md
+++ b/skills/assist/SKILL.md
@@ -53,7 +53,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 Render the Report shape (output-rules.md). For an utterance test: the exact response text Assist gave, what it did (or did not) match, and which entities it touched. For pipelines: name, engines, language, and which one is preferred. Never paraphrase Assist's answer into something friendlier than it was.
 

--- a/skills/backup/SKILL.md
+++ b/skills/backup/SKILL.md
@@ -72,7 +72,7 @@ Other skills name HA Backups as the recovery path (see `skills/ha-nova/write-saf
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all output.
+Apply `skills/ha-nova/output-rules.md` to all output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 - `Backups` / `Status`
 - `Planned change`

--- a/skills/camera/SKILL.md
+++ b/skills/camera/SKILL.md
@@ -48,7 +48,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 Render the Report shape (output-rules.md). For a snapshot, describe what is visible in the frame and name the camera plus the time it was taken. For a stream, give the URL and say it is short-lived. Never claim to have seen something the frame does not show.
 

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -129,7 +129,7 @@ Critical behavior:
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 For list/read:
 - `Dashboard`

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -80,7 +80,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 Render the Report shape, Diagnosis specialization (output-rules.md → Report Shape): root cause first, then the evidence chain, then the recommended fix with the owning skill. Quote log lines sparingly — never dump raw logs.
 

--- a/skills/energy/SKILL.md
+++ b/skills/energy/SKILL.md
@@ -70,7 +70,7 @@ Write guards (schema details in the reference):
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md`.
+Apply `skills/ha-nova/output-rules.md`. Write previews, delete confirmations, and results render as the Cards defined there.
 
 - `Energy` / `Status`
 - `Planned change`

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -239,7 +239,7 @@ Experimental calls may fail with unfamiliar errors. Full relay/upstream error ta
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 Every experimental call result names the tier (Relay-Ready / Roadmap / External), carries the EXPERIMENTAL marker where required, and summarizes verified outcomes only.
 

--- a/skills/ha-nova/config-snapshots.md
+++ b/skills/ha-nova/config-snapshots.md
@@ -94,6 +94,8 @@ the user just decides informed.
 2. `load` → treat `data` as the restore draft.
 3. Diff against the LIVE state (`ha-nova diff` where the family supports it),
    preview, and confirm — a restore is a normal write, never a blind put.
+   The restore preview and result render as the Preview and Result Cards
+   (`skills/ha-nova/output-rules.md` → Cards), like any write of that family.
 4. Write IN PLACE via the family's own API — never delete+recreate.
    A deleted item restores as a create that reuses the original identity key
    where the API allows it (see the fidelity table).

--- a/skills/ha-nova/output-rules.md
+++ b/skills/ha-nova/output-rules.md
@@ -101,7 +101,7 @@ write flow renders outside this system:
 | Batch mutation (manifest-gated) | Batch Cards (`skills/ha-nova/batch-safety.md`) |
 | Snapshot restore (`skills/ha-nova/config-snapshots.md`) | Preview Card → Result Card |
 | Post-write test offer | Test Plan Card |
-| Runtime action (service call, experimental write) | Preview Card (`apply · cancel`) → Result Card |
+| Runtime action (service call, experimental write) | Preview Card (`apply · cancel`; high-consequence actions escalate to the typed confirmation code — context skill → Confirmation Tiers) → Result Card |
 
 ## Report Shape (Read & Analysis Results)
 

--- a/skills/ha-nova/output-rules.md
+++ b/skills/ha-nova/output-rules.md
@@ -97,7 +97,8 @@ write flow renders outside this system:
 | Flow | Cards |
 |---|---|
 | Create / update (any supported family) | Preview Card → Result Card |
-| Delete / destructive operation | Delete Card → Result Card |
+| Delete / destructive operation (typed confirmation code) | Delete Card → Result Card |
+| Natural-confirmation removals (e.g. snapshot prune, todo item removes) | Preview Card → Result Card |
 | Batch mutation (manifest-gated) | Batch Cards (`skills/ha-nova/batch-safety.md`) |
 | Snapshot restore (`skills/ha-nova/config-snapshots.md`) | Preview Card → Result Card |
 | Post-write test offer | Test Plan Card |

--- a/skills/ha-nova/output-rules.md
+++ b/skills/ha-nova/output-rules.md
@@ -91,6 +91,18 @@ skip — test later
 Recommended option first and marked; at most 3 options plus `skip`; the option
 choice is the single confirmation bound to that exact card.
 
+Card coverage — every mutation and restore flow maps onto these cards; no
+write flow renders outside this system:
+
+| Flow | Cards |
+|---|---|
+| Create / update (any supported family) | Preview Card → Result Card |
+| Delete / destructive operation | Delete Card → Result Card |
+| Batch mutation (manifest-gated) | Batch Cards (`skills/ha-nova/batch-safety.md`) |
+| Snapshot restore (`skills/ha-nova/config-snapshots.md`) | Preview Card → Result Card |
+| Post-write test offer | Test Plan Card |
+| Runtime action (service call, experimental write) | Preview Card (`apply · cancel`) → Result Card |
+
 ## Report Shape (Read & Analysis Results)
 
 Every read or analysis answer follows one shape: lead with the answer in one or

--- a/skills/maintenance/SKILL.md
+++ b/skills/maintenance/SKILL.md
@@ -67,7 +67,7 @@ Per entity, label the timestamp source: LTS last-data bucket (reliable, years ba
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md`.
+Apply `skills/ha-nova/output-rules.md`. Write previews, delete confirmations, and results render as the Cards defined there.
 
 - `Maintenance` / `Status`
 - `Planned change`

--- a/skills/media/SKILL.md
+++ b/skills/media/SKILL.md
@@ -85,7 +85,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 Render the Report shape (output-rules.md): what is playing where — player, state, current media, volume, source, and group members when relevant. Browse results render the List Frame (title + type), never the raw tree.
 

--- a/skills/mqtt/SKILL.md
+++ b/skills/mqtt/SKILL.md
@@ -72,7 +72,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 Render the Report shape (output-rules.md). For a listen: the topic, the window length, how many messages arrived (live versus retained — never merge those two), the distinct topics seen, and a few representative payloads — never the raw dump. Say explicitly when nothing arrived, and when everything that arrived was a retained replay. For a publish: the topic, payload, and whether it was retained.
 

--- a/skills/notify/SKILL.md
+++ b/skills/notify/SKILL.md
@@ -80,7 +80,7 @@ Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handl
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 Render the Report shape (output-rules.md): the resolved target, the sent title/message, and any extras used. Report acceptance honestly (accepted by Home Assistant, not confirmed on the device). Discovery renders the List Frame, grouped by surface (entities vs mobile-app services).
 

--- a/skills/organize/SKILL.md
+++ b/skills/organize/SKILL.md
@@ -102,7 +102,7 @@ Do not guess unsupported fields.
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 - `Target`
 - `Current metadata`

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -378,7 +378,7 @@ Rules:
 
 Apply `skills/ha-nova/output-rules.md` to all user-facing output.
 
-Review output is sectioned, not card-framed; only a Section 8 quick-fix proposal renders as the service-call action preview when it proposes a call.
+Review output is sectioned, not card-framed; only a Section 8 quick-fix proposal renders as the service-call Preview Card (`apply · cancel`, output-rules.md → Cards) when it proposes a call.
 
 Exception: if a maintainer-provided release-validation or machine-check prompt explicitly pins exact section titles or machine markers, follow that override exactly so automated validation can compare the fixed headings. This exception does not allow internal check codes in normal user-facing prose.
 

--- a/skills/scene/SKILL.md
+++ b/skills/scene/SKILL.md
@@ -107,7 +107,7 @@ Persistence routing per `skills/ha-nova/best-practices.md` → Persistence Model
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all user-facing output.
+Apply `skills/ha-nova/output-rules.md` to all user-facing output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 - `Scene`
 - `Mode`

--- a/skills/todo/SKILL.md
+++ b/skills/todo/SKILL.md
@@ -103,7 +103,7 @@ Other providers configure lists in their own integration — point there instead
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md` to all output.
+Apply `skills/ha-nova/output-rules.md` to all output. Write previews, delete confirmations, and results render as the Cards defined there.
 
 - `List`
 - `Items` / `Planned change`

--- a/skills/updates/SKILL.md
+++ b/skills/updates/SKILL.md
@@ -81,7 +81,7 @@ Bit 16 set: WS `{"type":"update/release_notes","entity_id":"update.<id>"}` → m
 
 ## Output Format
 
-Apply `skills/ha-nova/output-rules.md`.
+Apply `skills/ha-nova/output-rules.md`. Write previews, delete confirmations, and results render as the Cards defined there.
 
 - `Updates` / `Status`
 - `Planned change`

--- a/tests/skills/output-design-contract.test.ts
+++ b/tests/skills/output-design-contract.test.ts
@@ -177,7 +177,14 @@ describe("output design system (Cards)", () => {
     expect(outputRules).toContain(
       "| Create / update (any supported family) | Preview Card → Result Card |",
     );
-    expect(outputRules).toContain("| Delete / destructive operation | Delete Card → Result Card |");
+    expect(outputRules).toContain(
+      "| Delete / destructive operation (typed confirmation code) | Delete Card → Result Card |",
+    );
+    // Natural-confirmation removals (snapshot prune, todo item removes) never
+    // pull the Delete Card's typed gate.
+    expect(outputRules).toContain(
+      "| Natural-confirmation removals (e.g. snapshot prune, todo item removes) | Preview Card → Result Card |",
+    );
     expect(outputRules).toContain(
       "| Batch mutation (manifest-gated) | Batch Cards (`skills/ha-nova/batch-safety.md`) |",
     );

--- a/tests/skills/output-design-contract.test.ts
+++ b/tests/skills/output-design-contract.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -150,6 +151,94 @@ describe("output design system (Cards)", () => {
   it("keeps the canonical Next step label free of drift", () => {
     const contextSkill = readFileSync("skills/ha-nova/SKILL.md", "utf8");
     expect(contextSkill).not.toContain("Next Step");
+  });
+
+  it("makes every skill with a typed-confirmation flow reference the Cards contract (issue #389)", () => {
+    // Self-maintaining adoption lint: any sub-skill carrying a confirm: flow
+    // must name the Cards contract. skills/ha-nova defines the contract itself.
+    const CARD_REF =
+      /(Preview Card|Delete Card|Result Card|Test Plan Card|Cards defined there|card-framed)/;
+    const skillDirs = readdirSync("skills").filter(
+      (d) => d !== "ha-nova" && statSync(join("skills", d)).isDirectory(),
+    );
+    for (const name of skillDirs) {
+      const content = readFileSync(`skills/${name}/SKILL.md`, "utf8");
+      if (!content.includes("confirm:")) continue;
+      expect(
+        CARD_REF.test(content),
+        `skills/${name}/SKILL.md contains a confirm: flow but never references the Cards contract (output-rules.md → Cards)`,
+      ).toBe(true);
+    }
+  });
+
+  it("maps every mutation and restore flow onto a card (coverage matrix, issue #389)", () => {
+    expect(outputRules).toContain("Card coverage");
+    expect(outputRules).toContain("no\nwrite flow renders outside this system");
+    expect(outputRules).toContain(
+      "| Create / update (any supported family) | Preview Card → Result Card |",
+    );
+    expect(outputRules).toContain("| Delete / destructive operation | Delete Card → Result Card |");
+    expect(outputRules).toContain(
+      "| Batch mutation (manifest-gated) | Batch Cards (`skills/ha-nova/batch-safety.md`) |",
+    );
+    expect(outputRules).toContain(
+      "| Snapshot restore (`skills/ha-nova/config-snapshots.md`) | Preview Card → Result Card |",
+    );
+    expect(outputRules).toContain("| Post-write test offer | Test Plan Card |");
+    // Restore flows are covered explicitly, not by convention.
+    const configSnapshots = readFileSync("skills/ha-nova/config-snapshots.md", "utf8");
+    expect(configSnapshots).toContain("render as the Preview and Result Cards");
+  });
+
+  it("keeps each canonical card template structurally sound (issue #389)", () => {
+    // Parse the fenced template after each card marker; fail when a required
+    // section or icon is missing, duplicated, or reordered.
+    const cardTemplate = (name: string): string[] => {
+      const idx = outputRules.indexOf(`**${name}**`);
+      expect(idx, `${name} marker missing`).toBeGreaterThan(-1);
+      const fenceStart = outputRules.indexOf("```", idx);
+      expect(fenceStart, `${name} template fence missing`).toBeGreaterThan(-1);
+      const fenceEnd = outputRules.indexOf("```", fenceStart + 3);
+      expect(fenceEnd, `${name} template fence unterminated`).toBeGreaterThan(fenceStart);
+      return outputRules
+        .slice(fenceStart + 3, fenceEnd)
+        .trim()
+        .split("\n");
+    };
+
+    const preview = cardTemplate("Preview Card");
+    expect(preview[0]).toMatch(/^📝 Preview:/);
+    expect(preview.filter((l) => l.startsWith("⚠️")), "exactly one status line").toHaveLength(1);
+    const previewOptions = preview.filter((l) => l.startsWith("Options:"));
+    expect(previewOptions, "exactly one action block").toHaveLength(1);
+    expect(preview[preview.length - 1], "action block closes the card").toBe(previewOptions[0]);
+    expect(
+      preview.findIndex((l) => l.startsWith("⚠️")),
+      "status line precedes the action block",
+    ).toBe(preview.length - 2);
+
+    const del = cardTemplate("Delete Card");
+    expect(del[0]).toMatch(/^🗑️ {2}Delete:/);
+    expect(del.filter((l) => l.startsWith("⚠️")), "exactly one status line").toHaveLength(1);
+    expect(del[del.length - 1], "confirmation prompt closes the card").toBe(
+      "To delete, reply exactly: confirm:<token>",
+    );
+    expect(del.findIndex((l) => l.startsWith("⚠️")), "status precedes the prompt").toBe(
+      del.length - 2,
+    );
+
+    const result = cardTemplate("Result Card");
+    expect(result[0]).toMatch(/^✅ Saved:/);
+    expect(result.filter((l) => l.startsWith("✅")), "exactly one result title").toHaveLength(1);
+
+    const testPlan = cardTemplate("Test Plan Card");
+    expect(testPlan[0]).toMatch(/^📝 Test:/);
+    const recommended = testPlan.findIndex((l) => l.startsWith("1 (recommended)"));
+    const second = testPlan.findIndex((l) => l.startsWith("2 —"));
+    const skip = testPlan.findIndex((l) => l.startsWith("skip"));
+    expect(recommended, "recommended option present").toBeGreaterThan(0);
+    expect(second, "options stay ordered").toBeGreaterThan(recommended);
+    expect(skip, "skip closes the menu").toBeGreaterThan(second);
   });
 
   it("rolls the cards into the three special-format skills", () => {

--- a/tests/skills/output-design-contract.test.ts
+++ b/tests/skills/output-design-contract.test.ts
@@ -156,8 +156,8 @@ describe("output design system (Cards)", () => {
   it("makes every skill with a typed-confirmation flow reference the Cards contract (issue #389)", () => {
     // Self-maintaining adoption lint: any sub-skill carrying a confirm: flow
     // must name the Cards contract. skills/ha-nova defines the contract itself.
-    const CARD_REF =
-      /(Preview Card|Delete Card|Result Card|Test Plan Card|Cards defined there|card-framed)/;
+    // Negative prose ("not card-framed") does not count as a reference.
+    const CARD_REF = /(Preview Card|Delete Card|Result Card|Test Plan Card|Cards defined there)/;
     const skillDirs = readdirSync("skills").filter(
       (d) => d !== "ha-nova" && statSync(join("skills", d)).isDirectory(),
     );
@@ -185,6 +185,10 @@ describe("output design system (Cards)", () => {
       "| Snapshot restore (`skills/ha-nova/config-snapshots.md`) | Preview Card → Result Card |",
     );
     expect(outputRules).toContain("| Post-write test offer | Test Plan Card |");
+    // Runtime actions never downgrade the high-consequence typed gate.
+    expect(outputRules).toContain(
+      "high-consequence actions escalate to the typed confirmation code",
+    );
     // Restore flows are covered explicitly, not by convention.
     const configSnapshots = readFileSync("skills/ha-nova/config-snapshots.md", "utf8");
     expect(configSnapshots).toContain("render as the Preview and Result Cards");

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -118,7 +118,8 @@ const WORD_BUDGETS: Record<string, number> = {
   // write again for the Phase 5 test offer (test-run.md).
   // pre-delete snapshot capture + config-snapshots reference (Wave 2).
   write: 1700,
-  diagnose: 1450,
+  // Cards adoption pointer (#389).
+  diagnose: 1500,
   // Report-shape declaration line (shared output shapes); repair dedup,
   // attention-threshold definition, cause↔symptom linking (2026-h2 Wave 1c).
   health: 1350,
@@ -128,7 +129,8 @@ const WORD_BUDGETS: Record<string, number> = {
   // high-consequence carve-out (Wave 3).
   scene: 1600,
   // buffering settle-window on verify (2026-h2 Wave 1a).
-  media: 1200,
+  // Cards adoption pointer (#389).
+  media: 1250,
   // test-offer single-confirmation + reference bullets (test-run.md);
   // ratcheted for the owning-skill deferral table + high-consequence
   // confirmation rule (Wave 0), and again for the differentiated verify
@@ -146,8 +148,10 @@ const WORD_BUDGETS: Record<string, number> = {
   // batch-safety opt-in with the merged-save card rule (#327);
   // safety-backup offer (Wave 0) + drift check before the full-document
   // save (Wave 1a) + pre-delete/pre-save snapshot capture (Wave 2).
-  dashboard: 1400,
-  updates: 1200,
+  // Cards adoption pointer (#389).
+  dashboard: 1450,
+  // Cards adoption pointer (#389).
+  updates: 1250,
   // batch-safety alignment: batch code format + cap-split rule (#327);
   // purge quantification, glob expansion, apply_filter semantics
   // (2026-h2 Wave 1b).

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -165,7 +165,8 @@ const WORD_BUDGETS: Record<string, number> = {
   helper: 3850,
   // Suggestion Block item-shape pointer (shared output shapes); scene/
   // dashboard first-class targets with flow adaptation (2026-h2 Wave 3).
-  review: 4500,
+  // Quick-fix Preview Card reference (#389).
+  review: 4550,
 };
 const DEFAULT_WORD_BUDGET = 1150;
 


### PR DESCRIPTION
## Summary

- 16 mutation-capable skills (admin, assist, backup, camera, dashboard, diagnose, energy, fallback, maintenance, media, mqtt, notify, organize, scene, todo, updates) carried `confirm:` flows without naming the canonical Cards contract. Each now extends its existing `Apply output-rules.md` pointer line with: previews, delete confirmations, and results render as the Cards defined there.
- Restore flows are covered explicitly rather than by convention: `config-snapshots.md` → Restore now states the restore preview/result render as Preview/Result Cards.
- A compact operation-to-card coverage matrix sits in `output-rules.md` directly under the Cards definition (create/update, delete, batch, restore, test offer, runtime action).
- New tests in `output-design-contract.test.ts`:
  - self-maintaining adoption lint — any `skills/<dir>/SKILL.md` containing a `confirm:` flow must reference the Cards contract (new skills cannot silently escape),
  - structural template check — parses the four canonical card templates and fails when an icon or required section is missing, duplicated, or reordered (exactly one status block, one action block, prompt closes the Delete Card, ordered test-plan menu),
  - coverage-matrix pins.
- Word budgets ratcheted +50 for diagnose/dashboard/media/updates (+13 words each from the pointer sentence).

## Verification

- `npx vitest run tests/skills tests/e2e` → 421/421 (incl. the 3 new tests)
- Adoption grep: no `confirm:`-capable SKILL.md without a Cards reference

Fixes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b1UiBoUzZ5s3UZLJKb1XT