### PR TITLE
feat(demo): re-generatable terminal recording pipeline for README/launch demos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,12 @@ docs/internal/
 # Demo-recording identity denylist (personal strings, never committed)
 scripts/demo/denylist.local
 
+# Demo-recording working outputs (compressed casts, scrub exports, markers)
+# — private session content; curated casts go to scripts/demo/casts/ only.
+scripts/demo/*.cast
+scripts/demo/*.txt
+scripts/demo/*.markers.json
+
 # Python cache artifacts from local validation harnesses
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ scripts/demo/denylist.local
 scripts/demo/*.cast
 scripts/demo/*.txt
 scripts/demo/*.markers.json
+scripts/demo/casts/*.txt
+scripts/demo/casts/*.markers.json
 
 # Python cache artifacts from local validation harnesses
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ docs/internal/
 # Local validation artifacts
 .artifacts/
 
+# Demo-recording identity denylist (personal strings, never committed)
+scripts/demo/denylist.local
+
 # Python cache artifacts from local validation harnesses
 __pycache__/
 *.py[cod]

--- a/docs/reference/demo-recording.md
+++ b/docs/reference/demo-recording.md
@@ -24,7 +24,7 @@ Assistant — only waiting time is compressed.
 | tmux, asciinema, ffmpeg, jq | `brew install tmux asciinema ffmpeg jq` | drive + record + post-process |
 | vhs (pulls ttyd) | `brew install vhs` | replay renderer (Chromium: correct color emoji) |
 | gif2webp | `brew install webp` | GIF -> animated WebP (Homebrew ffmpeg ships without libwebp) |
-| pyte | `python3 -m pip install pyte` | terminal emulation in `compress-cast.py` (new-text detection for time compression) |
+| pyte, Pillow | `python3 -m pip install pyte Pillow` | terminal emulation in `compress-cast.py`; cursor-overlay drawing in `render.sh` |
 | JetBrains Mono | `cp` the two TTFs from [JetBrainsMono releases](https://github.com/JetBrains/JetBrainsMono) to `~/Library/Fonts/` (Regular + Bold) | deterministic glyph metrics in vhs |
 
 Plus: the `ha-nova` CLI onboarded against a live Home Assistant, and the

--- a/docs/reference/demo-recording.md
+++ b/docs/reference/demo-recording.md
@@ -104,7 +104,9 @@ since changed.
 
 - Scrub gate passed; exported txt eyeballed once.
 - Hero: Preview Card (behavior sentences on create; the before/after change
-  table appears on updates) -> `apply` -> Result Card with revert offer.
+  table appears on updates) -> `apply` -> Result Card. A revert offer appears
+  only when the take includes an update — creates carry no revert and are
+  cleaned up via `cleanup-hero.sh` (write contract: `skills/write/SKILL.md`).
   Clarifying-question menus and auto-confirmed approval prompts are fine —
   they are the real product — but no errors, English throughout.
 - Review: >= 2 severity findings in plain language, no internal check codes,

--- a/docs/reference/demo-recording.md
+++ b/docs/reference/demo-recording.md
@@ -30,6 +30,13 @@ Assistant — only waiting time is compressed.
 Plus: the `ha-nova` CLI onboarded against a live Home Assistant, and the
 `claude` CLI with the ha-nova plugin installed.
 
+Before the first real take, create the untracked identity denylist
+`scripts/demo/denylist.local` (one fixed string per line: account names,
+family names, street/city — anything that must never appear in a cast).
+`scrub-check.sh` warns when it is missing; the committed denylist carries
+only generic credential patterns, because a committed identity list would
+publish exactly what it protects.
+
 ## Pipeline
 
 ```

--- a/docs/reference/demo-recording.md
+++ b/docs/reference/demo-recording.md
@@ -1,0 +1,113 @@
+# Demo Recording Pipeline
+
+How animated terminal demos (`assets/demo-*.webp`) are produced for README
+and launch material, and how to re-record them for a future release.
+Everything shown is a REAL Claude Code session against a live Home
+Assistant — only waiting time is compressed.
+
+## Honesty rules
+
+- No staged output. The cast is recorded from a live session; retakes are
+  allowed, edits of content are not.
+- Time compression only: spinner/thinking windows and idle gaps are shortened
+  (`compress-cast.py`); every frame shown really happened.
+- One disclosed exception: the account e-mail in claude's welcome header is
+  replaced byte-level with `demo@example.com` (same length, PII redaction —
+  nothing about the product is altered).
+- The camera picture-in-picture may only show the snapshot fetched in that
+  exact session (`record-camera.sh` preserves it).
+
+## Prerequisites (macOS)
+
+| Tool | Install | Why |
+|------|---------|-----|
+| tmux, asciinema, ffmpeg, jq | `brew install tmux asciinema ffmpeg jq` | drive + record + post-process |
+| vhs (pulls ttyd) | `brew install vhs` | replay renderer (Chromium: correct color emoji) |
+| gif2webp | `brew install webp` | GIF -> animated WebP (Homebrew ffmpeg ships without libwebp) |
+| JetBrains Mono | `cp` the two TTFs from [JetBrainsMono releases](https://github.com/JetBrains/JetBrainsMono) to `~/Library/Fonts/` (Regular + Bold) | deterministic glyph metrics in vhs |
+
+Plus: the `ha-nova` CLI onboarded against a live Home Assistant, and the
+`claude` CLI with the ha-nova plugin installed.
+
+## Pipeline
+
+```
+record-*.sh       real session in tmux (exact grid!), asciinema cast
+compress-cast.py  e-mail redaction + tail cut (/exit onwards)
+                  + busy-window rescale + gap capping + markers.json
+scrub-check.sh    privacy gate on the compressed cast       [blocks take]
+render.sh         vhs replay -> [PiP] -> gif2webp -> size gate -> QA frames
+```
+
+### Why the odd architecture
+
+Verified constraints force it (see the 2026-07 refresh PR):
+
+1. **Claude's spinner defeats idle limiting.** The TUI repaints ~10x/s while
+   thinking, so `asciinema rec -i` / renderer idle limits never fire.
+   `compress-cast.py` rescales those windows on the timestamp level instead.
+2. **Terminal grid must match exactly.** The fullscreen TUI stream garbles if
+   the replay terminal differs by even one column. `geometry.env` carries the
+   calibrated vhs pixel size for the tmux grid; recalibrate with
+   `calibrate-geometry.sh` after changing font or vhs versions.
+3. **Only trailing cuts are safe.** Cutting events at the start drops
+   terminal-state setup (scroll regions) that later bytes depend on; the
+   session therefore starts at claude's launch and the welcome header's
+   e-mail is neutralized by redaction instead (ANSI-sequence-aware — a naive
+   regex eats SGR terminators and garbles the replay).
+4. **agg cannot render color emoji on macOS** (Cards depend on them), and
+   Homebrew ffmpeg has no libwebp. Hence vhs for rendering and gif2webp for
+   the final conversion.
+
+## Recording a new set
+
+```bash
+cd scripts/demo
+
+# once per machine
+bash calibrate-geometry.sh              # refresh geometry.env if needed
+
+# once per recording day: warm-up (absorbs trust dialog + one-time notices)
+mkdir -p ~/smart-home && cd ~/smart-home && claude   # say hi, /exit
+
+# hero (creates + reverts a real automation; cleanup after EVERY take)
+bash record-hero.sh --take 1
+bash cleanup-hero.sh
+
+# review (read-only; dry-run unrecorded first, watch for sensitive names)
+bash record-review.sh --take 1 --scope "light automations"
+
+# camera (read-only; preserves the session snapshot for the PiP)
+bash record-camera.sh --take 1
+
+# compress (redact + cut + tighten) -> scrub gate -> render
+python3 compress-cast.py ../../.artifacts/demo/hero/take-1.cast hero.cast \
+  --prompt-hint "When the sun sets"
+bash scrub-check.sh hero.cast
+bash render.sh hero.cast ../../assets/demo-hero.webp --max-kb 3072
+
+python3 compress-cast.py ../../.artifacts/demo/camera/take-1.cast camera.cast \
+  --prompt-hint "Check the garage camera"
+bash scrub-check.sh camera.cast
+bash render.sh camera.cast ../../assets/demo-camera.webp --max-kb 1536 \
+  --pip-image ../../.artifacts/demo/camera/take-1-snapshot.jpg \
+  --pip-label "camera.garage — live snapshot"
+```
+
+Selected final casts may be committed to `scripts/demo/casts/` so a future
+theme or size change can re-render without re-recording — commit only casts
+that passed the scrub gate, and re-record instead when the recorded UI has
+since changed.
+
+## Acceptance gates per asset
+
+- Scrub gate passed; exported txt eyeballed once.
+- Hero: Preview Card (behavior sentences on create; the before/after change
+  table appears on updates) -> `apply` -> Result Card with revert offer.
+  Clarifying-question menus and auto-confirmed approval prompts are fine —
+  they are the real product — but no errors, English throughout.
+- Review: >= 2 severity findings in plain language, no internal check codes,
+  no sensitive automation names.
+- Camera: snapshot fetch visible, PiP shows the session's real frame, clear
+  verdict; nothing sensitive in image or description.
+- Size budgets: hero <= 3 MB, review <= 1.5 MB, camera <= 1.5 MB.

--- a/docs/reference/demo-recording.md
+++ b/docs/reference/demo-recording.md
@@ -24,6 +24,7 @@ Assistant — only waiting time is compressed.
 | tmux, asciinema, ffmpeg, jq | `brew install tmux asciinema ffmpeg jq` | drive + record + post-process |
 | vhs (pulls ttyd) | `brew install vhs` | replay renderer (Chromium: correct color emoji) |
 | gif2webp | `brew install webp` | GIF -> animated WebP (Homebrew ffmpeg ships without libwebp) |
+| pyte | `python3 -m pip install pyte` | terminal emulation in `compress-cast.py` (new-text detection for time compression) |
 | JetBrains Mono | `cp` the two TTFs from [JetBrainsMono releases](https://github.com/JetBrains/JetBrainsMono) to `~/Library/Fonts/` (Regular + Bold) | deterministic glyph metrics in vhs |
 
 Plus: the `ha-nova` CLI onboarded against a live Home Assistant, and the

--- a/scripts/demo/calibrate-geometry.sh
+++ b/scripts/demo/calibrate-geometry.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# calibrate-geometry.sh — measure the exact pixel size at which vhs produces
+# the target terminal grid, then write geometry.env.
+#
+# Why: vhs sizes its terminal in pixels; the resulting cols/rows depend on the
+# font raster. Recording (tmux) and rendering (vhs) must agree on the grid
+# EXACTLY or fullscreen-TUI replays garble. This probe asks vhs itself.
+set -euo pipefail
+
+DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_COLS="${1:-100}"
+TARGET_ROWS="${2:-30}"
+FONT_SIZE="${3:-16}"
+PADDING=12
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+probe() { # width height -> "cols rows"
+  local w="$1" h="$2"
+  # Paths inside the tape must be RELATIVE — vhs' parser chokes on the dots
+  # that mktemp puts into absolute paths.
+  cat >"$WORK/probe.tape" <<EOF
+Output probe.gif
+Set Shell bash
+Set FontSize $FONT_SIZE
+Set FontFamily "JetBrains Mono"
+Set Width $w
+Set Height $h
+Set Padding $PADDING
+Hide
+Type "echo GEO \$(tput cols) \$(tput lines) > geo.txt"
+Enter
+Sleep 1.5
+Show
+Sleep 0.3
+EOF
+  (cd "$WORK" && vhs probe.tape >/dev/null 2>&1)
+  awk '{print $2, $3}' "$WORK/geo.txt"
+}
+
+echo "Probing vhs cell metrics (font size $FONT_SIZE)..."
+read -r cols rows <<<"$(probe 1000 680)"
+cell_w=$(python3 -c "print((1000-2*$PADDING)/$cols)")
+cell_h=$(python3 -c "print((680-2*$PADDING)/$rows)")
+
+width=$(python3 -c "import math; print(math.ceil($TARGET_COLS*$cell_w)+2*$PADDING+2)")
+height=$(python3 -c "import math; print(math.ceil($TARGET_ROWS*$cell_h)+2*$PADDING+2)")
+
+for _ in 1 2 3 4; do
+  read -r cols rows <<<"$(probe "$width" "$height")"
+  echo "  ${width}x${height}px -> ${cols}x${rows}"
+  [[ "$cols" == "$TARGET_COLS" && "$rows" == "$TARGET_ROWS" ]] && break
+  ((cols < TARGET_COLS)) && width=$((width + 4))
+  ((cols > TARGET_COLS)) && width=$((width - 4))
+  ((rows < TARGET_ROWS)) && height=$((height + 4))
+  ((rows > TARGET_ROWS)) && height=$((height - 4))
+done
+
+if [[ "$cols" != "$TARGET_COLS" || "$rows" != "$TARGET_ROWS" ]]; then
+  echo "ERROR: could not converge on ${TARGET_COLS}x${TARGET_ROWS} (got ${cols}x${rows})." >&2
+  exit 1
+fi
+
+cat >"$DEMO_DIR/geometry.env" <<EOF
+# Calibrated vhs <-> tmux geometry. Regenerate with calibrate-geometry.sh.
+# Measured $(date +%Y-%m-%d) with vhs $(vhs --version 2>/dev/null | awk '{print $3}').
+# CRITICAL: recordings and renders must use the SAME cell grid, or the
+# fullscreen-TUI replay garbles (verified failure mode).
+DEMO_COLS=$TARGET_COLS
+DEMO_ROWS=$TARGET_ROWS
+VHS_WIDTH=$width
+VHS_HEIGHT=$height
+VHS_FONT_SIZE=$FONT_SIZE
+VHS_PADDING=$PADDING
+VHS_FONT_FAMILY="JetBrains Mono"
+VHS_THEME="GitHub Dark"
+EOF
+echo "Wrote $DEMO_DIR/geometry.env (${width}x${height}px = ${TARGET_COLS}x${TARGET_ROWS})"

--- a/scripts/demo/calibrate-geometry.sh
+++ b/scripts/demo/calibrate-geometry.sh
@@ -9,10 +9,18 @@
 set -euo pipefail
 
 DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET_COLS="${1:-100}"
-TARGET_ROWS="${2:-30}"
-FONT_SIZE="${3:-16}"
-PADDING=12
+
+# Default to the committed calibration so a bare re-run REFRESHES the
+# existing grid instead of silently switching layout and asset dimensions.
+DEMO_COLS=100 DEMO_ROWS=30 VHS_FONT_SIZE=16 VHS_PADDING=12
+if [[ -f "$DEMO_DIR/geometry.env" ]]; then
+  # shellcheck source=geometry.env
+  source "$DEMO_DIR/geometry.env"
+fi
+TARGET_COLS="${1:-$DEMO_COLS}"
+TARGET_ROWS="${2:-$DEMO_ROWS}"
+FONT_SIZE="${3:-$VHS_FONT_SIZE}"
+PADDING="$VHS_PADDING"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 

--- a/scripts/demo/cleanup-hero.sh
+++ b/scripts/demo/cleanup-hero.sh
@@ -25,13 +25,19 @@ done
 
 list_matches() {
   # Case-insensitive: the model may title-case the alias ("Pool Deck Lights…").
-  local prefix_lc
+  # A failed relay lookup must never read as "nothing to clean" — the demo
+  # automation would silently survive in the live instance.
+  local prefix_lc raw
   prefix_lc=$(tr '[:upper:]' '[:lower:]' <<<"$PREFIX")
-  ha-nova relay ws -d '{"type":"config/entity_registry/list_for_display"}' \
+  if ! raw=$(ha-nova relay ws -d '{"type":"config/entity_registry/list_for_display"}' \
     -jq "[.data.entities[]
           | select((.ei | startswith(\"automation.\"))
                    and ((.en // \"\") | ascii_downcase | startswith(\"$prefix_lc\")))
-          | \"\(.ei)\t\(.en // \"?\")\"]" 2>/dev/null | ha-nova relay jq -r '.[]' || true
+          | \"\(.ei)\t\(.en // \"?\")\"]"); then
+    echo "ERROR: relay lookup failed — cannot tell whether demo automations remain." >&2
+    exit 1
+  fi
+  ha-nova relay jq -r '.[]' <<<"$raw"
 }
 
 list_entity_ids() {

--- a/scripts/demo/cleanup-hero.sh
+++ b/scripts/demo/cleanup-hero.sh
@@ -7,12 +7,23 @@
 # entity registry (WS) -> unique_id -> REST DELETE on the config id. There is
 # no REST list route for automation configs.
 #
-# Usage: cleanup-hero.sh ["Alias Prefix"]
+# Usage: cleanup-hero.sh ["Alias Prefix"] [--yes]
+#
+# Prefix matching can catch a user's own automation on a live instance
+# ("Pool deck lights evening"), so every delete lists the matched names and
+# requires interactive confirmation unless --yes is passed.
 set -euo pipefail
 
-PREFIX="${1:-Pool deck lights}"
+PREFIX="Pool deck lights"
+ASSUME_YES=0
+for arg in "$@"; do
+  case "$arg" in
+    --yes) ASSUME_YES=1 ;;
+    *) PREFIX="$arg" ;;
+  esac
+done
 
-list_entity_ids() {
+list_matches() {
   # Case-insensitive: the model may title-case the alias ("Pool Deck Lights…").
   local prefix_lc
   prefix_lc=$(tr '[:upper:]' '[:lower:]' <<<"$PREFIX")
@@ -20,14 +31,26 @@ list_entity_ids() {
     -jq "[.data.entities[]
           | select((.ei | startswith(\"automation.\"))
                    and ((.en // \"\") | ascii_downcase | startswith(\"$prefix_lc\")))
-          | .ei]" 2>/dev/null | ha-nova relay jq -r '.[]' || true
+          | \"\(.ei)\t\(.en // \"?\")\"]" 2>/dev/null | ha-nova relay jq -r '.[]' || true
 }
 
-mapfile -t ids < <(list_entity_ids)
+list_entity_ids() {
+  list_matches | cut -f1
+}
+
+mapfile -t matches < <(list_matches)
+mapfile -t ids < <(printf '%s\n' "${matches[@]:-}" | cut -f1 | sed '/^$/d')
 
 if ((${#ids[@]} == 0)); then
   echo "No demo automation matching alias prefix \"$PREFIX\" — nothing to clean."
   exit 0
+fi
+
+echo "Matched ${#ids[@]} automation(s) by alias prefix \"$PREFIX\":"
+printf '  %s\n' "${matches[@]}"
+if ((!ASSUME_YES)); then
+  read -r -p "Delete ALL of the above? Only demo automations should be listed. [y/N] " answer
+  [[ "$answer" == "y" || "$answer" == "Y" ]] || { echo "Aborted — nothing deleted."; exit 1; }
 fi
 
 echo "Deleting ${#ids[@]} demo automation(s): ${ids[*]}"

--- a/scripts/demo/cleanup-hero.sh
+++ b/scripts/demo/cleanup-hero.sh
@@ -44,8 +44,17 @@ list_entity_ids() {
   list_matches | cut -f1
 }
 
-mapfile -t matches < <(list_matches)
-mapfile -t ids < <(printf '%s\n' "${matches[@]:-}" | cut -f1 | sed '/^$/d')
+# Plain assignment, not process substitution: an exit inside <(...) never
+# reaches the parent, which would turn a failed lookup into "nothing to clean".
+matches_raw=$(list_matches)
+matches=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && matches+=("$line")
+done <<<"$matches_raw"
+ids=()
+for m in "${matches[@]:-}"; do
+  [[ -n "$m" ]] && ids+=("${m%%$'\t'*}")
+done
 
 if ((${#ids[@]} == 0)); then
   echo "No demo automation matching alias prefix \"$PREFIX\" — nothing to clean."
@@ -72,9 +81,9 @@ for ei in "${ids[@]}"; do
 done
 
 sleep 1
-mapfile -t left < <(list_entity_ids)
-if ((${#left[@]} > 0)); then
-  echo "ERROR: still present after delete: ${left[*]}" >&2
+left_raw=$(list_entity_ids)
+if [[ -n "$left_raw" ]]; then
+  echo "ERROR: still present after delete: $(tr '\n' ' ' <<<"$left_raw")" >&2
   exit 1
 fi
 echo "Verified: no demo automation left."

--- a/scripts/demo/cleanup-hero.sh
+++ b/scripts/demo/cleanup-hero.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# cleanup-hero.sh — delete the demo automation created by a hero take and
+# verify it is gone. Run after EVERY take, successful or not.
+#
+# Resolution path (see skills/ha-nova/relay-api.md, "ID Types & Resolution"):
+# entity registry (WS) -> unique_id -> REST DELETE on the config id. There is
+# no REST list route for automation configs.
+#
+# Usage: cleanup-hero.sh ["Alias Prefix"]
+set -euo pipefail
+
+PREFIX="${1:-Pool deck lights}"
+
+list_entity_ids() {
+  # Case-insensitive: the model may title-case the alias ("Pool Deck Lights…").
+  local prefix_lc
+  prefix_lc=$(tr '[:upper:]' '[:lower:]' <<<"$PREFIX")
+  ha-nova relay ws -d '{"type":"config/entity_registry/list_for_display"}' \
+    -jq "[.data.entities[]
+          | select((.ei | startswith(\"automation.\"))
+                   and ((.en // \"\") | ascii_downcase | startswith(\"$prefix_lc\")))
+          | .ei]" 2>/dev/null | ha-nova relay jq -r '.[]' || true
+}
+
+mapfile -t ids < <(list_entity_ids)
+
+if ((${#ids[@]} == 0)); then
+  echo "No demo automation matching alias prefix \"$PREFIX\" — nothing to clean."
+  exit 0
+fi
+
+echo "Deleting ${#ids[@]} demo automation(s): ${ids[*]}"
+for ei in "${ids[@]}"; do
+  uid=$(ha-nova relay ws -d "{\"type\":\"config/entity_registry/get\",\"entity_id\":\"$ei\"}" \
+    -jq '.data.unique_id' | ha-nova relay jq -r '.')
+  if [[ -z "$uid" || "$uid" == "null" ]]; then
+    echo "ERROR: no unique_id for $ei — delete manually." >&2
+    exit 1
+  fi
+  ha-nova relay core -method DELETE -path "/api/config/automation/config/$uid" >/dev/null
+  echo "  deleted $ei (config id $uid)"
+done
+
+sleep 1
+mapfile -t left < <(list_entity_ids)
+if ((${#left[@]} > 0)); then
+  echo "ERROR: still present after delete: ${left[*]}" >&2
+  exit 1
+fi
+echo "Verified: no demo automation left."

--- a/scripts/demo/compress-cast.py
+++ b/scripts/demo/compress-cast.py
@@ -163,7 +163,10 @@ def new_text_per_event(events, cols, rows):
     across two consecutive events (i.e. finished streaming) — otherwise every
     growing prefix of a streamed line would count again. Digits are masked so
     spinner ticks and counters do not count as new text."""
-    import pyte
+    try:
+        import pyte
+    except ImportError:
+        sys.exit("compress-cast.py needs the 'pyte' package: python3 -m pip install pyte")
     screen = pyte.Screen(cols, rows)
     stream = pyte.Stream(screen)
     # Word-level dedup: the TUI repaints the same content in many wrap and

--- a/scripts/demo/compress-cast.py
+++ b/scripts/demo/compress-cast.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""compress-cast.py — tighten a real asciinema recording without faking it.
+
+Approach: a uniform time-lapse toward --target seconds, with driver-declared
+protection. The recording driver logs its own typing windows (epoch pairs in
+<cast>.protect, written by lib.sh) — those keep their natural cadence, and
+intervals right after a content marker (preview card, options line, result
+card) keep a reading hold. Everything else — thinking pauses, spinner phases,
+tool latency, streamed output — is scaled uniformly. Every frame shown really
+happened; only time shrinks. (Content-based busy-detection was tried first
+and lost: spinner tick shapes and periodic full repaints vary too much across
+claude versions to classify reliably. The spinner also ticks ~10x/s, so
+interval-length heuristics cannot tell thinking from typing.)
+
+Also:
+- E-mail addresses are redacted byte-level (ANSI-sequence-aware — a naive
+  regex eats SGR terminators and garbles the replay; verified). The claude
+  welcome header prints the account e-mail and survives every repaint.
+- The tail is cut in event space: everything from the typed "/exit" onwards
+  (teardown, resume screen) is dropped. Trailing cuts are safe; LEADING cuts
+  drop terminal-state setup later bytes depend on and garble the replay.
+- Emits <out>.markers.json with post-compression timestamps for render.sh
+  (camera picture-in-picture timing).
+- A final no-op event is appended: asciinema play can swallow the very last
+  event's rendering otherwise.
+"""
+import argparse
+import json
+import re
+import sys
+
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+ANSI_RE = re.compile(
+    r"\x1b(?:\[[0-9;?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[()][0-9A-Za-z]|[@-_])"
+)
+MARKER_PATTERNS = {
+    "preview_card": "Preview:",
+    "options_line": "Options:",
+    "result_card": "Saved",
+    "revert_offer": "revert",
+    "delete_card": "Delete",
+    "snapshot": "snapshot",
+    "exit_typed": "/exit",
+}
+# Intervals following these markers keep at least READ_HOLD seconds — the
+# viewer must be able to actually read cards and menus (user requirement:
+# fast-forward the waiting, hold the decisions).
+READ_MARKERS = ("preview_card", "options_line", "result_card", "revert_offer",
+                "delete_card")
+# Menu screens repaint often; a new hold is granted when one appears more
+# than MENU_GAP real seconds after the previous hold point.
+MENU_PATTERNS = ("Enter to select", "Ready to submit")
+MENU_GAP = 8.0
+READ_HOLD = 3.0
+
+
+def _mask(m):
+    s = m.group(0)
+    repl = "demo@example.com"
+    return (repl + " " * len(s))[: len(s)] if len(s) >= len(repl) else "*" * len(s)
+
+
+def redact(data):
+    out, pos = [], 0
+    for m in ANSI_RE.finditer(data):
+        out.append(EMAIL_RE.sub(_mask, data[pos:m.start()]))
+        out.append(m.group(0))
+        pos = m.end()
+    out.append(EMAIL_RE.sub(_mask, data[pos:]))
+    return "".join(out)
+
+
+def load(path):
+    with open(path) as f:
+        lines = [l for l in f if l.strip()]
+    return json.loads(lines[0]), [json.loads(l) for l in lines[1:]]
+
+
+def find_marker_indices(events, prompt_hint):
+    idx = {}
+    for i, (_, _, data) in enumerate(events):
+        if prompt_hint and "first_input" not in idx and prompt_hint[:24] in data:
+            idx["first_input"] = i
+        for name, pat in MARKER_PATTERNS.items():
+            if name not in idx and pat in data:
+                idx[name] = i
+    return idx
+
+
+def cut_tail(events, cut_end):
+    """Drop trailing events (typed /exit, teardown, resume screen)."""
+    if cut_end is None:
+        return events
+    kept = [e for e in events if e[0] <= cut_end]
+    return kept or events
+
+
+PGUP, PGDN = "\x1b[5~", "\x1b[6~"
+
+
+def windows_from_input_events(events):
+    """Derive protection windows from captured input events ("i" type,
+    recorded via `asciinema rec --capture-input`) — on the cast's own clock,
+    immune to the wall-clock drift that killed the sidecar approach.
+
+    Returns (windows, cut_end):
+    - "type" windows: clusters of >= 3 printable keystrokes ending in Enter
+      (the typed prompts; menu picks like "1"/Tab don't qualify)
+    - "read" windows: pauses > 1.5s between consecutive PageDown events —
+      the reading holds of read_back(); they also anchor the reading cursor
+    - cut_end: start of the final "/exit" cluster (tail cut), or None
+    """
+    ins = [(t, d) for t, ty, d in events if ty == "i"]
+    windows, cut_end = [], None
+
+    cluster = []  # [(t, ch)]
+    for t, d in ins:
+        if d == "\r":
+            if len(cluster) >= 3:
+                text = "".join(ch for _, ch in cluster)
+                if text.startswith("/exit"):
+                    cut_end = cluster[0][0] - 0.3
+                else:
+                    windows.append((cluster[0][0] - 0.2, t + 0.2, "type"))
+            cluster = []
+        elif len(d) == 1 and d.isprintable():
+            if cluster and t - cluster[-1][0] > 0.8:
+                cluster = []
+            cluster.append((t, d))
+        else:
+            cluster = []
+
+    # Any PageUp/PageDown marks an (abandoned) TUI scroll attempt — the TUI
+    # auto-jumps back to the bottom on every repaint, so scrolling is not
+    # usable for reading holds. Cut the recording before the first one.
+    pages = [t for t, d in ins if d in (PGUP, PGDN)]
+    if pages:
+        first_page = min(pages) - 0.3
+        cut_end = min(cut_end, first_page) if cut_end else first_page
+
+    return windows, cut_end
+
+
+def in_windows(t, windows, kinds=("type",)):
+    return any(a <= t <= b for a, b, k in windows if k in kinds)
+
+
+def hold_points(events, marker_idx):
+    """Event indices after which the timeline must pause for READ_HOLD."""
+    holds = {marker_idx[m] for m in READ_MARKERS if m in marker_idx}
+    last_hold_t = None
+    for i, (t, _, data) in enumerate(events):
+        if any(p in data for p in MENU_PATTERNS):
+            if last_hold_t is None or t - last_hold_t > MENU_GAP:
+                holds.add(i)
+                last_hold_t = t
+    return holds
+
+
+def new_text_per_event(events, cols, rows):
+    """Ground truth via terminal emulation: per event, how many characters of
+    genuinely NEW visible text appear. A line only counts once it is STABLE
+    across two consecutive events (i.e. finished streaming) — otherwise every
+    growing prefix of a streamed line would count again. Digits are masked so
+    spinner ticks and counters do not count as new text."""
+    import pyte
+    screen = pyte.Screen(cols, rows)
+    stream = pyte.Stream(screen)
+    # Word-level dedup: the TUI repaints the same content in many wrap and
+    # indent variants (stream buffer vs. transcript vs. after scroll), so
+    # line-level sets over-count massively. A word counts once, ever.
+    word_re = re.compile(r"[A-Za-zÀ-ſ_./:-]{4,}")
+    # Command echoes, heredocs and permission boxes are tool internals, not
+    # reading material — they must fly by at cut pace.
+    skip_line_re = re.compile(
+        r"^\$ |<<'EOF'|^EOF\b|--data-file|--jq-file|--out |/scratchpad/"
+        r"|^Bash command|Do you want to proceed|^1\. Yes|^2\. No"
+        r"|Esc to cancel|Contains .*(quote|expansion)|^done\b|^echo |^cat "
+        r"|relay (ws|core) |^for \w+ in |requires approval"
+    )
+    seen_words = set()
+    prev_display = []
+    out = []
+    for _, _, data in events:
+        try:
+            stream.feed(data)
+        except Exception:
+            pass
+        display = [l.strip() for l in screen.display]
+        prev_set = set(prev_display)
+        new = 0
+        for s in display:
+            if len(s) < 6 or s not in prev_set:
+                continue
+            # Terminal-integration junk (Warp notify OSC leaking through
+            # tmux) is not reading material.
+            if "warp://" in s or '"cwd"' in s:
+                continue
+            if skip_line_re.search(s):
+                continue
+            # Positive prose gate: reading time is only earned by sentence-
+            # like lines. JSON payloads, jq filters and heredocs structurally
+            # fail this (few pure words, or shell/JSON punctuation).
+            if sum(1 for w in s.split()
+                   if w.strip(".,:;()!?·—-\"'`").isalpha()) < 3:
+                continue
+            if any(c in s for c in "{}<>") or "--" in s or "/private/" in s:
+                continue
+            for w in word_re.findall(s):
+                if len(w) > 15 and "/" in w:
+                    continue  # paths/ids — nobody reads those
+                if w not in seen_words:
+                    seen_words.add(w)
+                    new += min(len(w), 12) + 1
+        prev_display = display
+        out.append(new)
+    return out
+
+
+def compress(events, marker_idx, windows, new_chars, target, max_dt,
+             typing_max, skim_rate):
+    times = [e[0] for e in events]
+    dts = [times[0]] + [times[k] - times[k - 1] for k in range(1, len(times))]
+    hold_after = hold_points(events, marker_idx)
+
+    # An interval is protected only when it lies fully inside a typing window
+    # (both endpoints) — otherwise a long wait that merely ENDS at the first
+    # keystroke would be exempted from scaling.
+    protected = [
+        in_windows(times[k], windows) and in_windows(times[k] - dts[k], windows)
+        for k in range(len(dts))
+    ]
+
+    orig_dts = list(dts)
+
+    # Typing keeps its cadence LOOK but not its full duration: squeeze each
+    # typing window proportionally to at most typing_max seconds.
+    for a, b, kind in windows:
+        if kind != "type":
+            continue
+        ks = [k for k in range(len(dts)) if protected[k] and a <= times[k] <= b]
+        w_dur = sum(dts[k] for k in ks)
+        if w_dur > typing_max:
+            tf = typing_max / w_dur
+            for k in ks:
+                dts[k] *= tf
+
+    prot_sum = sum(dt for k, dt in enumerate(dts) if protected[k])
+    free = [(k, dt) for k, dt in enumerate(dts) if not protected[k]]
+    free_sum = sum(dt for _, dt in free)
+
+    budget = max(target - prot_sum, 5.0)
+    f = min(1.0, budget / free_sum) if free_sum > 0 else 1.0
+
+    for k, dt in free:
+        floor = READ_HOLD if (k - 1) in hold_after else 0.0
+        dts[k] = min(max(dt * f, floor), max(max_dt, floor))
+
+    # READING TIME (the core viewer requirement), measured on ground truth:
+    # new_chars[k] is how much genuinely new text event k painted (terminal
+    # emulation; digits masked so spinners/counters don't count). Every burst
+    # of new text earns dwell time at skim rate — so the top of a multi-screen
+    # answer stays visible before it scrolls off — and a pause after a burst
+    # earns a reading hold proportional to what just appeared.
+    for k in range(len(dts)):
+        if new_chars[k] > 90:
+            dts[k] = max(dts[k], min(new_chars[k] / skim_rate, 6.0))
+
+    read_holds = []
+    for k in range(len(dts) - 1):
+        if orig_dts[k + 1] < 3.0:
+            continue
+        recent = 0
+        j = k
+        while j >= 0 and times[k] - times[j] <= 5.0:
+            recent += new_chars[j]
+            j -= 1
+        if recent < 120:
+            continue
+        hold = min(max(1.5 + recent / 90.0, 2.5), 8.0)
+        if hold > dts[k + 1]:
+            dts[k + 1] = hold
+        read_holds.append(k + 1)
+
+    t = 0.0
+    out = []
+    new_times = []
+    for k, (_, typ, data) in enumerate(events):
+        t += dts[k]
+        out.append([round(t, 4), typ, data])
+        new_times.append(t)
+
+    def remap(t_old):
+        """Old-clock time -> new-clock time (nearest following event)."""
+        for k in range(len(times)):
+            if times[k] >= t_old:
+                return new_times[k]
+        return new_times[-1]
+
+    # Reading windows for the cursor overlay: contiguous new-text regions
+    # (gap < 4s on the original clock) plus the explicit holds.
+    hold_windows = [
+        (round(new_times[k] - dts[k], 2), round(new_times[k], 2), "read")
+        for k in read_holds
+    ]
+    first = None
+    last = None
+    for k in range(len(dts)):
+        if new_chars[k] > 90:
+            if first is not None and times[k] - times[last] > 4.0:
+                if new_times[last] - new_times[first] >= 2.5:
+                    hold_windows.append((round(new_times[first] - dts[first], 2),
+                                         round(new_times[last], 2), "read"))
+                first = None
+            if first is None:
+                first = k
+            last = k
+    if first is not None and new_times[last] - new_times[first] >= 2.5:
+        hold_windows.append((round(new_times[first] - dts[first], 2),
+                             round(new_times[last], 2), "read"))
+    return out, remap, hold_windows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("cast_in")
+    ap.add_argument("cast_out")
+    ap.add_argument("--target", type=float, default=45.0,
+                    help="rough target duration in seconds")
+    ap.add_argument("--max-dt", type=float, default=0.4,
+                    help="hard cap for any single non-hold interval — work "
+                         "phases read as cuts, like the original demo")
+    ap.add_argument("--typing-max", type=float, default=2.5,
+                    help="squeeze each typing window to at most this")
+    ap.add_argument("--skim-rate", type=float, default=40.0,
+                    help="unique-word chars per second granted as dwell time")
+    ap.add_argument("--prompt-hint", default="", help="first words of the typed prompt")
+    ap.add_argument("--no-cut", action="store_true", help="keep the full session")
+    args = ap.parse_args()
+
+    header, events = load(args.cast_in)
+    if not events:
+        sys.exit("empty cast")
+
+    before = events[-1][0]
+    windows, cut_end = windows_from_input_events(events)
+    # Input events served their purpose; only output events are replayed.
+    events = [[t, typ, redact(data)] for t, typ, data in events if typ == "o"]
+    if not args.no_cut:
+        events = cut_tail(events, cut_end)
+    # Clamp the open-ended answer window to the actual cast end.
+    last_t = events[-1][0]
+    windows = [(a, min(b, last_t), k) for a, b, k in windows if a < last_t]
+    marker_idx = find_marker_indices(events, args.prompt_hint)
+    cast_end = events[-1][0]
+    new_chars = new_text_per_event(events, header.get("width", 106),
+                                   header.get("height", 21))
+    events, remap, hold_windows = compress(events, marker_idx, windows,
+                                           new_chars, args.target,
+                                           args.max_dt, args.typing_max,
+                                           args.skim_rate)
+    events.append([round(events[-1][0] + 0.5, 4), "o", "\x1b[0m"])
+
+    with open(args.cast_out, "w") as f:
+        f.write(json.dumps(header) + "\n")
+        for e in events:
+            f.write(json.dumps(e, ensure_ascii=False) + "\n")
+
+    markers = {name: events[i][0] for name, i in marker_idx.items() if i < len(events)}
+    markers["end"] = events[-1][0]
+    # Windows on the compressed clock — render.sh anchors the reading cursor
+    # to the "read" entries.
+    markers["windows"] = [
+        [round(remap(max(a, 0)), 2), round(remap(min(b, cast_end)), 2), k]
+        for a, b, k in windows
+        if a < cast_end
+    ] + [list(w) for w in hold_windows]
+    with open(args.cast_out + ".markers.json", "w") as f:
+        json.dump(markers, f, indent=2, sort_keys=True)
+
+    print(f"{args.cast_in}: {before:.1f}s -> {events[-1][0]:.1f}s "
+          f"(markers: {', '.join(sorted(markers))})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demo/geometry.env
+++ b/scripts/demo/geometry.env
@@ -1,0 +1,12 @@
+# Calibrated vhs <-> tmux geometry. Regenerate with calibrate-geometry.sh.
+# Measured 2026-07-13 with vhs 0.11.0.
+# CRITICAL: recordings and renders must use the SAME cell grid, or the
+# fullscreen-TUI replay garbles (verified failure mode).
+DEMO_COLS=106
+DEMO_ROWS=21
+VHS_WIDTH=1225
+VHS_HEIGHT=518
+VHS_FONT_SIZE=18
+VHS_PADDING=12
+VHS_FONT_FAMILY="JetBrains Mono"
+VHS_THEME="GitHub Dark"

--- a/scripts/demo/lib.sh
+++ b/scripts/demo/lib.sh
@@ -38,7 +38,16 @@ require_tools() {
 # --- workspace ---------------------------------------------------------------
 
 setup_workspace() {
+  # Never clobber a user's own Claude workspace: only a directory this
+  # pipeline created (marker file) or an empty/new one is acceptable.
+  if [[ -d "$WORKSPACE" && ! -e "$WORKSPACE/.ha-nova-demo-workspace" ]] \
+     && [[ -n "$(ls -A "$WORKSPACE" 2>/dev/null)" ]]; then
+    echo "ERROR: $WORKSPACE exists and is not a demo workspace." >&2
+    echo "Point DEMO_WORKSPACE at a dedicated directory instead." >&2
+    exit 1
+  fi
   mkdir -p "$WORKSPACE"
+  touch "$WORKSPACE/.ha-nova-demo-workspace"
   cp "$DEMO_DIR/workspace-template/CLAUDE.md" "$WORKSPACE/CLAUDE.md"
   # The literal name .claude/settings.local.json is gitignored in this repo,
   # so the template ships under a neutral name and is materialized here.

--- a/scripts/demo/lib.sh
+++ b/scripts/demo/lib.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# lib.sh — shared driver functions for demo recordings.
+#
+# Drives a REAL interactive `claude` session inside a detached tmux pane while
+# asciinema records the pty. Synchronization reads the rendered screen via
+# `tmux capture-pane` — never the byte stream — because the fullscreen TUI
+# constantly repaints.
+#
+# Hard rules learned from the calibration spikes (2026-07-13):
+# - The tmux pane MUST match the vhs render geometry exactly (see geometry.env).
+#   A single column of drift garbles the fullscreen-TUI replay.
+# - Turn completion = busy indicator gone + two identical consecutive captures.
+#   Content greps alone match the echo of the prompt we typed ourselves.
+set -euo pipefail
+
+DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034  # consumed by the record-*.sh scripts that source this library
+ARTIFACTS_DIR="${DEMO_ARTIFACTS:-$(cd "$DEMO_DIR/../.." && pwd)/.artifacts/demo}"
+WORKSPACE="${DEMO_WORKSPACE:-$HOME/smart-home}"
+SESSION="${DEMO_TMUX_SESSION:-ha-nova-demo}"
+BUSY_PATTERN="esc to interrupt"
+
+# shellcheck source=geometry.env
+source "$DEMO_DIR/geometry.env"
+
+require_tools() {
+  local missing=()
+  for t in tmux asciinema vhs ffmpeg gif2webp python3 jq; do
+    command -v "$t" >/dev/null 2>&1 || missing+=("$t")
+  done
+  if ((${#missing[@]})); then
+    echo "ERROR: missing tools: ${missing[*]} — see docs/reference/demo-recording.md" >&2
+    exit 1
+  fi
+}
+
+# --- workspace ---------------------------------------------------------------
+
+setup_workspace() {
+  mkdir -p "$WORKSPACE"
+  cp "$DEMO_DIR/workspace-template/CLAUDE.md" "$WORKSPACE/CLAUDE.md"
+  # The literal name .claude/settings.local.json is gitignored in this repo,
+  # so the template ships under a neutral name and is materialized here.
+  cp "$DEMO_DIR/workspace-template/claude-settings.json" "$WORKSPACE/demo-settings.json"
+  mkdir -p "$WORKSPACE/.claude"
+  cp "$DEMO_DIR/workspace-template/claude-settings.json" "$WORKSPACE/.claude/settings.local.json"
+}
+
+# Demo sessions run on latest Sonnet with high reasoning effort — configured
+# declaratively in workspace-template/claude-settings.json. DEMO_MODEL is an
+# ad-hoc override knob (e.g. DEMO_MODEL=haiku for cheap driver tests).
+claude_cmd() {
+  local model="${DEMO_MODEL:-}"
+  local cmd="claude --settings demo-settings.json --strict-mcp-config"
+  [[ -n "$model" ]] && cmd+=" --model $model"
+  echo "$cmd"
+}
+
+# --- tmux session ------------------------------------------------------------
+
+start_session() {
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x "$DEMO_COLS" -y "$DEMO_ROWS"
+  # Silence the "focus-events off" hint claude prints otherwise.
+  tmux set -t "$SESSION" focus-events on
+  trap 'tmux kill-session -t "$SESSION" 2>/dev/null || true' EXIT
+}
+
+kill_session() {
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+}
+
+screen() { tmux capture-pane -pt "$SESSION"; }
+
+# Visible pane plus scrollback — long turns scroll earlier content (e.g. the
+# Preview card) out of the 30-row window.
+screen_history() { tmux capture-pane -pt "$SESSION" -S -200; }
+
+dump_screen() {
+  echo "--- screen dump ($1) ---" >&2
+  screen >&2
+  echo "--- end dump ---" >&2
+}
+
+# --- input -------------------------------------------------------------------
+# Timing windows (typing cadence, reading holds, the /exit cut point) are NOT
+# logged wall-clock: asciinema's cast clock drifts against the wall clock, so
+# recordings capture input events instead (`rec --capture-input`) and
+# compress-cast.py derives every window from the "i" events on the cast's own
+# clock.
+
+# Type text with a brisk but human cadence (15-40 ms jitter per keystroke).
+type_text() {
+  local text="$1" i ch
+  for ((i = 0; i < ${#text}; i++)); do
+    ch="${text:$i:1}"
+    tmux send-keys -t "$SESSION" -l "$ch"
+    sleep "0.0$((RANDOM % 3 + 1))$((RANDOM % 10))"
+  done
+}
+
+submit() {
+  sleep 0.5
+  tmux send-keys -t "$SESSION" Enter
+}
+
+# NOTE: TUI scrolling (PageUp/PageDown) is NOT usable for reading holds —
+# the fullscreen TUI auto-jumps back to the bottom on every repaint (verified;
+# the "Jump to bottom" toast). Instead, the final answer is shown at its real
+# streaming pace: compress-cast.py protects everything after the last submit
+# as an "answer" window, and the viewer reads along as it appears.
+
+# --- synchronization ---------------------------------------------------------
+
+# Wait until a pattern appears on screen. Args: pattern, timeout-seconds.
+wait_for_screen() {
+  local pattern="$1" timeout="${2:-60}" i
+  for ((i = 0; i < timeout; i++)); do
+    screen | grep -qF "$pattern" && return 0
+    sleep 1
+  done
+  dump_screen "timeout waiting for: $pattern"
+  return 1
+}
+
+# Wait until claude's turn is over: busy indicator gone AND the screen stable
+# for two consecutive captures. Permission dialogs (some command shapes force
+# manual approval regardless of the allowlist) are confirmed automatically —
+# in the compressed rendering they are a blink, and an honest one.
+# Args: timeout-seconds.
+wait_idle() {
+  local timeout="${1:-240}" i prev cur
+  for ((i = 0; i < timeout; i++)); do
+    cur="$(screen)"
+    if grep -qF "Do you want to proceed?" <<<"$cur"; then
+      tmux send-keys -t "$SESSION" -l "1"
+      prev=""
+      sleep 1
+      continue
+    fi
+    if ! grep -qF "$BUSY_PATTERN" <<<"$cur"; then
+      if [[ -n "${prev:-}" && "$cur" == "$prev" ]]; then
+        return 0
+      fi
+      prev="$cur"
+    else
+      prev=""
+    fi
+    sleep 1
+  done
+  dump_screen "timeout waiting for idle"
+  return 1
+}
+
+# Assert that a pattern is on screen right now; dump and fail otherwise.
+expect_on_screen() {
+  local pattern="$1"
+  if ! screen | grep -qF "$pattern"; then
+    dump_screen "expected on screen: $pattern"
+    return 1
+  fi
+}
+
+# Assert that a pattern appeared at some point (visible pane or scrollback).
+expect_in_history() {
+  local pattern="$1"
+  if ! screen_history | grep -qF "$pattern"; then
+    dump_screen "expected in history: $pattern"
+    return 1
+  fi
+}
+
+# Skills may ask clarifying questions via a native select menu (tabs, options,
+# a Submit step). Walk it by always picking option 1 — the skill's Recommended
+# choice. Multi-select tabs toggle on "1" and need an explicit Tab to advance;
+# single-select questions advance by themselves (observed live).
+answer_menu_recommended() {
+  local i scr
+  for ((i = 0; i < 10; i++)); do
+    scr="$(screen)"
+    if grep -qF "Ready to submit" <<<"$scr"; then
+      tmux send-keys -t "$SESSION" -l "1"
+      sleep 2
+      return 0
+    fi
+    if grep -qF "Enter to select" <<<"$scr"; then
+      tmux send-keys -t "$SESSION" -l "1"
+      sleep 1.5
+      if screen | grep -qF "[✔]"; then
+        tmux send-keys -t "$SESSION" Tab
+        sleep 1.5
+      fi
+      continue
+    fi
+    return 0 # menu gone (question flow finished or never existed)
+  done
+  dump_screen "menu did not converge"
+  return 1
+}
+
+# --- recording ---------------------------------------------------------------
+
+# Launch `asciinema rec -c claude ...` inside the pane and wait for the input
+# prompt. Args: cast-path.
+start_recording() {
+  local cast="$1"
+  mkdir -p "$(dirname "$cast")"
+  tmux send-keys -t "$SESSION" \
+    "cd $WORKSPACE && asciinema rec -f asciicast-v2 --capture-input --overwrite -c '$(claude_cmd)' $cast" Enter
+  # Status line reads "... · ← for agents" in every permission mode (the
+  # "? for shortcuts" variant appears only sometimes) — wait for the stable part.
+  wait_for_screen "for agents" 90
+  sleep 2 # let startup notices settle before the first keystroke
+}
+
+# End the claude session and wait for asciinema to finalize the cast file.
+# compress-cast.py cuts the tail at the "/exit" input-event cluster (the
+# per-keystroke echo never paints "/exit" as one string in the output).
+# Args: cast-path.
+end_recording() {
+  local cast="$1" i
+  type_text "/exit"
+  sleep 1
+  tmux send-keys -t "$SESSION" Enter
+  for ((i = 0; i < 30; i++)); do
+    [[ -s "$cast" ]] && screen | grep -qF "Recorded to" && return 0
+    sleep 1
+  done
+  [[ -s "$cast" ]] # accept a written cast even if the notice scrolled away
+}

--- a/scripts/demo/record-camera.sh
+++ b/scripts/demo/record-camera.sh
@@ -31,10 +31,13 @@ end_recording "$CAST"
 kill_session
 
 # Preserve the snapshot fetched during THIS take (newest image since STAMP).
+# Search ONLY Claude's own scratch root: a broad /tmp scan could pick up an
+# unrelated process's image, violating the PiP honesty rule and potentially
+# copying another app's sensitive temp file.
 # Only search roots that exist — a missing root makes find exit non-zero,
 # which would kill the script under set -e before the warning below.
 roots=()
-for d in "/private/tmp/claude-$(id -u)" /tmp; do
+for d in "/private/tmp/claude-$(id -u)"; do
   [[ -d "$d" ]] && roots+=("$d")
 done
 snapshot=""

--- a/scripts/demo/record-camera.sh
+++ b/scripts/demo/record-camera.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# record-camera.sh — record the camera flow: fetch a live frame, describe it.
+# Read-only. Also preserves the exact snapshot Claude looked at, so render.sh
+# can blend it in as picture-in-picture (honesty rule: only the image from
+# THIS session may be shown).
+#
+# Usage: record-camera.sh [--take N]
+# Output: .artifacts/demo/camera/take-N.cast (+ take-N-snapshot.<ext>)
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TAKE=1
+[[ "${1:-}" == "--take" ]] && TAKE="$2"
+CAST="$ARTIFACTS_DIR/camera/take-$TAKE.cast"
+
+PROMPT="Check the garage camera — did I leave the door open?"
+
+require_tools
+setup_workspace
+start_session
+STAMP="$(mktemp)"
+start_recording "$CAST"
+
+type_text "$PROMPT"
+submit
+wait_idle 300
+sleep 4 # closing hold on the answer
+
+end_recording "$CAST"
+kill_session
+
+# Preserve the snapshot fetched during THIS take (newest image since STAMP).
+snapshot=$(find "/private/tmp/claude-$(id -u)" /tmp -type f \
+  \( -name '*.jpg' -o -name '*.jpeg' -o -name '*.png' \) \
+  -newer "$STAMP" 2>/dev/null | xargs -I{} stat -f '%m {}' {} 2>/dev/null \
+  | sort -rn | head -1 | cut -d' ' -f2-)
+rm -f "$STAMP"
+
+if [[ -n "$snapshot" ]]; then
+  cp "$snapshot" "$ARTIFACTS_DIR/camera/take-$TAKE-snapshot.${snapshot##*.}"
+  echo "Snapshot preserved: $ARTIFACTS_DIR/camera/take-$TAKE-snapshot.${snapshot##*.}"
+else
+  echo "WARNING: no session snapshot found — PiP pass will not be possible." >&2
+fi
+
+echo "Recorded $CAST"
+echo "NEXT: compress-cast.py + scrub-check.sh; review the snapshot image itself"

--- a/scripts/demo/record-camera.sh
+++ b/scripts/demo/record-camera.sh
@@ -31,10 +31,19 @@ end_recording "$CAST"
 kill_session
 
 # Preserve the snapshot fetched during THIS take (newest image since STAMP).
-snapshot=$(find "/private/tmp/claude-$(id -u)" /tmp -type f \
-  \( -name '*.jpg' -o -name '*.jpeg' -o -name '*.png' \) \
-  -newer "$STAMP" 2>/dev/null | xargs -I{} stat -f '%m {}' {} 2>/dev/null \
-  | sort -rn | head -1 | cut -d' ' -f2-)
+# Only search roots that exist — a missing root makes find exit non-zero,
+# which would kill the script under set -e before the warning below.
+roots=()
+for d in "/private/tmp/claude-$(id -u)" /tmp; do
+  [[ -d "$d" ]] && roots+=("$d")
+done
+snapshot=""
+if ((${#roots[@]})); then
+  snapshot=$(find "${roots[@]}" -type f \
+    \( -name '*.jpg' -o -name '*.jpeg' -o -name '*.png' \) \
+    -newer "$STAMP" 2>/dev/null | xargs -I{} stat -f '%m {}' {} 2>/dev/null \
+    | sort -rn | head -1 | cut -d' ' -f2- || true)
+fi
 rm -f "$STAMP"
 
 if [[ -n "$snapshot" ]]; then

--- a/scripts/demo/record-hero.sh
+++ b/scripts/demo/record-hero.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# record-hero.sh — record the hero flow: plain-English request -> Preview Card
+# -> apply -> Result Card with revert offer.
+#
+# Usage: record-hero.sh [--take N]
+# Output: .artifacts/demo/hero/take-N.cast
+#
+# The created automation never fires during recording (sunset trigger). Run
+# cleanup-hero.sh after EVERY take; this script reminds you and verifies.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TAKE=1
+[[ "${1:-}" == "--take" ]] && TAKE="$2"
+CAST="$ARTIFACTS_DIR/hero/take-$TAKE.cast"
+
+PROMPT="When the sun sets, turn on the pool deck lights — but only if someone is home."
+
+require_tools
+setup_workspace
+start_session
+start_recording "$CAST"
+
+type_text "$PROMPT"
+submit
+# The write skill may ask clarifying questions before the preview — as a
+# native menu (walk the Recommended route) or as a plain-text question about
+# optional enhancements (answer "skip"). Both outcomes are authentic takes.
+for round in 1 2 3; do
+  wait_idle 420
+  screen_history | grep -qF "Preview:" && break
+  if screen | grep -qF "Enter to select"; then
+    answer_menu_recommended
+    continue
+  fi
+  if ((round < 3)); then
+    sleep 1.5 # let viewers read the question
+    type_text "skip"
+    submit
+  fi
+done
+expect_in_history "Preview:"
+expect_in_history "Options:"
+sleep 2 # let viewers read the card before we answer
+
+type_text "apply"
+submit
+wait_idle 420
+expect_in_history "Saved and checked"
+sleep 3 # closing hold; the answer itself replays at streaming pace
+
+end_recording "$CAST"
+kill_session
+
+echo "Recorded $CAST"
+echo "NEXT: bash $DEMO_DIR/cleanup-hero.sh   # delete the demo automation (every take!)"
+echo "THEN: compress-cast.py + scrub-check.sh (see docs/reference/demo-recording.md)"

--- a/scripts/demo/record-review.sh
+++ b/scripts/demo/record-review.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# record-review.sh — record the review flow: audit automations, severity
+# findings in plain language. Read-only on the Home Assistant side.
+#
+# Usage: record-review.sh [--take N] [--scope "light automations"]
+# Output: .artifacts/demo/review/take-N.cast
+#
+# Run an UNRECORDED dry-run first and check which automation names surface;
+# narrow the scope if findings are noisy or names are sensitive.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TAKE=1 SCOPE="automations"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --take) TAKE="$2"; shift 2 ;;
+    --scope) SCOPE="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+CAST="$ARTIFACTS_DIR/review/take-$TAKE.cast"
+
+PROMPT="Review my $SCOPE for problems."
+
+require_tools
+setup_workspace
+start_session
+start_recording "$CAST"
+
+type_text "$PROMPT"
+submit
+wait_idle 420
+if screen | grep -qF "Enter to select"; then
+  answer_menu_recommended
+  wait_idle 420
+fi
+sleep 3 # closing hold; the findings replay at streaming pace
+
+end_recording "$CAST"
+kill_session
+
+echo "Recorded $CAST"
+echo "NEXT: compress-cast.py + scrub-check.sh (see docs/reference/demo-recording.md)"

--- a/scripts/demo/render.sh
+++ b/scripts/demo/render.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+#
+# render.sh — turn a compressed+cut cast into the final animated WebP.
+#
+#   cast -> vhs replay (Chromium: correct color emoji, calibrated grid)
+#        [-> picture-in-picture pass, camera demo only]
+#        -> gif2webp -> size gate -> QA frames
+#
+# All timeline surgery (start/end cut, spinner compression) happens in cast
+# space via compress-cast.py — the replay clock drifts against the cast clock,
+# so mapping cast times onto rendered frames is a losing game. The tape's
+# trailing sleep freezes the last content frame, which provides the closing
+# hold for free.
+#
+# Usage:
+#   render.sh <cast> <out.webp> [--max-kb N] [--hold S]
+#             [--pip-image FILE] [--pip-at S] [--pip-label TEXT]
+#
+# --pip-at defaults to the snapshot marker in <cast>.markers.json.
+set -euo pipefail
+
+DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$DEMO_DIR/geometry.env"
+
+CAST="${1:?usage: render.sh <cast> <out.webp> [options]}"
+OUT="${2:?usage: render.sh <cast> <out.webp> [options]}"
+shift 2
+
+MAX_KB=3072 HOLD=4 PIP_IMAGE="" PIP_AT="" PIP_LABEL=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --max-kb) MAX_KB="$2"; shift 2 ;;
+    --hold) HOLD="$2"; shift 2 ;;
+    --pip-image) PIP_IMAGE="$2"; shift 2 ;;
+    --pip-at) PIP_AT="$2"; shift 2 ;;
+    --pip-label) PIP_LABEL="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+MARKERS="$CAST.markers.json"
+marker() { jq -r ".$1 // empty" "$MARKERS" 2>/dev/null || true; }
+
+CAST_END=$(python3 -c "
+import json
+print(json.loads([l for l in open('$CAST') if l.strip()][-1])[0])")
+
+if [[ -n "$PIP_IMAGE" && -z "$PIP_AT" ]]; then
+  PIP_AT=$(marker snapshot)
+  [[ -z "$PIP_AT" ]] && { echo "ERROR: --pip-at not given and no snapshot marker" >&2; exit 1; }
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cp "$CAST" "$WORK/replay.cast"
+
+# --- 1. vhs replay ------------------------------------------------------------
+# The replay content starts ~1s into the GIF (Show offset + clear + player
+# startup). Only the PiP overlay timing needs this constant; slop there is
+# hidden by the fade-in.
+LEAD=1.0
+TAPE_SLEEP=$(python3 -c "print(round($CAST_END + $HOLD + 2.5, 1))")
+# NOTE: paths inside the tape must be RELATIVE — vhs' parser chokes on the
+# dots that mktemp puts into absolute paths (and exits 0 while doing so).
+cat >"$WORK/replay.tape" <<EOF
+Output full.gif
+Set Shell bash
+Set FontSize $VHS_FONT_SIZE
+Set FontFamily "$VHS_FONT_FAMILY"
+Set Width $VHS_WIDTH
+Set Height $VHS_HEIGHT
+Set Padding $VHS_PADDING
+Set Theme "$VHS_THEME"
+Set Framerate 15
+Hide
+Type "clear && sleep 0.4 && asciinema play -q replay.cast && sleep $HOLD"
+Enter
+Sleep 0.4
+Show
+Sleep $TAPE_SLEEP
+EOF
+(cd "$WORK" && vhs replay.tape >/dev/null 2>&1) || true
+[[ -s "$WORK/full.gif" ]] || { echo "ERROR: vhs produced no GIF" >&2; exit 1; }
+
+# vhs drops frames under load without adjusting delays, compressing the GIF
+# clock against the cast clock (30% observed at 50fps; Framerate 15 keeps it
+# small). Measure the residual drift and scale overlay timings by it.
+GIF_DUR=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$WORK/full.gif")
+CLOCK_SCALE=$(python3 -c "
+expected = $CAST_END + $LEAD + $HOLD
+print(round(min(1.0, ($GIF_DUR - 0.5) / expected), 4))")
+echo "GIF ${GIF_DUR}s vs. erwartete $(python3 -c "print(round($CAST_END + $LEAD + $HOLD, 1))")s — clock scale $CLOCK_SCALE"
+
+# --- 2. optional picture-in-picture -------------------------------------------
+FINAL_GIF="$WORK/full.gif"
+if [[ -n "$PIP_IMAGE" ]]; then
+  PIP_SHOW=$(python3 -c "print(max(0, ($PIP_AT + $LEAD) * $CLOCK_SCALE))")
+  PIP_W=$(python3 -c "print(int($VHS_WIDTH * 0.36))")
+  # Homebrew ffmpeg ships without drawtext (no freetype) — the caption is a
+  # nice-to-have; fall back to the plain framed snapshot.
+  CAPTION=""
+  if ffmpeg -hide_banner -filters 2>/dev/null | grep -q " drawtext "; then
+    label="${PIP_LABEL:-live snapshot}"
+    CAPTION="pad=iw:ih+26:0:0:color=white,\
+drawtext=fontfile=$HOME/Library/Fonts/JetBrainsMono-Regular.ttf:text='$label':\
+fontsize=16:fontcolor=black:x=(w-text_w)/2:y=h-22,"
+  fi
+  GRAPH="[1:v]scale=$PIP_W:-1,pad=iw+8:ih+8:4:4:color=white,\
+${CAPTION}format=rgba,\
+fade=t=in:st=$PIP_SHOW:d=0.4:alpha=1[snap];\
+[0:v][snap]overlay=W-w-20:20:enable='gte(t,$PIP_SHOW)'"
+  ffmpeg -hide_banner -loglevel error -y -i "$WORK/full.gif" \
+    -loop 1 -t "$GIF_DUR" -i "$PIP_IMAGE" -filter_complex "$GRAPH" \
+    -c:v ffv1 "$WORK/pip.mkv"
+  ffmpeg -hide_banner -loglevel error -y -i "$WORK/pip.mkv" \
+    -vf "palettegen=stats_mode=diff" "$WORK/palette.png"
+  ffmpeg -hide_banner -loglevel error -y -i "$WORK/pip.mkv" -i "$WORK/palette.png" \
+    -lavfi "paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle" \
+    -f gif "$WORK/pip.gif"
+  FINAL_GIF="$WORK/pip.gif"
+fi
+
+# --- 2b. reading cursor -------------------------------------------------------
+# During driver-logged "read" windows a small pointer sweeps left-to-right
+# across two text lines per page — the skim gesture from the original demo
+# (which was a real screen recording). Purely cosmetic overlay.
+CURSOR_FILTER=$(python3 - "$MARKERS" "$VHS_WIDTH" "$VHS_HEIGHT" "$LEAD" "$CLOCK_SCALE" <<'PY'
+import json, sys
+try:
+    m = json.load(open(sys.argv[1]))
+except Exception:
+    print("")
+    raise SystemExit
+W, H = int(sys.argv[2]), int(sys.argv[3])
+LEAD, SCALE = float(sys.argv[4]), float(sys.argv[5])
+wins = [w for w in m.get("windows", []) if w[2] in ("read", "answer")]
+x0, x1 = 70, W - 230
+parts, prev, idx = [], "0:v", 0
+for a, b, _ in wins:
+    A = (a + LEAD) * SCALE + 0.2
+    B = (b + LEAD) * SCALE - 0.2
+    if B - A < 2.0:
+        continue
+    lanes_n = max(2, int((B - A) / 3.2))
+    ys = [int(H * (0.22 + 0.5 * j / max(1, lanes_n - 1))) for j in range(lanes_n)]
+    seg = (B - A) / lanes_n
+    for j, y in enumerate(ys):
+        s, e = A + j * seg, A + (j + 1) * seg
+        x = f"{x0}+{x1 - x0}*(t-{s:.2f})/{seg:.2f}"
+        parts.append((prev, x, y, s, e, f"c{idx}"))
+        prev, idx = f"c{idx}", idx + 1
+if not parts:
+    print("")
+    raise SystemExit
+chain = []
+for k, (src, x, y, s, e, out) in enumerate(parts):
+    label = "" if k == len(parts) - 1 else f"[{out}]"
+    chain.append(f"[{src}][1:v]overlay=x='{x}':y={y}:enable='between(t,{s:.2f},{e:.2f})'{label}")
+print(";".join(chain))
+PY
+)
+if [[ -n "$CURSOR_FILTER" ]]; then
+  python3 - "$WORK/cursor.png" <<'PY'
+import sys
+from PIL import Image, ImageDraw
+img = Image.new("RGBA", (22, 30), (0, 0, 0, 0))
+d = ImageDraw.Draw(img)
+# macOS-style arrow: white fill, black outline
+pts = [(2, 2), (2, 24), (8, 18), (12, 27), (16, 25), (12, 16), (20, 16)]
+d.polygon(pts, fill=(250, 250, 250, 235), outline=(20, 20, 20, 255))
+img.save(sys.argv[1])
+PY
+  ffmpeg -hide_banner -loglevel error -y -i "$FINAL_GIF" -i "$WORK/cursor.png" \
+    -filter_complex "$CURSOR_FILTER" -c:v ffv1 "$WORK/cursor.mkv"
+  ffmpeg -hide_banner -loglevel error -y -i "$WORK/cursor.mkv" \
+    -vf "palettegen=stats_mode=diff" "$WORK/cpal.png"
+  ffmpeg -hide_banner -loglevel error -y -i "$WORK/cursor.mkv" -i "$WORK/cpal.png" \
+    -lavfi "paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle" \
+    -f gif "$WORK/cursor.gif"
+  FINAL_GIF="$WORK/cursor.gif"
+fi
+
+# --- 3. webp + size gate (with automatic fps/quality fallback) ----------------
+mkdir -p "$(dirname "$OUT")"
+gif2webp -q 65 -m 6 "$FINAL_GIF" -o "$OUT" >/dev/null 2>&1
+
+reduce_and_convert() { # fps quality outfile-gif — reduces FINAL_GIF (keeps PiP)
+  # -fps_mode cfr keeps duplicate frames: ffmpeg's GIF muxer otherwise drops
+  # them WITHOUT extending delays, silently compressing the clock (verified).
+  ffmpeg -hide_banner -loglevel error -y -i "$FINAL_GIF" -filter_complex \
+    "fps=$1,split[a][b];[a]palettegen=stats_mode=diff[p];[b][p]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle" \
+    -fps_mode cfr -f gif "$3"
+  gif2webp -q "$2" -m 6 "$3" -o "$OUT" >/dev/null 2>&1
+}
+
+SIZE_KB=$(( $(stat -f %z "$OUT") / 1024 ))
+if (( SIZE_KB > MAX_KB )); then
+  echo "Over budget at q65 (${SIZE_KB} KB) — retrying with fps=14 and q55..."
+  reduce_and_convert 14 55 "$WORK/reduced.gif"
+  FINAL_GIF="$WORK/reduced.gif"
+  SIZE_KB=$(( $(stat -f %z "$OUT") / 1024 ))
+fi
+if (( SIZE_KB > MAX_KB )); then
+  echo "Still over budget (${SIZE_KB} KB) — final attempt with fps=10 and q45..."
+  reduce_and_convert 10 45 "$WORK/reduced2.gif"
+  FINAL_GIF="$WORK/reduced2.gif"
+  SIZE_KB=$(( $(stat -f %z "$OUT") / 1024 ))
+fi
+# --- 3b. duration assert --------------------------------------------------------
+# The whole pipeline stands on time fidelity; fail loudly if the final WebP's
+# clock deviates from the rendered GIF's by more than 5%.
+WEBP_DUR=$(python3 -c "
+import re, subprocess
+out = subprocess.run(['webpmux', '-info', '$OUT'], capture_output=True, text=True).stdout
+durs = [int(m.group(1)) for m in
+        re.finditer(r'^\s*\d+:\s+\d+\s+\d+\s+\w+\s+\d+\s+\d+\s+(\d+)', out, re.M)]
+print(round(sum(durs) / 1000, 1))")
+python3 -c "
+gif, webp = float('$GIF_DUR'), float('$WEBP_DUR')
+dev = abs(gif - webp) / gif
+print(f'Dauer-Check: GIF {gif}s vs WebP {webp}s ({dev:.1%} Abweichung)')
+raise SystemExit(1 if dev > 0.05 else 0)" || { echo "ERROR: WebP clock drifted" >&2; exit 1; }
+
+# --- 4. QA frames (before the size gate — content review must survive it) ------
+QA_DIR="${OUT%.webp}-qa"
+mkdir -p "$QA_DIR"
+N=$(ffprobe -v error -select_streams v -count_frames -show_entries stream=nb_read_frames -of csv=p=0 "$FINAL_GIF")
+ffmpeg -hide_banner -loglevel error -y -i "$FINAL_GIF" -vf "select='eq(n\,2)'" -frames:v 1 -update 1 "$QA_DIR/first.png"
+ffmpeg -hide_banner -loglevel error -y -i "$FINAL_GIF" -vf "select='eq(n\,$((N / 2)))'" -frames:v 1 -update 1 "$QA_DIR/mid.png"
+ffmpeg -hide_banner -loglevel error -y -i "$FINAL_GIF" -vf reverse -frames:v 1 -update 1 "$QA_DIR/last.png"
+
+if (( SIZE_KB > MAX_KB )); then
+  echo "ERROR: $OUT is ${SIZE_KB} KB (budget ${MAX_KB} KB) even after reduction." >&2
+  echo "QA frames in $QA_DIR/ — knobs: compress-cast --target lower, gif2webp -q 45." >&2
+  exit 1
+fi
+
+echo "Rendered $OUT (${SIZE_KB} KB, budget ${MAX_KB} KB) — QA frames in $QA_DIR/"

--- a/scripts/demo/render.sh
+++ b/scripts/demo/render.sh
@@ -160,6 +160,8 @@ print(";".join(chain))
 PY
 )
 if [[ -n "$CURSOR_FILTER" ]]; then
+  python3 -c "import PIL" 2>/dev/null \
+    || { echo "ERROR: the cursor overlay needs Pillow: python3 -m pip install Pillow" >&2; exit 1; }
   python3 - "$WORK/cursor.png" <<'PY'
 import sys
 from PIL import Image, ImageDraw

--- a/scripts/demo/scrub-check.sh
+++ b/scripts/demo/scrub-check.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# scrub-check.sh — privacy gate for a COMPRESSED cast (run after
+# compress-cast.py, which already redacts e-mail addresses byte-level).
+#
+# Exports the cast to plain text (this contains EVERYTHING that ever hit the
+# screen, including content that scrolled away) and greps a denylist with
+# zero tolerance. Any hit blocks the take. Always eyeball the exported text
+# once per selected take — the denylist catches credentials and identity,
+# not judgment calls.
+#
+# Usage: scrub-check.sh <compressed-cast>
+set -euo pipefail
+
+CAST="${1:?usage: scrub-check.sh <compressed-cast>}"
+TXT="${CAST%.cast}.txt"
+
+DENYLIST=(
+  "czerwonka"          # account identity (must be redacted by compress-cast)
+  "gmail"
+  "Bearer "
+  "eyJ"                # JWT prefix
+  "Authorization"
+  "SUPERVISOR_TOKEN"
+  "password"
+)
+
+asciinema convert -f txt --overwrite "$CAST" "$TXT"
+
+fail=0
+for pat in "${DENYLIST[@]}"; do
+  if hits=$(grep -inF "$pat" "$TXT"); then
+    echo "DENYLIST HIT [$pat]:" >&2
+    echo "$hits" | head -5 >&2
+    fail=1
+  fi
+done
+
+if hits=$(grep -inE "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}" "$TXT" | grep -v "demo@example.com"); then
+  echo "E-MAIL LEAK (redaction failed):" >&2
+  echo "$hits" | head -5 >&2
+  fail=1
+fi
+
+if (( fail )); then
+  echo "SCRUB FAILED: $CAST — do not use this take." >&2
+  exit 1
+fi
+
+echo "Scrub OK: $CAST"
+echo "Reminder: eyeball $TXT once (names, addresses, anything sensitive)."

--- a/scripts/demo/scrub-check.sh
+++ b/scripts/demo/scrub-check.sh
@@ -14,9 +14,9 @@ set -euo pipefail
 
 CAST="${1:?usage: scrub-check.sh <compressed-cast>}"
 TXT="${CAST%.cast}.txt"
+DEMO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 DENYLIST=(
-  "czerwonka"          # account identity (must be redacted by compress-cast)
   "gmail"
   "Bearer "
   "eyJ"                # JWT prefix
@@ -24,6 +24,18 @@ DENYLIST=(
   "SUPERVISOR_TOKEN"
   "password"
 )
+
+# Identity terms (account names, family names, street …) must never live in
+# the repo — the denylist would otherwise publish what it protects. Keep one
+# fixed-string pattern per line in the untracked scripts/demo/denylist.local.
+if [[ -f "$DEMO_DIR/denylist.local" ]]; then
+  while IFS= read -r pat; do
+    [[ -n "$pat" && "$pat" != \#* ]] && DENYLIST+=("$pat")
+  done < "$DEMO_DIR/denylist.local"
+else
+  echo "WARNING: $DEMO_DIR/denylist.local missing — identity terms are NOT checked." >&2
+  echo "Create it with your account/family/location strings before a real take." >&2
+fi
 
 asciinema convert -f txt --overwrite "$CAST" "$TXT"
 
@@ -36,7 +48,9 @@ for pat in "${DENYLIST[@]}"; do
   fi
 done
 
-if hits=$(grep -inE "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}" "$TXT" | grep -v "demo@example.com"); then
+# Token-level, not line-level: a line holding both the allowed redacted
+# address and a second leaked address must still fail.
+if hits=$(grep -oinE "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}" "$TXT" | grep -ivF "demo@example.com"); then
   echo "E-MAIL LEAK (redaction failed):" >&2
   echo "$hits" | head -5 >&2
   fail=1

--- a/scripts/demo/workspace-template/CLAUDE.md
+++ b/scripts/demo/workspace-template/CLAUDE.md
@@ -1,0 +1,7 @@
+# Demo workspace
+
+- Keep responses concise.
+- Respond in English.
+- In shell commands (yours and subagents'), use absolute file paths and do
+  not chain `cd` with output redirection — such compound commands force a
+  manual approval prompt.

--- a/scripts/demo/workspace-template/claude-settings.json
+++ b/scripts/demo/workspace-template/claude-settings.json
@@ -1,0 +1,18 @@
+{
+  "model": "sonnet",
+  "effortLevel": "high",
+  "language": "English",
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "allow": [
+      "Bash(ha-nova relay *)",
+      "Read(~/.config/ha-nova/**)",
+      "Read(~/.claude/plugins/**)",
+      "Read(~/.agents/**)",
+      "Read(//tmp/**)",
+      "Write(//tmp/**)",
+      "Read(//private/tmp/**)",
+      "Write(//private/tmp/**)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Ports the demo-recording toolchain from the `docs/readme-marketing-refresh` worktree (its only content not already on main) as a clean, standalone change:

- `scripts/demo/`: tmux-driven recording of **real** Claude Code sessions against a live Home Assistant on a vhs-calibrated cell grid, ANSI-sequence-aware e-mail redaction (byte-level, same-length `demo@example.com`), spinner-window time compression (the TUI repaints ~10x/s while thinking, so idle limits never fire), a privacy scrub gate that blocks a take, vhs replay rendering (color emoji for the Cards), gif2webp conversion with hard size budgets, and QA frame extraction.
- `docs/reference/demo-recording.md`: runbook with honesty rules (no staged output, time compression only, one disclosed redaction), the verified constraints behind the architecture, and per-asset acceptance gates.

Deliberately **not** included:
- No `README.md` changes — demo assets enter the README only through a release-prep PR (readme-release-gate).
- No committed recordings/casts — the existing takes predate the 0.19 pairing UI and will be re-recorded; the runbook states casts may be committed only after passing the scrub gate.

## Verification

- `bash -n` on all scripts, `python3 -m py_compile` on `compress-cast.py`, shellcheck reviewed (one documented library-variable directive)
- Privacy scan: no personal data in any ported file; redaction is pattern-based
- `bash scripts/check-docs.sh` → all documentation claims verified
- `npx vitest run tests/skills` → 328/328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b1UiBoUzZ5s3UZLJKb1XT