### PR TITLE
feat(cli): named server profiles — multi-server support layer 1 (#343)

### DIFF
--- a/cli/cmd_pair.go
+++ b/cli/cmd_pair.go
@@ -73,21 +73,6 @@ func runPairCommand(paths runtimePaths, args []string) int {
 		setServerSelectionOverride(serverName)
 		setActiveServerProfile(serverName)
 	}
-	if credentialStore == "file" {
-		// A readable keyring credential moves along BEFORE the backend flips:
-		// the flip must never mask a live desktop pairing. Locked or absent
-		// keyrings make this a silent no-op and pairing continues file-backed.
-		migrated, migrateErr := migrateKeyringDeviceCredentialToFile()
-		if migrateErr != nil {
-			printErr("cannot move the device credential into private file storage: %s", migrateErr)
-			printErr("Nothing was paired — no code was used.")
-			return 1
-		}
-		if migrated {
-			fmt.Println("Moved this install's device credential into private file storage.")
-		}
-		forceDeviceCredentialFileMode()
-	}
 
 	// Pairing can run before a full setup as long as a relay URL is known: an
 	// explicit --relay-url starts from a fresh config, otherwise the saved one.
@@ -127,6 +112,24 @@ func runPairCommand(paths runtimePaths, args []string) int {
 	if bootstrapURL == "" {
 		printErr("no relay URL known; pass --relay-url http://<ha-host>:8791 or run 'ha-nova setup' first")
 		return 1
+	}
+	// Storage mutation only AFTER every selection/bootstrap guard above: a pair
+	// that exits before pairing must never have flipped the backend or moved
+	// credentials.
+	if credentialStore == "file" {
+		// A readable keyring credential moves along BEFORE the backend flips:
+		// the flip must never mask a live desktop pairing. Locked or absent
+		// keyrings make this a silent no-op and pairing continues file-backed.
+		migrated, migrateErr := migrateKeyringDeviceCredentialToFile()
+		if migrateErr != nil {
+			printErr("cannot move the device credential into private file storage: %s", migrateErr)
+			printErr("Nothing was paired — no code was used.")
+			return 1
+		}
+		if migrated {
+			fmt.Println("Moved this install's device credential into private file storage.")
+		}
+		forceDeviceCredentialFileMode()
 	}
 	if cfgErr != nil {
 		cfg = runtimeConfig{RelayBaseURL: bootstrapURL}

--- a/cli/cmd_pair.go
+++ b/cli/cmd_pair.go
@@ -102,6 +102,16 @@ func runPairCommand(paths runtimePaths, args []string) int {
 		printErr("%s", cfgErr)
 		return 1
 	}
+	if serverName == "" && cfgErr != nil {
+		// loadConfig failed before profile resolution (missing/incomplete
+		// config), so an env-only selection never reached the credential seam —
+		// saves would target the env profile while credentials land in the
+		// default slots. Creation always requires the explicit flag.
+		if name, source := requestedServerSelection(); name != "" && name != defaultServerProfileName {
+			printErr("profile %q (from %s) is not set up; create it explicitly: ha-nova pair --server %s --relay-url http://<ha-host>:8791", name, source, name)
+			return 1
+		}
+	}
 	bootstrapURL := strings.TrimSpace(relayURL)
 	if bootstrapURL == "" {
 		if newProfile {

--- a/cli/cmd_pair.go
+++ b/cli/cmd_pair.go
@@ -17,7 +17,7 @@ var runSecurePairingForPairCmd = runSecurePairing
 // the secure endpoint; a re-pair replaces the old credential only after the new
 // one activates.
 func runPairCommand(paths runtimePaths, args []string) int {
-	relayURL, code, credentialStore := "", "", ""
+	relayURL, code, credentialStore, serverName := "", "", "", ""
 	credentialStoreSet := false
 	for i := 0; i < len(args); i++ {
 		// Accept both `--flag value` and `--flag=value` for the string flags.
@@ -45,10 +45,13 @@ func runPairCommand(paths runtimePaths, args []string) int {
 		case "--credential-store":
 			credentialStore = takeValue()
 			credentialStoreSet = true
+		case "--server":
+			serverName = takeValue()
 		case "-h", "--help":
-			fmt.Println("Usage: ha-nova pair [--relay-url http://<ha-host>:8791] [--code NNNNNN] [--credential-store=file]")
+			fmt.Println("Usage: ha-nova pair [--relay-url http://<ha-host>:8791] [--code NNNNNN] [--credential-store=file] [--server <name>]")
 			fmt.Println("Open NOVA in the Home Assistant sidebar, click \"Connect a device\", then run this.")
 			fmt.Println("--credential-store=file keeps the device credential in a private file — for headless systems and VMs whose desktop keyring is never unlocked.")
+			fmt.Println("--server <name> pairs into the named server profile (multi-server installs); a NEW profile also needs --relay-url.")
 			return 0
 		default:
 			printErr("unknown flag: %s", args[i])
@@ -58,6 +61,17 @@ func runPairCommand(paths runtimePaths, args []string) int {
 	if credentialStoreSet && credentialStore != "file" {
 		printErr("--credential-store supports only the value \"file\" (got %q)", credentialStore)
 		return 1
+	}
+	if serverName != "" {
+		if err := validateServerProfileName(serverName); err != nil {
+			printErr("%s", err)
+			return 1
+		}
+		// Route this run — config saves AND credential slots — to the named
+		// profile before anything touches storage. The seam is set here too so
+		// the storage probe/migration below already use the profile's slots.
+		setServerSelectionOverride(serverName)
+		setActiveServerProfile(serverName)
 	}
 	if credentialStore == "file" {
 		// A readable keyring credential moves along BEFORE the backend flips:
@@ -77,9 +91,23 @@ func runPairCommand(paths runtimePaths, args []string) int {
 
 	// Pairing can run before a full setup as long as a relay URL is known: an
 	// explicit --relay-url starts from a fresh config, otherwise the saved one.
+	// A NEW profile name has no saved relay URL by definition — falling back to
+	// another profile's URL would bootstrap against the wrong server, so it is a
+	// hard error without --relay-url.
 	cfg, cfgErr := loadConfig(paths)
+	newProfile := serverName != "" && errors.Is(cfgErr, errUnknownServerProfile)
+	if cfgErr != nil && errors.Is(cfgErr, errUnknownServerProfile) && !newProfile {
+		// Selection came from HA_NOVA_SERVER: a typo must fail loud, never
+		// silently pair a fresh profile.
+		printErr("%s", cfgErr)
+		return 1
+	}
 	bootstrapURL := strings.TrimSpace(relayURL)
 	if bootstrapURL == "" {
+		if newProfile {
+			printErr("server profile %q does not exist yet; pass --relay-url http://<ha-host>:8791 to create it", serverName)
+			return 1
+		}
 		if cfgErr != nil {
 			printErr("no relay URL known; pass --relay-url http://<ha-host>:8791 or run 'ha-nova setup' first")
 			return 1
@@ -92,6 +120,11 @@ func runPairCommand(paths runtimePaths, args []string) int {
 	}
 	if cfgErr != nil {
 		cfg = runtimeConfig{RelayBaseURL: bootstrapURL}
+		// Profiles share one install-wide client_install_id; inherit it so a new
+		// profile never mints a second install identity.
+		if raw, rawErr := loadRawDefaultProfileConfig(paths.ConfigFile); rawErr == nil {
+			cfg.ClientInstallID = raw.ClientInstallID
+		}
 	} else if strings.TrimSpace(relayURL) != "" {
 		// An explicit --relay-url must persist for later functional calls, not
 		// just drive this one pairing — the successful pairing saves cfg.

--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -99,7 +99,12 @@ func runDoctor(paths runtimePaths, args []string) int {
 			return 1
 		}
 		printHumanErr("This device was paired, but its device credential is missing from secure storage.")
-		printHumanErr("Pair again: run 'ha-nova setup' and enter a fresh code from the NOVA page.")
+		if profile := activeServerProfile(); profile != defaultServerProfileName {
+			// Setup refuses named profiles — their repair path is pair --server.
+			printHumanErr("Pair again: run 'ha-nova pair --server %s --relay-url %s' and enter a fresh code from the NOVA page.", profile, cfg.RelayBaseURL)
+		} else {
+			printHumanErr("Pair again: run 'ha-nova setup' and enter a fresh code from the NOVA page.")
+		}
 		return 1
 	} else if activeServerProfile() != defaultServerProfileName {
 		// Non-default profiles are device-credential-only: never check them with

--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -63,6 +63,11 @@ func runDoctor(paths runtimePaths, args []string) int {
 		printHumanErr("%s", cfgErr)
 		return 1
 	}
+	// Multi-server installs: name the checked profile so per-server doctor runs
+	// (HA_NOVA_SERVER=<name> ha-nova doctor) are unambiguous.
+	if profileName, profileCount := selectedServerProfileStatus(paths); profileCount > 1 || profileName != defaultServerProfileName {
+		doctorInfo("Server profile: %s", profileName)
+	}
 
 	// Finish a pairing interrupted between activation and promotion (crash or
 	// lost response); best-effort — failures leave the pending slot alone.
@@ -73,7 +78,7 @@ func runDoctor(paths runtimePaths, args []string) int {
 	// Paired devices authenticate with their own credential over pinned TLS;
 	// legacy installs keep the shared relay token. Doctor checks whichever
 	// transport this install actually uses.
-	transportBase, transportClient, transportCred, deviceMode, _ := relayFunctionalTransportForDoctor(cfg)
+	transportBase, transportClient, transportCred, deviceMode, transportErr := relayFunctionalTransportForDoctor(cfg)
 	pairedConfig := cfg.RelaySecureBaseURL != "" && cfg.RelaySpkiPin != ""
 	var token string
 	if deviceMode {
@@ -95,6 +100,14 @@ func runDoctor(paths runtimePaths, args []string) int {
 		}
 		printHumanErr("This device was paired, but its device credential is missing from secure storage.")
 		printHumanErr("Pair again: run 'ha-nova setup' and enter a fresh code from the NOVA page.")
+		return 1
+	} else if activeServerProfile() != defaultServerProfileName {
+		// Non-default profiles are device-credential-only: never check them with
+		// the machine-wide legacy token (it belongs to the default profile).
+		if transportErr == nil {
+			transportErr = fmt.Errorf("server profile %q has no completed device pairing; run: ha-nova pair --server %s --relay-url %s", activeServerProfile(), activeServerProfile(), cfg.RelayBaseURL)
+		}
+		printHumanErr("%s", transportErr)
 		return 1
 	} else {
 		legacyToken, tokenErr := readRelayAuthTokenForDoctor()

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"io"
 	"os"
@@ -49,11 +50,20 @@ func runSetup(paths runtimePaths, args []string) int {
 
 	cfg, cfgErr := loadConfig(paths)
 	if cfgErr != nil {
+		// A mistyped --server/HA_NOVA_SERVER selection must fail loud instead
+		// of silently running setup against a fresh config for the wrong house.
+		if errors.Is(cfgErr, errUnknownServerProfile) {
+			printHumanErr("%s", cfgErr)
+			return 1
+		}
 		// Preserve credential routing from an incomplete config: the token
 		// file setting decides where token reads/writes go, so the repair
-		// path must see it even when relay_base_url is missing.
-		if raw, rawErr := loadJSONConfig(paths.ConfigFile); rawErr == nil {
+		// path must see it even when relay_base_url is missing. The raw
+		// default-profile read also keeps the install-wide id, so a repaired
+		// setup never mints a second client_install_id.
+		if raw, rawErr := loadRawDefaultProfileConfig(paths.ConfigFile); rawErr == nil {
 			cfg.RelayTokenFile = raw.RelayTokenFile
+			cfg.ClientInstallID = raw.ClientInstallID
 		}
 	}
 	state, err := loadStateOrDefaultChecked(paths)

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -62,9 +62,14 @@ func runSetup(paths runtimePaths, args []string) int {
 	if cfgErr != nil {
 		// A mistyped --server/HA_NOVA_SERVER selection must fail loud instead
 		// of silently running setup against a fresh config for the wrong house.
+		// Exception: an EXPLICIT default selection on a config whose default
+		// profile does not exist yet (multi-server-first install) is exactly
+		// what setup onboards — continue on the fresh-config path.
 		if errors.Is(cfgErr, errUnknownServerProfile) {
-			printHumanErr("%s", cfgErr)
-			return 1
+			if name, _ := requestedServerSelection(); name != defaultServerProfileName {
+				printHumanErr("%s", cfgErr)
+				return 1
+			}
 		}
 		// Preserve credential routing from an incomplete config: the token
 		// file setting decides where token reads/writes go, so the repair
@@ -75,6 +80,14 @@ func runSetup(paths runtimePaths, args []string) int {
 			cfg.RelayTokenFile = raw.RelayTokenFile
 			cfg.ClientInstallID = raw.ClientInstallID
 		}
+	}
+	// The config's own default_server can activate a named profile without any
+	// explicit selection (e.g. after the first profile was created via pair
+	// --server). Setup's legacy-token machinery is default-profile-only, so it
+	// must never write or retire state for a named profile.
+	if activeServerProfile() != defaultServerProfileName {
+		printHumanErr("setup always onboards the default server profile, but this config selects %q (default_server); run: HA_NOVA_SERVER=default ha-nova setup", activeServerProfile())
+		return 1
 	}
 	state, err := loadStateOrDefaultChecked(paths)
 	if err != nil {

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -43,6 +43,16 @@ func runSetup(paths runtimePaths, args []string) int {
 		return 1
 	}
 
+	// Setup administers only the default server profile (layer 1): the legacy
+	// token flow, service mode, and client sync are default-profile machinery,
+	// and running them under a named selection would retire that profile's
+	// device credential while pairing nothing in its place. Named profiles are
+	// created and re-paired via pair --server.
+	if name, source := requestedServerSelection(); name != "" && name != defaultServerProfileName {
+		printHumanErr("setup always onboards the default server profile; use plain 'ha-nova setup' (profile %q from %s is managed with: ha-nova pair --server %s --relay-url http://<ha-host>:8791)", name, source, name)
+		return 1
+	}
+
 	target := ""
 	if remaining := fs.Args(); len(remaining) > 0 {
 		target = remaining[0]
@@ -54,14 +64,6 @@ func runSetup(paths runtimePaths, args []string) int {
 		// of silently running setup against a fresh config for the wrong house.
 		if errors.Is(cfgErr, errUnknownServerProfile) {
 			printHumanErr("%s", cfgErr)
-			return 1
-		}
-		// Fresh/incomplete install with a non-default selection: loadConfig
-		// failed before profile resolution, so the credential slots would stay
-		// on the default profile while saves route to the selected name.
-		// Named profiles are created via pair, never via setup (layer 1).
-		if name, source := requestedServerSelection(); name != "" && name != defaultServerProfileName {
-			printHumanErr("setup always onboards the default server profile; %q (from %s) is created with: ha-nova pair --server %s --relay-url http://<ha-host>:8791", name, source, name)
 			return 1
 		}
 		// Preserve credential routing from an incomplete config: the token

--- a/cli/command_setup.go
+++ b/cli/command_setup.go
@@ -56,6 +56,14 @@ func runSetup(paths runtimePaths, args []string) int {
 			printHumanErr("%s", cfgErr)
 			return 1
 		}
+		// Fresh/incomplete install with a non-default selection: loadConfig
+		// failed before profile resolution, so the credential slots would stay
+		// on the default profile while saves route to the selected name.
+		// Named profiles are created via pair, never via setup (layer 1).
+		if name, source := requestedServerSelection(); name != "" && name != defaultServerProfileName {
+			printHumanErr("setup always onboards the default server profile; %q (from %s) is created with: ha-nova pair --server %s --relay-url http://<ha-host>:8791", name, source, name)
+			return 1
+		}
 		// Preserve credential routing from an incomplete config: the token
 		// file setting decides where token reads/writes go, so the repair
 		// path must see it even when relay_base_url is missing. The raw

--- a/cli/command_uninstall.go
+++ b/cli/command_uninstall.go
@@ -291,17 +291,33 @@ func finalizeLocalUninstall(paths runtimePaths, state installState, report *unin
 
 func finalizeLocalUninstallWithProgress(paths runtimePaths, state installState, report *uninstallReport, mode uninstallMode, beforeStep func(string) error, relayAlreadyRemoved bool) error {
 	relayTokenFile := ""
-	deviceSecureBase, deviceSpkiPin := "", ""
+	var purgeTargets []profilePurgeTarget
 	if mode == uninstallModePurge {
-		// Read the raw config: token-file cleanup must not depend on setup
-		// completeness (loadConfig fails when relay_base_url is missing,
+		// Read the raw config document: token-file cleanup must not depend on
+		// setup completeness (loadConfig fails when relay_base_url is missing,
 		// which would silently skip service token file removal on purge).
-		// The secure-endpoint fields are captured here too — config_cleanup
-		// removes config.json before token_cleanup runs the device revoke.
-		if cfg, err := loadJSONConfig(paths.ConfigFile); err == nil {
-			relayTokenFile = strings.TrimSpace(cfg.RelayTokenFile)
-			deviceSecureBase = strings.TrimSpace(cfg.RelaySecureBaseURL)
-			deviceSpkiPin = strings.TrimSpace(cfg.RelaySpkiPin)
+		// EVERY profile's secure endpoint is captured here too — config_cleanup
+		// removes config.json before token_cleanup runs the device revokes, and
+		// each profile's device entry lives on ITS relay.
+		if doc, err := loadConfigDocument(paths.ConfigFile); err == nil {
+			if cfg, ok := doc.flatProfile(doc.defaultServerName()); ok {
+				relayTokenFile = strings.TrimSpace(cfg.RelayTokenFile)
+			}
+			for _, name := range doc.profileNames() {
+				cfg, ok := doc.flatProfile(name)
+				if !ok {
+					continue
+				}
+				purgeTargets = append(purgeTargets, profilePurgeTarget{
+					name:          name,
+					secureBaseURL: strings.TrimSpace(cfg.RelaySecureBaseURL),
+					spkiPin:       strings.TrimSpace(cfg.RelaySpkiPin),
+				})
+			}
+		}
+		if len(purgeTargets) == 0 {
+			// Config gone or unreadable: still clear the active profile's slots.
+			purgeTargets = append(purgeTargets, profilePurgeTarget{name: activeServerProfile()})
 		}
 	}
 	if beforeStep != nil {
@@ -349,7 +365,7 @@ func finalizeLocalUninstallWithProgress(paths runtimePaths, state installState, 
 				return fmt.Errorf("failed before token_cleanup: %w", err)
 			}
 		}
-		purgeDeviceCredentialWithReport(deviceSecureBase, deviceSpkiPin, report, relayAlreadyRemoved)
+		purgeAllDeviceCredentialsWithReport(purgeTargets, report, relayAlreadyRemoved)
 		tokenFileHandled := false
 		if relayTokenFile != "" {
 			var err error

--- a/cli/command_uninstall.go
+++ b/cli/command_uninstall.go
@@ -300,7 +300,9 @@ func finalizeLocalUninstallWithProgress(paths runtimePaths, state installState, 
 		// removes config.json before token_cleanup runs the device revokes, and
 		// each profile's device entry lives on ITS relay.
 		if doc, err := loadConfigDocument(paths.ConfigFile); err == nil {
-			if cfg, ok := doc.flatProfile(doc.defaultServerName()); ok {
+			// Literal default profile: the legacy service token is
+			// default-profile-only, regardless of where default_server points.
+			if cfg, ok := doc.flatProfile(defaultServerProfileName); ok {
 				relayTokenFile = strings.TrimSpace(cfg.RelayTokenFile)
 			}
 			for _, name := range doc.profileNames() {

--- a/cli/config.go
+++ b/cli/config.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 )
 
 type runtimeConfig struct {
@@ -14,7 +12,8 @@ type runtimeConfig struct {
 	RelayTokenFile string `json:"relay_token_file,omitempty"`
 	// Stable, non-secret identifier for this OS-user installation. All AI clients
 	// on the same machine share one device credential keyed by this id; the relay
-	// records it so re-pairing replaces the same install's credential.
+	// records it so re-pairing replaces the same install's credential. Install-
+	// wide: server profiles share it (see config_profiles.go).
 	ClientInstallID string `json:"client_install_id,omitempty"`
 	// Secure device endpoint learned from pairing: the pinned TLS base URL and the
 	// exact SHA-256 SPKI pin. Functional device calls go here; a pin change forces
@@ -31,17 +30,30 @@ type runtimeConfig struct {
 
 type config = runtimeConfig
 
+// loadRuntimeConfig returns the flat runtimeConfig of the SELECTED server
+// profile (--server flag > HA_NOVA_SERVER env > default_server), so the many
+// direct config readers stay profile-agnostic. An unknown selection fails loud
+// with the list of known profiles.
 func loadRuntimeConfig(pathArgs ...runtimePaths) (runtimeConfig, error) {
 	paths, err := resolveRuntimePaths(pathArgs...)
 	if err != nil {
 		return runtimeConfig{}, err
 	}
 
-	cfg, err := loadJSONConfig(paths.ConfigFile)
+	doc, err := loadConfigDocument(paths.ConfigFile)
 	if err != nil {
 		return runtimeConfig{}, fmt.Errorf("HA NOVA is not set up yet. Run: ha-nova setup")
 	}
-	if cfg.RelayBaseURL == "" {
+	name, err := resolveSelectedServerProfile(doc)
+	if err != nil {
+		return runtimeConfig{}, err
+	}
+	setActiveServerProfile(name)
+	cfg, ok := doc.flatProfile(name)
+	if !ok || cfg.RelayBaseURL == "" {
+		if name != defaultServerProfileName {
+			return runtimeConfig{}, fmt.Errorf("server profile %q is not set up yet. Run: ha-nova pair --server %s --relay-url http://<ha-host>:8791", name, name)
+		}
 		return runtimeConfig{}, fmt.Errorf("HA NOVA is not set up yet. Run: ha-nova setup")
 	}
 	return cfg, nil
@@ -51,19 +63,6 @@ func loadConfig(pathArgs ...runtimePaths) (config, error) {
 	return loadRuntimeConfig(pathArgs...)
 }
 
-func loadJSONConfig(path string) (runtimeConfig, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return runtimeConfig{}, err
-	}
-
-	var cfg runtimeConfig
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return runtimeConfig{}, err
-	}
-	return cfg, nil
-}
-
 func resolveRuntimePaths(pathArgs ...runtimePaths) (runtimePaths, error) {
 	if len(pathArgs) > 0 {
 		return pathArgs[0], nil
@@ -71,7 +70,10 @@ func resolveRuntimePaths(pathArgs ...runtimePaths) (runtimePaths, error) {
 	return detectPaths()
 }
 
+// saveConfig writes cfg into the SELECTED server profile of the on-disk
+// document, preserving sibling profiles and unknown top-level fields, and
+// mirrors the default profile into the legacy flat fields (downgrade floor).
 func saveConfig(paths runtimePaths, cfg runtimeConfig) error {
 	cfg.SchemaVersion = configSchemaVersion
-	return writeJSONFile(paths.ConfigFile, cfg, 0o600)
+	return saveProfileConfig(paths, cfg)
 }

--- a/cli/config_profiles.go
+++ b/cli/config_profiles.go
@@ -124,9 +124,9 @@ func (d *configDocument) flatProfile(name string) (runtimeConfig, bool) {
 				return runtimeConfig{}, false
 			}
 			fields = parsed
-		case name == d.defaultServerName():
-			// Hand-edited v2 without a default entry: the legacy mirror still
-			// carries the default profile's data.
+		case name == defaultServerProfileName:
+			// Hand-edited v2 without a default entry: the legacy mirror (when
+			// present) carries the LITERAL default profile's data.
 		default:
 			return runtimeConfig{}, false
 		}
@@ -169,7 +169,10 @@ func loadRawDefaultProfileConfig(path string) (runtimeConfig, error) {
 	if err != nil {
 		return runtimeConfig{}, err
 	}
-	if cfg, ok := doc.flatProfile(doc.defaultServerName()); ok {
+	// Always the LITERAL default profile — never default_server: the legacy
+	// token (and its relay_token_file) belongs to the migrated v1 install even
+	// when the user later points default_server at another profile.
+	if cfg, ok := doc.flatProfile(defaultServerProfileName); ok {
 		return cfg, nil
 	}
 	// No usable default entry: fall back to the flat/mirror fields.
@@ -251,30 +254,38 @@ func (d *configDocument) withProfile(name string, cfg runtimeConfig) (map[string
 		defaultName = name
 	}
 
-	// Legacy mirror: the default profile's fields, rewritten on every save.
+	// Legacy mirror: the LITERAL default profile's fields, rewritten on every
+	// save — never default_server's. An old binary pairs the flat fields with
+	// the machine-wide legacy token, which belongs to the migrated v1 install;
+	// mirroring a named profile would send that token to another server. With
+	// no literal default profile there is no mirror: the old binary honestly
+	// reports "not set up yet".
 	var mirror serverProfileConfig
-	if name == defaultName {
+	hasMirror := true
+	if name == defaultServerProfileName {
 		mirror = serverProfileFromRuntime(cfg)
-	} else if raw, ok := servers[defaultName]; ok {
+	} else if raw, ok := servers[defaultServerProfileName]; ok {
 		if err := json.Unmarshal(raw, &mirror); err != nil {
 			return nil, err
 		}
 	} else {
-		mirror = d.flat
+		hasMirror = false
 	}
 	for _, key := range serverProfileFieldKeys {
 		delete(top, key)
 	}
-	mirrorRaw, err := json.Marshal(mirror)
-	if err != nil {
-		return nil, err
-	}
-	var mirrorMap map[string]json.RawMessage
-	if err := json.Unmarshal(mirrorRaw, &mirrorMap); err != nil {
-		return nil, err
-	}
-	for key, value := range mirrorMap {
-		top[key] = value
+	if hasMirror {
+		mirrorRaw, err := json.Marshal(mirror)
+		if err != nil {
+			return nil, err
+		}
+		var mirrorMap map[string]json.RawMessage
+		if err := json.Unmarshal(mirrorRaw, &mirrorMap); err != nil {
+			return nil, err
+		}
+		for key, value := range mirrorMap {
+			top[key] = value
+		}
 	}
 
 	serversRaw, err := json.Marshal(servers)

--- a/cli/config_profiles.go
+++ b/cli/config_profiles.go
@@ -1,0 +1,333 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+)
+
+// Config schema v2 (multi-server): config.json carries a `servers` map of named
+// profiles plus install-wide fields (`schema_version`, `default_server`,
+// `client_install_id`). v1 flat configs migrate transparently: on load the flat
+// fields ARE the default profile; the first save un-flattens them into
+// `servers.default`. Every save also mirrors the default profile back into the
+// legacy flat top-level fields, so an older binary keeps working against the
+// default profile (downgrade floor).
+
+// serverProfileConfig is the per-server field set — runtimeConfig minus the
+// install-wide fields (schema_version, client_install_id). JSON tags match the
+// v1 flat keys, so the same struct serves profile entries and the legacy mirror.
+type serverProfileConfig struct {
+	HAHost               string `json:"ha_host"`
+	HAURL                string `json:"ha_url"`
+	RelayBaseURL         string `json:"relay_base_url"`
+	RelayTokenFile       string `json:"relay_token_file,omitempty"`
+	RelaySecureBaseURL   string `json:"relay_secure_base_url,omitempty"`
+	RelaySpkiPin         string `json:"relay_spki_pin,omitempty"`
+	PendingSecureBaseURL string `json:"pending_secure_base_url,omitempty"`
+	PendingSpkiPin       string `json:"pending_spki_pin,omitempty"`
+}
+
+// serverProfileFieldKeys are the per-server JSON keys — the fields the legacy
+// mirror rewrites at the top level on every save.
+var serverProfileFieldKeys = []string{
+	"ha_host", "ha_url", "relay_base_url", "relay_token_file",
+	"relay_secure_base_url", "relay_spki_pin", "pending_secure_base_url", "pending_spki_pin",
+}
+
+type configDocumentMeta struct {
+	SchemaVersion   int    `json:"schema_version"`
+	DefaultServer   string `json:"default_server"`
+	ClientInstallID string `json:"client_install_id"`
+}
+
+// configDocument is the raw view of config.json: the typed install-wide fields,
+// the parsed flat/mirror fields, and every profile kept as raw JSON so saves
+// preserve sibling profiles byte-for-byte and unknown top-level fields intact.
+type configDocument struct {
+	top     map[string]json.RawMessage
+	servers map[string]json.RawMessage // nil while the config is still flat (v1)
+	meta    configDocumentMeta
+	flat    serverProfileConfig // top-level flat fields (v1 shape / legacy mirror)
+}
+
+func loadConfigDocument(path string) (*configDocument, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return parseConfigDocument(data)
+}
+
+func parseConfigDocument(data []byte) (*configDocument, error) {
+	doc := &configDocument{}
+	if err := json.Unmarshal(data, &doc.top); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &doc.meta); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &doc.flat); err != nil {
+		return nil, err
+	}
+	if raw, ok := doc.top["servers"]; ok {
+		if err := json.Unmarshal(raw, &doc.servers); err != nil {
+			return nil, fmt.Errorf("invalid servers map in config: %w", err)
+		}
+	}
+	return doc, nil
+}
+
+func (d *configDocument) defaultServerName() string {
+	if d.meta.DefaultServer != "" {
+		return d.meta.DefaultServer
+	}
+	return defaultServerProfileName
+}
+
+func (d *configDocument) hasProfile(name string) bool {
+	if d.servers == nil {
+		return name == defaultServerProfileName
+	}
+	_, ok := d.servers[name]
+	return ok
+}
+
+func (d *configDocument) profileNames() []string {
+	if d.servers == nil {
+		return []string{defaultServerProfileName}
+	}
+	names := make([]string, 0, len(d.servers))
+	for name := range d.servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// flatProfile returns the flat runtimeConfig view of one profile: its
+// per-server fields plus the install-wide fields shared by all profiles.
+func (d *configDocument) flatProfile(name string) (runtimeConfig, bool) {
+	fields := d.flat
+	if d.servers == nil {
+		if name != defaultServerProfileName {
+			return runtimeConfig{}, false
+		}
+	} else {
+		raw, ok := d.servers[name]
+		switch {
+		case ok:
+			var parsed serverProfileConfig
+			if err := json.Unmarshal(raw, &parsed); err != nil {
+				return runtimeConfig{}, false
+			}
+			fields = parsed
+		case name == d.defaultServerName():
+			// Hand-edited v2 without a default entry: the legacy mirror still
+			// carries the default profile's data.
+		default:
+			return runtimeConfig{}, false
+		}
+	}
+	return runtimeConfig{
+		SchemaVersion:        d.meta.SchemaVersion,
+		ClientInstallID:      d.meta.ClientInstallID,
+		HAHost:               fields.HAHost,
+		HAURL:                fields.HAURL,
+		RelayBaseURL:         fields.RelayBaseURL,
+		RelayTokenFile:       fields.RelayTokenFile,
+		RelaySecureBaseURL:   fields.RelaySecureBaseURL,
+		RelaySpkiPin:         fields.RelaySpkiPin,
+		PendingSecureBaseURL: fields.PendingSecureBaseURL,
+		PendingSpkiPin:       fields.PendingSpkiPin,
+	}, true
+}
+
+func serverProfileFromRuntime(cfg runtimeConfig) serverProfileConfig {
+	return serverProfileConfig{
+		HAHost:               cfg.HAHost,
+		HAURL:                cfg.HAURL,
+		RelayBaseURL:         cfg.RelayBaseURL,
+		RelayTokenFile:       cfg.RelayTokenFile,
+		RelaySecureBaseURL:   cfg.RelaySecureBaseURL,
+		RelaySpkiPin:         cfg.RelaySpkiPin,
+		PendingSecureBaseURL: cfg.PendingSecureBaseURL,
+		PendingSpkiPin:       cfg.PendingSpkiPin,
+	}
+}
+
+// loadRawDefaultProfileConfig reads config.json WITHOUT the setup-completeness
+// check of loadConfig, understanding both the v1 flat shape and the v2 servers
+// map. It is deliberately independent of loadConfig and runtime selection
+// (issue #200): relay-token storage must not depend on relay fields or on a
+// valid profile selection, and the legacy token machinery is default-profile-
+// only, so this always reads the DEFAULT profile.
+func loadRawDefaultProfileConfig(path string) (runtimeConfig, error) {
+	doc, err := loadConfigDocument(path)
+	if err != nil {
+		return runtimeConfig{}, err
+	}
+	if cfg, ok := doc.flatProfile(doc.defaultServerName()); ok {
+		return cfg, nil
+	}
+	// No usable default entry: fall back to the flat/mirror fields.
+	cfg := runtimeConfig{
+		SchemaVersion:        doc.meta.SchemaVersion,
+		ClientInstallID:      doc.meta.ClientInstallID,
+		HAHost:               doc.flat.HAHost,
+		HAURL:                doc.flat.HAURL,
+		RelayBaseURL:         doc.flat.RelayBaseURL,
+		RelayTokenFile:       doc.flat.RelayTokenFile,
+		RelaySecureBaseURL:   doc.flat.RelaySecureBaseURL,
+		RelaySpkiPin:         doc.flat.RelaySpkiPin,
+		PendingSecureBaseURL: doc.flat.PendingSecureBaseURL,
+		PendingSpkiPin:       doc.flat.PendingSpkiPin,
+	}
+	return cfg, nil
+}
+
+// loadConfigDocumentOrEmpty backs the save path. A missing or unreadable
+// config starts fresh — matching the pre-profile saveConfig, which always
+// overwrote the file so a corrupted config stayed repairable via setup.
+func loadConfigDocumentOrEmpty(path string) *configDocument {
+	doc, err := loadConfigDocument(path)
+	if err != nil {
+		return &configDocument{top: map[string]json.RawMessage{}}
+	}
+	if doc.top == nil {
+		doc.top = map[string]json.RawMessage{}
+	}
+	return doc
+}
+
+// saveTargetProfileName resolves which profile a save writes to (flag > env >
+// configured default) and name-validates profiles that would be created.
+func saveTargetProfileName(doc *configDocument) (string, error) {
+	name, _ := requestedServerSelection()
+	if name == "" {
+		name = doc.defaultServerName()
+	}
+	if name != defaultServerProfileName && !doc.hasProfile(name) {
+		if err := validateServerProfileName(name); err != nil {
+			return "", err
+		}
+	}
+	return name, nil
+}
+
+// withProfile builds the on-disk v2 document with cfg stored in the named
+// profile: sibling profiles and unknown top-level fields are preserved, a v1
+// flat document is migrated to the servers map, and the default profile is
+// mirrored into the legacy flat fields (downgrade floor for older binaries).
+func (d *configDocument) withProfile(name string, cfg runtimeConfig) (map[string]json.RawMessage, error) {
+	top := make(map[string]json.RawMessage, len(d.top)+4)
+	for key, value := range d.top {
+		top[key] = value
+	}
+	servers := make(map[string]json.RawMessage, len(d.servers)+1)
+	for key, value := range d.servers {
+		servers[key] = value
+	}
+	if d.servers == nil && d.flat != (serverProfileConfig{}) {
+		// v1 → v2 migration: the existing flat fields become the default
+		// profile, so a save into another profile never destroys that server.
+		raw, err := json.Marshal(d.flat)
+		if err != nil {
+			return nil, err
+		}
+		servers[defaultServerProfileName] = raw
+	}
+	profileRaw, err := json.Marshal(serverProfileFromRuntime(cfg))
+	if err != nil {
+		return nil, err
+	}
+	servers[name] = profileRaw
+
+	defaultName := d.defaultServerName()
+	if _, ok := servers[defaultName]; !ok {
+		// The first profile ever saved becomes the default.
+		defaultName = name
+	}
+
+	// Legacy mirror: the default profile's fields, rewritten on every save.
+	var mirror serverProfileConfig
+	if name == defaultName {
+		mirror = serverProfileFromRuntime(cfg)
+	} else if raw, ok := servers[defaultName]; ok {
+		if err := json.Unmarshal(raw, &mirror); err != nil {
+			return nil, err
+		}
+	} else {
+		mirror = d.flat
+	}
+	for _, key := range serverProfileFieldKeys {
+		delete(top, key)
+	}
+	mirrorRaw, err := json.Marshal(mirror)
+	if err != nil {
+		return nil, err
+	}
+	var mirrorMap map[string]json.RawMessage
+	if err := json.Unmarshal(mirrorRaw, &mirrorMap); err != nil {
+		return nil, err
+	}
+	for key, value := range mirrorMap {
+		top[key] = value
+	}
+
+	serversRaw, err := json.Marshal(servers)
+	if err != nil {
+		return nil, err
+	}
+	top["servers"] = serversRaw
+	top["schema_version"] = json.RawMessage(strconv.Itoa(configSchemaVersion))
+	defaultRaw, err := json.Marshal(defaultName)
+	if err != nil {
+		return nil, err
+	}
+	top["default_server"] = defaultRaw
+
+	installID := cfg.ClientInstallID
+	if installID == "" {
+		installID = d.meta.ClientInstallID
+	}
+	if installID != "" {
+		idRaw, err := json.Marshal(installID)
+		if err != nil {
+			return nil, err
+		}
+		top["client_install_id"] = idRaw
+	} else {
+		delete(top, "client_install_id")
+	}
+	return top, nil
+}
+
+// saveProfileConfig writes cfg into the selected profile of the on-disk
+// document. All 8 read-modify-write config sites go through here (via
+// saveConfig), so none of them can flatten the servers map away.
+func saveProfileConfig(paths runtimePaths, cfg runtimeConfig) error {
+	doc := loadConfigDocumentOrEmpty(paths.ConfigFile)
+	name, err := saveTargetProfileName(doc)
+	if err != nil {
+		return err
+	}
+	top, err := doc.withProfile(name, cfg)
+	if err != nil {
+		return err
+	}
+	return writeJSONFile(paths.ConfigFile, top, 0o600)
+}
+
+// selectedServerProfileStatus reports the active profile name and how many
+// profiles the config defines (best-effort; 1 when unreadable). Doctor uses it
+// to name the checked profile on multi-server installs.
+func selectedServerProfileStatus(paths runtimePaths) (string, int) {
+	count := 1
+	if doc, err := loadConfigDocument(paths.ConfigFile); err == nil {
+		count = len(doc.profileNames())
+	}
+	return activeServerProfile(), count
+}

--- a/cli/config_profiles_test.go
+++ b/cli/config_profiles_test.go
@@ -323,6 +323,23 @@ func TestRawDefaultProfileLoaderIgnoresDefaultServerRedirect(t *testing.T) {
 	}
 }
 
+func TestFreshSetupRejectsNonDefaultServerSelection(t *testing.T) {
+	// Fresh install + HA_NOVA_SERVER naming a new profile: loadConfig fails
+	// before profile resolution, so setup would pair credentials into the
+	// default slots while saving config into the named profile. Named profiles
+	// are created via pair, never via setup.
+	resetServerProfileSelection(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(serverSelectionEnvVar, "cabin")
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code := runSetup(paths, nil); code == 0 {
+		t.Fatal("fresh setup with a non-default server selection must fail loud")
+	}
+}
+
 func TestLegacyMirrorFollowsLiteralDefaultNotDefaultServer(t *testing.T) {
 	// The flat mirror pairs with the machine-wide legacy token in old binaries,
 	// so it must always carry the LITERAL default profile — never the profile

--- a/cli/config_profiles_test.go
+++ b/cli/config_profiles_test.go
@@ -346,6 +346,35 @@ func TestSetupRejectsAnyNonDefaultServerSelection(t *testing.T) {
 	}
 }
 
+func TestEnvOnlyFreshPairRequiresExplicitServerFlag(t *testing.T) {
+	// HA_NOVA_SERVER=cabin ha-nova pair --relay-url ... with no config yet:
+	// saves would target the env profile while credentials land in the default
+	// slots. Creation always requires the explicit --server flag.
+	resetServerProfileSelection(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("HA_NOVA_TEST_SECRET_DIR", t.TempDir())
+	t.Setenv(serverSelectionEnvVar, "cabin")
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code := runPairCommand(paths, []string{"--relay-url", "http://cabin:8791", "--code", "123456"}); code == 0 {
+		t.Fatal("env-only fresh pair must fail loud and require --server")
+	}
+}
+
+func TestSetupRejectsConfiguredNonDefaultDefaultServer(t *testing.T) {
+	// default_server can activate a named profile with no explicit selection
+	// (e.g. after the first profile came from pair --server). Setup's
+	// legacy-token machinery is default-profile-only.
+	resetServerProfileSelection(t)
+	t.Setenv("HOME", t.TempDir())
+	paths := writeTestConfigFile(t, `{"schema_version":2,"default_server":"cabin","servers":{"cabin":{"relay_base_url":"http://cabin:8791"}}}`)
+	if code := runSetup(paths, []string{"--relay-token", "tok", "--non-interactive"}); code == 0 {
+		t.Fatal("setup must reject a config whose default_server selects a named profile")
+	}
+}
+
 func TestLegacyMirrorFollowsLiteralDefaultNotDefaultServer(t *testing.T) {
 	// The flat mirror pairs with the machine-wide legacy token in old binaries,
 	// so it must always carry the LITERAL default profile — never the profile

--- a/cli/config_profiles_test.go
+++ b/cli/config_profiles_test.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Schema-v2 (multi-server) coverage: v1→v2 migration, save-path un-flatten,
+// sibling preservation, the legacy downgrade mirror, selection order, and the
+// issue-#200 raw default-profile loader.
+
+// resetServerProfileSelection isolates the process-global selection seam and
+// the HA_NOVA_SERVER env var for one test.
+func resetServerProfileSelection(t *testing.T) {
+	t.Helper()
+	prevOverride, prevActive := serverSelectionOverride, activeServerProfileName
+	t.Setenv(serverSelectionEnvVar, "")
+	t.Cleanup(func() {
+		serverSelectionOverride, activeServerProfileName = prevOverride, prevActive
+	})
+	serverSelectionOverride = ""
+	activeServerProfileName = defaultServerProfileName
+}
+
+func writeTestConfigFile(t *testing.T, content string) runtimePaths {
+	t.Helper()
+	dir := t.TempDir()
+	paths := runtimePaths{ConfigDir: dir, ConfigFile: filepath.Join(dir, "config.json")}
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return paths
+}
+
+func readTestConfigTopLevel(t *testing.T, paths runtimePaths) map[string]json.RawMessage {
+	t.Helper()
+	data, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatal(err)
+	}
+	return top
+}
+
+const testV1FlatConfig = `{"schema_version":1,"ha_host":"ha","ha_url":"http://ha:8123","relay_base_url":"http://ha:8791","relay_token_file":"relay-token","client_install_id":"inst-abc","relay_secure_base_url":"https://ha:18792","relay_spki_pin":"PIN"}`
+
+func TestV1FlatConfigMigratesToProfilesOnSaveWithLegacyMirror(t *testing.T) {
+	resetServerProfileSelection(t)
+	paths := writeTestConfigFile(t, testV1FlatConfig)
+
+	cfg, err := loadConfig(paths)
+	if err != nil {
+		t.Fatalf("loadConfig(v1): %v", err)
+	}
+	if cfg.RelayBaseURL != "http://ha:8791" || cfg.RelayTokenFile != "relay-token" || cfg.ClientInstallID != "inst-abc" {
+		t.Fatalf("v1 flat fields must load as the default profile, got %+v", cfg)
+	}
+	if activeServerProfile() != defaultServerProfileName {
+		t.Fatalf("active profile = %q, want default", activeServerProfile())
+	}
+
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+	top := readTestConfigTopLevel(t, paths)
+	if string(top["schema_version"]) != "2" {
+		t.Fatalf("schema_version = %s, want 2", top["schema_version"])
+	}
+	if string(top["default_server"]) != `"default"` {
+		t.Fatalf("default_server = %s, want \"default\"", top["default_server"])
+	}
+	if string(top["client_install_id"]) != `"inst-abc"` {
+		t.Fatalf("client_install_id must stay install-wide, got %s", top["client_install_id"])
+	}
+	var servers map[string]serverProfileConfig
+	if err := json.Unmarshal(top["servers"], &servers); err != nil {
+		t.Fatalf("servers map: %v", err)
+	}
+	if servers["default"].RelayBaseURL != "http://ha:8791" || servers["default"].RelayTokenFile != "relay-token" {
+		t.Fatalf("servers.default = %+v", servers["default"])
+	}
+	// Downgrade floor: an old binary unmarshals the flat mirror and keeps
+	// working against the default profile.
+	var oldShape runtimeConfig
+	data, _ := os.ReadFile(paths.ConfigFile)
+	if err := json.Unmarshal(data, &oldShape); err != nil {
+		t.Fatalf("old-binary shape unreadable: %v", err)
+	}
+	if oldShape.RelayBaseURL != "http://ha:8791" || oldShape.RelaySpkiPin != "PIN" || oldShape.RelayTokenFile != "relay-token" || oldShape.ClientInstallID != "inst-abc" {
+		t.Fatalf("legacy mirror incomplete: %+v", oldShape)
+	}
+
+	// Idempotent: load+save of the migrated file changes nothing.
+	reloaded, err := loadConfig(paths)
+	if err != nil {
+		t.Fatalf("loadConfig(v2): %v", err)
+	}
+	cfg.SchemaVersion = configSchemaVersion
+	if reloaded != cfg {
+		t.Fatalf("v2 reload differs from v1 load:\n  got  %+v\n  want %+v", reloaded, cfg)
+	}
+	before, _ := os.ReadFile(paths.ConfigFile)
+	if err := saveConfig(paths, reloaded); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.ReadFile(paths.ConfigFile)
+	if string(before) != string(after) {
+		t.Fatalf("second save must be byte-identical:\n before: %s\n after:  %s", before, after)
+	}
+}
+
+const testV2TwoProfileConfig = `{
+  "schema_version": 2,
+  "default_server": "default",
+  "client_install_id": "inst-abc",
+  "future_flag": {"keep": true},
+  "ha_host": "ha",
+  "ha_url": "http://ha:8123",
+  "relay_base_url": "http://ha:8791",
+  "servers": {
+    "default": {"ha_host": "ha", "ha_url": "http://ha:8123", "relay_base_url": "http://ha:8791"},
+    "cabin": {"ha_host": "cabin", "ha_url": "http://cabin:8123", "relay_base_url": "http://cabin:8791", "relay_secure_base_url": "https://cabin:18792", "relay_spki_pin": "PINB"}
+  }
+}`
+
+func TestSaveOnProfileBLeavesProfileAByteIdenticalAndKeepsUnknownFields(t *testing.T) {
+	resetServerProfileSelection(t)
+	paths := writeTestConfigFile(t, testV2TwoProfileConfig)
+
+	setServerSelectionOverride("cabin")
+	cfgB, err := loadConfig(paths)
+	if err != nil {
+		t.Fatalf("loadConfig(cabin): %v", err)
+	}
+	if cfgB.RelayBaseURL != "http://cabin:8791" || cfgB.ClientInstallID != "inst-abc" {
+		t.Fatalf("cabin profile = %+v", cfgB)
+	}
+	// Normalizing save, then a real change — like a doctor-resume or re-pair on
+	// profile B.
+	if err := saveConfig(paths, cfgB); err != nil {
+		t.Fatal(err)
+	}
+	topBefore := readTestConfigTopLevel(t, paths)
+	var serversBefore map[string]json.RawMessage
+	if err := json.Unmarshal(topBefore["servers"], &serversBefore); err != nil {
+		t.Fatal(err)
+	}
+	cfgB.RelaySpkiPin = "PINB-ROTATED"
+	if err := saveConfig(paths, cfgB); err != nil {
+		t.Fatal(err)
+	}
+	topAfter := readTestConfigTopLevel(t, paths)
+	var serversAfter map[string]json.RawMessage
+	if err := json.Unmarshal(topAfter["servers"], &serversAfter); err != nil {
+		t.Fatal(err)
+	}
+	if string(serversBefore["default"]) != string(serversAfter["default"]) {
+		t.Fatalf("sibling profile changed:\n before: %s\n after:  %s", serversBefore["default"], serversAfter["default"])
+	}
+	if !strings.Contains(string(serversAfter["cabin"]), "PINB-ROTATED") {
+		t.Fatalf("cabin profile not updated: %s", serversAfter["cabin"])
+	}
+	if string(topAfter["future_flag"]) != string(topBefore["future_flag"]) || topAfter["future_flag"] == nil {
+		t.Fatalf("unknown top-level field lost: %s", topAfter["future_flag"])
+	}
+	if string(topAfter["default_server"]) != `"default"` {
+		t.Fatalf("default_server changed: %s", topAfter["default_server"])
+	}
+	// The legacy mirror still carries the DEFAULT profile after a save on B.
+	var oldShape runtimeConfig
+	data, _ := os.ReadFile(paths.ConfigFile)
+	if err := json.Unmarshal(data, &oldShape); err != nil {
+		t.Fatal(err)
+	}
+	if oldShape.RelayBaseURL != "http://ha:8791" || oldShape.RelaySpkiPin != "" {
+		t.Fatalf("legacy mirror must stay the default profile's data: %+v", oldShape)
+	}
+}
+
+func TestServerSelectionOrderFlagOverEnvOverDefault(t *testing.T) {
+	resetServerProfileSelection(t)
+	paths := writeTestConfigFile(t, testV2TwoProfileConfig)
+
+	t.Setenv(serverSelectionEnvVar, "cabin")
+	cfg, err := loadConfig(paths)
+	if err != nil {
+		t.Fatalf("env selection: %v", err)
+	}
+	if cfg.RelayBaseURL != "http://cabin:8791" || activeServerProfile() != "cabin" {
+		t.Fatalf("env must select cabin, got %q / active %q", cfg.RelayBaseURL, activeServerProfile())
+	}
+
+	setServerSelectionOverride("default")
+	cfg, err = loadConfig(paths)
+	if err != nil {
+		t.Fatalf("flag selection: %v", err)
+	}
+	if cfg.RelayBaseURL != "http://ha:8791" || activeServerProfile() != defaultServerProfileName {
+		t.Fatalf("--server must beat the env, got %q / active %q", cfg.RelayBaseURL, activeServerProfile())
+	}
+
+	setServerSelectionOverride("")
+	t.Setenv(serverSelectionEnvVar, "")
+	cfg, err = loadConfig(paths)
+	if err != nil {
+		t.Fatalf("default selection: %v", err)
+	}
+	if cfg.RelayBaseURL != "http://ha:8791" {
+		t.Fatalf("default_server must apply, got %q", cfg.RelayBaseURL)
+	}
+
+	// A configured non-default default_server is honored too.
+	pathsB := writeTestConfigFile(t, strings.Replace(testV2TwoProfileConfig, `"default_server": "default"`, `"default_server": "cabin"`, 1))
+	cfg, err = loadConfig(pathsB)
+	if err != nil {
+		t.Fatalf("default_server=cabin: %v", err)
+	}
+	if cfg.RelayBaseURL != "http://cabin:8791" || activeServerProfile() != "cabin" {
+		t.Fatalf("default_server=cabin must select cabin, got %q", cfg.RelayBaseURL)
+	}
+}
+
+func TestUnknownServerSelectionFailsLoudListingProfiles(t *testing.T) {
+	resetServerProfileSelection(t)
+	paths := writeTestConfigFile(t, testV2TwoProfileConfig)
+	t.Setenv(serverSelectionEnvVar, "nope")
+
+	_, err := loadConfig(paths)
+	if !errors.Is(err, errUnknownServerProfile) {
+		t.Fatalf("expected errUnknownServerProfile, got %v", err)
+	}
+	message := err.Error()
+	if !strings.Contains(message, `"nope"`) || !strings.Contains(message, "cabin, default") {
+		t.Fatalf("error must name the typo and list known profiles, got: %s", message)
+	}
+	// A typo must not select anything: the seam stays on the default.
+	if activeServerProfile() != defaultServerProfileName {
+		t.Fatalf("active profile changed on a failed selection: %q", activeServerProfile())
+	}
+}
+
+func TestValidateServerProfileName(t *testing.T) {
+	valid := []string{"a", "cabin", "cabin-2", "0", strings.Repeat("x", 32), "default"}
+	for _, name := range valid {
+		if err := validateServerProfileName(name); err != nil {
+			t.Errorf("validateServerProfileName(%q) = %v, want nil", name, err)
+		}
+	}
+	invalid := []string{"", "Cabin", "ha_nova", "with space", "ä", strings.Repeat("x", 33), "pending", "probe"}
+	for _, name := range invalid {
+		if err := validateServerProfileName(name); err == nil {
+			t.Errorf("validateServerProfileName(%q) = nil, want error", name)
+		}
+	}
+}
+
+func TestSelectedServerProfileStatusCountsProfiles(t *testing.T) {
+	resetServerProfileSelection(t)
+	paths := writeTestConfigFile(t, testV2TwoProfileConfig)
+	name, count := selectedServerProfileStatus(paths)
+	if name != defaultServerProfileName || count != 2 {
+		t.Fatalf("status = %q/%d, want default/2", name, count)
+	}
+	pathsV1 := writeTestConfigFile(t, testV1FlatConfig)
+	if _, count := selectedServerProfileStatus(pathsV1); count != 1 {
+		t.Fatalf("v1 config must count as one profile, got %d", count)
+	}
+}
+
+func TestRawDefaultProfileLoaderResolvesTokenFileFromV2Config(t *testing.T) {
+	// Issue-#200 regression: relay-token storage reads the raw config so an
+	// incomplete setup (no relay fields at all) still routes token reads to the
+	// configured file instead of hanging in a headless Secret Service unlock.
+	// The raw loader must understand the v2 shape WITHOUT the legacy mirror.
+	resetServerProfileSelection(t)
+	paths := writeTestConfigFile(t, `{"schema_version":2,"default_server":"default","servers":{"default":{"relay_token_file":"relay-token"}}}`)
+
+	cfg, err := loadRawDefaultProfileConfig(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("loadRawDefaultProfileConfig: %v", err)
+	}
+	if cfg.RelayTokenFile != "relay-token" {
+		t.Fatalf("relay_token_file = %q, want relay-token", cfg.RelayTokenFile)
+	}
+	if cfg.RelayBaseURL != "" {
+		t.Fatalf("raw loader must not require relay fields, got %q", cfg.RelayBaseURL)
+	}
+	// loadConfig itself refuses this config (no relay_base_url) — the raw
+	// loader must stay independent of that check.
+	if _, err := loadConfig(paths); err == nil {
+		t.Fatal("loadConfig must still fail on an incomplete profile")
+	}
+
+	// v1 flat shape stays readable through the same loader.
+	pathsV1 := writeTestConfigFile(t, `{"schema_version":1,"relay_token_file":"legacy-token"}`)
+	cfgV1, err := loadRawDefaultProfileConfig(pathsV1.ConfigFile)
+	if err != nil || cfgV1.RelayTokenFile != "legacy-token" {
+		t.Fatalf("v1 raw read = %q err=%v", cfgV1.RelayTokenFile, err)
+	}
+}

--- a/cli/config_profiles_test.go
+++ b/cli/config_profiles_test.go
@@ -305,3 +305,55 @@ func TestRawDefaultProfileLoaderResolvesTokenFileFromV2Config(t *testing.T) {
 		t.Fatalf("v1 raw read = %q err=%v", cfgV1.RelayTokenFile, err)
 	}
 }
+
+func TestRawDefaultProfileLoaderIgnoresDefaultServerRedirect(t *testing.T) {
+	// The legacy token belongs to the LITERAL default profile (the migrated v1
+	// install). Pointing default_server at another profile must not make the
+	// raw loader read that profile's relay_token_file — the legacy token would
+	// travel to the wrong server.
+	resetServerProfileSelection(t)
+	paths := writeTestConfigFile(t, `{"schema_version":2,"default_server":"cabin","servers":{"default":{"relay_token_file":"default-token"},"cabin":{"relay_token_file":"cabin-token","relay_base_url":"http://cabin:8791"}}}`)
+
+	cfg, err := loadRawDefaultProfileConfig(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("loadRawDefaultProfileConfig: %v", err)
+	}
+	if cfg.RelayTokenFile != "default-token" {
+		t.Fatalf("relay_token_file = %q, want the literal default profile's default-token", cfg.RelayTokenFile)
+	}
+}
+
+func TestLegacyMirrorFollowsLiteralDefaultNotDefaultServer(t *testing.T) {
+	// The flat mirror pairs with the machine-wide legacy token in old binaries,
+	// so it must always carry the LITERAL default profile — never the profile
+	// default_server points at.
+	resetServerProfileSelection(t)
+	doc, err := parseConfigDocument([]byte(`{"schema_version":2,"default_server":"cabin","servers":{"default":{"relay_base_url":"http://home:8791"},"cabin":{"relay_base_url":"http://cabin:8791"}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	top, err := doc.withProfile("cabin", runtimeConfig{RelayBaseURL: "http://cabin:8791", HAHost: "cabin.local"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mirror serverProfileConfig
+	raw, _ := json.Marshal(top)
+	if err := json.Unmarshal(raw, &mirror); err != nil {
+		t.Fatal(err)
+	}
+	if mirror.RelayBaseURL != "http://home:8791" {
+		t.Fatalf("mirror relay_base_url = %q, want the literal default profile's http://home:8791", mirror.RelayBaseURL)
+	}
+
+	// Without a literal default profile there is no mirror at all: an old
+	// binary honestly reports "not set up yet" instead of pairing the legacy
+	// token with a named profile's server.
+	fresh := &configDocument{top: map[string]json.RawMessage{}}
+	top, err = fresh.withProfile("cabin", runtimeConfig{RelayBaseURL: "http://cabin:8791"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := top["relay_base_url"]; ok {
+		t.Fatal("no literal default profile: the flat mirror must be absent")
+	}
+}

--- a/cli/config_profiles_test.go
+++ b/cli/config_profiles_test.go
@@ -323,11 +323,11 @@ func TestRawDefaultProfileLoaderIgnoresDefaultServerRedirect(t *testing.T) {
 	}
 }
 
-func TestFreshSetupRejectsNonDefaultServerSelection(t *testing.T) {
-	// Fresh install + HA_NOVA_SERVER naming a new profile: loadConfig fails
-	// before profile resolution, so setup would pair credentials into the
-	// default slots while saving config into the named profile. Named profiles
-	// are created via pair, never via setup.
+func TestSetupRejectsAnyNonDefaultServerSelection(t *testing.T) {
+	// Setup administers only the default profile: under a named selection the
+	// legacy-token flow would retire that profile's device credential while
+	// pairing nothing in its place. This holds for fresh installs AND existing
+	// named profiles — named profiles are managed via pair --server.
 	resetServerProfileSelection(t)
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv(serverSelectionEnvVar, "cabin")
@@ -335,8 +335,14 @@ func TestFreshSetupRejectsNonDefaultServerSelection(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Fresh install.
 	if code := runSetup(paths, nil); code == 0 {
 		t.Fatal("fresh setup with a non-default server selection must fail loud")
+	}
+	// Existing named profile: still rejected before the token flow.
+	pathsExisting := writeTestConfigFile(t, testV2TwoProfileConfig)
+	if code := runSetup(pathsExisting, []string{"--relay-token", "tok", "--non-interactive"}); code == 0 {
+		t.Fatal("setup on an existing named profile must fail loud")
 	}
 }
 

--- a/cli/config_selection.go
+++ b/cli/config_selection.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// Server-profile selection (multi-server support, issue #343). One config file
+// holds named server profiles; every command operates on exactly ONE selected
+// profile. Selection order: --server flag > HA_NOVA_SERVER env > default_server.
+// The selected name also routes the per-profile credential slots through the
+// process-global seam below, so the zero-arg slot API stays unchanged.
+
+const defaultServerProfileName = "default"
+
+const serverSelectionEnvVar = "HA_NOVA_SERVER"
+
+var errUnknownServerProfile = errors.New("unknown server profile")
+
+// serverSelectionOverride carries an explicit --server flag value; it wins over
+// the environment and the configured default.
+var serverSelectionOverride = ""
+
+// activeServerProfileName is the process-global selected-profile seam: resolved
+// once when the config is loaded (or by pair's profile creation) and consumed
+// by the zero-arg device-credential slot API. It defaults to the default
+// profile, so every pre-profile code path keeps today's slot names.
+var activeServerProfileName = defaultServerProfileName
+
+func activeServerProfile() string { return activeServerProfileName }
+
+func setActiveServerProfile(name string) {
+	if strings.TrimSpace(name) == "" {
+		name = defaultServerProfileName
+	}
+	activeServerProfileName = name
+}
+
+func setServerSelectionOverride(name string) { serverSelectionOverride = name }
+
+func serverSelectionFromEnv() string { return strings.TrimSpace(os.Getenv(serverSelectionEnvVar)) }
+
+// requestedServerSelection returns the explicit selection (flag > env) and its
+// source label, or "" when the configured default applies.
+func requestedServerSelection() (name, source string) {
+	if serverSelectionOverride != "" {
+		return serverSelectionOverride, "--server"
+	}
+	if env := serverSelectionFromEnv(); env != "" {
+		return env, serverSelectionEnvVar
+	}
+	return "", ""
+}
+
+var serverProfileNamePattern = regexp.MustCompile(`^[a-z0-9-]{1,32}$`)
+
+// Reserved names would collide with the fixed credential-slot suffixes
+// ("ha-nova.device-credential.pending", "….probe").
+var reservedServerProfileNames = map[string]bool{"pending": true, "probe": true}
+
+// validateServerProfileName gates profile CREATION. Keyring service strings and
+// secret file names inherit the name, so the alphabet stays filesystem- and
+// keyring-safe on every platform.
+func validateServerProfileName(name string) error {
+	if !serverProfileNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid server profile name %q: use 1-32 characters of a-z, 0-9, or '-'", name)
+	}
+	if reservedServerProfileNames[name] {
+		return fmt.Errorf("server profile name %q is reserved", name)
+	}
+	return nil
+}
+
+// resolveSelectedServerProfile picks the profile this process operates on.
+// An unknown selection fails loud with the list of known profiles: a typo must
+// never route a mutation to the wrong house.
+func resolveSelectedServerProfile(doc *configDocument) (string, error) {
+	names := doc.profileNames()
+	pick, source := requestedServerSelection()
+	if pick == "" {
+		pick = doc.defaultServerName()
+		if !doc.hasProfile(pick) {
+			return "", fmt.Errorf("%w: default_server %q does not exist in config.json; known server profiles: %s",
+				errUnknownServerProfile, pick, strings.Join(names, ", "))
+		}
+		return pick, nil
+	}
+	if !doc.hasProfile(pick) {
+		return "", fmt.Errorf("%w %q (from %s); known server profiles: %s",
+			errUnknownServerProfile, pick, source, strings.Join(names, ", "))
+	}
+	return pick, nil
+}

--- a/cli/device_credential_migration.go
+++ b/cli/device_credential_migration.go
@@ -3,6 +3,8 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
+	"sort"
 
 	"github.com/zalando/go-keyring"
 )
@@ -33,82 +35,122 @@ func forceDeviceCredentialFileMode() {
 	deviceCredentialFileModeExplicit = true
 }
 
-// migrateKeyringDeviceCredentialToFile moves a READABLE keyring-held device
-// credential into the private-file backend. Both explicit opt-ins run it
-// before flipping the backend: `setup --service` re-runs with a healthy
-// pairing never reach the pairing stage (deviceAlreadyPaired short-circuits
-// to verify), and `pair --credential-store=file` on a desktop install must
-// never mask the live credential mid-flip. A locked/absent keyring or an
-// unpaired install is a normal no-op (false, nil) — the pairing path takes
-// over. A failed FILE WRITE is a real error: continuing would silently leave
-// the credential in the keyring despite the opt-in, so callers must abort.
+// migrateKeyringDeviceCredentialToFile moves READABLE keyring-held device
+// credentials — for EVERY known server profile — into the private-file backend.
+// Both explicit opt-ins run it before flipping the backend: `setup --service`
+// re-runs with a healthy pairing never reach the pairing stage
+// (deviceAlreadyPaired short-circuits to verify), and
+// `pair --credential-store=file` on a desktop install must never mask a live
+// credential mid-flip. All profiles' slots move BEFORE the machine-wide marker
+// commits: once the marker exists, reads resolve to files, and a
+// keyring-stranded slot of any profile would be invisible afterwards. A
+// locked/absent keyring or an unpaired install is a normal no-op (false, nil) —
+// the pairing path takes over. A failed FILE WRITE is a real error: continuing
+// would silently leave a credential in the keyring despite the opt-in, so
+// callers must abort.
 func migrateKeyringDeviceCredentialToFile() (bool, error) {
 	if deviceSecretFileBacked() {
 		return false, nil // already on the file backend
 	}
-	credential, ok, err := readDeviceCredential()
-	if err != nil || !ok {
-		if err != nil {
+	type slotValue struct{ service, value string }
+	var currents, pendings []slotValue
+	for _, profile := range credentialProfileNames() {
+		currentService := deviceCredentialServiceForProfile(profile)
+		pendingService := deviceCredentialPendingServiceForProfile(profile)
+		current, currentOK, currentErr := readCredentialSlot(currentService)
+		if currentErr != nil {
 			return false, nil // keyring unreadable (locked/absent): the pairing path takes over
 		}
-		// CURRENT is cleanly absent, but an interrupted FIRST pairing may have
-		// left a pending keyring credential (with the pending endpoint in the
-		// config). Resume would promote it back into the desktop keyring before
-		// service mode forces files — so move the pending itself and commit the
-		// backend, the same durable state an explicit file-mode pairing leaves
-		// behind; resume then finishes file-backed.
-		pending, pendingOK, pendingErr := readPendingKeyringSlotDirect()
+		if currentOK {
+			currents = append(currents, slotValue{currentService, current})
+		}
+		// A pending credential from an interrupted pairing must move with the
+		// install; an unreadable/malformed pending slot aborts BEFORE the flip.
+		pending, pendingOK, pendingErr := readKeyringSlotDirect(pendingService)
 		if pendingErr != nil {
 			return false, fmt.Errorf("cannot read the pending device credential from the keyring: %w", pendingErr)
 		}
-		if !pendingOK {
-			return false, nil // never paired: nothing to migrate
+		if pendingOK {
+			pendings = append(pendings, slotValue{pendingService, pending})
 		}
-		if err := deviceSecretFileSet(deviceCredentialPendingService, pending); err != nil {
-			return false, fmt.Errorf("cannot write the pending device credential file: %w", err)
-		}
-		if err := writeDeviceFileBackendMarker(); err != nil {
-			return false, fmt.Errorf("cannot persist the file-backend decision: %w", err)
-		}
-		_ = keyring.Delete(deviceCredentialPendingService, secretUser())
-		return true, nil
 	}
-	// A pending credential from an interrupted re-pair must move with the
-	// install — once the marker exists, pending reads resolve to files, and a
-	// keyring-stranded (or unreadable) pending slot would be invisible to
-	// resume even though activation may already have replaced the current
-	// credential server-side. So read AND copy it BEFORE the backend commits:
-	// every failure here aborts while nothing is flipped yet. (A pending FILE
-	// without a marker is a documented harmless orphan — reads never consult
-	// it.)
-	pending, pendingOK, pendingErr := readPendingKeyringSlotDirect()
-	if pendingErr != nil {
-		return false, fmt.Errorf("cannot read the pending device credential from the keyring: %w", pendingErr)
+	if len(currents) == 0 && len(pendings) == 0 {
+		return false, nil // never paired: nothing to migrate
 	}
-	if pendingOK {
-		if err := deviceSecretFileSet(deviceCredentialPendingService, pending); err != nil {
+	// Copy pendings first (provisional, never commits the backend), then EVERY
+	// current file, and only then the machine-wide marker: once the marker
+	// exists, reads resolve to files, so a failed later copy would leave that
+	// profile's keyring credential invisible. A marker failure rolls the current
+	// files back (a pending FILE without a marker is a documented harmless
+	// orphan that reads never consult), so every abort leaves nothing flipped.
+	for _, slot := range pendings {
+		if err := deviceSecretFileSet(slot.service, slot.value); err != nil {
 			return false, fmt.Errorf("cannot write the pending device credential file: %w", err)
 		}
 	}
-	// Mirrors promotePendingFileCredential: the explicit current-file write lays
-	// down the file-backend marker on first commit, flipping the install.
-	if err := deviceSecretFileSet(deviceCredentialService, credential); err != nil {
+	dir, err := deviceSecretFileDir()
+	if err != nil {
 		return false, fmt.Errorf("cannot write the device credential file: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return false, fmt.Errorf("cannot write the device credential file: %w", err)
+	}
+	var writtenCurrents []string
+	rollbackCurrents := func() {
+		for _, path := range writtenCurrents {
+			_ = os.Remove(path)
+		}
+	}
+	for _, slot := range currents {
+		path := testSecretPath(dir, slot.service)
+		if err := writeSecretFile0600(path, slot.value); err != nil {
+			rollbackCurrents()
+			return false, fmt.Errorf("cannot write the device credential file: %w", err)
+		}
+		writtenCurrents = append(writtenCurrents, path)
+	}
+	if err := writeDeviceFileBackendMarker(); err != nil {
+		rollbackCurrents()
+		return false, fmt.Errorf("cannot persist the file-backend decision: %w", err)
 	}
 	// The migrated copies are authoritative now. The keyring originals are the
 	// SAME live credentials, not inert leftovers — best-effort removal keeps a
 	// single storage location. (File reads win via the marker either way.)
 	user := secretUser()
-	_ = keyring.Delete(deviceCredentialService, user)
-	_ = keyring.Delete(deviceCredentialPendingService, user)
+	for _, slot := range currents {
+		_ = keyring.Delete(slot.service, user)
+	}
+	for _, slot := range pendings {
+		_ = keyring.Delete(slot.service, user)
+	}
 	return true, nil
 }
 
-// readPendingKeyringSlotDirect reads the pending slot from the OS keyring
-// bypassing the backend router — used only by the keyring→file migration,
-// whose reads must stay pinned to the keyring regardless of routing state.
-func readPendingKeyringSlotDirect() (string, bool, error) {
-	value, err := keyring.Get(deviceCredentialPendingService, secretUser())
+// credentialProfileNames returns every server profile whose credential slots
+// this machine may hold: the configured profiles plus the active one, always
+// including the default. Best-effort — a missing config yields the defaults.
+func credentialProfileNames() []string {
+	names := map[string]bool{defaultServerProfileName: true, activeServerProfile(): true}
+	if paths, err := detectPaths(); err == nil {
+		if doc, err := loadConfigDocument(paths.ConfigFile); err == nil {
+			for _, name := range doc.profileNames() {
+				names[name] = true
+			}
+		}
+	}
+	list := make([]string, 0, len(names))
+	for name := range names {
+		list = append(list, name)
+	}
+	sort.Strings(list)
+	return list
+}
+
+// readKeyringSlotDirect reads a credential slot from the OS keyring bypassing
+// the backend router — used only by the keyring→file migration, whose reads
+// must stay pinned to the keyring regardless of routing state.
+func readKeyringSlotDirect(service string) (string, bool, error) {
+	value, err := keyring.Get(service, secretUser())
 	if err != nil {
 		if errors.Is(err, keyring.ErrNotFound) {
 			return "", false, nil
@@ -116,7 +158,13 @@ func readPendingKeyringSlotDirect() (string, bool, error) {
 		return "", false, err
 	}
 	if parseDeviceCredential(value) == nil {
-		return "", false, fmt.Errorf("pending keyring credential is malformed")
+		return "", false, fmt.Errorf("keyring credential in %s is malformed", service)
 	}
 	return value, true, nil
+}
+
+// readPendingKeyringSlotDirect keeps the historic default-profile helper name
+// for the resume path and tests.
+func readPendingKeyringSlotDirect() (string, bool, error) {
+	return readKeyringSlotDirect(deviceCredentialPendingService)
 }

--- a/cli/device_credential_residue.go
+++ b/cli/device_credential_residue.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Profile-aware residue cleanup for the file-backed device-credential slots.
+// Split from device_credential_storage.go (router/probe/canary) per the
+// <~400 LOC file guideline.
+
+// isCurrentDeviceCredentialSlotService reports whether service names a CURRENT
+// (active) credential slot of ANY profile — the writes that commit the file
+// backend and lay down the machine-wide marker.
+func isCurrentDeviceCredentialSlotService(service string) bool {
+	if service == deviceCredentialService {
+		return true
+	}
+	prefix := deviceCredentialService + "."
+	if !strings.HasPrefix(service, prefix) {
+		return false
+	}
+	suffix := strings.TrimPrefix(service, prefix)
+	if suffix == "" || suffix == "probe" || suffix == "pending" || strings.HasPrefix(suffix, "pending.") {
+		return false
+	}
+	return true
+}
+
+// removeDeviceFileStorageResidueForProfile removes ONE profile's file-backed
+// credential slots. The machine-wide marker (and the secrets dir) go only when
+// NO profile's slot files remain — the marker describes the machine, and
+// removing it while another server's files exist would break the invariant
+// "credential file exists IFF marker exists" and strand that server's pairing.
+// Slots are deleted DIRECTLY (by path), not through the marker-routed deleters:
+// a headless pairing interrupted before promotion leaves a pending FILE with no
+// marker, so routed deletes would go to the keyring and leave the orphan file
+// (and a non-empty secrets dir) behind.
+func removeDeviceFileStorageResidueForProfile(profile string) {
+	_ = deviceSecretFileDelete(deviceCredentialServiceForProfile(profile))
+	_ = deviceSecretFileDelete(deviceCredentialPendingServiceForProfile(profile))
+	if !deviceCredentialSlotFilesRemain() {
+		removeDeviceFileStorageMarkerAndDir()
+	}
+}
+
+// removeAllDeviceFileStorageResidue clears EVERY profile's slot files, the
+// marker, and the (then empty) secrets dir. Full-purge only: a leftover marker
+// would otherwise make a fresh reinstall inherit file mode without re-probing.
+func removeAllDeviceFileStorageResidue() {
+	if dir, err := deviceSecretFileDir(); err == nil {
+		if entries, readErr := os.ReadDir(dir); readErr == nil {
+			for _, entry := range entries {
+				if strings.HasPrefix(entry.Name(), deviceCredentialService) {
+					_ = os.Remove(filepath.Join(dir, entry.Name()))
+				}
+			}
+		}
+	}
+	removeDeviceFileStorageMarkerAndDir()
+}
+
+func deviceCredentialSlotFilesRemain() bool {
+	dir, err := deviceSecretFileDir()
+	if err != nil {
+		return false
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, deviceCredentialService) && name != deviceCredentialProbeService {
+			return true
+		}
+	}
+	return false
+}
+
+// removeDeviceFileStorageMarkerAndDir drops the machine-wide backend marker and
+// the secrets dir (only when empty), and resets the in-process flags so the
+// same run re-decides the backend.
+func removeDeviceFileStorageMarkerAndDir() {
+	if path, err := deviceFileBackendMarkerPath(); err == nil {
+		_ = os.Remove(path)
+	}
+	if dir, err := deviceSecretFileDir(); err == nil {
+		_ = os.Remove(dir) // removes only when now empty
+	}
+	deviceCredentialFileModeForced = false
+	deviceCredentialFileModeExplicit = false
+}

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -260,6 +260,13 @@ func probeDeviceCredentialStorage() (deviceStorageProbe, error) {
 		// switch happens only when a current credential is actually promoted to a
 		// file (deviceSecretFileSet). A canceled pair/setup then leaves nothing
 		// behind and can never mask or downgrade an existing keyring credential.
+		if profile := activeServerProfile(); profile != defaultServerProfileName && !deviceFileBackendMarkerExists() {
+			// The eventual marker commit is machine-wide: auto-falling back while
+			// pairing a NAMED profile would hide the default profile's keyring
+			// credential (SSH-into-desktop case). That switch needs the explicit
+			// opt-in, which also migrates reachable keyring credentials first.
+			return deviceStorageProbe{}, fmt.Errorf("no desktop keyring reachable here (%v), and this install has not switched to file storage; pairing profile %q would hide the default profile's keyring credential. Re-run with --credential-store=file to switch this install explicitly, or pair from the desktop session", keyringErr, profile)
+		}
 		if fileErr := deviceStorageFileCanary(); fileErr != nil {
 			return deviceStorageProbe{}, fmt.Errorf("no desktop keyring (%v) and the file fallback failed: %w", keyringErr, fileErr)
 		}

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -168,7 +168,7 @@ func deviceSecretFileSet(service, value string) error {
 	// re-pair/resume just overwrites the credential: never rewrite the marker
 	// there (a marker gone 0400 would otherwise fail and trigger a rollback that
 	// deletes the freshly promoted, already-activated credential).
-	if service == deviceCredentialService {
+	if isCurrentDeviceCredentialSlotService(service) {
 		path := testSecretPath(dir, service)
 		if deviceFileBackendMarkerExists() {
 			return writeSecretFile0600(path, value)
@@ -209,27 +209,6 @@ func deviceSecretFileDelete(service string) error {
 		return err
 	}
 	return nil
-}
-
-// removeDeviceFileStorageResidue clears the file-backend marker and removes the
-// secrets directory if it is now empty. Best-effort, purge-only: a leftover
-// marker would otherwise make a fresh reinstall inherit file mode without
-// re-probing. Also drops the in-process forced flag so the same run re-decides.
-func removeDeviceFileStorageResidue() {
-	// Delete the file-backed credential slots DIRECTLY (by path), not through the
-	// marker-routed deleters: a headless pairing interrupted before promotion
-	// leaves a pending FILE with no marker, so routed deletes would go to the
-	// keyring and leave the orphan file (and a non-empty secrets dir) behind.
-	_ = deviceSecretFileDelete(deviceCredentialService)
-	_ = deviceSecretFileDelete(deviceCredentialPendingService)
-	if path, err := deviceFileBackendMarkerPath(); err == nil {
-		_ = os.Remove(path)
-	}
-	if dir, err := deviceSecretFileDir(); err == nil {
-		_ = os.Remove(dir) // removes only when now empty
-	}
-	deviceCredentialFileModeForced = false
-	deviceCredentialFileModeExplicit = false
 }
 
 // Test seams: the canaries hit the real OS keyring / filesystem by default.
@@ -320,9 +299,9 @@ func keyringStorageCanary() error {
 }
 
 // fileStorageCanary proves the file backend can actually store credentials: the
-// secrets directory accepts a new file, AND every existing credential slot is
-// overwritable (a root-owned or 0400 credential file would otherwise only fail
-// at promotion, after the one-time code was already spent).
+// secrets directory accepts a new file, AND the TARGET profile's existing slots
+// are overwritable (a root-owned or 0400 credential file would otherwise only
+// fail at promotion, after the one-time code was already spent).
 func fileStorageCanary() error {
 	if err := deviceSecretFileSet(deviceCredentialProbeService, "probe"); err != nil {
 		return err
@@ -333,7 +312,7 @@ func fileStorageCanary() error {
 	if err := deviceSecretFileDelete(deviceCredentialProbeService); err != nil {
 		return err
 	}
-	for _, service := range []string{deviceCredentialService, deviceCredentialPendingService} {
+	for _, service := range []string{activeDeviceCredentialService(), activeDeviceCredentialPendingService()} {
 		path, err := deviceSecretFilePath(service)
 		if err != nil {
 			return err

--- a/cli/device_credential_store.go
+++ b/cli/device_credential_store.go
@@ -6,45 +6,72 @@ import (
 	"fmt"
 )
 
-// Device-credential storage for the secure-pairing flow. Two OS-keyring slots:
+// Device-credential storage for the secure-pairing flow. Two OS-keyring slots
+// per server profile:
 //   - current: the active credential every AI client on this install uses;
 //   - pending: a freshly paired credential held locally BEFORE activation, so a
 //     re-pair never destroys the working credential until the new one is proven.
 // The relay stores only a digest; the plaintext lives here, owner-only.
+// The default profile keeps the historic slot names (no re-pairing on upgrade);
+// other profiles suffix the profile name. The zero-arg API below routes through
+// the process-global selected profile (config_selection.go), so call sites stay
+// profile-agnostic.
 
 const (
 	deviceCredentialService        = "ha-nova.device-credential"
 	deviceCredentialPendingService = "ha-nova.device-credential.pending"
 )
 
+func deviceCredentialServiceForProfile(profile string) string {
+	if profile == "" || profile == defaultServerProfileName {
+		return deviceCredentialService
+	}
+	return deviceCredentialService + "." + profile
+}
+
+func deviceCredentialPendingServiceForProfile(profile string) string {
+	if profile == "" || profile == defaultServerProfileName {
+		return deviceCredentialPendingService
+	}
+	return deviceCredentialPendingService + "." + profile
+}
+
+func activeDeviceCredentialService() string {
+	return deviceCredentialServiceForProfile(activeServerProfile())
+}
+
+func activeDeviceCredentialPendingService() string {
+	return deviceCredentialPendingServiceForProfile(activeServerProfile())
+}
+
 func readDeviceCredential() (string, bool, error) {
-	return readCredentialSlot(deviceCredentialService)
+	return readCredentialSlot(activeDeviceCredentialService())
 }
 
 func writeDeviceCredential(credential string) error {
 	if parseDeviceCredential(credential) == nil {
 		return fmt.Errorf("refusing to store a malformed device credential")
 	}
-	return secretSet(deviceCredentialService, credential)
+	return secretSet(activeDeviceCredentialService(), credential)
 }
 
 func deleteDeviceCredential() error {
-	return secretDelete(deviceCredentialService)
+	return secretDelete(activeDeviceCredentialService())
 }
 
 func readPendingDeviceCredential() (string, bool, error) {
-	return readCredentialSlot(deviceCredentialPendingService)
+	return readCredentialSlot(activeDeviceCredentialPendingService())
 }
 
 func writePendingDeviceCredential(credential string) error {
 	if parseDeviceCredential(credential) == nil {
 		return fmt.Errorf("refusing to store a malformed pending credential")
 	}
-	return secretSet(deviceCredentialPendingService, credential)
+	return secretSet(activeDeviceCredentialPendingService(), credential)
 }
 
 func deletePendingDeviceCredential() error {
-	return secretDelete(deviceCredentialPendingService)
+	return secretDelete(activeDeviceCredentialPendingService())
 }
 
 // promotePendingDeviceCredential makes the pending credential current and clears
@@ -77,10 +104,10 @@ func promotePendingFileCredential(pending string) error {
 	if parseDeviceCredential(pending) == nil {
 		return fmt.Errorf("refusing to store a malformed device credential")
 	}
-	if err := deviceSecretFileSet(deviceCredentialService, pending); err != nil {
+	if err := deviceSecretFileSet(activeDeviceCredentialService(), pending); err != nil {
 		return err
 	}
-	return deviceSecretFileDelete(deviceCredentialPendingService)
+	return deviceSecretFileDelete(activeDeviceCredentialPendingService())
 }
 
 func readCredentialSlot(service string) (string, bool, error) {

--- a/cli/keyring_service.go
+++ b/cli/keyring_service.go
@@ -92,12 +92,13 @@ func relayAuthTokenFilePathFromConfig() (string, bool, error) {
 	if err != nil {
 		return "", false, err
 	}
-	// Read the raw config instead of loadConfig: token storage must not
-	// depend on relay_base_url being set, and an unreadable config must
-	// fail loud instead of silently falling back to the OS keyring — on
-	// headless Linux that fallback can hang in Secret Service unlock
-	// prompts even though a token file is configured (issue #200).
-	cfg, err := loadJSONConfig(paths.ConfigFile)
+	// Read the raw default profile instead of loadConfig: token storage must
+	// not depend on relay_base_url being set or on a valid profile selection
+	// (the legacy relay token is default-profile-only), and an unreadable
+	// config must fail loud instead of silently falling back to the OS
+	// keyring — on headless Linux that fallback can hang in Secret Service
+	// unlock prompts even though a token file is configured (issue #200).
+	cfg, err := loadRawDefaultProfileConfig(paths.ConfigFile)
 	if err != nil {
 		if isNotExist(err) {
 			return "", false, nil

--- a/cli/pairing_flow.go
+++ b/cli/pairing_flow.go
@@ -151,15 +151,16 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 	// promotion.
 	var pending string
 	fileMode := false
+	pendingService := activeDeviceCredentialPendingService()
 	if deviceSecretFileBacked() {
 		// Established file-backed install (marker present, or forced this process):
 		// the pending slot is a file. Do NOT probe the keyring — a locked/present
 		// Secret Service on this box is irrelevant and must not block resuming a
 		// valid file pending.
-		if !deviceSecretFileExists(deviceCredentialPendingService) {
+		if !deviceSecretFileExists(pendingService) {
 			return false, nil
 		}
-		raw, err := deviceSecretFileGet(deviceCredentialPendingService)
+		raw, err := deviceSecretFileGet(pendingService)
 		if err != nil {
 			return false, err
 		}
@@ -173,7 +174,7 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 		// orphan file) or a headless-interrupted pairing whose marker is not
 		// written until promotion. Prefer a real keyring pending over an orphan
 		// file; only an absent/empty keyring falls back to the file.
-		kp, kok, kerr := readKeyringDeviceSecret(deviceCredentialPendingService)
+		kp, kok, kerr := readKeyringDeviceSecret(pendingService)
 		switch {
 		case kok && parseDeviceCredential(kp) != nil:
 			pending = kp
@@ -185,10 +186,10 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 			// Keyring EXISTS but is unreadable (locked/uninitialized): a real
 			// keyring pending may hide behind it — refuse to downgrade to a file.
 			return false, kerr
-		case deviceSecretFileExists(deviceCredentialPendingService):
+		case deviceSecretFileExists(pendingService):
 			// Keyring empty (not-found) or genuinely unreachable (headless): the
 			// file holds the interrupted headless pairing.
-			raw, err := deviceSecretFileGet(deviceCredentialPendingService)
+			raw, err := deviceSecretFileGet(pendingService)
 			if err != nil {
 				return false, err
 			}
@@ -269,11 +270,12 @@ func retireDeviceCredential(cfg *runtimeConfig) {
 	// live endpoint — cannot be resumed after the user chose the legacy/manual path.
 	_ = deleteDeviceCredential()
 	_ = deletePendingDeviceCredential()
-	// Clear the file-backend marker + empty secrets dir too: otherwise a
-	// credential-less install stays classified as file-backed, and a later desktop
-	// re-pair with a healthy keyring would skip the keyring probe and keep storing
-	// device credentials in files.
-	removeDeviceFileStorageResidue()
+	// Clear this profile's slot files too — and, once NO profile's slots remain,
+	// the file-backend marker + empty secrets dir: otherwise a credential-less
+	// install stays classified as file-backed, and a later desktop re-pair with a
+	// healthy keyring would skip the keyring probe and keep storing device
+	// credentials in files. Sibling profiles' file slots stay untouched.
+	removeDeviceFileStorageResidueForProfile(activeServerProfile())
 	cfg.RelaySecureBaseURL = ""
 	cfg.RelaySpkiPin = ""
 	cfg.PendingSecureBaseURL = ""

--- a/cli/paths.go
+++ b/cli/paths.go
@@ -9,7 +9,10 @@ import (
 )
 
 const (
-	configSchemaVersion = 1
+	// v2: named server profiles in a `servers` map (see config_profiles.go).
+	// v1 flat configs migrate on their first save; the default profile stays
+	// mirrored into the flat fields, so v1 binaries keep reading the file.
+	configSchemaVersion = 2
 	stateSchemaVersion  = 1
 	bundleFormatVersion = 1
 	keyringServiceName  = "ha-nova.relay-auth-token"

--- a/cli/relay.go
+++ b/cli/relay.go
@@ -56,6 +56,7 @@ type relayRequestOptions struct {
 	Method        string
 	Path          string
 	StrictStatus  bool
+	Server        string
 }
 
 func runRelayCommand(paths runtimePaths, args []string) int {
@@ -120,6 +121,7 @@ func parseRelayFlags(command string, args []string) (relayRequestOptions, error)
 	fs.StringVar(&opts.JQFilter, "jq", "", "jq filter")
 	fs.StringVar(&opts.JQFile, "jq-file", "", "path to jq filter file")
 	fs.StringVar(&opts.OutputFile, "out", "", "write command output to file")
+	fs.StringVar(&opts.Server, "server", "", "server profile name (multi-server installs)")
 
 	if err := fs.Parse(args); err != nil {
 		if helpRequested(err, fs, "ha-nova relay "+command+" [flags]") {
@@ -198,6 +200,11 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 		}
 		printErr("%s", err)
 		return 1
+	}
+	if opts.Server != "" {
+		// Selection order: --server > HA_NOVA_SERVER > default_server. An
+		// unknown name fails loud in loadConfig with the list of profiles.
+		setServerSelectionOverride(opts.Server)
 	}
 
 	cfg, err := loadConfig(paths)
@@ -367,6 +374,7 @@ func relayCoreUpstreamExitStatus(body []byte, strict bool) int {
 type healthOptions struct {
 	ConnectTimeoutSeconds float64
 	MaxTimeSeconds        float64
+	Server                string
 }
 
 // parseHealthFlags accepts curl-compatible flag names so callers (session-start
@@ -379,6 +387,7 @@ func parseHealthFlags(args []string) (healthOptions, error) {
 	opts := healthOptions{}
 	fs.Float64Var(&opts.ConnectTimeoutSeconds, "connect-timeout", defaultRelayConnectTimeoutSeconds, "connection timeout in seconds")
 	fs.Float64Var(&opts.MaxTimeSeconds, "max-time", defaultRelayMaxTimeSeconds, "total request timeout in seconds")
+	fs.StringVar(&opts.Server, "server", "", "server profile name (multi-server installs)")
 	if err := fs.Parse(args); err != nil {
 		if helpRequested(err, fs, "ha-nova relay health [--connect-timeout <s>] [--max-time <s>]") {
 			return opts, errHelpShown
@@ -401,6 +410,9 @@ func runHealth(paths runtimePaths, args []string) int {
 		return 1
 	}
 	client := newRelayHTTPClient(healthOpts.ConnectTimeoutSeconds, healthOpts.MaxTimeSeconds)
+	if healthOpts.Server != "" {
+		setServerSelectionOverride(healthOpts.Server)
+	}
 
 	cfg, err := loadConfig(paths)
 	if err != nil {

--- a/cli/relay_transport.go
+++ b/cli/relay_transport.go
@@ -26,7 +26,12 @@ func relayFunctionalTransport(cfg runtimeConfig) (baseURL string, client *http.C
 		}
 		// Paired config but the device credential is gone: fail closed. In a paired
 		// flow the device credential IS the auth, so never silently downgrade to the
-		// shared token over the unpinned plain port. Re-pair to recover.
+		// shared token over the unpinned plain port. Re-pair to recover — via setup
+		// for the default profile, via pair --server for named profiles (setup
+		// refuses those).
+		if profile := activeServerProfile(); profile != defaultServerProfileName {
+			return "", nil, "", false, fmt.Errorf("device credential unavailable for a paired relay; re-pair with: ha-nova pair --server %s --relay-url %s", profile, cfg.RelayBaseURL)
+		}
 		return "", nil, "", false, errors.New("device credential unavailable for a paired relay; run 'ha-nova setup' to re-pair")
 	}
 	if profile := activeServerProfile(); profile != defaultServerProfileName {

--- a/cli/relay_transport.go
+++ b/cli/relay_transport.go
@@ -62,6 +62,12 @@ func functionalEndpoint(cfg runtimeConfig, legacyToken string) (string, *http.Cl
 		}
 		return "", nil, "", fmt.Errorf("secure relay endpoint unavailable: %w", err)
 	}
+	// Non-default profiles are device-credential-only — same fail-closed
+	// contract as relayFunctionalTransport: the caller's legacy token belongs
+	// to the default profile and must never travel to another server's URL.
+	if profile := activeServerProfile(); profile != defaultServerProfileName {
+		return "", nil, "", fmt.Errorf("server profile %q has no completed device pairing; run: ha-nova pair --server %s --relay-url %s", profile, profile, cfg.RelayBaseURL)
+	}
 	return cfg.RelayBaseURL, httpClient, legacyToken, nil
 }
 

--- a/cli/relay_transport.go
+++ b/cli/relay_transport.go
@@ -11,6 +11,7 @@ import (
 //   - device mode: a paired device credential over the SPKI-pinned TLS secure
 //     endpoint learned from pairing;
 //   - legacy mode: the shared relay auth token over the plain bootstrap URL.
+//
 // Device mode wins whenever a device credential and a pinned secure endpoint are
 // both present; this is the passwordless default after pairing. Legacy keeps
 // existing installs and non-interactive/service setups working unchanged.
@@ -27,6 +28,12 @@ func relayFunctionalTransport(cfg runtimeConfig) (baseURL string, client *http.C
 		// flow the device credential IS the auth, so never silently downgrade to the
 		// shared token over the unpinned plain port. Re-pair to recover.
 		return "", nil, "", false, errors.New("device credential unavailable for a paired relay; run 'ha-nova setup' to re-pair")
+	}
+	if profile := activeServerProfile(); profile != defaultServerProfileName {
+		// Non-default server profiles are device-credential-only: the machine-wide
+		// legacy relay token belongs to the default profile, and a half-paired
+		// profile must never send that token to another server's URL. Fail closed.
+		return "", nil, "", false, fmt.Errorf("server profile %q has no completed device pairing; run: ha-nova pair --server %s --relay-url %s", profile, profile, cfg.RelayBaseURL)
 	}
 	relayToken, tokenErr := readRelayAuthToken()
 	if tokenErr != nil {

--- a/cli/server_profile_credentials_test.go
+++ b/cli/server_profile_credentials_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+// Per-profile credential-slot coverage (multi-server support): slot naming,
+// isolation between profiles, fail-closed legacy fallback, profile-aware
+// purge/canary, and the all-profiles keyring→file migration.
+
+const testProfileCredentialB = "hanova-dev-v1.CCCCCCCCCCCCCCCCCCCCCC.DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
+
+func TestDeviceCredentialSlotNamesPerProfile(t *testing.T) {
+	if got := deviceCredentialServiceForProfile("default"); got != "ha-nova.device-credential" {
+		t.Fatalf("default current slot = %q", got)
+	}
+	if got := deviceCredentialPendingServiceForProfile("default"); got != "ha-nova.device-credential.pending" {
+		t.Fatalf("default pending slot = %q", got)
+	}
+	if got := deviceCredentialServiceForProfile("cabin"); got != "ha-nova.device-credential.cabin" {
+		t.Fatalf("cabin current slot = %q", got)
+	}
+	if got := deviceCredentialPendingServiceForProfile("cabin"); got != "ha-nova.device-credential.pending.cabin" {
+		t.Fatalf("cabin pending slot = %q", got)
+	}
+
+	currentCases := map[string]bool{
+		"ha-nova.device-credential":               true,
+		"ha-nova.device-credential.cabin":         true,
+		"ha-nova.device-credential.pending":       false,
+		"ha-nova.device-credential.pending.cabin": false,
+		"ha-nova.device-credential.probe":         false,
+		"ha-nova.relay-auth-token":                false,
+	}
+	for service, want := range currentCases {
+		if got := isCurrentDeviceCredentialSlotService(service); got != want {
+			t.Errorf("isCurrentDeviceCredentialSlotService(%q) = %v, want %v", service, got, want)
+		}
+	}
+}
+
+func TestCredentialSlotIsolationAcrossProfiles(t *testing.T) {
+	resetServerProfileSelection(t)
+	dir := t.TempDir()
+	t.Setenv("HA_NOVA_TEST_SECRET_DIR", dir)
+
+	defaultCred := generateTestDeviceCredential(t)
+	if err := writeDeviceCredential(defaultCred); err != nil {
+		t.Fatal(err)
+	}
+	setActiveServerProfile("cabin")
+	if err := writeDeviceCredential(testProfileCredentialB); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePendingDeviceCredential(testProfileCredentialB); err != nil {
+		t.Fatal(err)
+	}
+	// Default keeps its legacy slot name; cabin gets the suffixed one.
+	if _, err := os.Stat(filepath.Join(dir, "ha-nova.device-credential")); err != nil {
+		t.Fatalf("default slot file missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ha-nova.device-credential.cabin")); err != nil {
+		t.Fatalf("cabin slot file missing: %v", err)
+	}
+	if got, ok, err := readDeviceCredential(); err != nil || !ok || got != testProfileCredentialB {
+		t.Fatalf("cabin read = %q ok=%v err=%v", got, ok, err)
+	}
+	setActiveServerProfile(defaultServerProfileName)
+	if got, ok, err := readDeviceCredential(); err != nil || !ok || got != defaultCred {
+		t.Fatalf("default read = %q ok=%v err=%v", got, ok, err)
+	}
+
+	// Purging cabin never touches default's slots.
+	setActiveServerProfile("cabin")
+	original := revokeSelfDeviceV1ForUninstall
+	revokeSelfDeviceV1ForUninstall = func(_, _, _ string) error { return nil }
+	t.Cleanup(func() { revokeSelfDeviceV1ForUninstall = original })
+	report := &uninstallReport{}
+	purgeDeviceCredentialWithReport("https://cabin:18792", "pin", report, false)
+	if _, ok, _ := readDeviceCredential(); ok {
+		t.Fatal("cabin credential must be purged")
+	}
+	if !strings.Contains(strings.Join(report.removed, "\n"), `server "cabin"`) {
+		t.Fatalf("purge report must name the profile, got: %v", report.removed)
+	}
+	setActiveServerProfile(defaultServerProfileName)
+	if got, ok, err := readDeviceCredential(); err != nil || !ok || got != defaultCred {
+		t.Fatalf("default credential lost by cabin purge: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestNonDefaultProfileFailsClosedWithoutDevicePairing(t *testing.T) {
+	resetServerProfileSelection(t)
+	t.Setenv("HA_NOVA_TEST_SECRET_DIR", t.TempDir())
+	setActiveServerProfile("cabin")
+
+	cfg := runtimeConfig{RelayBaseURL: "http://cabin:8791"}
+	_, _, _, _, err := relayFunctionalTransport(cfg)
+	if err == nil {
+		t.Fatal("a non-default profile without device credentials must fail closed")
+	}
+	if !strings.Contains(err.Error(), `server profile "cabin"`) || !strings.Contains(err.Error(), "pair --server cabin") {
+		t.Fatalf("fail-closed message must name the profile and the fix, got: %v", err)
+	}
+
+	// With a paired credential the same profile uses device mode normally.
+	if err := writeDeviceCredential(testProfileCredentialB); err != nil {
+		t.Fatal(err)
+	}
+	paired := runtimeConfig{RelayBaseURL: "http://cabin:8791", RelaySecureBaseURL: "https://cabin:18792", RelaySpkiPin: "PIN"}
+	base, _, token, deviceMode, err := relayFunctionalTransport(paired)
+	if err != nil || !deviceMode || base != "https://cabin:18792" || token != testProfileCredentialB {
+		t.Fatalf("device mode on cabin failed: base=%q deviceMode=%v err=%v", base, deviceMode, err)
+	}
+}
+
+func TestPurgeAllProfilesRevokesEachAgainstItsOwnEndpoint(t *testing.T) {
+	resetServerProfileSelection(t)
+	t.Setenv("HA_NOVA_TEST_SECRET_DIR", t.TempDir())
+
+	if err := writeDeviceCredential(generateTestDeviceCredential(t)); err != nil {
+		t.Fatal(err)
+	}
+	setActiveServerProfile("cabin")
+	if err := writeDeviceCredential(testProfileCredentialB); err != nil {
+		t.Fatal(err)
+	}
+	setActiveServerProfile(defaultServerProfileName)
+
+	var revokedAt []string
+	original := revokeSelfDeviceV1ForUninstall
+	revokeSelfDeviceV1ForUninstall = func(base, _, _ string) error {
+		revokedAt = append(revokedAt, base)
+		return nil
+	}
+	t.Cleanup(func() { revokeSelfDeviceV1ForUninstall = original })
+
+	report := &uninstallReport{}
+	purgeAllDeviceCredentialsWithReport([]profilePurgeTarget{
+		{name: "default", secureBaseURL: "https://ha:18792", spkiPin: "pin"},
+		{name: "cabin", secureBaseURL: "https://cabin:18792", spkiPin: "pin"},
+	}, report, false)
+
+	if len(revokedAt) != 2 || revokedAt[0] != "https://ha:18792" || revokedAt[1] != "https://cabin:18792" {
+		t.Fatalf("revokes must go to each profile's own endpoint, got %v", revokedAt)
+	}
+	for _, profile := range []string{"default", "cabin"} {
+		if _, ok, _ := readCredentialSlot(deviceCredentialServiceForProfile(profile)); ok {
+			t.Fatalf("profile %q credential must be purged", profile)
+		}
+	}
+}
+
+func TestFileResidueMarkerRemovedOnlyWhenLastProfileSlotGone(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	// First current-slot write commits the machine-wide marker.
+	if err := deviceSecretFileSet(deviceCredentialServiceForProfile("default"), "cred-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := deviceSecretFileSet(deviceCredentialServiceForProfile("cabin"), "cred-b"); err != nil {
+		t.Fatal(err)
+	}
+	if !deviceFileBackendMarkerExists() {
+		t.Fatal("precondition: marker must exist")
+	}
+
+	removeDeviceFileStorageResidueForProfile("cabin")
+	if !deviceFileBackendMarkerExists() {
+		t.Fatal("marker must survive while another profile's slot files remain")
+	}
+	if _, err := deviceSecretFileGet(deviceCredentialServiceForProfile("default")); err != nil {
+		t.Fatalf("default slot must survive a cabin cleanup: %v", err)
+	}
+
+	removeDeviceFileStorageResidueForProfile("default")
+	if deviceFileBackendMarkerExists() {
+		t.Fatal("marker must go once the last profile's slots are gone")
+	}
+	if dir, err := deviceSecretFileDir(); err == nil {
+		if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
+			t.Fatalf("secrets dir must be removed when empty, stat err=%v", statErr)
+		}
+	}
+}
+
+func TestFileStorageCanaryChecksTargetProfileSlots(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission semantics")
+	}
+	resetServerProfileSelection(t)
+	withDeviceStorageTestHome(t)
+	setActiveServerProfile("cabin")
+
+	// An unwritable DEFAULT slot must not fail cabin's canary…
+	if err := deviceSecretFileSet(deviceCredentialServiceForProfile("default"), "cred-a"); err != nil {
+		t.Fatal(err)
+	}
+	defaultPath, err := deviceSecretFilePath(deviceCredentialServiceForProfile("default"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(defaultPath, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(defaultPath, 0o600) })
+	if err := fileStorageCanary(); err != nil {
+		t.Fatalf("cabin canary must ignore default's slots: %v", err)
+	}
+
+	// …but an unwritable CABIN slot must.
+	if err := deviceSecretFileSet(deviceCredentialServiceForProfile("cabin"), "cred-b"); err != nil {
+		t.Fatal(err)
+	}
+	cabinPath, err := deviceSecretFilePath(deviceCredentialServiceForProfile("cabin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cabinPath, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(cabinPath, 0o600) })
+	if err := fileStorageCanary(); err == nil {
+		t.Fatal("cabin canary must fail on cabin's unwritable slot")
+	}
+}
+
+func TestKeyringToFileMigrationMovesAllProfilesBeforeMarkerCommit(t *testing.T) {
+	resetServerProfileSelection(t)
+	withDeviceStorageTestHome(t)
+	resetKeyringDeviceSlots(t)
+	cabinService := deviceCredentialServiceForProfile("cabin")
+	t.Cleanup(func() { _ = keyring.Delete(cabinService, secretUser()) })
+
+	defaultCred := generateTestDeviceCredential(t)
+	if err := writeDeviceCredential(defaultCred); err != nil {
+		t.Fatal(err)
+	}
+	if err := keyring.Set(cabinService, secretUser(), testProfileCredentialB); err != nil {
+		t.Fatal(err)
+	}
+	// The cabin profile is known via the active-profile seam.
+	setActiveServerProfile("cabin")
+
+	migrated, err := migrateKeyringDeviceCredentialToFile()
+	if err != nil || !migrated {
+		t.Fatalf("migration must run: migrated=%v err=%v", migrated, err)
+	}
+	if !deviceFileBackendMarkerExists() {
+		t.Fatal("migration must commit the marker")
+	}
+	if got, err := deviceSecretFileGet(deviceCredentialServiceForProfile("default")); err != nil || strings.TrimSpace(got) != defaultCred {
+		t.Fatalf("default credential file = %q err=%v", got, err)
+	}
+	if got, err := deviceSecretFileGet(cabinService); err != nil || strings.TrimSpace(got) != testProfileCredentialB {
+		t.Fatalf("cabin credential file = %q err=%v", got, err)
+	}
+	if _, err := keyring.Get(deviceCredentialService, secretUser()); !errors.Is(err, keyring.ErrNotFound) {
+		t.Fatalf("default keyring copy must be gone, err=%v", err)
+	}
+	if _, err := keyring.Get(cabinService, secretUser()); !errors.Is(err, keyring.ErrNotFound) {
+		t.Fatalf("cabin keyring copy must be gone, err=%v", err)
+	}
+}
+
+func TestPairServerNewProfileWithoutRelayURLIsHardError(t *testing.T) {
+	resetServerProfileSelection(t)
+	t.Setenv("HA_NOVA_TEST_SECRET_DIR", t.TempDir())
+	dir := t.TempDir()
+	paths := runtimePaths{ConfigDir: dir, ConfigFile: filepath.Join(dir, "config.json")}
+	if err := saveConfig(paths, runtimeConfig{HAHost: "ha", HAURL: "http://ha:8123", RelayBaseURL: "http://ha:8791"}); err != nil {
+		t.Fatal(err)
+	}
+
+	original := runSecurePairingForPairCmd
+	runSecurePairingForPairCmd = func(_, _ string, _ *runtimeConfig, _ func(*runtimeConfig) error, _ pairingClientInfo) (string, error) {
+		t.Fatal("pairing must not start for a new profile without --relay-url")
+		return "", nil
+	}
+	t.Cleanup(func() { runSecurePairingForPairCmd = original })
+
+	// The saved default relay URL must NOT bootstrap the new profile.
+	if rc := runPairCommand(paths, []string{"--server", "cabin", "--code", "123456"}); rc != 1 {
+		t.Fatalf("rc = %d, want 1", rc)
+	}
+	// Invalid profile names are rejected at creation.
+	if rc := runPairCommand(paths, []string{"--server", "Bad_Name", "--code", "123456"}); rc != 1 {
+		t.Fatalf("invalid name rc = %d, want 1", rc)
+	}
+}
+
+func TestPairServerCreatesProfileAndLeavesDefaultUntouched(t *testing.T) {
+	resetServerProfileSelection(t)
+	t.Setenv("HA_NOVA_TEST_SECRET_DIR", t.TempDir())
+	dir := t.TempDir()
+	paths := runtimePaths{ConfigDir: dir, ConfigFile: filepath.Join(dir, "config.json")}
+	if err := saveConfig(paths, runtimeConfig{HAHost: "ha", HAURL: "http://ha:8123", RelayBaseURL: "http://ha:8791", ClientInstallID: "inst-abc"}); err != nil {
+		t.Fatal(err)
+	}
+
+	original := runSecurePairingForPairCmd
+	runSecurePairingForPairCmd = func(_, _ string, cfg *runtimeConfig, save func(*runtimeConfig) error, _ pairingClientInfo) (string, error) {
+		cfg.RelaySecureBaseURL = "https://cabin:18792"
+		cfg.RelaySpkiPin = "PINB"
+		return "dev-cabin", save(cfg)
+	}
+	t.Cleanup(func() { runSecurePairingForPairCmd = original })
+
+	if rc := runPairCommand(paths, []string{"--server", "cabin", "--relay-url", "http://cabin:8791", "--code", "123456"}); rc != 0 {
+		t.Fatalf("rc = %d, want 0", rc)
+	}
+
+	resetServerProfileSelection(t)
+	cfgDefault, err := loadConfig(paths)
+	if err != nil {
+		t.Fatalf("default profile after cabin pair: %v", err)
+	}
+	if cfgDefault.RelayBaseURL != "http://ha:8791" || cfgDefault.RelaySecureBaseURL != "" {
+		t.Fatalf("default profile mutated by cabin pair: %+v", cfgDefault)
+	}
+	setServerSelectionOverride("cabin")
+	cfgCabin, err := loadConfig(paths)
+	if err != nil {
+		t.Fatalf("cabin profile: %v", err)
+	}
+	if cfgCabin.RelayBaseURL != "http://cabin:8791" || cfgCabin.RelaySecureBaseURL != "https://cabin:18792" {
+		t.Fatalf("cabin profile = %+v", cfgCabin)
+	}
+	if cfgCabin.ClientInstallID != "inst-abc" {
+		t.Fatalf("cabin must inherit the install-wide client_install_id, got %q", cfgCabin.ClientInstallID)
+	}
+}

--- a/cli/server_profile_credentials_test.go
+++ b/cli/server_profile_credentials_test.go
@@ -141,6 +141,35 @@ func TestNonDefaultProfileNoticeAndEndpointPathsStayFailClosed(t *testing.T) {
 	}
 }
 
+func TestAutoFileFallbackRefusesNamedProfileWithoutMarker(t *testing.T) {
+	// SSH-into-desktop case: keyring unreachable, no file-backend marker yet.
+	// Auto-committing the machine-wide marker while pairing a NAMED profile
+	// would hide the default profile's keyring credential — the switch needs
+	// the explicit --credential-store=file opt-in.
+	resetServerProfileSelection(t)
+	t.Setenv("HOME", t.TempDir())
+	// The suite-wide test secret dir short-circuits the probe; this test needs
+	// the real probe path with a mocked keyring canary.
+	t.Setenv("HA_NOVA_TEST_SECRET_DIR", "")
+	prevCanary := deviceStorageKeyringCanary
+	deviceStorageKeyringCanary = func() error { return errDesktopKeyringSessionUnavailable }
+	t.Cleanup(func() { deviceStorageKeyringCanary = prevCanary })
+
+	setActiveServerProfile("cabin")
+	if _, err := probeDeviceCredentialStorage(); err == nil {
+		t.Fatal("auto file fallback for a named profile without a marker must fail loud")
+	} else if !strings.Contains(err.Error(), "--credential-store=file") {
+		t.Fatalf("error must name the explicit opt-in, got: %v", err)
+	}
+
+	// The default profile keeps today's auto-fallback behavior.
+	setActiveServerProfile(defaultServerProfileName)
+	probe, err := probeDeviceCredentialStorage()
+	if err != nil || probe.mode != "file" {
+		t.Fatalf("default-profile auto fallback changed: mode=%q err=%v", probe.mode, err)
+	}
+}
+
 func TestPurgeAllProfilesRevokesEachAgainstItsOwnEndpoint(t *testing.T) {
 	resetServerProfileSelection(t)
 	t.Setenv("HA_NOVA_TEST_SECRET_DIR", t.TempDir())

--- a/cli/server_profile_credentials_test.go
+++ b/cli/server_profile_credentials_test.go
@@ -121,6 +121,26 @@ func TestNonDefaultProfileFailsClosedWithoutDevicePairing(t *testing.T) {
 	}
 }
 
+func TestNonDefaultProfileNoticeAndEndpointPathsStayFailClosed(t *testing.T) {
+	resetServerProfileSelection(t)
+	t.Setenv("HA_NOVA_TEST_SECRET_DIR", t.TempDir())
+	setActiveServerProfile("cabin")
+
+	// The best-effort notice transport must stay silent, never fall back to
+	// the default profile's machine-wide token against cabin's URL.
+	cfg := runtimeConfig{RelayBaseURL: "http://cabin:8791"}
+	if base, _, token, ok := relayNoticeTransport(cfg); ok || base != "" || token != "" {
+		t.Fatalf("notice transport must stay silent for an unpaired non-default profile, got base=%q ok=%v", base, ok)
+	}
+
+	// The guided-update endpoint resolver must propagate the fail-closed error.
+	if _, _, _, err := functionalEndpoint(cfg, "legacy-token"); err == nil {
+		t.Fatal("functionalEndpoint must fail closed for an unpaired non-default profile")
+	} else if !strings.Contains(err.Error(), `server profile "cabin"`) {
+		t.Fatalf("fail-closed message must name the profile, got: %v", err)
+	}
+}
+
 func TestPurgeAllProfilesRevokesEachAgainstItsOwnEndpoint(t *testing.T) {
 	resetServerProfileSelection(t)
 	t.Setenv("HA_NOVA_TEST_SECRET_DIR", t.TempDir())

--- a/cli/uninstall_device.go
+++ b/cli/uninstall_device.go
@@ -8,9 +8,19 @@ import (
 // Hook for tests.
 var revokeSelfDeviceV1ForUninstall = revokeSelfDeviceV1
 
-// purgeDeviceCredentialWithReport revokes this device's pairing on the relay
-// and removes both local credential slots (current + pending). Full purge only —
-// standard uninstall keeps the pairing so a reinstall reconnects instantly.
+// profilePurgeTarget names one server profile's credential slots plus the
+// pinned endpoint its revoke must go to — each profile's device entry lives on
+// ITS relay, never on a sibling's.
+type profilePurgeTarget struct {
+	name          string
+	secureBaseURL string
+	spkiPin       string
+}
+
+// purgeDeviceCredentialWithReport revokes ONE profile's pairing on its relay
+// and removes both of that profile's local credential slots (current +
+// pending). Full purge only — standard uninstall keeps the pairing so a
+// reinstall reconnects instantly. Defaults to the active server profile.
 //
 // Revocation is best-effort: revokeSelfDeviceV1 already treats HTTP 401 as
 // success (a lost earlier response means the relay no longer knows us). An
@@ -20,19 +30,44 @@ var revokeSelfDeviceV1ForUninstall = revokeSelfDeviceV1
 // its device registry died with the App's data, so the NOVA-page hint makes no
 // sense there. The revoke itself is still attempted — see below.
 func purgeDeviceCredentialWithReport(secureBaseURL, spkiPin string, report *uninstallReport, relayExpectedGone bool) {
-	// The pending slot is purely local (never activated): just drop it.
-	_ = deletePendingDeviceCredential()
-	// File-backed installs also leave the storage-mode marker; drop it (and the
-	// now-empty secrets dir) so a later reinstall re-probes cleanly rather than
-	// inheriting a stale file-mode decision.
-	defer removeDeviceFileStorageResidue()
+	purgeProfileDeviceCredentialWithReport(profilePurgeTarget{
+		name:          activeServerProfile(),
+		secureBaseURL: secureBaseURL,
+		spkiPin:       spkiPin,
+	}, report, relayExpectedGone)
+}
 
-	credential, ok, err := readDeviceCredential()
+// purgeAllDeviceCredentialsWithReport iterates EVERY server profile: revoke per
+// profile against that profile's pinned endpoint, delete every namespaced slot,
+// then sweep the remaining slot files, the machine-wide file-backend marker,
+// and the (then empty) secrets dir.
+func purgeAllDeviceCredentialsWithReport(targets []profilePurgeTarget, report *uninstallReport, relayExpectedGone bool) {
+	for _, target := range targets {
+		purgeProfileDeviceCredentialWithReport(target, report, relayExpectedGone)
+	}
+	removeAllDeviceFileStorageResidue()
+}
+
+func purgeProfileDeviceCredentialWithReport(target profilePurgeTarget, report *uninstallReport, relayExpectedGone bool) {
+	currentService := deviceCredentialServiceForProfile(target.name)
+	// The pending slot is purely local (never activated): just drop it.
+	_ = secretDelete(deviceCredentialPendingServiceForProfile(target.name))
+	// File-backed installs also leave the storage-mode marker; drop it (and the
+	// now-empty secrets dir) once NO profile's slots remain, so a later reinstall
+	// re-probes cleanly rather than inheriting a stale file-mode decision.
+	defer removeDeviceFileStorageResidueForProfile(target.name)
+
+	slotLabel := "Device credential (secure storage)"
+	if target.name != defaultServerProfileName {
+		slotLabel = fmt.Sprintf("Device credential (secure storage, server %q)", target.name)
+	}
+
+	credential, ok, err := readCredentialSlot(currentService)
 	if err != nil {
 		// The slot exists but is unreadable/malformed: removing it needs no
 		// parse, and staying silent would leave a stale secret behind.
-		if deleteDeviceCredential() == nil {
-			report.addRemoved("Device credential (secure storage)")
+		if secretDelete(currentService) == nil {
+			report.addRemoved(slotLabel)
 			if relayExpectedGone {
 				report.addNote("The stored device credential was unreadable and was removed without revoking.")
 			} else {
@@ -51,14 +86,14 @@ func purgeDeviceCredentialWithReport(secureBaseURL, spkiPin string, report *unin
 	// relay): a teardown the user believed complete may not have removed the
 	// App, and skipping the revoke would strand an ACTIVE device entry.
 	revoked := false
-	secureBaseURL = strings.TrimSpace(secureBaseURL)
-	spkiPin = strings.TrimSpace(spkiPin)
+	secureBaseURL := strings.TrimSpace(target.secureBaseURL)
+	spkiPin := strings.TrimSpace(target.spkiPin)
 	if secureBaseURL != "" && spkiPin != "" {
 		revoked = revokeSelfDeviceV1ForUninstall(secureBaseURL, spkiPin, credential) == nil
 	}
 
-	if deleteDeviceCredential() == nil {
-		report.addRemoved("Device credential (secure storage)")
+	if secretDelete(currentService) == nil {
+		report.addRemoved(slotLabel)
 	}
 	switch {
 	case revoked:
@@ -75,8 +110,13 @@ func purgeDeviceCredentialWithReport(secureBaseURL, spkiPin string, report *unin
 }
 
 // deviceCredentialExistsForUninstall reports whether this install holds an
-// activated device credential (standard uninstall keeps it and says so).
+// activated device credential in ANY server profile (standard uninstall keeps
+// them and says so).
 func deviceCredentialExistsForUninstall() bool {
-	_, ok, err := readDeviceCredential()
-	return err == nil && ok
+	for _, profile := range credentialProfileNames() {
+		if _, ok, err := readCredentialSlot(deviceCredentialServiceForProfile(profile)); err == nil && ok {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/uninstall_preflight.go
+++ b/cli/uninstall_preflight.go
@@ -60,13 +60,14 @@ func uninstallWindowsBundleNote() string {
 	return "Windows bundle note: a short-lived helper finishes the uninstall after the running ha-nova.exe exits. Please wait a moment for the final removal to complete."
 }
 
-// collectUninstallPreflight reads the raw config (loadJSONConfig, not
-// loadConfig: partial setups must still yield the HA URL for the server-side
-// checklist) and probes whether the relay still answers.
+// collectUninstallPreflight reads the raw default profile (not loadConfig:
+// partial setups must still yield the HA URL for the server-side checklist,
+// and uninstall is install-wide, so no runtime selection applies) and probes
+// whether the relay still answers.
 func collectUninstallPreflight(paths runtimePaths) uninstallPreflight {
 	preflight := uninstallPreflight{}
 
-	cfg, err := loadJSONConfig(paths.ConfigFile)
+	cfg, err := loadRawDefaultProfileConfig(paths.ConfigFile)
 	if err != nil {
 		return preflight
 	}

--- a/cli/version.go
+++ b/cli/version.go
@@ -287,6 +287,12 @@ func relayNoticeTransport(cfg config) (string, *http.Client, string, bool) {
 	if cfg.RelaySecureBaseURL != "" && cfg.RelaySpkiPin != "" {
 		return "", nil, "", false
 	}
+	// Non-default profiles are device-credential-only: a best-effort notice
+	// must never send the default profile's machine-wide token to another
+	// server's URL. Stay silent instead.
+	if activeServerProfile() != defaultServerProfileName {
+		return "", nil, "", false
+	}
 	token, err := readRelayAuthTokenForDoctor()
 	if err != nil || token == "" {
 		return "", nil, "", false

--- a/docs/work/2026-07-20-multi-server-spec.md
+++ b/docs/work/2026-07-20-multi-server-spec.md
@@ -29,14 +29,95 @@ Trigger: issue #343 — one client machine should reach more than one Home Assis
 - No profile-aware Home Base UI changes.
 - No new first-run wizard questions, and no profile management (rename/delete/default) inside the wizard — see the wizard-integration decision above.
 
+## Implementation hardening (2026-07-21 code-review findings)
+
+Verified against the working tree; all of these are LAYER-1 scope, not follow-ups.
+
+- **Save path must un-flatten (P1).** `saveConfig` writes the flat struct verbatim
+  (`cli/config.go:74-77`); 8 read-modify-write sites exist (`cmd_pair.go:127`,
+  `setup_device_verify.go:35`, `setup_pairing.go:280`, `setup_interactive.go:45,299,448,548`,
+  and `command_doctor.go:69` — even `doctor` writes config via `resumePendingActivation`).
+  After migration, the first such save would destroy the `servers` map. Save re-reads the
+  raw profile document, writes the flat fields into the selected profile, preserves
+  siblings and unknown top-level fields. Roundtrip test: "pair/doctor-resume on profile B
+  leaves profile A byte-identical".
+- **Raw readers need a profile-aware path (P1).** Four deliberate `loadJSONConfig`
+  bypasses would silently break at schema v2: `keyring_service.go:100` (issue-#200
+  fix: token storage must not depend on relay fields — regression risk: headless
+  Secret-Service hang returns), `uninstall_preflight.go:69`, `command_uninstall.go:301-304`
+  (purge would find nothing to revoke), `command_setup.go:55`. Route them through a
+  profile-aware raw loader; add the #200 regression test.
+- **Purge/uninstall iterates all profiles (P1).** `purgeDeviceCredentialWithReport`
+  (`uninstall_device.go:22-75`) and `removeDeviceFileStorageResidue`
+  (`device_credential_storage.go:218-233`) handle only the default slots and remove the
+  machine-wide `.file-backend` marker while server B's files remain — breaking the
+  "file exists IFF marker exists" invariant and leaving B's device active on its relay.
+  Purge revokes per profile against that profile's pinned endpoint, deletes every
+  namespaced slot, removes marker/dir only when all slots are gone.
+- **Legacy-token fallback is default-profile-only (P2).** `relayFunctionalTransport`
+  (`relay_transport.go:17-33`) falls back to the machine-wide legacy token for any config
+  without secure fields — a half-paired profile B would send server A's token to server
+  B's URL. Decision: non-default profiles are device-credential-only and fail closed.
+  Slot routing happens via one process-global selected-profile seam resolved at startup
+  (zero-arg slot API call sites stay untouched).
+- **Field partitioning (P2).** Per-server: `ha_host`, `ha_url`, `relay_base_url`,
+  `relay_secure_base_url`, `relay_spki_pin`, pending-pair fields, `relay_token_file`
+  (default profile only). Install-wide (top-level): `schema_version`,
+  `client_install_id` (comment says "this OS-user installation"; per-profile flattening
+  would mint new install ids), `default_server`.
+- **Downgrade floor (P2).** An older binary reading v2 config sees empty
+  `relay_base_url` → "not set up yet". Mirror the default profile into the legacy flat
+  fields for at least one release (write both shapes); name the supported downgrade
+  floor in the release notes.
+- **Doctor/update scope declared (P2).** Layer 1 keeps `doctor`, relay floor warnings,
+  and guided App updates per selected server; doctor output names the checked profile;
+  docs say "run `HA_NOVA_SERVER=<name> ha-nova doctor` per server".
+- **Profile-name constraints (P2).** `[a-z0-9-]{1,32}` at creation (keyring service
+  strings and secret file names inherit the name; Windows-invalid chars and
+  case-insensitive-FS collisions are otherwise unhandled). `HA_NOVA_KEYRING_SERVICE`
+  override applies to the legacy token only, which is default-profile-only (above) —
+  profiles do not multiply the override.
+- **Pair bootstrap (P2).** `pair --server <new-name>` without `--relay-url` is a hard
+  error (the saved-URL fallback at `cmd_pair.go:80-99` would bootstrap against the
+  default profile's relay).
+- **Unknown selection fails loud (P2).** Unknown `--server`/`HA_NOVA_SERVER` exits
+  non-zero listing known profiles (a typo must never route a mutation to the wrong
+  house). Contract test + one context-skill routing line (`HA_NOVA_SERVER` env is the
+  AI-client selection path — skills never read config.json; ~39 skill files shell out
+  to `ha-nova relay` without a server argument) ship with layer 1.
+- **File-backend canary + keyring→file migration are profile-aware (P3).**
+  `fileStorageCanary` checks the target profile's slot names;
+  `migrateKeyringDeviceCredentialToFile` moves ALL profiles' slots before committing
+  the machine-wide marker.
+
+## Release split (decision 2026-07-21)
+
+- **Release A:** layer 1 (profiles, migration, credential namespacing, selection,
+  hardening above) + layer 3 (profile management subcommand) + docs slice
+  (`pair --server`, onboarding note, context-skill routing line). Ships together with
+  the accumulated 0.20.0 skills features. Issue #343 closes with this release; the
+  wizard ships as a follow-up issue.
+- **Release B:** layer 2 (wizard "add another server" via `renderSetupAlreadyDoneBanner`,
+  discovery filtering, profile-parameterized stages) — riskiest test surface
+  (`setup_interactive_test.go`, 2625 LOC), gets a released layer-1 baseline to diff
+  against.
+- Both releases: full gate incl. RC rehearsal (Go + onboarding flow per CLAUDE.md).
+- Rationale: the reporter is CLI-capable and unblocked by `pair --server` alone; the
+  one-way migration gets bake time before the wizard churn lands.
+
 ## Open questions
 
 - How do skills surface which server answered (prefix in output vs. only on ambiguity)?
+  To resolve in the layer-1 docs slice: default is no prefix; on any ambiguity or
+  non-default selection, name the profile once per response.
 
 ## Verification (when implemented)
 
-- Migration round-trip tests (flat → profiles, idempotent, rollback-safe).
-- Credential-slot isolation tests (pairing server B never touches server A's slot).
-- Selection-order contract tests (flag > env > default).
+- Migration round-trip tests (flat → profiles, idempotent, rollback-safe) incl. the
+  save-path un-flatten roundtrip and the legacy-mirror downgrade shape.
+- Credential-slot isolation tests (pairing server B never touches server A's slot);
+  profile-aware purge/canary/migration tests; the #200 raw-reader regression test.
+- Selection-order contract tests (flag > env > default; unknown selection fails loud
+  with the profile list).
 - Wizard contract tests: first-run flow byte-identical for single-server users; completed-install re-run offers the add-server entry; the add flow filters already-configured instances.
 - Live acceptance with two HA instances.

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -27,6 +27,7 @@ Before HA operations in this session:
 3. Do not run diagnostics proactively; diagnose only after real failure.
 4. Relay-only auth model: do not request or persist LLAT client-side.
    - The Home Assistant App uses its process-local Supervisor credential automatically. Standalone Container/Core keeps `HA_LLAT` in the relay host environment (`docs/reference/relay-container.md`).
+5. Multi-server installs: to target a non-default server profile, prefix every `ha-nova` command with `HA_NOVA_SERVER=<name>` (for example `HA_NOVA_SERVER=cabin ha-nova relay health`). When a non-default server is selected, name that server once per response.
 
 Do not ask user to paste tokens in chat.
 


### PR DESCRIPTION
## Summary

Layer 1 of multi-server support per `docs/work/2026-07-20-multi-server-spec.md` (updated in this PR with the 2026-07-21 hardening findings — all of them layer-1 scope). Wizard integration (layer 2) and profile-management commands (layer 3) follow separately per the documented release split; **#343 closes with Release A**, not with this PR.

- **Schema v2:** `servers` map of named profiles + install-wide `schema_version`/`default_server`/`client_install_id`. Flat v1 configs migrate transparently; every save mirrors the default profile into the legacy flat fields (downgrade floor for older binaries).
- **Selection** `--server` > `HA_NOVA_SERVER` > `default_server`, resolved inside `loadConfig` (direct readers untouched). Unknown selection fails loud with the profile list. Names `[a-z0-9-]{1,32}`; `pending`/`probe` reserved (slot-suffix collision).
- **Save un-flatten:** sibling profiles preserved byte-for-byte via `json.RawMessage`; unknown top-level fields kept; all 8 read-modify-write sites (incl. `doctor`'s `resumePendingActivation`) route through it.
- **Raw readers** (#200 isolation preserved): keyring service, uninstall preflight, purge, setup read v1+v2 via `loadRawDefaultProfileConfig` — regression test included.
- **Credential namespacing:** per-profile slot service names via a process-global selected-profile seam (zero-arg slot API unchanged); default profile keeps historic names → **no re-pairing on upgrade**; `.file-backend` marker stays machine-wide.
- **Fail closed:** non-default profiles are device-credential-only — the machine-wide legacy token is never sent to another server's URL (transport + doctor).
- **Profile-aware lifecycle:** purge revokes per profile against that profile's pinned endpoint, marker removed only with the last slot; canary targets the active profile; keyring→file migration moves ALL profiles' slots with rollback before committing the marker.
- **`pair --server <name>`** creates/pairs named profiles (new name requires `--relay-url`; `HA_NOVA_SERVER` typos fail loud); install id inherited. `relay ws/core/files/backups/health` accept `--server`; the context skill documents `HA_NOVA_SERVER` routing for AI clients.

## Verification

- `go test -count=1 ./...` (cli) — ok, 52s; 16 new tests (migration roundtrip/idempotence, sibling byte-identity, mirror/old-binary shape, selection order, fail-loud, name validation, slot isolation, fail-closed transport, multi-profile purge/canary/migration, #200 regression, pair --server errors). `go vet` clean.
- `npx vitest run` — 107 files / 1006 tests green; `bash scripts/check-docs.sh` clean.
- Plain `pair`/`setup`/`doctor` on single-server installs stay byte-identical (default profile keeps legacy slot names and messages).

## Out of scope (follow-ups per spec)

- Wizard "Add another server" (layer 2, own release), profile management subcommand (layer 3), docs slice beyond the context-skill line, release-notes downgrade-floor mention (release-prep PR).

Part of #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSugUrwx7naXjuhhMx4j5q