### PR TITLE
build(deps): migrate relay TLS to x509 v2

### DIFF
--- a/.github/workflows/pairing-e2e.yml
+++ b/.github/workflows/pairing-e2e.yml
@@ -51,13 +51,13 @@ jobs:
           go-version-file: cli/go.mod
 
       - name: Install and build the relay (for the pairing harness)
+        working-directory: nova
         run: |
           npm ci
           npm run build
 
       - name: Run the pairing e2e (real CLI client vs real relay handlers)
+        working-directory: cli
         env:
           HA_NOVA_PAIR_E2E_HARNESS: ${{ github.workspace }}/scripts/e2e/pairing-harness.mjs
-        run: |
-          cd cli
-          go test -count=1 -run 'TestPairingClientV1EndToEnd|TestRunSecurePairingEndToEnd' -v ./...
+        run: go test -count=1 -run 'TestPairingClientV1EndToEnd|TestRunSecurePairingEndToEnd' -v ./...

--- a/nova/package-lock.json
+++ b/nova/package-lock.json
@@ -6,9 +6,10 @@
     "": {
       "name": "ha-nova-relay",
       "dependencies": {
-        "@peculiar/x509": "^1.12.3",
+        "@peculiar/x509": "^2.0.0",
         "@serenity-kit/opaque": "^1.1.0",
         "home-assistant-js-websocket": "^9.6.0",
+        "reflect-metadata": "^0.2.2",
         "ws": "^8.21.0"
       },
       "devDependencies": {
@@ -153,22 +154,24 @@
       }
     },
     "node_modules/@peculiar/x509": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.12.3.tgz",
-      "integrity": "sha512-+Mzq+W7cNEKfkNZzyLl6A6ffqc3r21HGZUezgfKxpZrkORfOqgRXnS80Zu0IV6a9Ue9QBJeKD7kN0iWfc3bhRQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-2.0.0.tgz",
+      "integrity": "sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.3.13",
-        "@peculiar/asn1-csr": "^2.3.13",
-        "@peculiar/asn1-ecc": "^2.3.14",
-        "@peculiar/asn1-pkcs9": "^2.3.13",
-        "@peculiar/asn1-rsa": "^2.3.13",
-        "@peculiar/asn1-schema": "^2.3.13",
-        "@peculiar/asn1-x509": "^2.3.13",
-        "pvtsutils": "^1.3.5",
-        "reflect-metadata": "^0.2.2",
-        "tslib": "^2.7.0",
-        "tsyringe": "^4.8.0"
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@serenity-kit/opaque": {

--- a/nova/package.json
+++ b/nova/package.json
@@ -6,9 +6,10 @@
     "build": "node --input-type=module -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true });\" && tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@peculiar/x509": "^1.12.3",
+    "@peculiar/x509": "^2.0.0",
     "@serenity-kit/opaque": "^1.1.0",
     "home-assistant-js-websocket": "^9.6.0",
+    "reflect-metadata": "^0.2.2",
     "ws": "^8.21.0"
   },
   "devDependencies": {

--- a/nova/src/security/tls-identity.ts
+++ b/nova/src/security/tls-identity.ts
@@ -1,3 +1,5 @@
+import "reflect-metadata";
+
 import { createHash, createPrivateKey, createPublicKey, webcrypto } from "node:crypto";
 import { join } from "node:path";
 
@@ -24,10 +26,11 @@ export interface TlsIdentity {
   spkiPin: string;
 }
 
-// A present-but-inconsistent identity (only one file, an unparseable cert, or a
-// key/cert from different generations) is fail-closed like the device registry:
-// we never silently overwrite a still-valid key or rotate the pinned identity,
-// because that would break every paired client with no server-side explanation.
+// A complete but inconsistent identity (an unparseable cert/key, or key/cert
+// from different generations) is fail-closed like the device registry: we never
+// silently overwrite a complete identity and rotate every paired client's pin.
+// A partial identity is different: it cannot serve TLS, so startup regenerates
+// both files and deliberately requires re-pairing instead of bricking the App.
 export class TlsIdentityCorruptError extends Error {}
 
 const crypto = webcrypto as unknown as Crypto;
@@ -44,11 +47,10 @@ function spkiPinFromDer(spkiDer: ArrayBuffer | Uint8Array): string {
   return createHash("sha256").update(buf).digest("base64url");
 }
 
-// Loads the persisted identity, or creates and persists a fresh one. A fresh
-// identity is only ever generated when BOTH files are absent (a genuine first
-// run); any other state is corruption and throws rather than silently rotating
-// the pinned key. Concurrent creation is avoided by the caller's startup
-// ordering (single relay process).
+// Loads the persisted identity, or creates and persists a fresh one when both
+// files are absent or the stored state is partial. A complete but invalid pair
+// throws rather than silently rotating the pinned key. Concurrent creation is
+// avoided by the caller's startup ordering (single relay process).
 export async function loadOrCreateTlsIdentity(dataDir: string): Promise<TlsIdentity> {
   ensureProvider();
   const keyPath = join(dataDir, KEY_FILE);
@@ -56,8 +58,10 @@ export async function loadOrCreateTlsIdentity(dataDir: string): Promise<TlsIdent
 
   const existingKey = readPrivateFileSync(keyPath, MAX_PEM_BYTES);
   const existingCert = readPrivateFileSync(certPath, MAX_PEM_BYTES);
+  const hasKey = existingKey !== null;
+  const hasCert = existingCert !== null;
 
-  if (existingKey && existingCert) {
+  if (hasKey && hasCert) {
     return await loadExisting(existingKey.toString("utf8"), existingCert.toString("utf8"));
   }
 
@@ -68,9 +72,18 @@ export async function loadOrCreateTlsIdentity(dataDir: string): Promise<TlsIdent
   // Regenerating recovers instead of bricking the App before the owner console can
   // even start; the pin rotation just forces re-pairing, the documented recovery.
   const identity = await generateIdentity();
-  // Write the key first (0600) so the cert never exists without its key.
-  writeFileAtomicSync(keyPath, identity.keyPem);
-  writeFileAtomicSync(certPath, identity.certPem);
+  // Keep an interrupted recovery retryable. Starting from cert-only, replace
+  // the cert before creating its matching key; starting from key-only (or an
+  // empty directory), replace/create the key before its matching cert. A crash
+  // between writes therefore always leaves a partial state, never a complete
+  // mismatched pair that would correctly fail closed on the next startup.
+  if (!hasKey && hasCert) {
+    writeFileAtomicSync(certPath, identity.certPem);
+    writeFileAtomicSync(keyPath, identity.keyPem);
+  } else {
+    writeFileAtomicSync(keyPath, identity.keyPem);
+    writeFileAtomicSync(certPath, identity.certPem);
+  }
   return identity;
 }
 
@@ -78,24 +91,26 @@ export async function loadOrCreateTlsIdentity(dataDir: string): Promise<TlsIdent
 // must match the key's public SPKI) so a mixed restore is caught here rather
 // than deep inside the TLS stack at handshake time.
 async function loadExisting(keyPem: string, certPem: string): Promise<TlsIdentity> {
-  let cert: x509.X509Certificate;
+  let certSpki: Buffer;
   try {
-    cert = new x509.X509Certificate(certPem);
+    const cert = new x509.X509Certificate(certPem);
+    // x509 v2 resolves PublicKey lazily, so a malformed SPKI can throw here
+    // even when the outer certificate parsed successfully.
+    certSpki = Buffer.from(cert.publicKey.rawData);
   } catch (error) {
     throw new TlsIdentityCorruptError(`stored TLS certificate is unparseable: ${errText(error)}`);
   }
 
-  let keyObject;
+  let keySpki: Buffer;
   try {
-    keyObject = createPrivateKey(keyPem);
+    const keyObject = createPrivateKey(keyPem);
+    keySpki = createPublicKey(keyObject).export({ type: "spki", format: "der" });
   } catch (error) {
     throw new TlsIdentityCorruptError(`stored TLS private key is unparseable: ${errText(error)}`);
   }
 
   // @peculiar's PublicKey.rawData is the DER SubjectPublicKeyInfo — the exact
   // bytes the pin hashes. Compare it to the key's own public SPKI.
-  const certSpki = Buffer.from(cert.publicKey.rawData);
-  const keySpki = createPublicKey(keyObject).export({ type: "spki", format: "der" });
   if (!certSpki.equals(keySpki)) {
     throw new TlsIdentityCorruptError("stored TLS key and certificate do not match (mixed restore?)");
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,10 @@
       "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/x509": "^1.12.3",
+        "@peculiar/x509": "^2.0.0",
         "@serenity-kit/opaque": "^1.1.0",
         "home-assistant-js-websocket": "^9.6.0",
+        "reflect-metadata": "^0.2.2",
         "ws": "^8.21.0",
         "yaml": "^2.9.0"
       },
@@ -683,22 +684,24 @@
       }
     },
     "node_modules/@peculiar/x509": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.12.3.tgz",
-      "integrity": "sha512-+Mzq+W7cNEKfkNZzyLl6A6ffqc3r21HGZUezgfKxpZrkORfOqgRXnS80Zu0IV6a9Ue9QBJeKD7kN0iWfc3bhRQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-2.0.0.tgz",
+      "integrity": "sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.3.13",
-        "@peculiar/asn1-csr": "^2.3.13",
-        "@peculiar/asn1-ecc": "^2.3.14",
-        "@peculiar/asn1-pkcs9": "^2.3.13",
-        "@peculiar/asn1-rsa": "^2.3.13",
-        "@peculiar/asn1-schema": "^2.3.13",
-        "@peculiar/asn1-x509": "^2.3.13",
-        "pvtsutils": "^1.3.5",
-        "reflect-metadata": "^0.2.2",
-        "tslib": "^2.7.0",
-        "tsyringe": "^4.8.0"
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/package.json
+++ b/package.json
@@ -93,9 +93,10 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@peculiar/x509": "^1.12.3",
+    "@peculiar/x509": "^2.0.0",
     "@serenity-kit/opaque": "^1.1.0",
     "home-assistant-js-websocket": "^9.6.0",
+    "reflect-metadata": "^0.2.2",
     "ws": "^8.21.0",
     "yaml": "^2.9.0"
   },

--- a/tests/app/dev-contract.test.ts
+++ b/tests/app/dev-contract.test.ts
@@ -32,4 +32,58 @@ describe("app dev contract", () => {
     expect(rootPkg.scripts?.build).toContain("rmSync('nova/dist'");
     expect(relayPkg.scripts?.build).toContain("rmSync('dist'");
   });
+
+  it("keeps the shipped relay dependency tree aligned with root development", () => {
+    const rootPkg = JSON.parse(readFileSync("package.json", "utf8")) as {
+      dependencies?: Record<string, string>;
+    };
+    const relayPkg = JSON.parse(readFileSync("nova/package.json", "utf8")) as {
+      dependencies?: Record<string, string>;
+    };
+    const rootLock = JSON.parse(readFileSync("package-lock.json", "utf8")) as {
+      lockfileVersion?: number;
+      packages?: Record<
+        string,
+        { dependencies?: Record<string, string>; dev?: boolean; integrity?: string; version?: string }
+      >;
+    };
+    const relayLock = JSON.parse(readFileSync("nova/package-lock.json", "utf8")) as {
+      lockfileVersion?: number;
+      packages?: Record<
+        string,
+        { dependencies?: Record<string, string>; dev?: boolean; integrity?: string; version?: string }
+      >;
+    };
+
+    const relayDependencies = relayPkg.dependencies ?? {};
+    expect(Object.keys(relayDependencies).length).toBeGreaterThan(0);
+    expect(rootLock.lockfileVersion).toBe(3);
+    expect(relayLock.lockfileVersion).toBe(3);
+
+    for (const [name, range] of Object.entries(relayDependencies)) {
+      const rootRange = rootPkg.dependencies?.[name];
+      expect(rootRange, `${name} declared range`).toBe(range);
+      expect(relayLock.packages?.[""]?.dependencies?.[name], `${name} relay lock range`).toBe(range);
+      expect(rootLock.packages?.[""]?.dependencies?.[name], `${name} root lock range`).toBe(rootRange);
+
+      const lockKey = `node_modules/${name}`;
+      const relayVersion = relayLock.packages?.[lockKey]?.version;
+      const rootVersion = rootLock.packages?.[lockKey]?.version;
+      expect(relayVersion, `${name} relay lock resolution`).toBeTypeOf("string");
+      expect(rootVersion, `${name} root lock resolution`).toBeTypeOf("string");
+      expect(rootVersion, `${name} resolved version parity`).toBe(relayVersion);
+    }
+
+    for (const [lockPath, relayPackage] of Object.entries(relayLock.packages ?? {})) {
+      if (lockPath === "" || relayPackage.dev === true) {
+        continue;
+      }
+      const rootPackage = rootLock.packages?.[lockPath];
+      expect(rootPackage, `${lockPath} exists in root lock`).toBeDefined();
+      expect(relayPackage.version, `${lockPath} relay version`).toBeTypeOf("string");
+      expect(relayPackage.integrity, `${lockPath} relay integrity`).toBeTypeOf("string");
+      expect(rootPackage?.version, `${lockPath} production version parity`).toBe(relayPackage.version);
+      expect(rootPackage?.integrity, `${lockPath} production integrity parity`).toBe(relayPackage.integrity);
+    }
+  });
 });

--- a/tests/security/tls-identity.test.ts
+++ b/tests/security/tls-identity.test.ts
@@ -1,16 +1,49 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdtempSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { connect } from "node:tls";
 
 import { createServer } from "node:https";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { TlsIdentityCorruptError, loadOrCreateTlsIdentity } from "../../nova/src/security/tls-identity.js";
+const storageMock = vi.hoisted(() => ({
+  actualWriteFileAtomicSync: undefined as
+    | ((path: string, data: Buffer | string) => void)
+    | undefined,
+  writeFileAtomicSync: vi.fn<(path: string, data: Buffer | string) => void>(),
+}));
+
+vi.mock("../../nova/src/storage/atomic-file.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../nova/src/storage/atomic-file.js")>();
+  storageMock.actualWriteFileAtomicSync = actual.writeFileAtomicSync;
+  storageMock.writeFileAtomicSync.mockImplementation(actual.writeFileAtomicSync);
+  return { ...actual, writeFileAtomicSync: storageMock.writeFileAtomicSync };
+});
+
+import {
+  TlsIdentityCorruptError,
+  loadOrCreateTlsIdentity,
+  type TlsIdentity,
+} from "../../nova/src/security/tls-identity.js";
+
+// Disposable test identity generated once with @peculiar/x509 1.12.3. This
+// pins the persisted on-disk format across the v2 parser migration without
+// committing standalone key files.
+const V1_KEY_DER_BASE64 =
+  "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgArSZttQUP+/fq67RcAaABIrKKjGgvOlyZz0gwtuPufuhRANCAAS19FeMXhI9p1x59dG9LQ5BSHeY3+2ibDtEbnd/GZI87XjKDvsHax+PKMvY2OK/govBTICc4KbjwPEZJsk0yh4z";
+const V1_CERT_DER_BASE64 =
+  "MIIBdTCCARugAwIBAgIIASNFZ4mrze8wCgYIKoZIzj0EAwIwIDEeMBwGA1UEAxMVbm92YS1yZWxheS12MS1maXh0dXJlMB4XDTI2MDEwMTAwMDAwMFoXDTM2MDEwMTAwMDAwMFowIDEeMBwGA1UEAxMVbm92YS1yZWxheS12MS1maXh0dXJlMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtfRXjF4SPadcefXRvS0OQUh3mN/tomw7RG53fxmSPO14yg77B2sfjyjL2Njiv4KLwUyAnOCm48DxGSbJNMoeM6M/MD0wDAYDVR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0OBBYEFHxmyLD48lhf+8f3Pyn1tS1u/l6OMAoGCCqGSM49BAMCA0gAMEUCIQDjHBvRVn/mlyxfB5l1/MCIFApxCqHDJfUFFu6igBwJ3AIgJSLnaUiugzblHnGoMcbxH+ZdbnV1ISGDatLMLoLX5XE=";
+const V1_SPKI_PIN = "0_EzkFSqRs0SLug7pkcvidBx4bVC537dgq-qImfDj0I";
 
 let dir: string;
 beforeEach(() => {
+  const actualWrite = storageMock.actualWriteFileAtomicSync;
+  if (!actualWrite) {
+    throw new Error("atomic file mock was not initialized");
+  }
+  storageMock.writeFileAtomicSync.mockReset();
+  storageMock.writeFileAtomicSync.mockImplementation(actualWrite);
   dir = mkdtempSync(join(tmpdir(), "ha-nova-tls-"));
 });
 afterEach(() => {
@@ -30,34 +63,29 @@ describe("tls-identity", () => {
 
   it("serves TLS 1.3 whose leaf SPKI matches the advertised pin", async () => {
     const id = await loadOrCreateTlsIdentity(dir);
-    const server = createServer(
-      { key: id.keyPem, cert: id.certPem, minVersion: "TLSv1.3", maxVersion: "TLSv1.3" },
-      (_req, res) => res.end("ok")
-    );
-    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
-    const port = (server.address() as { port: number }).port;
+    expect(await spkiPinSeenOverTls(id)).toBe(id.spkiPin);
+  });
 
-    const pin = await new Promise<string>((resolve, reject) => {
-      const socket = connect(
-        // Trust the self-signed leaf as its own CA and skip only the hostname
-        // check — the relay's TLS is pin-based, not CA/hostname-based, but
-        // disabling verification outright trips security scanners.
-        { host: "127.0.0.1", port, ca: id.certPem, checkServerIdentity: () => undefined, minVersion: "TLSv1.3" },
-        () => {
-          const cert = socket.getPeerX509Certificate();
-          const proto = socket.getProtocol();
-          socket.end();
-          if (!cert || proto !== "TLSv1.3") {
-            reject(new Error("no cert or not TLS1.3"));
-            return;
-          }
-          resolve(createHash("sha256").update(cert.publicKey.export({ type: "spki", format: "der" })).digest("base64url"));
-        }
-      );
-      socket.on("error", reject);
-    });
-    server.close();
-    expect(pin).toBe(id.spkiPin);
+  it("loads a v1.12.3 identity without changing its pin or persisted bytes", async () => {
+    const keyPem = pemFromDer("PRIVATE KEY", Buffer.from(V1_KEY_DER_BASE64, "base64"));
+    const certPem = pemFromDer("CERTIFICATE", Buffer.from(V1_CERT_DER_BASE64, "base64"));
+    const keyPath = join(dir, "tls-key.pem");
+    const certPath = join(dir, "tls-cert.pem");
+    writeFileSync(keyPath, keyPem);
+    writeFileSync(certPath, certPem);
+
+    const keyBefore = readFileSync(keyPath);
+    const certBefore = readFileSync(certPath);
+    const keyInodeBefore = statSync(keyPath).ino;
+    const certInodeBefore = statSync(certPath).ino;
+    const loaded = await loadOrCreateTlsIdentity(dir);
+
+    expect(loaded.spkiPin).toBe(V1_SPKI_PIN);
+    expect(readFileSync(keyPath)).toEqual(keyBefore);
+    expect(readFileSync(certPath)).toEqual(certBefore);
+    expect(statSync(keyPath).ino).toBe(keyInodeBefore);
+    expect(statSync(certPath).ino).toBe(certInodeBefore);
+    expect(await spkiPinSeenOverTls(loaded)).toBe(V1_SPKI_PIN);
   });
 
   it("regenerates when only the certificate is present (a keyless cert cannot serve TLS)", async () => {
@@ -79,9 +107,56 @@ describe("tls-identity", () => {
     expect(regenerated.spkiPin).not.toBe(first.spkiPin);
   });
 
+  it("keeps cert-only recovery retryable when the matching key write fails", async () => {
+    const first = await loadOrCreateTlsIdentity(dir);
+    const keyPath = join(dir, "tls-key.pem");
+    const certPath = join(dir, "tls-cert.pem");
+    unlinkSync(keyPath);
+    const staleCert = readFileSync(certPath);
+
+    const actualWrite = storageMock.actualWriteFileAtomicSync;
+    if (!actualWrite) {
+      throw new Error("atomic file mock was not initialized");
+    }
+    let writes = 0;
+    storageMock.writeFileAtomicSync.mockImplementation((path, data) => {
+      writes += 1;
+      if (writes === 2) {
+        throw new Error("injected key write failure");
+      }
+      actualWrite(path, data);
+    });
+
+    await expect(loadOrCreateTlsIdentity(dir)).rejects.toThrow("injected key write failure");
+    expect(writes).toBe(2);
+    expect(existsSync(keyPath)).toBe(false);
+    expect(readFileSync(certPath)).not.toEqual(staleCert);
+
+    storageMock.writeFileAtomicSync.mockImplementation(actualWrite);
+    const recovered = await loadOrCreateTlsIdentity(dir);
+    expect(existsSync(keyPath)).toBe(true);
+    expect(existsSync(certPath)).toBe(true);
+    expect(recovered.spkiPin).not.toBe(first.spkiPin);
+    const reloaded = await loadOrCreateTlsIdentity(dir);
+    expect(reloaded.spkiPin).toBe(recovered.spkiPin);
+    expect(await spkiPinSeenOverTls(reloaded)).toBe(recovered.spkiPin);
+  });
+
   it("fail-closed on an unparseable certificate", async () => {
     await loadOrCreateTlsIdentity(dir);
     writeFileSync(join(dir, "tls-cert.pem"), "-----BEGIN CERTIFICATE-----\ngarbage\n-----END CERTIFICATE-----\n");
+    await expect(loadOrCreateTlsIdentity(dir)).rejects.toBeInstanceOf(TlsIdentityCorruptError);
+  });
+
+  it("fail-closed when a parseable certificate contains malformed SPKI parameters", async () => {
+    const identity = await loadOrCreateTlsIdentity(dir);
+    writeFileSync(join(dir, "tls-cert.pem"), invalidateEcCurveParameters(identity.certPem));
+    await expect(loadOrCreateTlsIdentity(dir)).rejects.toBeInstanceOf(TlsIdentityCorruptError);
+  });
+
+  it("fail-closed on an unparseable private key", async () => {
+    await loadOrCreateTlsIdentity(dir);
+    writeFileSync(join(dir, "tls-key.pem"), "-----BEGIN PRIVATE KEY-----\ngarbage\n-----END PRIVATE KEY-----\n");
     await expect(loadOrCreateTlsIdentity(dir)).rejects.toBeInstanceOf(TlsIdentityCorruptError);
   });
 
@@ -99,3 +174,73 @@ describe("tls-identity", () => {
     }
   });
 });
+
+function pemFromDer(label: string, der: Buffer): string {
+  const body = der.toString("base64").replace(/(.{64})/g, "$1\n");
+  return `-----BEGIN ${label}-----\n${body}\n-----END ${label}-----\n`;
+}
+
+function invalidateEcCurveParameters(certPem: string): string {
+  const der = Buffer.from(certPem.replace(/-----[^-]+-----|\s/g, ""), "base64");
+  const p256CurveOid = Buffer.from("06082a8648ce3d030107", "hex");
+  const offset = der.indexOf(p256CurveOid);
+  expect(offset).toBeGreaterThanOrEqual(0);
+  // Keep the outer certificate parseable while making the lazy PublicKey
+  // decoder reject the required EC parameters.
+  der[offset] = 0x05;
+  return pemFromDer("CERTIFICATE", der);
+}
+
+async function spkiPinSeenOverTls(identity: TlsIdentity): Promise<string> {
+  const server = createServer(
+    { key: identity.keyPem, cert: identity.certPem, minVersion: "TLSv1.3", maxVersion: "TLSv1.3" },
+    (_req, res) => res.end("ok")
+  );
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as { port: number }).port;
+
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      const socket = connect(
+        // Trust the self-signed leaf as its own CA and skip only the hostname
+        // check — the relay's TLS is pin-based, not CA/hostname-based, but
+        // disabling verification outright trips security scanners.
+        {
+          host: "127.0.0.1",
+          port,
+          ca: identity.certPem,
+          checkServerIdentity: () => undefined,
+          minVersion: "TLSv1.3",
+        },
+        () => {
+          socket.setTimeout(0);
+          try {
+            const cert = socket.getPeerX509Certificate();
+            const proto = socket.getProtocol();
+            if (!cert || proto !== "TLSv1.3") {
+              throw new Error("no cert or not TLS1.3");
+            }
+            resolve(
+              createHash("sha256")
+                .update(cert.publicKey.export({ type: "spki", format: "der" }))
+                .digest("base64url")
+            );
+          } catch (error) {
+            reject(error);
+          } finally {
+            socket.end();
+          }
+        }
+      );
+      socket.setTimeout(5_000, () => {
+        socket.destroy();
+        reject(new Error("TLS handshake timed out"));
+      });
+      socket.once("error", reject);
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Migrate both Relay manifests to `@peculiar/x509` 2.0.0, make its required metadata polyfill explicit, and strengthen the TLS identity/pairing coverage around persisted certificates and interrupted recovery.

Supersedes Dependabot PRs #378 and #379 with one atomic, security-reviewed runtime update.

Upstream migration sources:
- https://github.com/PeculiarVentures/x509/releases/tag/v2.0.0
- https://github.com/PeculiarVentures/x509/pull/130

## Problem

The root and NOVA manifests independently pin the Relay's certificate library. Updating them separately can leave shipped/runtime dependency graphs out of sync. x509 v2 also stops loading `reflect-metadata` transitively.

The existing pairing workflow installed the root lockfile instead of the NOVA runtime lockfile. Existing TLS tests did not prove that a persisted v1 identity remains byte-for-byte stable and can still serve TLS after the major upgrade.

Adversarial review additionally found that cert-only recovery wrote the replacement key first. An interrupted second write could therefore strand a complete but mismatched key/certificate pair that fails permanently instead of remaining retryable.

## Solution

- update root and NOVA runtime manifests/locks together to x509 2.0.0
- add `reflect-metadata` as a direct runtime dependency and import it before x509
- keep certificate parsing and lazy public-key extraction inside typed validation failures
- export/validate the loaded private key inside the same typed key failure path
- order partial-identity recovery writes so an interrupted write always leaves a partial, retryable state
- make Pairing E2E install/build from `nova/package-lock.json`
- enforce root/NOVA production dependency closure parity, including nested lockfile entries
- add persisted-v1, malformed-SPKI, invalid-key, interrupted-write/retry, pin-stability, and real TLS regressions

## Release Notes / User Impact

### Why this release exists

Unblocks the security-sensitive certificate dependency update required before the next Relay release.

### What users get

Existing valid Relay TLS identities remain unchanged, retain the same pairing pin, and continue serving TLS. Partial identities recover deterministically without creating a complete mismatched pair after an interrupted write.

### Upgrade notes / caveats

No user action. This is a dependency/runtime hardening change, not an upstream security-fix claim.

### Issues closed

Supersedes #378 and #379.

## Risk

High-sensitivity path: Relay TLS identity loading and pairing.

Mitigations:
- v1.12.3-generated DER fixture verified byte-for-byte and inode-stable
- TLS 1.3 handshake exercised from the persisted fixture and regenerated identities
- failure-class and interrupted-write regressions cover every identity state
- three-agent adversarial review rerun clean after all findings were fixed
- full repository gate and real Go pairing E2E passed
- both HA App and standalone Relay images built; standalone smoke and in-image module import passed

## Verification

- [x] `npm run verify`
- [x] `npx vitest run tests/security/tls-identity.test.ts tests/app/dev-contract.test.ts` (14 focused tests)
- [x] NOVA `npm ci && npm run build` plus `go test -count=1 -run 'TestPairingClientV1EndToEnd|TestRunSecurePairingEndToEnd' -v ./...`
- [x] `npm ls --package-lock-only --all` in root and NOVA
- [x] `npm audit` in root and NOVA (0 vulnerabilities)
- [x] HA App and standalone Docker image builds; standalone Relay smoke
- [x] `git diff --check`
- [x] Docs updated (not needed; no public behavior or release claim changed)
- [x] Release-facing support/validation claims updated (not needed)
- [x] Tests added/updated
