### PR TITLE
fix: reject invalid UTF-8 inputs before relay dispatch

### DIFF
--- a/cli/client_claude.go
+++ b/cli/client_claude.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,8 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 )
-
-var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
 func installClaudePlugin(paths runtimePaths, sourceRoot string) error {
 	if _, err := exec.LookPath("claude"); err != nil {
@@ -240,7 +237,7 @@ func removeClaudePluginRecord(home string) error {
 }
 
 func unmarshalClaudeJSON(data []byte, target any) error {
-	return json.Unmarshal(bytes.TrimPrefix(data, utf8BOM), target)
+	return unmarshalStrictJSON(data, "Claude JSON", target)
 }
 
 func removeClaudePluginCache(home string) error {

--- a/cli/cmd_pair.go
+++ b/cli/cmd_pair.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -18,7 +20,7 @@ var runSecurePairingForPairCmd = runSecurePairing
 // one activates.
 func runPairCommand(paths runtimePaths, args []string) int {
 	relayURL, code, credentialStore, serverName := "", "", "", ""
-	credentialStoreSet := false
+	relayURLSet, codeSet, credentialStoreSet, serverNameSet := false, false, false, false
 	for i := 0; i < len(args); i++ {
 		// Accept both `--flag value` and `--flag=value` for the string flags.
 		name, inlineValue, hasInline := args[i], "", false
@@ -40,13 +42,16 @@ func runPairCommand(paths runtimePaths, args []string) int {
 		switch name {
 		case "--relay-url":
 			relayURL = takeValue()
+			relayURLSet = true
 		case "--code":
 			code = takeValue()
+			codeSet = true
 		case "--credential-store":
 			credentialStore = takeValue()
 			credentialStoreSet = true
 		case "--server":
 			serverName = takeValue()
+			serverNameSet = true
 		case "-h", "--help":
 			fmt.Println("Usage: ha-nova pair [--relay-url http://<ha-host>:8791] [--code NNNNNN] [--credential-store=file] [--server <name>]")
 			fmt.Println("Open NOVA in the Home Assistant sidebar, click \"Connect a device\", then run this.")
@@ -58,15 +63,53 @@ func runPairCommand(paths runtimePaths, args []string) int {
 			return 1
 		}
 	}
+	if relayURLSet && strings.TrimSpace(relayURL) == "" {
+		printErr("--relay-url requires a non-empty URL; nothing was paired")
+		return 1
+	}
+	if codeSet && strings.TrimSpace(code) == "" {
+		printErr("--code requires a non-empty pairing code; nothing was paired")
+		return 1
+	}
+	if serverNameSet && strings.TrimSpace(serverName) == "" {
+		printErr("--server requires a non-empty profile name; nothing was paired")
+		return 1
+	}
 	if credentialStoreSet && credentialStore != "file" {
 		printErr("--credential-store supports only the value \"file\" (got %q)", credentialStore)
 		return 1
 	}
-	if serverName != "" {
+	if serverNameSet {
+		if err := validateUTF8String(serverName, "server profile name"); err != nil {
+			printErr("%s; nothing was paired", err)
+			return 1
+		}
 		if err := validateServerProfileName(serverName); err != nil {
 			printErr("%s", err)
 			return 1
 		}
+	}
+	bootstrapURL := strings.TrimSpace(relayURL)
+	if relayURLSet {
+		if err := validatePairRelayURL(bootstrapURL); err != nil {
+			printErr("%s; nothing was paired", err)
+			return 1
+		}
+	}
+	normalizedCode := ""
+	if codeSet {
+		if err := validateUTF8String(code, "pairing code"); err != nil {
+			printErr("%s; nothing was paired", err)
+			return 1
+		}
+		var err error
+		normalizedCode, err = normalizeRelayPairingCode(code)
+		if err != nil {
+			printErr("%s; nothing was paired", err)
+			return 1
+		}
+	}
+	if serverNameSet {
 		// Route this run — config saves AND credential slots — to the named
 		// profile before anything touches storage. The seam is set here too so
 		// the storage probe/migration below already use the profile's slots.
@@ -80,14 +123,14 @@ func runPairCommand(paths runtimePaths, args []string) int {
 	// another profile's URL would bootstrap against the wrong server, so it is a
 	// hard error without --relay-url.
 	cfg, cfgErr := loadConfig(paths)
-	newProfile := serverName != "" && errors.Is(cfgErr, errUnknownServerProfile)
+	newProfile := serverNameSet && errors.Is(cfgErr, errUnknownServerProfile)
 	if cfgErr != nil && errors.Is(cfgErr, errUnknownServerProfile) && !newProfile {
 		// Selection came from HA_NOVA_SERVER: a typo must fail loud, never
 		// silently pair a fresh profile.
 		printErr("%s", cfgErr)
 		return 1
 	}
-	if serverName == "" && cfgErr != nil {
+	if !serverNameSet && cfgErr != nil {
 		// loadConfig failed before profile resolution (missing/incomplete
 		// config), so an env-only selection never reached the credential seam —
 		// saves would target the env profile while credentials land in the
@@ -97,8 +140,7 @@ func runPairCommand(paths runtimePaths, args []string) int {
 			return 1
 		}
 	}
-	bootstrapURL := strings.TrimSpace(relayURL)
-	if bootstrapURL == "" {
+	if !relayURLSet {
 		if newProfile {
 			printErr("server profile %q does not exist yet; pass --relay-url http://<ha-host>:8791 to create it", serverName)
 			return 1
@@ -111,6 +153,10 @@ func runPairCommand(paths runtimePaths, args []string) int {
 	}
 	if bootstrapURL == "" {
 		printErr("no relay URL known; pass --relay-url http://<ha-host>:8791 or run 'ha-nova setup' first")
+		return 1
+	}
+	if err := validatePairRelayURL(bootstrapURL); err != nil {
+		printErr("saved %s; nothing was paired", err)
 		return 1
 	}
 	// Storage mutation only AFTER every selection/bootstrap guard above: a pair
@@ -138,7 +184,7 @@ func runPairCommand(paths runtimePaths, args []string) int {
 		if raw, rawErr := loadRawDefaultProfileConfig(paths.ConfigFile); rawErr == nil {
 			cfg.ClientInstallID = raw.ClientInstallID
 		}
-	} else if strings.TrimSpace(relayURL) != "" {
+	} else if relayURLSet {
 		// An explicit --relay-url must persist for later functional calls, not
 		// just drive this one pairing — the successful pairing saves cfg.
 		cfg.RelayBaseURL = bootstrapURL
@@ -157,21 +203,22 @@ func runPairCommand(paths runtimePaths, args []string) int {
 		fmt.Println(probe.note)
 	}
 
-	if code == "" {
+	if !codeSet {
 		entered, promptErr := promptWizardLineFromReader(bufio.NewReader(os.Stdin), os.Stdout, "Six-digit code from the NOVA page", "")
 		if promptErr != nil {
 			return 1
 		}
 		code = entered
-	}
-	normalized, err := normalizeRelayPairingCode(code)
-	if err != nil {
-		printErr("%s", err)
-		return 1
+		normalized, normalizeErr := normalizeRelayPairingCode(code)
+		if normalizeErr != nil {
+			printErr("%s", normalizeErr)
+			return 1
+		}
+		normalizedCode = normalized
 	}
 
 	save := func(c *runtimeConfig) error { return saveConfig(paths, *c) }
-	deviceID, err := runSecurePairingForPairCmd(bootstrapURL, normalized, &cfg, save, defaultPairingClientInfo())
+	deviceID, err := runSecurePairingForPairCmd(bootstrapURL, normalizedCode, &cfg, save, defaultPairingClientInfo())
 	if err != nil {
 		switch {
 		case errors.Is(err, errPairingCodeRejected):
@@ -189,4 +236,34 @@ func runPairCommand(paths runtimePaths, args []string) int {
 	}
 	fmt.Printf("Paired securely. This device is connected (id %s).\n", deviceID)
 	return 0
+}
+
+func validatePairRelayURL(value string) error {
+	if err := validateUTF8String(value, "relay URL"); err != nil {
+		return err
+	}
+	parsed, err := url.ParseRequestURI(value)
+	if err != nil {
+		return fmt.Errorf("relay URL is invalid: %w", err)
+	}
+	hostname := parsed.Hostname()
+	if (!strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https")) || hostname == "" {
+		return errors.New("relay URL must be an absolute HTTP(S) URL with a host")
+	}
+	if err := validateUTF8String(hostname, "relay URL host"); err != nil {
+		return err
+	}
+	if strings.HasSuffix(parsed.Host, ":") {
+		return errors.New("relay URL port must not be empty")
+	}
+	if port := parsed.Port(); port != "" {
+		portNumber, err := strconv.Atoi(port)
+		if err != nil || portNumber < 1 || portNumber > 65535 {
+			return errors.New("relay URL port must be between 1 and 65535")
+		}
+	}
+	if (parsed.Path != "" && parsed.Path != "/") || parsed.ForceQuery || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return errors.New("relay URL must be a base URL without a path, query, or fragment")
+	}
+	return nil
 }

--- a/cli/diff.go
+++ b/cli/diff.go
@@ -23,6 +23,7 @@ func runDiffCommand(_ runtimePaths, args []string) int {
 	fs := flag.NewFlagSet("diff", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	var beforePath, afterPath, outPath string
+	var outPathSet bool
 	fs.StringVar(&beforePath, "before", "", "path to the current/before config JSON")
 	fs.StringVar(&afterPath, "after", "", "path to the proposed/after config JSON")
 	fs.StringVar(&outPath, "out", "", "optional path to write the rendered diff")
@@ -31,6 +32,19 @@ func runDiffCommand(_ runtimePaths, args []string) int {
 			return 0
 		}
 		printErr("%s", err)
+		return 1
+	}
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "out" {
+			outPathSet = true
+		}
+	})
+	if fs.NArg() != 0 {
+		printErr("diff does not accept positional arguments; no diff was rendered")
+		return 1
+	}
+	if outPathSet && strings.TrimSpace(outPath) == "" {
+		printErr("--out requires a non-empty path; no diff was rendered")
 		return 1
 	}
 	if strings.TrimSpace(beforePath) == "" || strings.TrimSpace(afterPath) == "" {
@@ -48,7 +62,7 @@ func runDiffCommand(_ runtimePaths, args []string) int {
 		return 1
 	}
 	lines := renderConfigChanges(before, after)
-	if strings.TrimSpace(outPath) != "" {
+	if outPathSet {
 		rendered := ""
 		if len(lines) > 0 {
 			rendered = strings.Join(lines, "\n") + "\n"
@@ -89,6 +103,10 @@ func configObjectFromBytes(data []byte) (map[string]interface{}, error) {
 }
 
 func decodeJSONNumber(data []byte) (interface{}, error) {
+	data, err := strictJSONBytes(data, "config JSON")
+	if err != nil {
+		return nil, err
+	}
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
 	var v interface{}

--- a/cli/jq.go
+++ b/cli/jq.go
@@ -17,6 +17,10 @@ type jqResult struct {
 	lastValue interface{}
 }
 
+type jqProgram struct {
+	code *gojq.Code
+}
+
 func trimWrappedJQFilter(filter string) string {
 	trimmed := strings.TrimSpace(filter)
 	if len(trimmed) >= 2 {
@@ -62,18 +66,28 @@ func parseJQFilter(filter string) (*gojq.Query, error) {
 	return nil, lastErr
 }
 
-// applyJQFilter runs a jq filter on input bytes.
-func applyJQFilter(filter string, input []byte, raw bool) (jqResult, error) {
-	query, err := parseJQFilter(filter)
+func compileJQFilter(filter string) (*jqProgram, error) {
+	filterBytes, err := normalizeUTF8Bytes([]byte(filter), "jq filter")
 	if err != nil {
-		return jqResult{}, fmt.Errorf("jq parse error: %w", err)
+		return nil, err
+	}
+	query, err := parseJQFilter(string(filterBytes))
+	if err != nil {
+		return nil, fmt.Errorf("jq parse error: %w", err)
 	}
 
 	code, err := gojq.Compile(query)
 	if err != nil {
-		return jqResult{}, fmt.Errorf("jq compile error: %w", err)
+		return nil, fmt.Errorf("jq compile error: %w", err)
 	}
+	return &jqProgram{code: code}, nil
+}
 
+func applyCompiledJQFilter(program *jqProgram, input []byte, raw bool) (jqResult, error) {
+	input, err := strictJSONBytes(input, "jq input")
+	if err != nil {
+		return jqResult{}, err
+	}
 	var inputVal interface{}
 	if err := json.Unmarshal(input, &inputVal); err != nil {
 		return jqResult{}, fmt.Errorf("invalid JSON input: %w", err)
@@ -81,7 +95,7 @@ func applyJQFilter(filter string, input []byte, raw bool) (jqResult, error) {
 
 	var out strings.Builder
 	var lastVal interface{}
-	iter := code.Run(inputVal)
+	iter := program.code.Run(inputVal)
 	for {
 		v, ok := iter.Next()
 		if !ok {
@@ -106,6 +120,15 @@ func applyJQFilter(filter string, input []byte, raw bool) (jqResult, error) {
 	return jqResult{output: out.String(), lastValue: lastVal}, nil
 }
 
+// applyJQFilter runs a jq filter on input bytes.
+func applyJQFilter(filter string, input []byte, raw bool) (jqResult, error) {
+	program, err := compileJQFilter(filter)
+	if err != nil {
+		return jqResult{}, err
+	}
+	return applyCompiledJQFilter(program, input, raw)
+}
+
 func runJQ(args []string) int {
 	if len(args) == 0 {
 		fmt.Fprintln(os.Stderr, "Usage: relay jq [-r] [-e] [-c] [--jq-file <filter-file>] '<filter>'")
@@ -116,6 +139,8 @@ func runJQ(args []string) int {
 	exitStatus := false // -e: exit 1 if last output is false or null
 	inputFile := ""
 	filterFile := ""
+	inputFileSet := false
+	filterFileSet := false
 	remaining := args
 	for len(remaining) > 0 && strings.HasPrefix(remaining[0], "-") {
 		switch remaining[0] {
@@ -135,6 +160,7 @@ func runJQ(args []string) int {
 				return 1
 			}
 			inputFile = remaining[1]
+			inputFileSet = true
 			remaining = remaining[1:]
 		case "--jq-file":
 			if len(remaining) < 2 {
@@ -142,6 +168,7 @@ func runJQ(args []string) int {
 				return 1
 			}
 			filterFile = remaining[1]
+			filterFileSet = true
 			remaining = remaining[1:]
 		default:
 			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", remaining[0])
@@ -149,31 +176,50 @@ func runJQ(args []string) int {
 		}
 		remaining = remaining[1:]
 	}
-	if filterFile != "" && len(remaining) > 0 {
+	if filterFileSet && len(remaining) > 0 {
 		fmt.Fprintln(os.Stderr, "use either an inline jq filter or --jq-file, not both")
 		return 1
 	}
-	if filterFile == "" && len(remaining) == 0 {
+	if !filterFileSet && len(remaining) != 1 {
 		fmt.Fprintln(os.Stderr, "Usage: relay jq [-r] [-e] [-c] [--jq-file <filter-file>] '<filter>'")
 		return 1
 	}
 	filter := ""
-	if filterFile != "" {
+	if filterFileSet {
+		if strings.TrimSpace(filterFile) == "" {
+			fmt.Fprintln(os.Stderr, "--jq-file requires a non-empty path")
+			return 1
+		}
 		filterBytes, err := os.ReadFile(filepath.Clean(filterFile))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error reading jq filter: %s\n", err)
 			return 1
 		}
+		filterBytes, err = normalizeUTF8Bytes(filterBytes, fmt.Sprintf("jq filter file %q", filterFile))
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
 		filter = strings.TrimSpace(string(filterBytes))
+		if filter == "" {
+			fmt.Fprintf(os.Stderr, "jq filter file %q is empty\n", filterFile)
+			return 1
+		}
 	} else {
 		filter = remaining[0]
 	}
+	program, err := compileJQFilter(filter)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
 
-	var (
-		input []byte
-		err   error
-	)
-	if inputFile != "" {
+	var input []byte
+	if inputFileSet {
+		if strings.TrimSpace(inputFile) == "" {
+			fmt.Fprintln(os.Stderr, "--file requires a non-empty path")
+			return 1
+		}
 		input, err = os.ReadFile(filepath.Clean(inputFile))
 	} else {
 		input, err = io.ReadAll(os.Stdin)
@@ -182,8 +228,17 @@ func runJQ(args []string) int {
 		fmt.Fprintf(os.Stderr, "error reading jq input: %s\n", err)
 		return 1
 	}
+	inputSource := "jq stdin"
+	if inputFileSet {
+		inputSource = fmt.Sprintf("jq input file %q", inputFile)
+	}
+	input, err = strictJSONBytes(input, inputSource)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
 
-	res, err := applyJQFilter(filter, input, raw)
+	res, err := applyCompiledJQFilter(program, input, raw)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		return 1

--- a/cli/relay.go
+++ b/cli/relay.go
@@ -49,14 +49,21 @@ func applyHealthTimeouts(client *http.Client, connectTimeoutSeconds, maxTimeSeco
 type relayRequestOptions struct {
 	InlineJSON    string
 	JSONFile      string
+	InlineJSONSet bool
+	JSONFileSet   bool
 	JQFilter      string
 	JQFile        string
+	JQFilterSet   bool
+	JQFileSet     bool
 	OutputFile    string
 	BinaryOutFile string
+	OutputFileSet bool
+	BinaryOutSet  bool
 	Method        string
 	Path          string
 	StrictStatus  bool
 	Server        string
+	ServerSet     bool
 }
 
 func runRelayCommand(paths runtimePaths, args []string) int {
@@ -129,37 +136,118 @@ func parseRelayFlags(command string, args []string) (relayRequestOptions, error)
 		}
 		return opts, err
 	}
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "data", "body", "d":
+			opts.InlineJSONSet = true
+		case "data-file", "body-file":
+			opts.JSONFileSet = true
+		case "jq":
+			opts.JQFilterSet = true
+		case "jq-file":
+			opts.JQFileSet = true
+		case "out":
+			opts.OutputFileSet = true
+		case "out-binary":
+			opts.BinaryOutSet = true
+		case "server":
+			opts.ServerSet = true
+		}
+	})
+	if fs.NArg() != 0 {
+		return opts, fmt.Errorf("relay %s does not accept positional arguments; nothing was sent", command)
+	}
 	if command == "core" {
 		if opts.Method == "" || opts.Path == "" {
 			return opts, errors.New("--method and --path are required for relay core")
 		}
 	}
-	if opts.BinaryOutFile != "" {
-		if opts.JQFilter != "" || opts.JQFile != "" {
+	if opts.OutputFileSet && strings.TrimSpace(opts.OutputFile) == "" {
+		return opts, errors.New("--out requires a non-empty path; nothing was sent")
+	}
+	if opts.BinaryOutSet && strings.TrimSpace(opts.BinaryOutFile) == "" {
+		return opts, errors.New("--out-binary requires a non-empty path; nothing was sent")
+	}
+	if opts.BinaryOutSet {
+		if opts.JQFilterSet || opts.JQFileSet {
 			return opts, errors.New("--out-binary cannot be combined with --jq/--jq-file: the binary body is decoded from the raw envelope")
 		}
-		if opts.OutputFile != "" {
+		if opts.OutputFileSet {
 			return opts, errors.New("use either --out or --out-binary, not both")
 		}
+	}
+	if opts.ServerSet && strings.TrimSpace(opts.Server) == "" {
+		return opts, errors.New("--server requires a non-empty profile name; nothing was sent")
 	}
 	return opts, nil
 }
 
 func loadRelayPayload(opts relayRequestOptions) ([]byte, error) {
+	inlineSelected := opts.InlineJSONSet || opts.InlineJSON != ""
+	fileSelected := opts.JSONFileSet || opts.JSONFile != ""
 	switch {
-	case opts.InlineJSON != "" && opts.JSONFile != "":
+	case inlineSelected && fileSelected:
 		return nil, errors.New("use either inline JSON or a file, not both")
-	case opts.JSONFile != "":
-		return os.ReadFile(opts.JSONFile)
-	case opts.InlineJSON != "":
-		payload := normalizeInlineJSON(opts.InlineJSON)
-		if !json.Valid([]byte(payload)) {
-			return nil, errors.New("inline JSON payload is not valid JSON; on PowerShell prefer --data-file if quoting rewrites the payload")
+	case fileSelected:
+		if strings.TrimSpace(opts.JSONFile) == "" {
+			return nil, errors.New("JSON payload file flag requires a non-empty path; nothing was sent")
 		}
-		return []byte(payload), nil
+		path := filepath.Clean(opts.JSONFile)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read JSON payload file %q; nothing was sent: %w", opts.JSONFile, err)
+		}
+		source := fmt.Sprintf("JSON payload file %q", opts.JSONFile)
+		data, err = normalizeUTF8Bytes(data, source)
+		if err != nil {
+			return nil, fmt.Errorf("%w; nothing was sent. Windows PowerShell 5.1: recreate the file with Set-Content -Encoding UTF8 (a leading UTF-8 BOM is accepted; Out-File and > default to UTF-16LE)", err)
+		}
+		if !json.Valid(data) {
+			return nil, fmt.Errorf("%s is not valid JSON; nothing was sent", source)
+		}
+		return data, nil
+	case inlineSelected:
+		payload := normalizeInlineJSON(opts.InlineJSON)
+		payloadBytes, err := normalizeUTF8Bytes([]byte(payload), "inline JSON payload")
+		if err != nil {
+			return nil, fmt.Errorf("%w; nothing was sent", err)
+		}
+		if !json.Valid(payloadBytes) {
+			return nil, errors.New("inline JSON payload is not valid JSON; nothing was sent. On PowerShell prefer --data-file if quoting rewrites the payload")
+		}
+		return payloadBytes, nil
 	default:
 		return nil, nil
 	}
+}
+
+func buildRelayRequestBody(endpoint string, opts relayRequestOptions, payload []byte) ([]byte, error) {
+	if endpoint != "core" {
+		return payload, nil
+	}
+	if err := validateUTF8String(opts.Method, "core method"); err != nil {
+		return nil, fmt.Errorf("%w; nothing was sent", err)
+	}
+	if err := validateUTF8String(opts.Path, "core path"); err != nil {
+		return nil, fmt.Errorf("%w; nothing was sent", err)
+	}
+	prefix, err := json.Marshal(struct {
+		Method string `json:"method"`
+		Path   string `json:"path"`
+	}{Method: strings.ToUpper(opts.Method), Path: opts.Path})
+	if err != nil {
+		return nil, fmt.Errorf("cannot build Relay core request; nothing was sent: %w", err)
+	}
+	requestBody := append([]byte{}, prefix[:len(prefix)-1]...)
+	if len(payload) > 0 {
+		requestBody = append(requestBody, []byte(`,"body":`)...)
+		requestBody = append(requestBody, payload...)
+	}
+	requestBody = append(requestBody, '}')
+	if _, err := strictJSONBytes(requestBody, "Relay core request"); err != nil {
+		return nil, fmt.Errorf("%w; nothing was sent", err)
+	}
+	return requestBody, nil
 }
 
 func normalizeInlineJSON(value string) string {
@@ -176,17 +264,35 @@ func normalizeInlineJSON(value string) string {
 }
 
 func loadJQFilter(opts relayRequestOptions) (string, error) {
+	filterSelected := opts.JQFilterSet || opts.JQFilter != ""
+	fileSelected := opts.JQFileSet || opts.JQFile != ""
 	switch {
-	case opts.JQFilter != "" && opts.JQFile != "":
+	case filterSelected && fileSelected:
 		return "", errors.New("use either --jq or --jq-file, not both")
-	case opts.JQFile != "":
-		data, err := os.ReadFile(opts.JQFile)
-		if err != nil {
-			return "", err
+	case fileSelected:
+		if strings.TrimSpace(opts.JQFile) == "" {
+			return "", errors.New("--jq-file requires a non-empty path; nothing was sent")
 		}
-		return strings.TrimSpace(string(data)), nil
-	default:
+		data, err := os.ReadFile(filepath.Clean(opts.JQFile))
+		if err != nil {
+			return "", fmt.Errorf("cannot read jq filter file %q; nothing was sent: %w", opts.JQFile, err)
+		}
+		data, err = normalizeUTF8Bytes(data, fmt.Sprintf("jq filter file %q", opts.JQFile))
+		if err != nil {
+			return "", fmt.Errorf("%w; nothing was sent", err)
+		}
+		filter := strings.TrimSpace(string(data))
+		if filter == "" {
+			return "", fmt.Errorf("jq filter file %q is empty; nothing was sent", opts.JQFile)
+		}
+		return filter, nil
+	case filterSelected:
+		if strings.TrimSpace(opts.JQFilter) == "" {
+			return "", errors.New("--jq requires a non-empty filter; nothing was sent")
+		}
 		return opts.JQFilter, nil
+	default:
+		return "", nil
 	}
 }
 
@@ -201,7 +307,30 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 		printErr("%s", err)
 		return 1
 	}
-	if opts.Server != "" {
+	payloadBytes, err := loadRelayPayload(opts)
+	if err != nil {
+		printErr("%s", err)
+		return 1
+	}
+	jqFilter, err := loadJQFilter(opts)
+	if err != nil {
+		printErr("%s", err)
+		return 1
+	}
+	var compiledJQ *jqProgram
+	if jqFilter != "" {
+		compiledJQ, err = compileJQFilter(jqFilter)
+		if err != nil {
+			printErr("%s; nothing was sent", err)
+			return 1
+		}
+	}
+	requestBody, err := buildRelayRequestBody(endpoint, opts, payloadBytes)
+	if err != nil {
+		printErr("%s", err)
+		return 1
+	}
+	if opts.ServerSet {
 		// Selection order: --server > HA_NOVA_SERVER > default_server. An
 		// unknown name fails loud in loadConfig with the list of profiles.
 		setServerSelectionOverride(opts.Server)
@@ -219,24 +348,6 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 		return 1
 	}
 
-	payloadBytes, err := loadRelayPayload(opts)
-	if err != nil {
-		printErr("%s", err)
-		return 1
-	}
-
-	var requestBody []byte
-	if endpoint == "core" {
-		requestBody = []byte(fmt.Sprintf(`{"method":%q,"path":%q`, strings.ToUpper(opts.Method), opts.Path))
-		if len(payloadBytes) > 0 {
-			requestBody = append(requestBody, []byte(`,"body":`)...)
-			requestBody = append(requestBody, payloadBytes...)
-		}
-		requestBody = append(requestBody, '}')
-	} else {
-		requestBody = payloadBytes
-	}
-
 	url := strings.TrimRight(baseURL, "/") + "/" + endpoint
 	req, err := http.NewRequest("POST", url, bytes.NewReader(requestBody))
 	if err != nil {
@@ -248,7 +359,10 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		printErr("%s", relayConnectErrorMessage(baseURL, err))
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		printErr("%s", relayRequestOutcomeUnknownMessage(baseURL, err))
 		return 1
 	}
 	defer resp.Body.Close()
@@ -262,7 +376,7 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 
 	bodyBytes, err := readAllLimited(resp.Body, maxRelayResponseBytes)
 	if err != nil {
-		printErr("%s", err)
+		printRelayPostRequestError("reading the Relay response", err)
 		return 1
 	}
 	upstreamExitStatus := 0
@@ -270,15 +384,10 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 		upstreamExitStatus = relayCoreUpstreamExitStatus(bodyBytes, opts.StrictStatus)
 	}
 
-	jqFilter, err := loadJQFilter(opts)
-	if err != nil {
-		printErr("%s", err)
-		return 1
-	}
-	if jqFilter != "" {
-		res, err := applyJQFilter(jqFilter, bodyBytes, false)
+	if compiledJQ != nil {
+		res, err := applyCompiledJQFilter(compiledJQ, bodyBytes, false)
 		if err != nil {
-			printErr("%s", err)
+			printRelayPostRequestError("jq filtering", err)
 			return 1
 		}
 		bodyBytes = []byte(res.output)
@@ -286,22 +395,32 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 
 	if opts.BinaryOutFile != "" {
 		if err := writeRelayBinaryBody(bodyBytes, opts.BinaryOutFile); err != nil {
-			printErr("%s", err)
+			printRelayPostRequestError("processing --out-binary", err)
 			return 1
 		}
 	} else if opts.OutputFile != "" {
 		if err := os.MkdirAll(filepath.Dir(opts.OutputFile), 0o755); err != nil {
-			printErr("%s", err)
+			printRelayPostRequestError("creating the --out directory", err)
 			return 1
 		}
 		if err := os.WriteFile(opts.OutputFile, bodyBytes, 0o644); err != nil {
-			printErr("%s", err)
+			printRelayPostRequestError("writing --out", err)
 			return 1
 		}
 	} else {
-		_, _ = os.Stdout.Write(bodyBytes)
+		written, err := os.Stdout.Write(bodyBytes)
+		if err == nil && written != len(bodyBytes) {
+			err = io.ErrShortWrite
+		}
+		if err != nil {
+			printRelayPostRequestError("writing stdout", err)
+			return 1
+		}
 		if len(bodyBytes) > 0 && bodyBytes[len(bodyBytes)-1] != '\n' {
-			fmt.Fprintln(os.Stdout)
+			if _, err := fmt.Fprintln(os.Stdout); err != nil {
+				printRelayPostRequestError("writing stdout", err)
+				return 1
+			}
 		}
 	}
 
@@ -375,6 +494,7 @@ type healthOptions struct {
 	ConnectTimeoutSeconds float64
 	MaxTimeSeconds        float64
 	Server                string
+	ServerSet             bool
 }
 
 // parseHealthFlags accepts curl-compatible flag names so callers (session-start
@@ -394,6 +514,17 @@ func parseHealthFlags(args []string) (healthOptions, error) {
 		}
 		return opts, err
 	}
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "server" {
+			opts.ServerSet = true
+		}
+	})
+	if fs.NArg() != 0 {
+		return opts, errors.New("relay health does not accept positional arguments")
+	}
+	if opts.ServerSet && strings.TrimSpace(opts.Server) == "" {
+		return opts, errors.New("--server requires a non-empty profile name")
+	}
 	if opts.ConnectTimeoutSeconds <= 0 || opts.MaxTimeSeconds <= 0 {
 		return opts, errors.New("--connect-timeout and --max-time must be positive seconds")
 	}
@@ -410,7 +541,7 @@ func runHealth(paths runtimePaths, args []string) int {
 		return 1
 	}
 	client := newRelayHTTPClient(healthOpts.ConnectTimeoutSeconds, healthOpts.MaxTimeSeconds)
-	if healthOpts.Server != "" {
+	if healthOpts.ServerSet {
 		setServerSelectionOverride(healthOpts.Server)
 	}
 
@@ -493,6 +624,21 @@ func relayConnectErrorMessage(baseURL string, err error) string {
 	return fmt.Sprintf(
 		"cannot reach the NOVA Relay at %s: %s\nCheck that the NOVA Relay App is running in Home Assistant, then run: ha-nova doctor",
 		strings.TrimRight(baseURL, "/"), err,
+	)
+}
+
+func relayRequestOutcomeUnknownMessage(baseURL string, err error) string {
+	return fmt.Sprintf(
+		"%s\nThe request outcome is unknown: it may have reached the Relay. Verify the target state; do not retry automatically.",
+		relayConnectErrorMessage(baseURL, err),
+	)
+}
+
+func printRelayPostRequestError(stage string, err error) {
+	printErr(
+		"Relay request was already sent and may have succeeded, but %s failed: %s\nVerify the target state; do not retry automatically.",
+		stage,
+		err,
 	)
 }
 

--- a/cli/snapshot.go
+++ b/cli/snapshot.go
@@ -82,6 +82,7 @@ func runSnapshotSave(paths runtimePaths, args []string) int {
 	fs := flag.NewFlagSet("snapshot save", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	var dataFile string
+	var dataFileSet bool
 	fs.StringVar(&dataFile, "data-file", "", "path to the JSON record (defaults to stdin)")
 	if err := fs.Parse(args); err != nil {
 		if helpRequested(err, fs, "ha-nova snapshot save [--data-file <file>]") {
@@ -90,17 +91,26 @@ func runSnapshotSave(paths runtimePaths, args []string) int {
 		printErr("%s", err)
 		return 1
 	}
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "data-file" {
+			dataFileSet = true
+		}
+	})
 	if fs.NArg() != 0 {
 		printErr("snapshot save takes no positional arguments; use --data-file <file> or pipe the record on stdin")
 		return 1
 	}
 	var data []byte
 	var err error
-	if strings.TrimSpace(dataFile) != "" {
+	if dataFileSet {
+		if strings.TrimSpace(dataFile) == "" {
+			printErr("--data-file requires a non-empty path; no snapshot was written")
+			return 1
+		}
 		// File-based input is shell-agnostic — the canonical relay contract and
 		// `ha-nova diff --before/--after` are file-based too, so the skill never
 		// has to build a stdin redirect/pipe (fragile on Windows PowerShell).
-		data, err = os.ReadFile(dataFile)
+		data, err = os.ReadFile(filepath.Clean(dataFile))
 		if err != nil {
 			printErr("cannot read snapshot record: %s", err)
 			return 1
@@ -136,6 +146,35 @@ func runSnapshotShow(paths runtimePaths, args []string) int {
 			return 0
 		}
 		printErr("%s", err)
+		return 1
+	}
+	var targetSet, domainSet bool
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "target":
+			targetSet = true
+		case "domain":
+			domainSet = true
+		}
+	})
+	if fs.NArg() != 0 {
+		printErr("snapshot show does not accept positional arguments")
+		return 1
+	}
+	if targetSet && strings.TrimSpace(target) == "" {
+		printErr("--target requires a non-empty target_id")
+		return 1
+	}
+	if domainSet && strings.TrimSpace(domain) == "" {
+		printErr("--domain requires a non-empty domain")
+		return 1
+	}
+	if domainSet && !targetSet {
+		printErr("--domain requires --target")
+		return 1
+	}
+	if list && (targetSet || domainSet) {
+		printErr("--list cannot be combined with --target or --domain")
 		return 1
 	}
 	if list {
@@ -189,6 +228,31 @@ func runSnapshotVerify(paths runtimePaths, args []string) int {
 		printErr("%s", err)
 		return 1
 	}
+	var targetSet, domainSet bool
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "target":
+			targetSet = true
+		case "domain":
+			domainSet = true
+		}
+	})
+	if fs.NArg() != 0 {
+		printErr("snapshot verify does not accept positional arguments")
+		return 1
+	}
+	if targetSet && strings.TrimSpace(target) == "" {
+		printErr("--target requires a non-empty target_id")
+		return 1
+	}
+	if domainSet && strings.TrimSpace(domain) == "" {
+		printErr("--domain requires a non-empty domain")
+		return 1
+	}
+	if domainSet && !targetSet {
+		printErr("--domain requires --target")
+		return 1
+	}
 	if strings.TrimSpace(against) == "" {
 		printErr("--against <live.json> is required")
 		return 1
@@ -224,8 +288,8 @@ func runSnapshotVerify(paths runtimePaths, args []string) int {
 // reader never sees a torn file even if that assumption is violated.
 func saveUndoSnapshotBytes(paths runtimePaths, data []byte) error {
 	var snap undoSnapshot
-	if err := json.Unmarshal(data, &snap); err != nil {
-		return fmt.Errorf("snapshot payload is not valid JSON: %s", err)
+	if err := unmarshalStrictJSON(data, "snapshot payload", &snap); err != nil {
+		return err
 	}
 	if err := validateUndoSnapshot(snap); err != nil {
 		return err
@@ -266,7 +330,7 @@ func loadUndoSnapshotStack(paths runtimePaths) (undoSnapshotStack, error) {
 	data, err := os.ReadFile(undoSnapshotStackPath(paths))
 	if err == nil {
 		var stack undoSnapshotStack
-		if err := json.Unmarshal(data, &stack); err != nil {
+		if err := unmarshalStrictJSON(data, "undo snapshot store", &stack); err != nil {
 			return undoSnapshotStack{}, fmt.Errorf("undo snapshot store is corrupt: %s", err)
 		}
 		return stack, nil
@@ -282,7 +346,7 @@ func loadUndoSnapshotStack(paths runtimePaths) (undoSnapshotStack, error) {
 		return undoSnapshotStack{}, err
 	}
 	var snap undoSnapshot
-	if err := json.Unmarshal(legacy, &snap); err != nil {
+	if err := unmarshalStrictJSON(legacy, "legacy undo snapshot", &snap); err != nil {
 		return undoSnapshotStack{}, fmt.Errorf("undo snapshot is corrupt: %s", err)
 	}
 	return undoSnapshotStack{

--- a/cli/strict_selector_test.go
+++ b/cli/strict_selector_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+func TestRelayRejectsEmptyServerBeforeEnvironmentFallback(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	t.Setenv("HA_NOVA_SERVER", defaultServerProfileName)
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "ws", []string{"--server=", "--data", `{"type":"ping"}`})
+	})
+	if exitCode != 1 || !strings.Contains(output, "--server requires a non-empty profile name") || !strings.Contains(output, "nothing was sent") {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+	if got := capture.requests.Load(); got != 0 {
+		t.Fatalf("request count = %d, want 0", got)
+	}
+}
+
+func TestHealthRejectsEmptyServerAndPositionals(t *testing.T) {
+	for name, tc := range map[string]struct {
+		args []string
+		want string
+	}{
+		"empty server": {args: []string{"--server="}, want: "--server requires a non-empty profile name"},
+		"positional":   {args: []string{"unexpected", "--server", "cabin"}, want: "does not accept positional arguments"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseHealthFlags(tc.args); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("parseHealthFlags() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestPairRejectsExplicitEmptySelectorsBeforeFallback(t *testing.T) {
+	original := runSecurePairingForPairCmd
+	pairCalls := 0
+	runSecurePairingForPairCmd = func(string, string, *runtimeConfig, func(*runtimeConfig) error, pairingClientInfo) (string, error) {
+		pairCalls++
+		return "unexpected", nil
+	}
+	t.Cleanup(func() { runSecurePairingForPairCmd = original })
+
+	paths := runtimePaths{ConfigFile: filepath.Join(t.TempDir(), "missing-config.json")}
+	for name, tc := range map[string]struct {
+		args []string
+		want string
+	}{
+		"server":    {args: []string{"--server="}, want: "--server requires a non-empty profile name"},
+		"relay URL": {args: []string{"--relay-url="}, want: "--relay-url requires a non-empty URL"},
+		"code":      {args: []string{"--code="}, want: "--code requires a non-empty pairing code"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, func() int { return runPairCommand(paths, tc.args) })
+			if exitCode != 1 || !strings.Contains(output, tc.want) || !strings.Contains(output, "nothing was paired") {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+			if pairCalls != 0 {
+				t.Fatalf("pairing calls = %d, want 0", pairCalls)
+			}
+		})
+	}
+}
+
+func TestPairPreflightsExplicitInputsBeforeCredentialMigration(t *testing.T) {
+	invalidUTF8URL := string(append([]byte("http://relay/"), 0xdc))
+	invalidUTF8Server := string([]byte{'c', 'a', 0xdc})
+	for name, tc := range map[string]struct {
+		args []string
+		want string
+	}{
+		"invalid UTF-8 URL": {
+			args: []string{"--credential-store=file", "--relay-url", invalidUTF8URL, "--code", "123456"},
+			want: "relay URL is not valid UTF-8",
+		},
+		"malformed URL": {
+			args: []string{"--credential-store=file", "--relay-url", "http://", "--code", "123456"},
+			want: "relay URL",
+		},
+		"URL with path": {
+			args: []string{"--credential-store=file", "--relay-url", "http://relay.test/not-a-base", "--code", "123456"},
+			want: "without a path",
+		},
+		"empty URL query": {
+			args: []string{"--credential-store=file", "--relay-url", "http://relay.test:8791?", "--code", "123456"},
+			want: "without a path",
+		},
+		"out-of-range URL port": {
+			args: []string{"--credential-store=file", "--relay-url", "http://relay.test:65536", "--code", "123456"},
+			want: "port must be between 1 and 65535",
+		},
+		"empty URL port": {
+			args: []string{"--credential-store=file", "--relay-url", "http://relay.test:", "--code", "123456"},
+			want: "port must not be empty",
+		},
+		"invalid decoded host UTF-8": {
+			args: []string{"--credential-store=file", "--relay-url", "http://%DC:8791", "--code", "123456"},
+			want: "relay URL host is not valid UTF-8",
+		},
+		"invalid code": {
+			args: []string{"--credential-store=file", "--relay-url", "http://relay.test:8791", "--code", "bad"},
+			want: "exactly six digits",
+		},
+		"invalid UTF-8 server": {
+			args: []string{"--credential-store=file", "--server", invalidUTF8Server, "--relay-url", "http://relay.test:8791", "--code", "123456"},
+			want: "server profile name is not valid UTF-8",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			withDeviceStorageTestHome(t)
+			resetKeyringDeviceSlots(t)
+			keyringCredential := generateTestDeviceCredential(t)
+			if err := writeDeviceCredential(keyringCredential); err != nil {
+				t.Fatalf("seed keyring credential: %v", err)
+			}
+			configFile := filepath.Join(t.TempDir(), "config.json")
+			if err := saveConfig(runtimePaths{ConfigFile: configFile}, runtimeConfig{RelayBaseURL: "http://saved.test:8791"}); err != nil {
+				t.Fatal(err)
+			}
+
+			pairCalls := 0
+			original := runSecurePairingForPairCmd
+			runSecurePairingForPairCmd = func(string, string, *runtimeConfig, func(*runtimeConfig) error, pairingClientInfo) (string, error) {
+				pairCalls++
+				return "unexpected", nil
+			}
+			t.Cleanup(func() { runSecurePairingForPairCmd = original })
+
+			exitCode, output := captureCommandOutput(t, func() int {
+				return runPairCommand(runtimePaths{ConfigFile: configFile}, tc.args)
+			})
+			if exitCode != 1 || !strings.Contains(output, tc.want) || !strings.Contains(output, "nothing was paired") {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+			if pairCalls != 0 || deviceCredentialFileModeForced || deviceFileBackendMarkerExists() {
+				t.Fatalf("preflight mutated pairing/storage state: calls=%d forced=%v marker=%v", pairCalls, deviceCredentialFileModeForced, deviceFileBackendMarkerExists())
+			}
+			got, err := keyring.Get(deviceCredentialService, secretUser())
+			if err != nil || got != keyringCredential {
+				t.Fatalf("keyring credential changed: got=%q err=%v", got, err)
+			}
+			if deviceSecretFileExists(deviceCredentialService) {
+				t.Fatal("credential was copied to file before input validation")
+			}
+			if _, err := keyring.Get(deviceCredentialPendingService, secretUser()); !errors.Is(err, keyring.ErrNotFound) {
+				t.Fatalf("pending keyring slot changed: %v", err)
+			}
+		})
+	}
+}
+
+func TestSnapshotRejectsEmptyOrAmbiguousSelectionBeforeNewestFallback(t *testing.T) {
+	paths := testSnapshotPaths(t)
+	for _, record := range []string{
+		`{"op":"update","domain":"automation","target_id":"t1","before_config":{"v":0},"expected_after":{"v":1}}`,
+		`{"op":"update","domain":"automation","target_id":"t2","before_config":{"v":1},"expected_after":{"v":2}}`,
+	} {
+		if err := saveUndoSnapshotBytes(paths, []byte(record)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	livePath := filepath.Join(t.TempDir(), "live.json")
+	if err := os.WriteFile(livePath, []byte(`{"v":2}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	showCases := map[string]struct {
+		args []string
+		want string
+	}{
+		"empty target":  {args: []string{"--target="}, want: "--target requires a non-empty target_id"},
+		"empty domain":  {args: []string{"--domain="}, want: "--domain requires a non-empty domain"},
+		"positional":    {args: []string{"unexpected", "--target", "t1"}, want: "does not accept positional arguments"},
+		"list selector": {args: []string{"--list", "--target", "t1"}, want: "--list cannot be combined"},
+	}
+	for name, tc := range showCases {
+		t.Run("show "+name, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, func() int { return runSnapshotShow(paths, tc.args) })
+			if exitCode != 1 || !strings.Contains(output, tc.want) || strings.Contains(output, `"target_id": "t2"`) {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+		})
+	}
+
+	verifyCases := map[string]struct {
+		args []string
+		want string
+	}{
+		"empty target": {args: []string{"--against", livePath, "--target="}, want: "--target requires a non-empty target_id"},
+		"empty domain": {args: []string{"--against", livePath, "--target", "t1", "--domain="}, want: "--domain requires a non-empty domain"},
+		"positional":   {args: []string{"--against", livePath, "unexpected", "--target", "t1"}, want: "does not accept positional arguments"},
+	}
+	for name, tc := range verifyCases {
+		t.Run("verify "+name, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, func() int { return runSnapshotVerify(paths, tc.args) })
+			if exitCode != 1 || !strings.Contains(output, tc.want) || strings.TrimSpace(output) == "match" {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+		})
+	}
+}
+
+func TestSnapshotRejectsDomainWithoutTargetBeforeStoreAccess(t *testing.T) {
+	paths := testSnapshotPaths(t)
+	for name, run := range map[string]func() int{
+		"show": func() int {
+			return runSnapshotShow(paths, []string{"--domain", "automation"})
+		},
+		"verify": func() int {
+			return runSnapshotVerify(paths, []string{"--against", filepath.Join(t.TempDir(), "missing.json"), "--domain", "automation"})
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, run)
+			if exitCode != 1 || !strings.Contains(output, "--domain requires --target") || strings.Contains(output, "no undo snapshot") {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+		})
+	}
+}
+
+func TestDiffRejectsEmptyOutputAndPositionalsBeforeRendering(t *testing.T) {
+	dir := t.TempDir()
+	beforePath := filepath.Join(dir, "before.json")
+	afterPath := filepath.Join(dir, "after.json")
+	if err := os.WriteFile(beforePath, []byte(`{"mode":"single"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(afterPath, []byte(`{"mode":"restart"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, tc := range map[string]struct {
+		args []string
+		want string
+	}{
+		"empty output": {
+			args: []string{"--before", beforePath, "--after", afterPath, "--out="},
+			want: "--out requires a non-empty path",
+		},
+		"positional": {
+			args: []string{"--before", beforePath, "--after", afterPath, "unexpected"},
+			want: "does not accept positional arguments",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, func() int { return runDiffCommand(runtimePaths{}, tc.args) })
+			if exitCode != 1 || !strings.Contains(output, tc.want) || strings.Contains(output, "| mode |") {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+		})
+	}
+}

--- a/cli/strict_utf8_input_test.go
+++ b/cli/strict_utf8_input_test.go
@@ -1,0 +1,395 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestStrictJSONBytesPreservesUnicodeAndAcceptsOneBOM(t *testing.T) {
+	valid := []byte("{\"title\":\"Übersicht ☕ \uFFFD \uFEFF\"}")
+
+	for name, input := range map[string][]byte{
+		"plain": valid,
+		"bom":   append(append([]byte{}, utf8BOM...), valid...),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := strictJSONBytes(input, "test JSON")
+			if err != nil {
+				t.Fatalf("strictJSONBytes() error: %v", err)
+			}
+			if !bytes.Equal(got, valid) {
+				t.Fatalf("bytes changed:\n got %x\nwant %x", got, valid)
+			}
+		})
+	}
+}
+
+func TestStrictJSONBytesRejectsInvalidEncodingsBeforeJSON(t *testing.T) {
+	cases := map[string][]byte{
+		"active legacy code page byte": append(append([]byte(`{"title":"`), 0xDC), []byte(`bersicht"}`)...),
+		"truncated UTF-8":              append([]byte(`{"title":"`), 0xC3),
+		"UTF-16LE":                     {0xFF, 0xFE, '{', 0x00, '}', 0x00},
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := strictJSONBytes(input, "test JSON")
+			if err == nil || !strings.Contains(err.Error(), "not valid UTF-8") {
+				t.Fatalf("error = %v, want UTF-8 rejection", err)
+			}
+		})
+	}
+
+	for name, input := range map[string][]byte{
+		"malformed JSON": []byte(`{"title":`),
+		"empty":          nil,
+		"BOM only":       append([]byte{}, utf8BOM...),
+		"double BOM":     append(append(append([]byte{}, utf8BOM...), utf8BOM...), []byte(`{}`)...),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := strictJSONBytes(input, "test JSON")
+			if err == nil || !strings.Contains(err.Error(), "not valid JSON") {
+				t.Fatalf("error = %v, want JSON rejection", err)
+			}
+		})
+	}
+}
+
+func TestLoadRelayPayloadExplainsWindowsEncodingWithoutSending(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "payload.json")
+	invalid := append(append([]byte(`{"title":"`), 0xDC), []byte(`bersicht"}`)...)
+	if err := os.WriteFile(path, invalid, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadRelayPayload(relayRequestOptions{JSONFile: path})
+	if err == nil {
+		t.Fatal("expected invalid UTF-8 to fail")
+	}
+	for _, want := range []string{path, "not valid UTF-8", "nothing was sent", "Set-Content -Encoding UTF8", "BOM is accepted"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestLoadRelayPayloadStripsBOMAndPreservesValidBytes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "payload.json")
+	want := []byte("{\"title\":\"Übersicht ☕ \uFFFD \uFEFF\"}")
+	if err := os.WriteFile(path, append(append([]byte{}, utf8BOM...), want...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadRelayPayload(relayRequestOptions{JSONFile: path})
+	if err != nil {
+		t.Fatalf("loadRelayPayload() error: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("payload changed:\n got %x\nwant %x", got, want)
+	}
+}
+
+func TestRelayFileInputsRejectInvalidUTF8BeforeEveryRequest(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	path := filepath.Join(t.TempDir(), "payload.json")
+	invalid := append(append([]byte(`{"title":"`), 0xDC), []byte(`bersicht"}`)...)
+	if err := os.WriteFile(path, invalid, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		endpoint string
+		args     []string
+	}{
+		{endpoint: "ws", args: []string{"--data-file", path}},
+		{endpoint: "files", args: []string{"--data-file", path}},
+		{endpoint: "backups", args: []string{"--data-file", path}},
+		{endpoint: "core", args: []string{"--method", "POST", "--path", "/api/test", "--body-file", path}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.endpoint, func(t *testing.T) {
+			before := capture.requests.Load()
+			exitCode, output := captureCommandOutput(t, func() int {
+				return runRelayProxy(paths, tc.endpoint, tc.args)
+			})
+			if exitCode != 1 {
+				t.Fatalf("exit = %d, want 1", exitCode)
+			}
+			if !strings.Contains(output, "not valid UTF-8") || !strings.Contains(output, "nothing was sent") {
+				t.Fatalf("unexpected output: %s", output)
+			}
+			if got := capture.requests.Load(); got != before {
+				t.Fatalf("request count = %d, want %d", got, before)
+			}
+		})
+	}
+}
+
+func TestRelayRejectsInvalidUTF8BeforeConfigLookup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "payload.json")
+	if err := os.WriteFile(path, append([]byte(`{"title":"`), 0xDC), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	paths := runtimePaths{ConfigFile: filepath.Join(dir, "missing-config.json")}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "ws", []string{"--data-file", path})
+	})
+	if exitCode != 1 || !strings.Contains(output, "not valid UTF-8") || !strings.Contains(output, "nothing was sent") {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+}
+
+func TestRelayRejectsMalformedJSONBeforeRequest(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	path := filepath.Join(t.TempDir(), "payload.json")
+	if err := os.WriteFile(path, []byte(`{"title":`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "ws", []string{"--data-file", path})
+	})
+	if exitCode != 1 || !strings.Contains(output, "not valid JSON") || !strings.Contains(output, "nothing was sent") {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+	if got := capture.requests.Load(); got != 0 {
+		t.Fatalf("request count = %d, want 0", got)
+	}
+}
+
+func TestRelayValidFilePayloadReachesNetworkWithoutTranscoding(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	payloadPath := filepath.Join(t.TempDir(), "payload.json")
+	payload := []byte("{\"title\":\"Übersicht ☕ \uFFFD \uFEFF\"}")
+	if err := os.WriteFile(payloadPath, append(append([]byte{}, utf8BOM...), payload...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name     string
+		endpoint string
+		args     []string
+		want     []byte
+	}{
+		{name: "ws", endpoint: "ws", args: []string{"--data-file", payloadPath}, want: payload},
+		{
+			name:     "core",
+			endpoint: "core",
+			args:     []string{"--method", "POST", "--path", "/api/test", "--body-file", payloadPath},
+			want:     append(append([]byte(`{"method":"POST","path":"/api/test","body":`), payload...), '}'),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, func() int {
+				return runRelayProxy(paths, tc.endpoint, tc.args)
+			})
+			if exitCode != 0 {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+			select {
+			case got := <-capture.bodies:
+				if !bytes.Equal(got, tc.want) {
+					t.Fatalf("request body changed:\n got %x\nwant %x", got, tc.want)
+				}
+			default:
+				t.Fatal("request body was not captured")
+			}
+		})
+	}
+}
+
+func TestRelayPreflightsJQFileAndSyntaxBeforeRequest(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	dir := t.TempDir()
+	payloadPath := filepath.Join(dir, "payload.json")
+	if err := os.WriteFile(payloadPath, []byte(`{"type":"ping"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	invalidUTF8Path := filepath.Join(dir, "invalid.jq")
+	if err := os.WriteFile(invalidUTF8Path, []byte{'.', 0xDC}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	invalidSyntaxPath := filepath.Join(dir, "syntax.jq")
+	if err := os.WriteFile(invalidSyntaxPath, []byte(`.[`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	emptyPath := filepath.Join(dir, "empty.jq")
+	if err := os.WriteFile(emptyPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	whitespacePath := filepath.Join(dir, "whitespace.jq")
+	if err := os.WriteFile(whitespacePath, []byte(" \r\n\t"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bomOnlyPath := filepath.Join(dir, "bom-only.jq")
+	if err := os.WriteFile(bomOnlyPath, append([]byte{}, utf8BOM...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, filterPath := range map[string]string{
+		"invalid UTF-8":  invalidUTF8Path,
+		"invalid syntax": invalidSyntaxPath,
+		"missing file":   filepath.Join(dir, "missing.jq"),
+		"empty":          emptyPath,
+		"whitespace":     whitespacePath,
+		"BOM only":       bomOnlyPath,
+	} {
+		t.Run(name, func(t *testing.T) {
+			before := capture.requests.Load()
+			exitCode, output := captureCommandOutput(t, func() int {
+				return runRelayProxy(paths, "ws", []string{"--data-file", payloadPath, "--jq-file", filterPath})
+			})
+			if exitCode != 1 || !strings.Contains(output, "nothing was sent") {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+			if got := capture.requests.Load(); got != before {
+				t.Fatalf("request count = %d, want %d", got, before)
+			}
+		})
+	}
+}
+
+func TestRunJQHandlesStrictUTF8OnCommandPaths(t *testing.T) {
+	dir := t.TempDir()
+	validInputPath := filepath.Join(dir, "valid.json")
+	validFilterPath := filepath.Join(dir, "valid.jq")
+	if err := os.WriteFile(validInputPath, append(append([]byte{}, utf8BOM...), []byte(`{"title":"Übersicht ☕"}`)...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(validFilterPath, append(append([]byte{}, utf8BOM...), []byte(`.title`)...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runJQ([]string{"-r", "--file", validInputPath, "--jq-file", validFilterPath})
+	})
+	if exitCode != 0 || output != "Übersicht ☕\n" {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+
+	invalidInputPath := filepath.Join(dir, "invalid.json")
+	invalidFilterPath := filepath.Join(dir, "invalid.jq")
+	if err := os.WriteFile(invalidInputPath, append([]byte(`{"title":"`), 0xDC), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(invalidFilterPath, []byte{'.', 0xDC}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for name, args := range map[string][]string{
+		"input file":  {"--file", invalidInputPath, "."},
+		"filter file": {"--file", validInputPath, "--jq-file", invalidFilterPath},
+	} {
+		t.Run(name, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, func() int { return runJQ(args) })
+			if exitCode != 1 || !strings.Contains(output, "not valid UTF-8") {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+		})
+	}
+}
+
+func TestRunJQRejectsInvalidUTF8FromStdin(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid := append(append([]byte(`{"title":"`), 0xDC), []byte(`bersicht"}`)...)
+	if _, err := writer.Write(invalid); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	originalStdin := os.Stdin
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+		_ = reader.Close()
+	})
+
+	exitCode, output := captureCommandOutput(t, func() int { return runJQ([]string{"."}) })
+	if exitCode != 1 || !strings.Contains(output, "jq stdin is not valid UTF-8") {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+}
+
+func TestSnapshotDiffAndJQRejectInvalidUTF8(t *testing.T) {
+	invalidObject := append(append([]byte(`{"title":"`), 0xDC), []byte(`bersicht"}`)...)
+	if _, err := configObjectFromBytes(invalidObject); err == nil || !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("config error = %v, want UTF-8 rejection", err)
+	}
+	if _, err := applyJQFilter(".", invalidObject, false); err == nil || !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("jq error = %v, want UTF-8 rejection", err)
+	}
+
+	paths := testSnapshotPaths(t)
+	invalidSnapshot := append(append([]byte(`{"op":"update","domain":"automation","target_id":"1","before_config":{"alias":"`), 0xDC), []byte(`"},"expected_after":{"alias":"ok"}}`)...)
+	if err := saveUndoSnapshotBytes(paths, invalidSnapshot); err == nil || !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("snapshot error = %v, want UTF-8 rejection", err)
+	}
+	if _, err := os.Stat(undoSnapshotStackPath(paths)); !os.IsNotExist(err) {
+		t.Fatalf("invalid snapshot must not be written: %v", err)
+	}
+}
+
+func TestStoredUndoSnapshotRejectsInvalidUTF8(t *testing.T) {
+	paths := testSnapshotPaths(t)
+	invalid := append(append([]byte(`{"schema_version":2,"snapshots":[{"op":"update","domain":"automation","target_id":"1","before_config":{"alias":"`), 0xDC), []byte(`"},"expected_after":{"alias":"ok"}}]}`)...)
+	if err := os.WriteFile(undoSnapshotStackPath(paths), invalid, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := loadUndoSnapshotStack(paths)
+	if err == nil || !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("error = %v, want corrupt UTF-8 rejection", err)
+	}
+}
+
+type strictInputRelayCapture struct {
+	requests atomic.Int32
+	bodies   chan []byte
+}
+
+func setupStrictInputRelay(t *testing.T) (runtimePaths, *strictInputRelayCapture) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".test-relay-token"))
+	t.Setenv("HA_NOVA_NO_UPDATE_NUDGE", "1")
+
+	capture := &strictInputRelayCapture{bodies: make(chan []byte, 8)}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capture.requests.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		capture.bodies <- body
+		w.Header().Set("content-type", "application/json")
+		_, _ = fmt.Fprint(w, `{"ok":true,"data":{}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths: %v", err)
+	}
+	if err := saveConfig(paths, runtimeConfig{
+		HAHost:       "127.0.0.1",
+		HAURL:        "http://127.0.0.1:8123",
+		RelayBaseURL: server.URL,
+	}); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+	if err := writeRelayAuthToken("test-token"); err != nil {
+		t.Fatalf("write relay token: %v", err)
+	}
+	return paths, capture
+}

--- a/cli/strict_utf8_ordering_test.go
+++ b/cli/strict_utf8_ordering_test.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRelayRejectsExplicitEmptyJQSelectionsBeforeRequest(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	payloadPath := filepath.Join(t.TempDir(), "payload.json")
+	if err := os.WriteFile(payloadPath, []byte(`{"type":"ping"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, arg := range []string{"--jq=", "--jq-file="} {
+		t.Run(arg, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, func() int {
+				return runRelayProxy(paths, "ws", []string{"--data-file", payloadPath, arg})
+			})
+			if exitCode != 1 || !strings.Contains(output, "nothing was sent") {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+			if got := capture.requests.Load(); got != 0 {
+				t.Fatalf("request count = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestRelayRejectsEmptyPayloadAndOutputSelectionsBeforeRequest(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	cases := map[string]struct {
+		endpoint string
+		args     []string
+	}{
+		"data":       {endpoint: "ws", args: []string{"--data="}},
+		"data file":  {endpoint: "ws", args: []string{"--data-file="}},
+		"body":       {endpoint: "core", args: []string{"--method", "POST", "--path", "/api/test", "--body="}},
+		"body file":  {endpoint: "core", args: []string{"--method", "POST", "--path", "/api/test", "--body-file="}},
+		"output":     {endpoint: "ws", args: []string{"--out="}},
+		"binary out": {endpoint: "core", args: []string{"--method", "GET", "--path", "/api/test", "--out-binary="}},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, func() int {
+				return runRelayProxy(paths, tc.endpoint, tc.args)
+			})
+			if exitCode != 1 || !strings.Contains(output, "nothing was sent") {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+			if got := capture.requests.Load(); got != 0 {
+				t.Fatalf("request count = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestRelayRejectsPositionalArgumentsBeforeRequest(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	cases := map[string]struct {
+		endpoint string
+		args     []string
+	}{
+		"ws": {endpoint: "ws", args: []string{"unexpected", "--data", `{"type":"ping"}`}},
+		"core": {
+			endpoint: "core",
+			args:     []string{"--method", "DELETE", "--path", "/api/test", "unexpected", "--body", `{}`},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, func() int {
+				return runRelayProxy(paths, tc.endpoint, tc.args)
+			})
+			if exitCode != 1 || !strings.Contains(output, "does not accept positional arguments") {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+			if got := capture.requests.Load(); got != 0 {
+				t.Fatalf("request count = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestRelayCoreEnvelopeUsesJSONEscaping(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	wantPath := "/api/control-\x01"
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "core", []string{"--method", "POST", "--path", wantPath})
+	})
+	if exitCode != 0 {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+	var body []byte
+	select {
+	case body = <-capture.bodies:
+	default:
+		t.Fatal("request body was not captured")
+	}
+	if !json.Valid(body) {
+		t.Fatalf("core envelope is not valid JSON: %q", body)
+	}
+	var envelope struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Path != wantPath {
+		t.Fatalf("path = %q, want %q", envelope.Path, wantPath)
+	}
+}
+
+func TestRelayCoreRejectsInvalidUTF8PathBeforeRequest(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	paths.ConfigFile = filepath.Join(t.TempDir(), "missing-config.json")
+	invalidPath := string([]byte{'/', 0xDC})
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "core", []string{"--method", "GET", "--path", invalidPath})
+	})
+	if exitCode != 1 || !strings.Contains(output, "core path is not valid UTF-8") || !strings.Contains(output, "nothing was sent") {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+	if got := capture.requests.Load(); got != 0 {
+		t.Fatalf("request count = %d, want 0", got)
+	}
+}
+
+func TestSnapshotAndJQRejectEmptyFileSelectors(t *testing.T) {
+	paths := testSnapshotPaths(t)
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runSnapshotSave(paths, []string{"--data-file="})
+	})
+	if exitCode != 1 || !strings.Contains(output, "non-empty path") {
+		t.Fatalf("snapshot exit/output = %d, %q", exitCode, output)
+	}
+
+	for name, tc := range map[string]struct {
+		args []string
+		want string
+	}{
+		"input":       {args: []string{"--file", "", "."}, want: "--file requires a non-empty path"},
+		"filter":      {args: []string{"--jq-file", ""}, want: "--jq-file requires a non-empty path"},
+		"positionals": {args: []string{".", "ignored"}, want: "Usage: relay jq"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, func() int { return runJQ(tc.args) })
+			if exitCode != 1 || !strings.Contains(output, tc.want) {
+				t.Fatalf("jq exit/output = %d, %q", exitCode, output)
+			}
+		})
+	}
+}
+
+func TestRelayInputPreflightWinsBeforeMissingCredential(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, "missing-token"))
+	t.Setenv("HA_NOVA_NO_UPDATE_NUDGE", "1")
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := saveConfig(paths, runtimeConfig{
+		HAHost:       "127.0.0.1",
+		HAURL:        "http://127.0.0.1:8123",
+		RelayBaseURL: "http://127.0.0.1:1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	invalidPayloadPath := filepath.Join(dir, "invalid.json")
+	validPayloadPath := filepath.Join(dir, "valid.json")
+	if err := os.WriteFile(invalidPayloadPath, append([]byte(`{"title":"`), 0xDC), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(validPayloadPath, []byte(`{"type":"ping"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := map[string]struct {
+		args []string
+		want string
+	}{
+		"payload": {args: []string{"--data-file", invalidPayloadPath}, want: "not valid UTF-8"},
+		"jq":      {args: []string{"--data-file", validPayloadPath, "--jq", ".["}, want: "jq parse error"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, func() int {
+				return runRelayProxy(paths, "ws", tc.args)
+			})
+			if exitCode != 1 || !strings.Contains(output, tc.want) || !strings.Contains(output, "nothing was sent") {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+		})
+	}
+}
+
+func TestRelayRuntimeJQFailureWarnsAgainstRetry(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	payloadPath := filepath.Join(t.TempDir(), "payload.json")
+	if err := os.WriteFile(payloadPath, []byte(`{"type":"ping"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "ws", []string{"--data-file", payloadPath, "--jq", `error("after-write")`})
+	})
+	if exitCode != 1 || !strings.Contains(output, "already sent") || !strings.Contains(output, "do not retry automatically") {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+	if got := capture.requests.Load(); got != 1 {
+		t.Fatalf("request count = %d, want 1", got)
+	}
+}
+
+func TestRelayOutputFailureWarnsAgainstRetry(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	dir := t.TempDir()
+	payloadPath := filepath.Join(dir, "payload.json")
+	blockedParent := filepath.Join(dir, "not-a-directory")
+	if err := os.WriteFile(payloadPath, []byte(`{"type":"ping"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(blockedParent, []byte("file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "ws", []string{
+			"--data-file", payloadPath,
+			"--out", filepath.Join(blockedParent, "response.json"),
+		})
+	})
+	if exitCode != 1 || !strings.Contains(output, "already sent") || !strings.Contains(output, "do not retry automatically") {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+	if got := capture.requests.Load(); got != 1 {
+		t.Fatalf("request count = %d, want 1", got)
+	}
+}
+
+func TestRelayUnknownOutcomeWarnsAgainstRetry(t *testing.T) {
+	paths, _ := setupStrictInputRelay(t)
+	var requests atomic.Int32
+	dropped := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		_, _ = io.Copy(io.Discard, request.Body)
+		connection, _, err := w.(http.Hijacker).Hijack()
+		if err == nil {
+			_ = connection.Close()
+		}
+	}))
+	t.Cleanup(dropped.Close)
+	cfg, err := loadConfig(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.RelayBaseURL = dropped.URL
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "ws", []string{"--data", `{"type":"config/area_registry/create","name":"Kitchen"}`})
+	})
+	if exitCode != 1 {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+	for _, want := range []string{"outcome is unknown", "may have reached the Relay", "do not retry automatically"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q: %s", want, output)
+		}
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("received requests = %d, want 1", got)
+	}
+}

--- a/cli/text_input.go
+++ b/cli/text_input.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"unicode/utf8"
+)
+
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// normalizeUTF8Bytes accepts one optional leading UTF-8 BOM and otherwise
+// preserves the input exactly. It never guesses or transcodes legacy code
+// pages: an ambiguous conversion would merely replace one silent corruption
+// path with another.
+func normalizeUTF8Bytes(data []byte, source string) ([]byte, error) {
+	normalized := bytes.TrimPrefix(data, utf8BOM)
+	if !utf8.Valid(normalized) {
+		return nil, fmt.Errorf("%s is not valid UTF-8", source)
+	}
+	return normalized, nil
+}
+
+func validateUTF8String(value string, source string) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%s is not valid UTF-8", source)
+	}
+	return nil
+}
+
+func strictJSONBytes(data []byte, source string) ([]byte, error) {
+	normalized, err := normalizeUTF8Bytes(data, source)
+	if err != nil {
+		return nil, err
+	}
+	if !json.Valid(normalized) {
+		return nil, fmt.Errorf("%s is not valid JSON", source)
+	}
+	return normalized, nil
+}
+
+func unmarshalStrictJSON(data []byte, source string, target any) error {
+	normalized, err := strictJSONBytes(data, source)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(normalized, target); err != nil {
+		return fmt.Errorf("cannot decode %s: %w", source, err)
+	}
+	return nil
+}

--- a/nova/src/http/errors.ts
+++ b/nova/src/http/errors.ts
@@ -17,6 +17,10 @@ export function invalidJson(): HttpError {
   return new HttpError(400, "INVALID_JSON", "Request body is not valid JSON");
 }
 
+export function invalidUtf8(): HttpError {
+  return new HttpError(400, "INVALID_UTF8", "Request body is not valid UTF-8");
+}
+
 export function invalidRequestUrl(): HttpError {
   return new HttpError(400, "INVALID_REQUEST_URL", "Request URL is not valid");
 }

--- a/nova/src/http/handlers/backups.ts
+++ b/nova/src/http/handlers/backups.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { gunzip, gzip } from "node:zlib";
 
+import { decodeUtf8Strict } from "../../shared/utf8.js";
 import { HttpError } from "../errors.js";
 import type { RouteContext, RouteHandler } from "../router.js";
 
@@ -322,7 +323,7 @@ async function loadSnapshot(
   let data: unknown;
   try {
     const raw = await gunzipAsync(compressed);
-    data = JSON.parse(raw.toString("utf8"));
+    data = JSON.parse(decodeUtf8Strict(raw));
   } catch {
     throw new HttpError(
       500,

--- a/nova/src/http/handlers/files-ops.ts
+++ b/nova/src/http/handlers/files-ops.ts
@@ -3,6 +3,7 @@ import type { Stats } from "node:fs";
 import { dirname, join, relative, sep } from "node:path";
 import { realpath } from "node:fs/promises";
 
+import { decodeUtf8Strict } from "../../shared/utf8.js";
 import { HttpError } from "../errors.js";
 import { assertWritableExtension, isNotFound, LOGICAL_PREFIX } from "./files-paths.js";
 
@@ -75,7 +76,7 @@ export async function readTextFile(absolute: string, logicalPath: string): Promi
   // the user's configuration. A fatal decoder refuses instead.
   let content: string;
   try {
-    content = new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+    content = decodeUtf8Strict(buffer);
   } catch {
     throw new HttpError(
       400,

--- a/nova/src/http/server.ts
+++ b/nova/src/http/server.ts
@@ -2,7 +2,8 @@ import { createServer, type IncomingMessage, type RequestListener, type Server, 
 
 import { authorizeRequest } from "../security/auth.js";
 import type { Principal } from "../security/principal.js";
-import { invalidJson, invalidRequestUrl, payloadTooLarge, toErrorResponse } from "./errors.js";
+import { decodeUtf8Strict } from "../shared/utf8.js";
+import { invalidJson, invalidRequestUrl, invalidUtf8, payloadTooLarge, toErrorResponse } from "./errors.js";
 import type { Router } from "./router.js";
 
 export const DEFAULT_MAX_JSON_BODY_BYTES = 1_048_576;
@@ -164,7 +165,7 @@ async function parseBody(request: IncomingMessage, policy: BodyPolicy): Promise<
     return null;
   }
   const rawBody = await readBody(request, policy.maxBytes);
-  if (!rawBody) {
+  if (rawBody === null) {
     return null;
   }
   if (policy.type === "form") {
@@ -190,7 +191,7 @@ function parseForm(request: IncomingMessage, rawBody: string): Record<string, st
   return out;
 }
 
-async function readBody(request: IncomingMessage, maxBytes: number): Promise<string> {
+async function readBody(request: IncomingMessage, maxBytes: number): Promise<string | null> {
   const chunks: Buffer[] = [];
   let totalBytes = 0;
   for await (const chunk of request) {
@@ -201,7 +202,14 @@ async function readBody(request: IncomingMessage, maxBytes: number): Promise<str
     }
     chunks.push(buffer);
   }
-  return Buffer.concat(chunks).toString("utf8");
+  if (totalBytes === 0) {
+    return null;
+  }
+  try {
+    return decodeUtf8Strict(Buffer.concat(chunks));
+  } catch {
+    throw invalidUtf8();
+  }
 }
 
 function writeJson(response: ServerResponse, status: number, payload: unknown): void {

--- a/nova/src/shared/utf8.ts
+++ b/nova/src/shared/utf8.ts
@@ -1,0 +1,6 @@
+// WHATWG TextDecoder accepts one optional leading UTF-8 BOM. `fatal` is the
+// important part: Buffer.toString("utf8") would silently replace malformed
+// bytes with U+FFFD and could turn a successful write into corrupted data.
+export function decodeUtf8Strict(data: Uint8Array): string {
+  return new TextDecoder("utf-8", { fatal: true }).decode(data);
+}

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -52,6 +52,7 @@ For agent-dispatched flows, use the CLI wrapper instead of raw curl:
 
 1. Write request JSON with the client's native file-writing tool.
    - POSIX heredocs are examples only; on Windows/PowerShell use the native file-writing equivalent while preserving the same JSON and jq file contents.
+   - Write JSON and jq files as UTF-8. One leading UTF-8 BOM is accepted. In Windows PowerShell 5.1, use `Set-Content -Encoding UTF8`: bare `Set-Content` uses the system's active ANSI code page and, on affected non-UTF-8 locales, can emit non-UTF-8 bytes, which are rejected before any Relay request is sent. `Out-File`/`>` emit UTF-16LE and are also rejected.
    - Write the final request body directly. Do not create placeholder payload templates such as `REPLACE_ENTITY_ID` and patch them later with `perl -0pi`, `sed -i`, or similar in-place rewrite commands.
 2. Use file-based relay flags as the default contract:
    - `ha-nova relay ws --data-file <payload-file>`
@@ -491,10 +492,13 @@ Trace response includes: `trace.trigger`, `trace.condition`, `trace.action` node
 
 Relay errors and upstream HA errors arrive differently. Agents must distinguish them.
 
+If the CLI says a request was already sent or its outcome is unknown, verify the target state and do not retry automatically.
+
 ### Relay Errors (HTTP-level)
 
 These are top-level HTTP errors produced by the relay itself. The response has `ok: false` and an HTTP status >= 400.
 
+- `400 / INVALID_UTF8`: request body bytes are not valid UTF-8
 - `400 / INVALID_JSON`: request body is not valid JSON
 - `400 / VALIDATION_ERROR`: missing required fields (e.g. ws `type`, core `method`/`path`)
 - `400 / CORE_PATH_INVALID`: core API path failed validation

--- a/tests/http/backups.test.ts
+++ b/tests/http/backups.test.ts
@@ -52,6 +52,19 @@ describe("backups handler", () => {
     expect(loaded.data).toEqual(data);
   });
 
+  it("rejects a stored snapshot with invalid UTF-8 instead of replacing bytes", async () => {
+    mkdirSync(join(root, "automations"), { recursive: true });
+    const file = "automations/broken-20260714T120000000Z.json.gz";
+    const invalid = Buffer.concat([
+      Buffer.from('{"title":"', "utf8"),
+      Buffer.from([0xdc]),
+      Buffer.from('bersicht"}', "utf8")
+    ]);
+    writeFileSync(join(root, file), gzipSync(invalid));
+
+    await expectHttpError(call({ action: "load", file }), 500, "SNAPSHOT_CORRUPT");
+  });
+
   it("lists snapshots newest first, optionally by category", async () => {
     await call({ action: "save", category: "automations", name: "auto-one", data: 1 });
     clockMs += 1000;

--- a/tests/http/server-limits.test.ts
+++ b/tests/http/server-limits.test.ts
@@ -83,6 +83,89 @@ describe("http server limits and logging", () => {
     expect(payload.error.code).toBe("PAYLOAD_TOO_LARGE");
   });
 
+  it("rejects invalid UTF-8 before JSON parsing or route dispatch", async () => {
+    let dispatches = 0;
+    const baseUrl = await start({
+      handler: ({ body }) => {
+        dispatches += 1;
+        return body;
+      }
+    });
+    const body = Buffer.concat([
+      Buffer.from('{"title":"', "utf8"),
+      Buffer.from([0xdc]),
+      Buffer.from('bersicht"}', "utf8")
+    ]);
+
+    const response = await fetch(`${baseUrl}/echo`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+        "content-type": "application/json"
+      },
+      body
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "INVALID_UTF8" }
+    });
+    expect(dispatches).toBe(0);
+  });
+
+  it("accepts one UTF-8 BOM and preserves legitimate replacement characters", async () => {
+    const baseUrl = await start({});
+    const title = "Übersicht ☕ \uFFFD \uFEFF";
+    const body = Buffer.concat([
+      Buffer.from([0xef, 0xbb, 0xbf]),
+      Buffer.from(JSON.stringify({ title }), "utf8")
+    ]);
+
+    const response = await fetch(`${baseUrl}/echo`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+        "content-type": "application/json"
+      },
+      body
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, data: { title } });
+  });
+
+  it("distinguishes a genuinely empty body from a BOM-only JSON body", async () => {
+    let dispatches = 0;
+    const baseUrl = await start({
+      handler: ({ body }) => {
+        dispatches += 1;
+        return body;
+      }
+    });
+    const headers = {
+      authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+      "content-type": "application/json"
+    };
+
+    const empty = await fetch(`${baseUrl}/echo`, { method: "POST", headers });
+    expect(empty.status).toBe(200);
+    await expect(empty.json()).resolves.toEqual({ ok: true, data: null });
+    expect(dispatches).toBe(1);
+
+    const bomOnly = await fetch(`${baseUrl}/echo`, {
+      method: "POST",
+      headers,
+      body: Buffer.from([0xef, 0xbb, 0xbf])
+    });
+    expect(bomOnly.status).toBe(400);
+    await expect(bomOnly.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "INVALID_JSON" }
+    });
+    expect(dispatches).toBe(1);
+  });
+
   it("logs rejected 401s with method, path, and remote", async () => {
     const logged: LoggedLine[] = [];
     const baseUrl = await start({ logged });

--- a/tests/onboarding/relay-cli-contract.test.ts
+++ b/tests/onboarding/relay-cli-contract.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 
 import { describe, expect, it } from "vitest";
@@ -13,6 +13,13 @@ describe("relay cli contract", () => {
     expect(existsSync("cli/config.go")).toBe(true);
     expect(existsSync("cli/jq.go")).toBe(true);
     expect(existsSync("cli/version.go")).toBe(true);
+  });
+
+  it("documents strict UTF-8 input and its Relay error code", () => {
+    const contract = readFileSync("skills/ha-nova/relay-api.md", "utf8");
+    expect(contract).toContain("One leading UTF-8 BOM is accepted");
+    expect(contract).toContain("400 / INVALID_UTF8");
+    expect(contract).toContain("do not retry automatically");
   });
 
   it("guides the user to setup when JSON config is missing", () => {


### PR DESCRIPTION
## Summary

- Reject invalid UTF-8, UTF-16, malformed JSON, and ambiguous empty selectors before config, credential, snapshot, or network access.
- Accept exactly one leading UTF-8 BOM without transcoding; preserve legitimate U+FFFD and internal U+FEFF.
- Use fatal UTF-8 decoding at the Relay HTTP boundary and return `400 / INVALID_UTF8` before route dispatch.
- Precompile jq filters before requests, build Core envelopes with real JSON escaping, and warn against automatic retries whenever a request may already have succeeded.
- Preflight pairing server, URL, and code before credential-backend migration.

## Root cause

Windows PowerShell 5.1 bare `Set-Content` can write JSON in the system active ANSI code page. The older CLI forwarded those raw bytes; the Relay then decoded them non-fatally and replaced malformed sequences with U+FFFD before a successful Home Assistant write.

## Verification

- `npm run verify` — security, typecheck, docs, 830 Core tests, 114 onboarding tests, full Go suite, build, and 43 release-contract tests
- pre-push gate — 1,036 safe tests, typecheck, build, docs fact-check
- three independent adversarial reviews — clean on final SHA
- deterministic regressions for `0xDC`, UTF-16LE, BOM-only/double-BOM, selector fallback, credential migration ordering, and a real dropped connection after one received mutating request

## Release note

Go and onboarding paths changed. The release train must run the documented RC and disposable-HA gates on the exact release commit.