### PR TITLE
feat(skills): verify real input-device gestures before planning a remap

### DIFF
--- a/docs/reference/safety.md
+++ b/docs/reference/safety.md
@@ -55,6 +55,7 @@ These are guarantees about what HA NOVA *says*, which matter as much as what it 
 | A notification that Home Assistant accepted is not claimed as delivered to your phone | `skills/notify/SKILL.md` | `tests/skills/skill-template-contract.test.ts` |
 | An empty MQTT window means "nothing was published", and retained broker replays are never counted as live device traffic | `skills/mqtt/SKILL.md` | `tests/skills/skill-template-contract.test.ts` |
 | Internal review codes (R-18, H-09, …) never reach you — findings are described in plain language | `skills/ha-nova/output-rules.md`; `skills/review/checks.md` → Output Guardrail | `tests/skills/skill-template-contract.test.ts` (check-code leak allowlist) |
+| A button remap is never planned against a gesture the device was not shown to support | `skills/ha-nova/input-capability-preflight.md`; `skills/write/SKILL.md` → Flow | `tests/skills/ha-nova-contract.test.ts` ("gates input-device remaps on the capability preflight") |
 
 ## Reproduce it
 

--- a/docs/reference/skill-architecture.md
+++ b/docs/reference/skill-architecture.md
@@ -27,6 +27,7 @@ skills/
   ha-nova/write-safety.md       (reference doc — pre-write diff + durable update-revert; SSOT for write/ + helper/)
   ha-nova/batch-safety.md       (reference doc — scoped batch manifest for destructive multi-target operations)
   ha-nova/config-snapshots.md   (reference doc — targeted config-snapshot capture/restore on the relay blob store)
+  ha-nova/input-capability-preflight.md (reference doc — verify input-device gestures before planning a remap)
   ha-nova/agents/               (agent templates: resolve, apply)
   read/SKILL.md                         (ha-nova:read — automation/script list/get/trace)
   write/SKILL.md                        (ha-nova:write — automation/script create/update/delete)

--- a/docs/work/0.20.0-release-body.md
+++ b/docs/work/0.20.0-release-body.md
@@ -8,6 +8,7 @@
 ## New Features
 
 - **Service setups pair like everyone else.** `ha-nova setup --service <client>` now goes straight to one-code device pairing and keeps the device credential in a protected file — no desktop keyring, no token copy-paste. (#TBD)
+- **Button remaps check reality first.** Before remapping a button, remote, or wall switch, the AI now verifies which gestures the device actually supports (integration metadata + real observations) and refuses to plan around a gesture it cannot confirm — offering the supported alternatives instead. (#396)
 - **Headless opt-in for pairing.** New `ha-nova pair --credential-store=file` stores the device credential in a private file on machines whose desktop keyring is never unlocked (agent VMs, autologin boxes, systemd user services). The locked-keyring error now names both ways out. (#TBD)
 
 ## What To Watch

--- a/docs/work/2026-07-21-input-capability-preflight-spec.md
+++ b/docs/work/2026-07-21-input-capability-preflight-spec.md
@@ -1,0 +1,80 @@
+# Input-Capability Preflight Spec (#396)
+
+Status: approved plan, Batch 1 of the 2026-07-21 issue wave
+Date: 2026-07-21
+Trigger: issue #396 — a remap plan may assume a gesture (double-press, hold) that the
+device/integration never emits; the resulting automation looks correct but can never fire.
+
+## Contract (new file `skills/ha-nova/input-capability-preflight.md`)
+
+Preflight required before planning or applying a remap of an input device
+(button, remote, wall switch, dial — anything whose value is the events it emits).
+
+- **Evidence classes** for every candidate gesture:
+  - *advertised* — integration/device metadata lists it: `device_automation/trigger/list`
+    (type/subtype rows), `event.*` entity `event_types` attribute, Z2M action metadata.
+  - *observed* — a bounded, existing observation shows it fired: trace history, logbook,
+    `event.*` entity state history, MQTT capture.
+  - *assumed* — neither; the gesture merely sounds plausible.
+- **Presentation binding:** reuse Claim-Evidence tiers (context skill) — advertised+observed
+  agree → Verified tone; advertised-only or observed-only → Likely, marked; assumed →
+  Uncertain, marked. An assumed gesture is NEVER described as supported or offered as a
+  working option.
+- **Mutation gate:** while the selected gesture is only assumed, the write flow is blocked
+  (same hard-block shape as the BP stale+complex gate). Offer: (a) pick a supported
+  alternative from the advertised/observed set, (b) live observation via User-Assisted
+  Readiness (context skill sequence; MQTT devices use the bounded-window variant), or
+  (c) cancel.
+- **Normalization rule:** compare action names case-insensitively with separators stripped
+  (`Single` / `single`, `double_press` / `double-press`); never equate names across
+  different integration paths (a Z2M `action: single` is not evidence for a ZHA
+  `command: toggle`) without an observation on the actual path.
+- **Evidence matrix** (pinned by tests): metadata-only → Likely, offerable with marker;
+  observation-only → Likely, offerable with marker; conflicting (metadata lists it, fresh
+  observation contradicts, or vice versa) → Uncertain, blocked, explain the conflict;
+  advertised+observed confirmed → Verified, proceed.
+- **Worked example** (pinned by tests): a button advertising `single` and `double` but no
+  `hold` — requested hold-remap is blocked, alternatives offered.
+- Report evidence quality without dumping unrelated device data (output-rules Technical
+  Noise rule applies).
+
+## Edits
+
+- `skills/ha-nova/relay-api.md`: new WS commands `device_automation/trigger/list`
+  + `device_automation/trigger/capabilities` (device_id-keyed), `event.*` entity
+  reads for `event_types`. Pass-through verified: `nova/src/http/handlers/ws-proxy.ts`
+  rejects only subscription commands — no relay change. Contingency: if live verification
+  finds a block, STOP; separate relay PR + spec addendum first.
+- `skills/write/SKILL.md`: one Flow-intro gate line (pattern of the Multi-Target line):
+  input-device remaps run the preflight before drafting; mutation blocked while the
+  gesture is only assumed. Plus one On-demand reference entry. Word budget `write`
+  ratchets 1700 → documented bump.
+- `skills/ha-nova/best-practices.md`: cross-link from Zigbee Button Patterns (discovery
+  is no longer manual-only: preflight first, Developer-Tools hint stays as fallback).
+
+## Tests (extend existing suites — no new file)
+
+- `tests/skills/ha-nova-contract.test.ts`: pin the write-flow gate line (same shape as
+  the BP-gate pins), the preflight file's evidence matrix rows, the never-supported rule,
+  the normalization rule, and the worked single/double/no-hold example.
+- `tests/skills/skill-template-contract.test.ts`: WORD_BUDGETS ratchet for `write`
+  (documented, attributed to #396).
+- New `skills/ha-nova/*.md` file passes repo-wide lints (confirmation-code terminology,
+  App wording, check-code allowlist — no allowlist growth expected).
+
+## Non-goals
+
+- No live e2e analyzer: the disposable-HA e2e environment has no physical input device;
+  a gesture-remap scenario cannot run there honestly. Contract tests carry the coverage.
+- No relay change; no new subscription-type WS usage (proxy rejects subscriptions).
+- Consumer discovery of the input's existing automations is #397, not this issue.
+
+## Verification
+
+- `npx vitest run tests/skills/` green; new pins fail on revert of the skill edits.
+- English-only check over changed skill files.
+- Live spot-check against the real HA instance (read-only): `device_automation/trigger/list`
+  for one Z2M button returns type/subtype rows through the relay.
+- Mandatory side-work: `docs/reference/safety.md` guarantee row quoting the new test title
+  verbatim; register the new reference file in `docs/reference/skill-architecture.md`
+  inventory; append the user-facing claim to `docs/work/0.20.0-release-body.md`.

--- a/skills/ha-nova/best-practices.md
+++ b/skills/ha-nova/best-practices.md
@@ -109,6 +109,8 @@ All the config-entry rows below — plus `template` itself when no built-in fits
 
 Zigbee buttons/remotes are stateless devices — they fire events, not state changes. The trigger pattern depends on the integration.
 
+Before remapping a button, verify the gesture exists on the active integration path: `skills/ha-nova/input-capability-preflight.md`. The Developer-Tools discovery below stays as the manual fallback.
+
 ### ZHA (Zigbee Home Automation)
 
 Use `event` trigger with `device_ieee` (persistent across re-adds):

--- a/skills/ha-nova/input-capability-preflight.md
+++ b/skills/ha-nova/input-capability-preflight.md
@@ -1,0 +1,76 @@
+# Input-Capability Preflight
+
+Verify what an input device can actually emit BEFORE planning or applying a remap.
+Applies to any device whose value is the events it fires — buttons, remotes, wall
+switches, dials, scene controllers. A remap planned against an unverified gesture
+produces a configuration that looks correct but can never trigger.
+
+## Evidence Classes
+
+Classify every candidate gesture (single, double, hold, rotate, ...) internally:
+
+- **advertised** — integration or device metadata lists it: a
+  `device_automation/trigger/list` row (type/subtype), an `event.*` entity's
+  `event_types` attribute, or Z2M action metadata for the device.
+- **observed** — a bounded, existing observation shows it fired on this device:
+  automation trace history, logbook entries, `event.*` state history, or a prior
+  MQTT capture.
+- **assumed** — neither source covers it; the gesture merely sounds plausible.
+
+Presentation binds to the context skill's Claim-Evidence tiers:
+
+| Evidence | Tier | Consequence |
+|---|---|---|
+| advertised + observed agree | Verified | proceed normally |
+| metadata-only (advertised, never observed) | Likely | offerable, marked "Based on device metadata, this likely works" |
+| observation-only (observed, not in metadata) | Likely | offerable, marked with the observation as evidence |
+| conflicting (one source contradicts the other) | Uncertain | blocked — explain the conflict, offer live observation |
+| assumed | Uncertain | blocked — never described as supported |
+
+An assumed gesture is never presented as a working option, never in the same tone
+as verified, and never silently planned around.
+
+## Discovery Sources
+
+1. Resolve the device (`config/device_registry/list`, `config/entity_registry/list`).
+2. Advertised set: `device_automation/trigger/list` for the device_id; for
+   event-entity devices read the `event.*` entity's `event_types` attribute
+   (`/api/states/{entity_id}`). See relay-api.md → Device Trigger Queries.
+3. Observed set: bounded reads only — existing traces of automations already
+   listening to the device, logbook window, `event.*` state history. Do not open
+   listen windows or fire anything during discovery.
+
+## Name Normalization
+
+Compare action names case-insensitively with separators stripped: `Single`,
+`single`, `double_press`, `double-press` normalize before comparison. Never equate
+names across different integration paths — a Z2M `action: single` is not evidence
+for a ZHA `command: toggle`; the active integration path may expose fewer actions
+than generic device documentation claims.
+
+## Mutation Gate
+
+While the selected gesture is only assumed or conflicting, the remap write is
+blocked (same hard-block shape as the best-practice stale+complex gate). Offer:
+
+1. a supported alternative from the advertised/observed set (continue after the
+   user selects it);
+2. live observation — only via context skill → User-Assisted Readiness (MQTT-path
+   devices use the bounded-window variant in `ha-nova:mqtt`); an empty window after
+   the user acted means re-arm and retry once, not a capability verdict;
+3. cancel.
+
+After a live observation confirms the gesture, it is observed evidence; proceed.
+
+## Worked Example
+
+A wall button advertises `single` and `double` but no `hold`. A requested
+hold-remap is blocked: "This button does not advertise a hold action (advertised:
+single, double). I can remap single or double, observe the device live to check
+for hold, or cancel." Never create the hold automation on spec.
+
+## Output
+
+Report evidence quality without dumping unrelated device data (output-rules →
+Technical Noise). Name the checked sources in one line; internal class labels
+(advertised/observed/assumed) stay internal — the user sees the tier wording.

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -455,6 +455,20 @@ List entity registry (includes area/device assignment):
 {"type":"config/entity_registry/list"}
 ```
 
+## Device Trigger Queries (via /ws)
+
+List the triggers a device advertises (type/subtype rows; the advertised action set for input devices):
+```json
+{"type":"device_automation/trigger/list","device_id":"{device_id}"}
+```
+
+Extra fields a trigger supports:
+```json
+{"type":"device_automation/trigger/capabilities","trigger":{"platform":"device","domain":"mqtt","device_id":"{device_id}","type":"action","subtype":"single"}}
+```
+
+For event-entity devices, the advertised set is the `event.*` entity's `event_types` attribute — read `/api/states/{entity_id}`. An empty trigger list is a valid answer (the integration advertises nothing), not an error. Advertised metadata is not proof an action fires — see `skills/ha-nova/input-capability-preflight.md`.
+
 ## Trace Queries (via /ws)
 
 **`item_id` must be the `unique_id` (config key), NOT the entity_id slug.** See [ID Types & Resolution](#id-types--resolution).

--- a/skills/write/SKILL.md
+++ b/skills/write/SKILL.md
@@ -32,6 +32,8 @@ File-based relay requests only: `ha-nova relay core --method <METHOD> --path <PA
 
 Multi-target logical changes: present the plan first per `skills/ha-nova/write-safety.md` → Multi-Target Changes.
 
+Input-device remaps (buttons, remotes, switches): run the capability preflight per `skills/ha-nova/input-capability-preflight.md` before drafting; the write stays blocked while the chosen gesture is only assumed.
+
 ### Phase 1: Resolve (Agent)
 
 1. Read `skills/ha-nova/agents/resolve-agent.md`.
@@ -154,3 +156,4 @@ On demand — read only when the trigger applies:
 - `skills/ha-nova/update-revert.md` — the user asks to revert, undo, or restore a verified update (create cleanup stays out — see write-safety)
 - `skills/ha-nova/config-snapshots.md` — capturing the pre-delete snapshot, or the user asks to restore from a config snapshot
 - `skills/ha-nova/test-run.md` — Phase 5 test offer: feasibility, options, post-run follow-up
+- `skills/ha-nova/input-capability-preflight.md` — remapping an input device (button, remote, switch)

--- a/skills/write/SKILL.md
+++ b/skills/write/SKILL.md
@@ -32,7 +32,7 @@ File-based relay requests only: `ha-nova relay core --method <METHOD> --path <PA
 
 Multi-target logical changes: present the plan first per `skills/ha-nova/write-safety.md` → Multi-Target Changes.
 
-Input-device remaps (buttons, remotes, switches): run the capability preflight per `skills/ha-nova/input-capability-preflight.md` before drafting; the write stays blocked while the chosen gesture is only assumed.
+Input-device remaps (buttons, remotes, switches): run the capability preflight per `skills/ha-nova/input-capability-preflight.md` before drafting; the write stays blocked while the chosen gesture is only assumed or its evidence conflicts.
 
 ### Phase 1: Resolve (Agent)
 

--- a/tests/skills/ha-nova-contract.test.ts
+++ b/tests/skills/ha-nova-contract.test.ts
@@ -370,6 +370,69 @@ describe("ha-nova contract", () => {
     expect(bp).toContain("Enforcement Checklist");
   });
 
+  it("gates input-device remaps on the capability preflight", () => {
+    const preflight = readFileSync(
+      "skills/ha-nova/input-capability-preflight.md",
+      "utf8",
+    );
+    const write = readFileSync("skills/write/SKILL.md", "utf8");
+    const bp = readFileSync("skills/ha-nova/best-practices.md", "utf8");
+    const relayApi = readFileSync("skills/ha-nova/relay-api.md", "utf8");
+
+    // Write flow blocks remap drafts until the gesture is more than assumed.
+    expect(write).toContain(
+      "run the capability preflight per `skills/ha-nova/input-capability-preflight.md` before drafting",
+    );
+    expect(write).toContain(
+      "the write stays blocked while the chosen gesture is only assumed",
+    );
+
+    // Evidence classes and the never-supported rule.
+    expect(preflight).toContain("**advertised**");
+    expect(preflight).toContain("**observed**");
+    expect(preflight).toContain("**assumed**");
+    expect(preflight).toContain(
+      "An assumed gesture is never presented as a working option",
+    );
+
+    // Evidence matrix: all four mixed-evidence rows with their consequences.
+    expect(preflight).toContain("| advertised + observed agree | Verified |");
+    expect(preflight).toContain(
+      "| metadata-only (advertised, never observed) | Likely |",
+    );
+    expect(preflight).toContain(
+      "| observation-only (observed, not in metadata) | Likely |",
+    );
+    expect(preflight).toContain(
+      "| conflicting (one source contradicts the other) | Uncertain |",
+    );
+    expect(preflight).toContain("| assumed | Uncertain |");
+
+    // Normalization: same-path comparison only, never cross-integration.
+    expect(preflight).toContain("case-insensitively with separators stripped");
+    expect(preflight).toContain("a Z2M `action: single` is not evidence");
+    expect(preflight).toContain(
+      "the active integration path may expose fewer actions",
+    );
+
+    // Live observation routes through the readiness sequence.
+    expect(preflight).toContain("User-Assisted Readiness");
+
+    // Worked example: single/double advertised, hold missing → blocked.
+    expect(preflight).toContain("advertises `single` and `double` but no `hold`");
+    expect(preflight).toContain("Never create the hold automation on spec");
+
+    // Discovery endpoints are documented, with the metadata-is-not-proof caveat.
+    expect(relayApi).toContain('"type":"device_automation/trigger/list"');
+    expect(relayApi).toContain('"type":"device_automation/trigger/capabilities"');
+    expect(relayApi).toContain(
+      "Advertised metadata is not proof an action fires",
+    );
+
+    // Zigbee button authoring points at the preflight first.
+    expect(bp).toContain("skills/ha-nova/input-capability-preflight.md");
+  });
+
   it("keeps agent templates parameterized and structured", () => {
     const resolve = readFileSync("skills/ha-nova/agents/resolve-agent.md", "utf8");
     const apply = readFileSync("skills/ha-nova/agents/apply-agent.md", "utf8");

--- a/tests/skills/ha-nova-contract.test.ts
+++ b/tests/skills/ha-nova-contract.test.ts
@@ -384,7 +384,7 @@ describe("ha-nova contract", () => {
       "run the capability preflight per `skills/ha-nova/input-capability-preflight.md` before drafting",
     );
     expect(write).toContain(
-      "the write stays blocked while the chosen gesture is only assumed",
+      "the write stays blocked while the chosen gesture is only assumed or its evidence conflicts",
     );
 
     // Evidence classes and the never-supported rule.


### PR DESCRIPTION
## Summary

Implements #396 (Batch 1 of the 2026-07-21 issue wave; spec: `docs/work/2026-07-21-input-capability-preflight-spec.md`).

- **New reference contract** `skills/ha-nova/input-capability-preflight.md`: every candidate gesture is internally classified **advertised / observed / assumed**; presentation binds to the existing Claim-Evidence tiers (Verified/Likely/Uncertain); the remap write is hard-blocked while the chosen gesture is only assumed or the evidence conflicts; supported alternatives are offered; live observation only via User-Assisted Readiness (MQTT devices: bounded-window variant).
- **Write flow gate**: `skills/write/SKILL.md` runs the preflight before drafting input-device remaps (+ on-demand reference entry). Word budget untouched (1677/1700).
- **relay-api.md**: documents `device_automation/trigger/list` + `/capabilities` and event-entity `event_types` reads. Pass-through verified live: a real Z2M STYRBAR remote returns type/subtype rows through the relay; shortcut buttons honestly return `[]` (documented as a valid answer). No relay change.
- **best-practices.md**: Zigbee button authoring points at the preflight first; Developer-Tools discovery stays as the manual fallback.
- **Tests**: `ha-nova-contract.test.ts` pins the gate line, all five evidence-matrix rows, the never-supported rule, the normalization rule (incl. no cross-integration equating), and the single/double/no-hold worked example.
- Side-work per process: `docs/reference/safety.md` guarantee row (verbatim test title), `skill-architecture.md` inventory entry, `0.20.0-release-body.md` claim.

## Verification

- `npx vitest run` — 106 files / 991 tests green (includes repo-wide skill MD lints).
- `bash scripts/check-docs.sh` — all claims verified.
- Live read-only spot-check against real HA: `device_automation/trigger/list` + `/capabilities` via `ha-nova relay ws` (see summary).

## Non-goals

- No live e2e analyzer: disposable-HA e2e has no physical input device; contract tests carry the coverage.
- Consumer discovery of an input's existing automations is #397 (next PR in this batch).

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSugUrwx7naXjuhhMx4j5q