### PR TITLE
fix(onboarding): pairing switch no longer dead-ends for legacy installs

### DIFF
--- a/cli/command_doctor.go
+++ b/cli/command_doctor.go
@@ -211,7 +211,7 @@ func runDoctor(paths runtimePaths, args []string) int {
 				// at the passwordless upgrade once, as information — never a
 				// failure, and skipped in --quiet's machine contract.
 				if !deviceMode && !*quiet && probePairingV1ForDoctor(cfg.RelayBaseURL) {
-					printHumanInfo("This relay supports passwordless device pairing. Run 'ha-nova setup' to switch this device to its own secure credential.")
+					printHumanInfo("This relay supports passwordless device pairing. Run 'ha-nova pair' and enter a fresh code from the NOVA page to switch this device to its own secure credential.")
 				}
 			case readiness.UpstreamAuthIssue:
 				printHumanErr("Relay reports degraded upstream WS capability")

--- a/cli/command_server.go
+++ b/cli/command_server.go
@@ -111,19 +111,20 @@ func runServerList(paths runtimePaths, args []string) int {
 				relay = cfg.RelayBaseURL
 			}
 		}
-		// Slot presence only — a local read, never a relay round-trip.
+		// A working pre-pairing install (default profile, relay URL saved, no
+		// pinned secure endpoint) is connected via the shared legacy token and
+		// by definition has no meaningful device credential — label the actual
+		// state without touching secure storage (headless keyrings would turn
+		// this into a misleading "unknown"; issue #419). Named profiles are
+		// device-credential-only, so a bare "no" there is accurate.
 		paired := "no"
-		if _, ok, err := readCredentialSlot(deviceCredentialServiceForProfile(name)); err != nil {
+		if cfg, okCfg := doc.flatProfile(name); okCfg && name == defaultServerProfileName && cfg.RelaySecureBaseURL == "" && cfg.RelayBaseURL != "" {
+			paired = "no (legacy token)"
+		} else if _, ok, err := readCredentialSlot(deviceCredentialServiceForProfile(name)); err != nil {
+			// Slot presence only — a local read, never a relay round-trip.
 			paired = "unknown"
 		} else if ok {
 			paired = "yes"
-		} else if cfg, okCfg := doc.flatProfile(name); okCfg && name == defaultServerProfileName && cfg.RelaySecureBaseURL == "" && cfg.RelayBaseURL != "" {
-			// A working pre-pairing install: connected via the shared legacy
-			// token, no per-device credential yet. Plain "no" reads as broken
-			// (issue #419) — label the actual state. Default profile ONLY:
-			// named profiles are device-credential-only, so a bare "no" there
-			// (e.g. an interrupted pair) is the accurate label.
-			paired = "no (legacy token)"
 		}
 		var markers []string
 		if name == defaultName {

--- a/cli/command_server.go
+++ b/cli/command_server.go
@@ -117,10 +117,12 @@ func runServerList(paths runtimePaths, args []string) int {
 			paired = "unknown"
 		} else if ok {
 			paired = "yes"
-		} else if cfg, okCfg := doc.flatProfile(name); okCfg && cfg.RelaySecureBaseURL == "" && cfg.RelayBaseURL != "" {
+		} else if cfg, okCfg := doc.flatProfile(name); okCfg && name == defaultServerProfileName && cfg.RelaySecureBaseURL == "" && cfg.RelayBaseURL != "" {
 			// A working pre-pairing install: connected via the shared legacy
 			// token, no per-device credential yet. Plain "no" reads as broken
-			// (issue #419) — label the actual state.
+			// (issue #419) — label the actual state. Default profile ONLY:
+			// named profiles are device-credential-only, so a bare "no" there
+			// (e.g. an interrupted pair) is the accurate label.
 			paired = "no (legacy token)"
 		}
 		var markers []string

--- a/cli/command_server.go
+++ b/cli/command_server.go
@@ -117,6 +117,11 @@ func runServerList(paths runtimePaths, args []string) int {
 			paired = "unknown"
 		} else if ok {
 			paired = "yes"
+		} else if cfg, okCfg := doc.flatProfile(name); okCfg && cfg.RelaySecureBaseURL == "" && cfg.RelayBaseURL != "" {
+			// A working pre-pairing install: connected via the shared legacy
+			// token, no per-device credential yet. Plain "no" reads as broken
+			// (issue #419) — label the actual state.
+			paired = "no (legacy token)"
 		}
 		var markers []string
 		if name == defaultName {

--- a/cli/command_server_test.go
+++ b/cli/command_server_test.go
@@ -382,3 +382,23 @@ func TestServerListLegacyLabelOnlyOnDefaultProfile(t *testing.T) {
 		t.Fatalf("default profile must carry the legacy-token label:\n%s", out)
 	}
 }
+
+func TestServerListLegacyLabelSurvivesUnreachableKeyring(t *testing.T) {
+	// Headless legacy install (issue #419 follow-up): the device-credential
+	// slot read may fail, but a legacy config has no meaningful device
+	// credential anyway — the label must come from the config, not from
+	// secure-storage reachability.
+	paths := setupServerCommandTest(t, `{"schema_version":1,"ha_host":"ha","ha_url":"http://ha:8123","relay_base_url":"http://ha:8791"}`)
+	t.Setenv("HA_NOVA_TEST_SECRET_DIR", "")
+	prevPreflight := deviceCredentialPreflight
+	deviceCredentialPreflight = func() error { return errDesktopKeyringSessionUnavailable }
+	t.Cleanup(func() { deviceCredentialPreflight = prevPreflight })
+
+	exit, out := captureCommandOutput(t, func() int { return runServerCommand(paths, []string{"list"}) })
+	if exit != 0 {
+		t.Fatalf("list exit = %d\n%s", exit, out)
+	}
+	if !strings.Contains(out, "no (legacy token)") {
+		t.Fatalf("legacy label must not degrade to unknown on headless installs:\n%s", out)
+	}
+}

--- a/cli/command_server_test.go
+++ b/cli/command_server_test.go
@@ -363,3 +363,22 @@ func TestSetupAlreadyDoneBannerOffersPairingSwitchForLegacyInstalls(t *testing.T
 		t.Fatalf("paired installs must not see the legacy hint:\n%s", out.String())
 	}
 }
+
+func TestServerListLegacyLabelOnlyOnDefaultProfile(t *testing.T) {
+	// Named profiles are device-credential-only: a half-paired named profile
+	// (relay URL saved, no credential yet) must show a bare "no", never the
+	// legacy-token label that only the default profile can earn.
+	paths := setupServerCommandTest(t, `{"schema_version":2,"default_server":"default","servers":{"default":{"relay_base_url":"http://ha:8791"},"cabin":{"relay_base_url":"http://cabin:8791"}}}`)
+	exit, out := captureCommandOutput(t, func() int { return runServerCommand(paths, []string{"list"}) })
+	if exit != 0 {
+		t.Fatalf("list exit = %d\n%s", exit, out)
+	}
+	row := serverListRow(t, out, "cabin")
+	joined := strings.Join(row, " ")
+	if strings.Contains(joined, "legacy") {
+		t.Fatalf("named profile must not carry the legacy-token label: %v", row)
+	}
+	if !strings.Contains(strings.Join(serverListRow(t, out, "default"), " "), "legacy") {
+		t.Fatalf("default profile must carry the legacy-token label:\n%s", out)
+	}
+}

--- a/cli/command_server_test.go
+++ b/cli/command_server_test.go
@@ -332,3 +332,34 @@ func TestServerRenameHeadlessKeepsMarkerlessPendingFile(t *testing.T) {
 		t.Fatalf("raw pending file not moved: %v", err)
 	}
 }
+
+func TestServerListLabelsLegacyTokenInstalls(t *testing.T) {
+	// gsgxnet's scenario (issue #419): a working pre-pairing install shows
+	// "PAIRED no", which reads as broken. The actual state — connected via the
+	// shared legacy token, no device credential yet — must be labeled.
+	paths := setupServerCommandTest(t, `{"schema_version":1,"ha_host":"ha","ha_url":"http://ha:8123","relay_base_url":"http://ha:8791"}`)
+	exit, out := captureCommandOutput(t, func() int { return runServerCommand(paths, []string{"list"}) })
+	if exit != 0 {
+		t.Fatalf("list exit = %d\n%s", exit, out)
+	}
+	if !strings.Contains(out, "no (legacy token)") {
+		t.Fatalf("legacy-token install must be labeled, got:\n%s", out)
+	}
+}
+
+func TestSetupAlreadyDoneBannerOffersPairingSwitchForLegacyInstalls(t *testing.T) {
+	// The already-done screen must not dead-end the pairing upgrade: doctor
+	// sends legacy users to setup, so setup must name the switch (issue #419).
+	var out strings.Builder
+	renderSetupAlreadyDoneBanner(&out, true)
+	for _, want := range []string{"shared legacy token", "ha-nova pair", "Connect a device"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("legacy banner must contain %q, got:\n%s", want, out.String())
+		}
+	}
+	out.Reset()
+	renderSetupAlreadyDoneBanner(&out, false)
+	if strings.Contains(out.String(), "legacy token") {
+		t.Fatalf("paired installs must not see the legacy hint:\n%s", out.String())
+	}
+}

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -47,7 +47,7 @@ func maybeHandleInteractiveSetupCurrentState(reader *bufio.Reader, out io.Writer
 				return true, 1
 			}
 		}
-		renderSetupAlreadyDoneBanner(out)
+		renderSetupAlreadyDoneBanner(out, cfg.RelaySecureBaseURL == "" && cfg.RelayBaseURL != "")
 		return true, 0
 	}
 	if summary := current.SkipSummary(); summary != "" {
@@ -450,7 +450,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 						return 1
 					}
 				}
-				renderSetupAlreadyDoneBanner(os.Stdout)
+				renderSetupAlreadyDoneBanner(os.Stdout, cfg.RelaySecureBaseURL == "" && cfg.RelayBaseURL != "")
 				return 0
 			}
 			stage = setupStageHost

--- a/cli/setup_ui.go
+++ b/cli/setup_ui.go
@@ -206,12 +206,21 @@ func renderSetupCompleteBanner(out io.Writer, clients []string) {
 	fmt.Fprintln(out)
 }
 
-func renderSetupAlreadyDoneBanner(out io.Writer) {
+func renderSetupAlreadyDoneBanner(out io.Writer, legacyToken bool) {
 	session := resolveSetupUISession(out)
 	renderSetupHeader(out)
 	fmt.Fprintln(out)
 	fmt.Fprintf(out, "  %s Everything is already set up!\n", session.style("success", session.successMarker()))
 	fmt.Fprintln(out)
+	if legacyToken {
+		// The upgrade path must not dead-end here (issue #419): a working
+		// legacy-token install passes every completeness check, so this screen
+		// is exactly where the pairing switch has to be offered.
+		fmt.Fprintln(out, "  This device still connects with the shared legacy token.")
+		fmt.Fprintln(out, "  Switch to its own revocable credential: run 'ha-nova pair' and")
+		fmt.Fprintln(out, "  enter a fresh code from the NOVA page (\"Connect a device\").")
+		fmt.Fprintln(out)
+	}
 	fmt.Fprintln(out, "  Run 'ha-nova doctor' for full diagnostics.")
 	fmt.Fprintln(out)
 }


### PR DESCRIPTION
Fixes the loop @gsgxnet reported in #343 after upgrading to v0.20.0: `doctor` sends legacy-token installs to `ha-nova setup` for the pairing switch, but setup's completeness checks pass on the valid legacy token and answer "Everything is already set up!" — the switch is never offered.

- **doctor** now points at `ha-nova pair` (the command that actually performs the switch) with the NOVA-page code instruction.
- **setup's already-done screen** offers the switch for legacy-token installs (config has a relay URL but no pinned secure endpoint) — one hint block, paired installs see nothing new.
- **`server list`** labels the state honestly: `no (legacy token)` for a working pre-pairing install, so `PAIRED no` no longer reads as broken.

Regression tests reproduce the exact reported scenario (v1 flat config → list label) and pin both banner variants.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSugUrwx7naXjuhhMx4j5q