### PR TITLE
fix(census): the ask explains WHY counting helps

### DIFF
--- a/cli/census_ask.go
+++ b/cli/census_ask.go
@@ -28,6 +28,8 @@ const censusAskIntro = `
   One-time question
 
   May HA NOVA count your install? HA NOVA has no telemetry — that stays.
+  The flip side: we don't know how many people use it or on which OS,
+  and that makes it hard to decide what to build and test first.
   A yes sends one anonymous ping, at most once a week:
       HA NOVA version  ·  relay version  ·  operating system
   No ID, no IP stored, nothing about your home — and the resulting
@@ -139,7 +141,7 @@ func censusFirstPingAfterYes(paths runtimePaths) {
 // question for good (answer=none).
 const censusSkillNoticeCap = 3
 
-const censusSkillNoticeBlock = `CENSUS ASK PENDING: One-time question for the user — may HA NOVA count this install? HA NOVA has no telemetry — that stays. An explicit yes sends one anonymous ping, at most once a week: HA NOVA version, relay version, operating system. No ID, no IP stored, nothing about the home — and the resulting numbers are public for everyone. Details: docs/reference/census.md. If the user explicitly says yes, run: ha-nova census on. If the user explicitly says no, run: ha-nova census off. If the user does not answer, run nothing.`
+const censusSkillNoticeBlock = `CENSUS ASK PENDING: One-time question for the user — may HA NOVA count this install? HA NOVA has no telemetry — that stays; but without any numbers it is hard to decide what to build and test first. An explicit yes sends one anonymous ping, at most once a week: HA NOVA version, relay version, operating system. No ID, no IP stored, nothing about the home — and the resulting numbers are public for everyone. Details: docs/reference/census.md. If the user explicitly says yes, run: ha-nova census on. If the user explicitly says no, run: ha-nova census off. If the user does not answer, run nothing.`
 
 // maybeEmitCensusSkillNotice prints the pending-ask block on the check-update
 // human paths (never --json). The counter is persisted BEFORE printing so a

--- a/docs/reference/census.md
+++ b/docs/reference/census.md
@@ -14,6 +14,8 @@ rendered by the terminal prompt):
   One-time question
 
   May HA NOVA count your install? HA NOVA has no telemetry — that stays.
+  The flip side: we don't know how many people use it or on which OS,
+  and that makes it hard to decide what to build and test first.
   A yes sends one anonymous ping, at most once a week:
       HA NOVA version  ·  relay version  ·  operating system
   No ID, no IP stored, nothing about your home — and the resulting


### PR DESCRIPTION
Follow-up to #417: the compact ask copy had lost the motivation line — the maintainer's central requirement for the census. Added to the TTY ask, the skill notice block, and the verbatim quote in census.md (all three stay in sync). Rendered and verified via a real PTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSugUrwx7naXjuhhMx4j5q