### PR TITLE
chore: prepare 0.21.1 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.21.0"
+    "version": "0.21.1"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,20 +82,16 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## New Features
 
-    - **Optional public census, off until you opt in.** The client records one ID-free attempt per ISO week before sending the HA NOVA version, operating system, and a recently observed Relay version when available; with local state intact, it does not attempt again that week. Totals are directional, not verified unique installs. Change anytime: `ha-nova census on|off`.
-
-    Details: [census payload and controls](https://github.com/markusleben/ha-nova/blob/{{ .Tag }}/docs/reference/census.md) · [privacy](https://github.com/markusleben/ha-nova/blob/{{ .Tag }}/PRIVACY.md)
+    - **Relay App updates now surface with the first Home Assistant task.** For a registry-proven NOVA Relay App, the notice can open the existing guided update path with a partial backup, confirmation, a last-second state/provenance recheck, latest-at-execution installation, and Relay-version verification. Container/Core installs keep their separate image-pull guidance.
 
     ## What To Watch
 
-    - **Update the Relay App after HA NOVA.** Run `ha-nova update`, then update NOVA Relay under **Settings > Apps**. Container/Core users must pull and recreate the Relay container. Start a new AI session afterward.
-
-    Relay 0.7.1 ships strict UTF-8 handling plus TLS-certificate and WebSocket dependency hardening.
+    - **Start a new AI session after updating.** This loads the refreshed skills and enables the restored first-task update check.
 
     ## Bug Fixes
 
-    - **Legacy-token upgrades no longer loop.** `doctor` and the already-configured setup screen now lead to the pairing command that actually performs the switch, and `server list` labels working legacy access honestly.
-    - **Unicode input fails safely instead of being corrupted.** Valid UTF-8 names and paths, including umlauts, remain unchanged. Invalid UTF-8/UTF-16 and ambiguous selectors fail before config, credentials, or network access.
+    - **Available updates are visible again on the first Home Assistant task.** Independently loaded skills now run the bounded update check instead of depending on a later background cache refresh.
+    - **Supported v0.20+ copied client installs repair their missing session bootstrap.** Managed current Codex, OpenCode, Antigravity, and Hermes layouts recover the update and census notice path. Older, foreign, or unreadable layouts still fail closed and require `ha-nova setup`.
 
     Stable install commands are release-pinned for this tag.
 

--- a/docs/archive/work/0.21.0-release-body.md
+++ b/docs/archive/work/0.21.0-release-body.md
@@ -5,7 +5,7 @@
 
 ## New Features
 
-- **Optional public census, off until you opt in.** The client records one ID-free attempt per ISO week before sending the HA NOVA version, operating system, and a recently observed Relay version when available; with local state intact, it does not attempt again that week. Totals are directional, not verified unique installs. Change anytime: `ha-nova census on|off`. ([details](../reference/census.md), [privacy](../../PRIVACY.md), #417, #418)
+- **Optional public census, off until you opt in.** The client records one ID-free attempt per ISO week before sending the HA NOVA version, operating system, and a recently observed Relay version when available; with local state intact, it does not attempt again that week. Totals are directional, not verified unique installs. Change anytime: `ha-nova census on|off`. ([details](../../reference/census.md), [privacy](../../../PRIVACY.md), #417, #418)
 
 ## What To Watch
 

--- a/docs/work/0.21.1-release-body.md
+++ b/docs/work/0.21.1-release-body.md
@@ -1,0 +1,17 @@
+# 0.21.1 Release Body
+
+> Bullet order expresses importance. Only the first action item plus the first
+> two feature/fix items feed the compact update notice.
+
+## New Features
+
+- **Relay App updates now surface with the first Home Assistant task.** For a registry-proven NOVA Relay App, the notice can open the existing guided update path with a partial backup, confirmation, a last-second state/provenance recheck, latest-at-execution installation, and Relay-version verification. Container/Core installs keep their separate image-pull guidance.
+
+## What To Watch
+
+- **Start a new AI session after updating.** This loads the refreshed skills and enables the restored first-task update check.
+
+## Bug Fixes
+
+- **Available updates are visible again on the first Home Assistant task.** Independently loaded skills now run the bounded update check instead of depending on a later background cache refresh. (#427)
+- **Supported v0.20+ copied client installs repair their missing session bootstrap.** Managed current Codex, OpenCode, Antigravity, and Hermes layouts recover the update and census notice path. Older, foreign, or unreadable layouts still fail closed and require `ha-nova setup`. (#427)

--- a/docs/work/2026-07-23-release-0.21.1-spec.md
+++ b/docs/work/2026-07-23-release-0.21.1-spec.md
@@ -1,0 +1,39 @@
+# HA NOVA 0.21.1 Release Spec
+
+Status: active
+Date: 2026-07-23
+
+## Purpose
+
+Ship the first-use update discovery fix already reviewed and merged in #427.
+The update check must run before the first Home Assistant task and surface
+available HA NOVA and NOVA Relay notices with that task's result instead of
+depending on a later cache refresh.
+
+## Scope
+
+- Bump the HA NOVA skill/client version from 0.21.0 to 0.21.1.
+- Keep the minimum Relay version at 0.7.1; no Relay App source changed.
+- Publish concise user-facing notes for restored first-use update notices,
+  safer routing into the existing guided Relay App updater, and scoped
+  copied-client self-repair.
+- Do not change README claims, Relay App version, census deployment, or release
+  machinery.
+
+## Release Gate
+
+- Release-prep PR with the full SHA-specific review and merge checklist.
+- RC required because the shipped delta includes Go code and update/onboarding
+  behavior.
+- Strict release-pipeline audit and dispatched disposable-HA E2E on the exact
+  reviewed merge commit.
+- Green RC publish and public installer verification before the final tag.
+- Green final publish and public stable installer verification.
+
+## Acceptance
+
+- All version-bearing client/plugin manifests report 0.21.1.
+- `version.json` and `nova/version.json` still require Relay 0.7.1.
+- Release notes match the behavior merged in #427 and contain no stale 0.21.0
+  census or UTF-8 claims.
+- No open PR is an immediate release blocker.

--- a/nova/version.json
+++ b/nova/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.21.0",
+  "skill_version": "0.21.1",
   "min_relay_version": "0.7.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",
@@ -82,7 +82,7 @@
     "preverify:onboarding": "node scripts/test/assert-vitest-files-exist.mjs verify:onboarding",
     "verify:onboarding": "npm run verify:installers && npx vitest run tests/onboarding/install-skills-per-client.test.ts tests/onboarding/dev-sync-contract.test.ts tests/onboarding/dev-sync-behavior.test.ts tests/onboarding/claude-plugin-state-helper.test.ts tests/onboarding/installer-contract.test.ts tests/onboarding/relay-cli-contract.test.ts tests/onboarding/self-update-contract.test.ts tests/onboarding/platform-dispatch.test.ts tests/onboarding/linux-keyring-contract.test.ts tests/onboarding/macos-keyring-contract.test.ts tests/onboarding/windows-keyring-interop-contract.test.ts tests/onboarding/legacy-cleanup-contract.test.ts tests/onboarding/onboarding-skill-contract.test.ts tests/onboarding/go-runtime-contract.test.ts tests/onboarding/safe-test-system-contract.test.ts tests/onboarding/bump-version.test.ts",
     "preverify:release-contracts": "node scripts/test/assert-vitest-files-exist.mjs verify:release-contracts",
-    "verify:release-contracts": "npm run verify:release-metadata && npx vitest run tests/onboarding/release-contract.test.ts tests/onboarding/release-gates-behavior.test.ts tests/onboarding/desktop-validation-contract.test.ts tests/onboarding/desktop-validation-behavior.test.ts tests/onboarding/dependabot-automation-contract.test.ts",
+    "verify:release-contracts": "npm run verify:release-metadata && npx vitest run tests/onboarding/release-contract.test.ts tests/onboarding/release-notes-contract.test.ts tests/onboarding/release-gates-behavior.test.ts tests/onboarding/desktop-validation-contract.test.ts tests/onboarding/desktop-validation-behavior.test.ts tests/onboarding/dependabot-automation-contract.test.ts",
     "typecheck": "tsc --noEmit && tsc -p census-worker/tsconfig.json --noEmit",
     "update:ha-reference": "node scripts/update-ha-template-reference.mjs",
     "verify:release-metadata": "bash scripts/release/verify-release-metadata.sh",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -28,18 +28,6 @@ describe("release contract", () => {
     scripts?: Record<string, string>;
   };
 
-  it("keeps release notes aligned to the single supported Windows install path", () => {
-    expect(goreleaser).toContain("Stable install commands are release-pinned for this tag.");
-    expect(goreleaser).toContain("https://raw.githubusercontent.com/markusleben/ha-nova/{{ .Tag }}/install.sh");
-    expect(goreleaser).toContain("HA_NOVA_VERSION={{ .Tag }}");
-    expect(goreleaser).toContain("https://raw.githubusercontent.com/markusleben/ha-nova/{{ .Tag }}/install.ps1");
-    expect(goreleaser).toContain("Windows uses a single supported install path: `install.ps1`.");
-    expect(goreleaser).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.sh");
-    expect(goreleaser).not.toContain("raw.githubusercontent.com/markusleben/ha-nova/main/install.ps1");
-    expect(goreleaser).not.toContain("$ProgressPreference = 'SilentlyContinue'");
-    expect(goreleaser).not.toContain("winget");
-  });
-
   it("keeps local RC packaging focused on install bundles only", () => {
     expect(pkg.scripts?.["release:rc:local"]).toBe(
       "goreleaser build --snapshot --clean && bash scripts/release/build-install-bundle.sh"
@@ -68,23 +56,6 @@ describe("release contract", () => {
     expect(releaseWorkflow).not.toContain("release-winget-manifests");
     expect(releaseWorkflow).not.toContain("winget validate");
     expect(releaseWorkflow).not.toContain("dist/winget");
-  });
-
-  it("keeps v0.21.0 release-facing wording user-centric and census-honest", () => {
-    // Shipped release-note bodies are archived (docs/archive/work/) and
-    // non-normative per documentation governance; only the active GoReleaser
-    // template is contract-checked here.
-    expect(goreleaser).toContain("Optional public census, off until you opt in");
-    expect(goreleaser).toContain("directional, not verified unique installs");
-    expect(goreleaser).toContain("Update the Relay App after HA NOVA");
-    expect(goreleaser).toContain("Legacy-token upgrades no longer loop");
-    expect(goreleaser).toContain("Valid UTF-8 names and paths, including umlauts, remain unchanged");
-    expect(goreleaser).toContain("Relay 0.7.1 ships strict UTF-8 handling");
-    expect(goreleaser).not.toContain("monthly_lower_bound");
-    expect(goreleaser).not.toContain("no App update needed");
-    expect(readme).toContain("Census off by default");
-    expect(readme).toContain("public aggregate ping counts");
-    expect(readme).toContain("not verified unique installs");
   });
 
   it("keeps README install commands visible and versionless", () => {

--- a/tests/onboarding/release-notes-contract.test.ts
+++ b/tests/onboarding/release-notes-contract.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+describe("release notes contract", () => {
+  const goreleaser = readFileSync(".goreleaser.yml", "utf8");
+  const readme = readFileSync("README.md", "utf8");
+
+  it("keeps release notes aligned to the single supported Windows install path", () => {
+    expect(goreleaser).toContain(
+      "Stable install commands are release-pinned for this tag.",
+    );
+    expect(goreleaser).toContain(
+      "https://raw.githubusercontent.com/markusleben/ha-nova/{{ .Tag }}/install.sh",
+    );
+    expect(goreleaser).toContain("HA_NOVA_VERSION={{ .Tag }}");
+    expect(goreleaser).toContain(
+      "https://raw.githubusercontent.com/markusleben/ha-nova/{{ .Tag }}/install.ps1",
+    );
+    expect(goreleaser).toContain(
+      "Windows uses a single supported install path: `install.ps1`.",
+    );
+    expect(goreleaser).not.toContain(
+      "raw.githubusercontent.com/markusleben/ha-nova/main/install.sh",
+    );
+    expect(goreleaser).not.toContain(
+      "raw.githubusercontent.com/markusleben/ha-nova/main/install.ps1",
+    );
+    expect(goreleaser).not.toContain(
+      "$ProgressPreference = 'SilentlyContinue'",
+    );
+    expect(goreleaser).not.toContain("winget");
+  });
+
+  it("keeps v0.21.1 release-facing wording aligned to first-task update discovery", () => {
+    expect(goreleaser).toContain(
+      "Relay App updates now surface with the first Home Assistant task",
+    );
+    expect(goreleaser).toContain("registry-proven NOVA Relay App");
+    expect(goreleaser).toContain("last-second state/provenance recheck");
+    expect(goreleaser).toContain("latest-at-execution installation");
+    expect(goreleaser).toContain("Start a new AI session after updating");
+    expect(goreleaser).toContain(
+      "Available updates are visible again on the first Home Assistant task",
+    );
+    expect(goreleaser).toContain("Supported v0.20+ copied client installs");
+    expect(goreleaser).toContain(
+      "Older, foreign, or unreadable layouts still fail closed",
+    );
+    expect(goreleaser).not.toContain(
+      "Optional public census, off until you opt in",
+    );
+    expect(readme).toContain("Census off by default");
+    expect(readme).toContain("public aggregate ping counts");
+    expect(readme).toContain("not verified unique installs");
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "skill_version": "0.21.0",
+  "skill_version": "0.21.1",
   "min_relay_version": "0.7.1"
 }


### PR DESCRIPTION
## Summary
- bump HA NOVA client and plugin metadata to 0.21.1
- publish concise notes for restored first-task update discovery and guided Relay App update routing
- archive the 0.21.0 release draft and add focused release-note contracts

## Verification
- `npm run verify`
- `npm run verify:docs`
- `npm run verify:release-contracts`
- `npm run verify:next-release-version -- v0.21.1`
- two independent adversarial release-prep reviews

## Release plan
RC required: reviewed merge SHA → strict pipeline audit + dispatched disposable-HA E2E → v0.21.1-rc1 → public platform verification → v0.21.1.