### PR TITLE
chore(deps): update ws to 8.21.1 atomically

### DIFF
--- a/nova/package-lock.json
+++ b/nova/package-lock.json
@@ -10,7 +10,7 @@
         "@serenity-kit/opaque": "^1.1.0",
         "home-assistant-js-websocket": "^9.6.0",
         "reflect-metadata": "^0.2.2",
-        "ws": "^8.21.0"
+        "ws": "^8.21.1"
       },
       "devDependencies": {
         "@types/node": "^25.9.5",
@@ -654,9 +654,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/nova/package.json
+++ b/nova/package.json
@@ -10,7 +10,7 @@
     "@serenity-kit/opaque": "^1.1.0",
     "home-assistant-js-websocket": "^9.6.0",
     "reflect-metadata": "^0.2.2",
-    "ws": "^8.21.0"
+    "ws": "^8.21.1"
   },
   "devDependencies": {
     "@types/node": "^25.9.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@serenity-kit/opaque": "^1.1.0",
         "home-assistant-js-websocket": "^9.6.0",
         "reflect-metadata": "^0.2.2",
-        "ws": "^8.21.0",
+        "ws": "^8.21.1",
         "yaml": "^2.9.0"
       },
       "devDependencies": {
@@ -2429,9 +2429,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@serenity-kit/opaque": "^1.1.0",
     "home-assistant-js-websocket": "^9.6.0",
     "reflect-metadata": "^0.2.2",
-    "ws": "^8.21.0",
+    "ws": "^8.21.1",
     "yaml": "^2.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- update `ws` from 8.21.0 to 8.21.1 in the root test/runtime tree and shipped NOVA Relay tree
- keep both manifests and lockfiles on one reviewed version; supersedes #377 and #380
- take upstream fragment-accounting fixes and lower defensive fragment/chunk ceilings

## Runtime review

- `nova/src/ha/socket.ts` is the only direct production import
- Relay already disables per-message compression and sets an explicit 256 MiB payload ceiling
- no API, engine, peer-dependency, or call-site changes
- deliberately fragmented messages above the new 16,384-fragment default would now be rejected; normal Home Assistant traffic is unaffected

## Verification

- `npm ci --ignore-scripts` in root and `nova/`: 0 vulnerabilities
- exact `ws@8.21.1` resolution verified in both dependency trees
- targeted socket, runtime-parity, framing, protocol, and security tests: green
- `npm run verify`: green
- three independent adversarial diff reviews: clean