### PR TITLE
fix: preserve Unicode through Relay files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,3 +123,100 @@ jobs:
           GOOS=windows GOARCH=amd64 go build -o /dev/null .
           GOOS=linux GOARCH=amd64 go build -o /dev/null .
           GOOS=linux GOARCH=arm64 go build -o /dev/null .
+
+  windows-powershell-unicode:
+    name: windows-powershell-unicode
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.26"
+          cache-dependency-path: cli/go.sum
+
+      - name: Verify PowerShell 5.1 UTF-8 round trip
+        shell: powershell
+        run: |
+          if ($PSVersionTable.PSVersion.Major -ne 5) {
+            throw "Windows PowerShell 5.1 required, got $($PSVersionTable.PSVersion)"
+          }
+
+          $expected = "Grüße – Öl & Überschuss · café · 東京 · 😀"
+          $document = [pscustomobject]@{ title = $expected }
+          $json = $document | ConvertTo-Json -Depth 100
+          $utf8NoBom = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+          $strictUtf8 = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false, $true
+          $expectedHex = "47-72-C3-BC-C3-9F-65-20-E2-80-93-20-C3-96-6C-20-26-20-C3-9C-62-65-72-73-63-68-75-73-73-20-C2-B7-20-63-61-66-C3-A9-20-C2-B7-20-E6-9D-B1-E4-BA-AC-20-C2-B7-20-F0-9F-98-80"
+
+          function Read-StrictUtf8([string]$Path) {
+            $inputBytes = [System.IO.File]::ReadAllBytes($Path)
+            $offset = 0
+            if ($inputBytes.Length -ge 3 -and $inputBytes[0] -eq 0xEF -and $inputBytes[1] -eq 0xBB -and $inputBytes[2] -eq 0xBF) {
+              $offset = 3
+            }
+            if ($inputBytes.Length -ge ($offset + 3) -and $inputBytes[$offset] -eq 0xEF -and $inputBytes[$offset + 1] -eq 0xBB -and $inputBytes[$offset + 2] -eq 0xBF) {
+              throw "More than one leading UTF-8 BOM is unsupported"
+            }
+            return $strictUtf8.GetString($inputBytes, $offset, $inputBytes.Length - $offset)
+          }
+
+          if ([System.BitConverter]::ToString($utf8NoBom.GetBytes($expected)) -cne $expectedHex) {
+            throw "Workflow source changed the expected Unicode code points"
+          }
+          [System.IO.File]::WriteAllText("$PWD\payload.json", $json, $utf8NoBom)
+
+          $bytes = [System.IO.File]::ReadAllBytes("$PWD\payload.json")
+          if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+            throw "payload.json unexpectedly contains a UTF-8 BOM"
+          }
+
+          $roundTrip = Read-StrictUtf8 "$PWD\payload.json" | ConvertFrom-Json
+          if ($roundTrip.title -cne $expected) {
+            throw "PowerShell 5.1 changed Unicode code points"
+          }
+
+          [byte[]]$utf8Bom = 0xEF, 0xBB, 0xBF
+          [System.IO.File]::WriteAllBytes("$PWD\payload-bom.json", [byte[]]($utf8Bom + $bytes))
+          $bomRoundTrip = Read-StrictUtf8 "$PWD\payload-bom.json" | ConvertFrom-Json
+          if ($bomRoundTrip.title -cne $expected) {
+            throw "PowerShell 5.1 changed Unicode code points after one UTF-8 BOM"
+          }
+
+          [System.IO.File]::WriteAllBytes("$PWD\payload-double-bom.json", [byte[]]($utf8Bom + $utf8Bom + $bytes))
+          $doubleBomRejected = $false
+          try {
+            $null = Read-StrictUtf8 "$PWD\payload-double-bom.json"
+          } catch {
+            $doubleBomRejected = $true
+          }
+          if (-not $doubleBomRejected) {
+            throw "Strict UTF-8 reader accepted more than one leading UTF-8 BOM"
+          }
+
+          [System.IO.File]::WriteAllText("$PWD\utf16le.json", $json, [System.Text.Encoding]::Unicode)
+          [System.IO.File]::WriteAllText("$PWD\utf16be.json", $json, [System.Text.Encoding]::BigEndianUnicode)
+          foreach ($unsupported in @("$PWD\utf16le.json", "$PWD\utf16be.json")) {
+            $rejected = $false
+            try {
+              $null = Read-StrictUtf8 $unsupported
+            } catch {
+              $rejected = $true
+            }
+            if (-not $rejected) {
+              throw "Strict UTF-8 reader accepted $unsupported"
+            }
+          }
+
+          Set-Location cli
+          go build -o ha-nova.exe .
+          [Console]::OutputEncoding = $utf8NoBom
+          $OutputEncoding = $utf8NoBom
+          $cliValue = & .\ha-nova.exe relay jq -r --file ..\payload.json '.title'
+          $cliHex = [System.BitConverter]::ToString($utf8NoBom.GetBytes([string]$cliValue))
+          if ($LASTEXITCODE -ne 0 -or $cliValue -cne $expected -or $cliHex -cne $expectedHex) {
+            throw "ha-nova.exe changed Unicode code points"
+          }
+          go test . -run 'Test(RelayUnicodeRoundTrip|RelayRejectsUTF16|RelayRejectsBOMLessUTF16JQ|RelayRejectsTwoResponseBOMs|RelayHealthResponseUsesStrictUTF8Boundary)' -count=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,12 +144,15 @@ jobs:
             throw "Windows PowerShell 5.1 required, got $($PSVersionTable.PSVersion)"
           }
 
-          $expected = "Grüße – Öl & Überschuss · café · 東京 · 😀"
-          $document = [pscustomobject]@{ title = $expected }
-          $json = $document | ConvertTo-Json -Depth 100
           $utf8NoBom = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
           $strictUtf8 = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false, $true
           $expectedHex = "47-72-C3-BC-C3-9F-65-20-E2-80-93-20-C3-96-6C-20-26-20-C3-9C-62-65-72-73-63-68-75-73-73-20-C2-B7-20-63-61-66-C3-A9-20-C2-B7-20-E6-9D-B1-E4-BA-AC-20-C2-B7-20-F0-9F-98-80"
+          [byte[]]$expectedBytes = $expectedHex.Split("-") | ForEach-Object {
+            [System.Convert]::ToByte($_, 16)
+          }
+          $expected = $strictUtf8.GetString($expectedBytes)
+          $document = [pscustomobject]@{ title = $expected }
+          $json = $document | ConvertTo-Json -Depth 100
 
           function Read-StrictUtf8([string]$Path) {
             $inputBytes = [System.IO.File]::ReadAllBytes($Path)
@@ -164,7 +167,7 @@ jobs:
           }
 
           if ([System.BitConverter]::ToString($utf8NoBom.GetBytes($expected)) -cne $expectedHex) {
-            throw "Workflow source changed the expected Unicode code points"
+            throw "UTF-8 test vector did not round-trip"
           }
           [System.IO.File]::WriteAllText("$PWD\payload.json", $json, $utf8NoBom)
 

--- a/cli/relay.go
+++ b/cli/relay.go
@@ -199,7 +199,7 @@ func loadRelayPayload(opts relayRequestOptions) ([]byte, error) {
 		source := fmt.Sprintf("JSON payload file %q", opts.JSONFile)
 		data, err = normalizeUTF8Bytes(data, source)
 		if err != nil {
-			return nil, fmt.Errorf("%w; nothing was sent. Windows PowerShell 5.1: recreate the file with Set-Content -Encoding UTF8 (a leading UTF-8 BOM is accepted; Out-File and > default to UTF-16LE)", err)
+			return nil, relayTextFileEncodingError(err)
 		}
 		if !json.Valid(data) {
 			return nil, fmt.Errorf("%s is not valid JSON; nothing was sent", source)
@@ -278,7 +278,7 @@ func loadJQFilter(opts relayRequestOptions) (string, error) {
 		}
 		data, err = normalizeUTF8Bytes(data, fmt.Sprintf("jq filter file %q", opts.JQFile))
 		if err != nil {
-			return "", fmt.Errorf("%w; nothing was sent", err)
+			return "", relayTextFileEncodingError(err)
 		}
 		filter := strings.TrimSpace(string(data))
 		if filter == "" {
@@ -381,6 +381,11 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 		printRelayPostRequestError("reading the Relay response", err)
 		return 1
 	}
+	bodyBytes, err = normalizeUTF8Bytes(bodyBytes, "Relay response")
+	if err != nil {
+		printRelayPostRequestError("validating the Relay response", err)
+		return 1
+	}
 	taskSucceeded := relayEnvelopeOK(bodyBytes)
 	upstreamExitStatus := 0
 	if endpoint == "core" {
@@ -403,11 +408,7 @@ func runRelayProxy(paths runtimePaths, endpoint string, args []string) int {
 			return 1
 		}
 	} else if opts.OutputFile != "" {
-		if err := os.MkdirAll(filepath.Dir(opts.OutputFile), 0o755); err != nil {
-			printRelayPostRequestError("creating the --out directory", err)
-			return 1
-		}
-		if err := os.WriteFile(opts.OutputFile, bodyBytes, 0o644); err != nil {
+		if err := writeRelayTextOutput(opts.OutputFile, bodyBytes); err != nil {
 			printRelayPostRequestError("writing --out", err)
 			return 1
 		}
@@ -624,6 +625,15 @@ func runHealth(paths runtimePaths, args []string) int {
 
 	bodyBytes, err := readAllLimited(resp.Body, maxRelayResponseBytes)
 	if err != nil || len(bodyBytes) == 0 {
+		printErr("relay health check failed")
+		return 1
+	}
+	bodyBytes, err = normalizeUTF8Bytes(bodyBytes, "Relay health response")
+	if err != nil {
+		printRelayPostRequestError("validating the Relay health response", err)
+		return 1
+	}
+	if len(bodyBytes) == 0 {
 		printErr("relay health check failed")
 		return 1
 	}

--- a/cli/relay_binary_unicode_test.go
+++ b/cli/relay_binary_unicode_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRelayBinaryOutputValidatesEnvelopeBeforeWriting(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	outputPath := filepath.Join(t.TempDir(), "image.bin")
+	capture.response = func([]byte) []byte {
+		return append([]byte(`{"ok":true,"data":"`), 0xDC)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "core", []string{
+			"--method", "GET",
+			"--path", "/api/camera_proxy/camera.test",
+			"--out-binary", outputPath,
+		})
+	})
+	if exitCode != 1 || !strings.Contains(output, "not valid UTF-8") {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("invalid response must not create binary output: %v", err)
+	}
+}
+
+func TestRelayBinaryOutputPreservesDecodedArbitraryBytes(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	want := []byte{0x00, 0xFF, 0xDC, 0x80, 0x7F}
+	capture.response = func([]byte) []byte {
+		return []byte(fmt.Sprintf(
+			`{"ok":true,"data":{"status":200,"body":%q,"body_encoding":"base64","content_type":"application/octet-stream"}}`,
+			base64.StdEncoding.EncodeToString(want),
+		))
+	}
+	outputPath := filepath.Join(t.TempDir(), "payload.bin")
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "core", []string{
+			"--method", "GET",
+			"--path", "/api/camera_proxy/camera.test",
+			"--out-binary", outputPath,
+		})
+	})
+	if exitCode != 0 {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+	got, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("binary bytes changed:\n got %x\nwant %x", got, want)
+	}
+}

--- a/cli/relay_unicode_roundtrip_test.go
+++ b/cli/relay_unicode_roundtrip_test.go
@@ -1,0 +1,345 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf16"
+)
+
+func TestRelayRejectsUTF16WithAndWithoutBOMBeforeRequest(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	dir := t.TempDir()
+	jsonText := `{"type":"ping","title":"Ж"}`
+
+	cases := map[string]struct {
+		input []byte
+		want  string
+	}{
+		"UTF-16LE BOM": {
+			input: encodeUTF16(jsonText, binary.LittleEndian, true),
+			want:  "detected UTF-16LE",
+		},
+		"UTF-16BE BOM": {
+			input: encodeUTF16(jsonText, binary.BigEndian, true),
+			want:  "detected UTF-16BE",
+		},
+		"UTF-16LE no BOM": {
+			input: encodeUTF16(jsonText, binary.LittleEndian, false),
+			want:  "detected BOM-less UTF-16LE",
+		},
+		"UTF-16BE no BOM": {
+			input: encodeUTF16(jsonText, binary.BigEndian, false),
+			want:  "detected BOM-less UTF-16BE",
+		},
+		"UTF-32LE no BOM": {
+			input: encodeUTF32(jsonText, binary.LittleEndian, false),
+			want:  "detected BOM-less UTF-32LE",
+		},
+		"UTF-32BE no BOM": {
+			input: encodeUTF32(jsonText, binary.BigEndian, false),
+			want:  "detected BOM-less UTF-32BE",
+		},
+		"UTF-32LE BOM": {
+			input: encodeUTF32(jsonText, binary.LittleEndian, true),
+			want:  "detected UTF-32LE",
+		},
+		"UTF-32BE BOM": {
+			input: encodeUTF32(jsonText, binary.BigEndian, true),
+			want:  "detected UTF-32BE",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(dir, strings.ReplaceAll(name, " ", "-")+".json")
+			if err := os.WriteFile(path, tc.input, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			exitCode, output := captureCommandOutput(t, func() int {
+				return runRelayProxy(paths, "ws", []string{"--data-file", path})
+			})
+			if exitCode != 1 || !strings.Contains(output, tc.want) || !strings.Contains(output, "nothing was sent") {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+			if got := capture.requests.Load(); got != 0 {
+				t.Fatalf("request count = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestRelayRejectsBOMLessUTF16JQFilterBeforeRequest(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	dir := t.TempDir()
+	payloadPath := filepath.Join(dir, "payload.json")
+	filterPath := filepath.Join(dir, "filter.jq")
+	if err := os.WriteFile(payloadPath, []byte(`{"type":"ping"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filterPath, encodeASCIIUnits([]byte("."), 2, 0), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "ws", []string{"--data-file", payloadPath, "--jq-file", filterPath})
+	})
+	for _, want := range []string{"detected BOM-less UTF-16LE", "nothing was sent", "System.IO.File", "System.Text.UTF8Encoding"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q: exit/output = %d, %q", want, exitCode, output)
+		}
+	}
+	if exitCode != 1 {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+	if got := capture.requests.Load(); got != 0 {
+		t.Fatalf("request count = %d, want 0", got)
+	}
+}
+
+func TestRelayUnicodeRoundTripAndOutAreDeterministicUTF8(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	payload := []byte(`{"title":"Grüße – Öl & Überschuss · café · 東京 · 😀"}`)
+
+	cases := []struct {
+		name        string
+		inputBOM    bool
+		responseBOM bool
+	}{
+		{name: "plain UTF-8"},
+		{name: "UTF-8 input BOM", inputBOM: true},
+		{name: "UTF-8 response BOM", responseBOM: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			capture.response = func(requestBody []byte) []byte {
+				response := append([]byte(`{"ok":true,"data":`), requestBody...)
+				response = append(response, '}')
+				if tc.responseBOM {
+					response = append(append([]byte{}, utf8BOM...), response...)
+				}
+				return response
+			}
+			input := append([]byte{}, payload...)
+			if tc.inputBOM {
+				input = append(append([]byte{}, utf8BOM...), payload...)
+			}
+			dir := t.TempDir()
+			payloadPath := filepath.Join(dir, "payload.json")
+			outputPath := filepath.Join(dir, "response.json")
+			if err := os.WriteFile(payloadPath, input, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			exitCode, output := captureCommandOutput(t, func() int {
+				return runRelayProxy(paths, "ws", []string{"--data-file", payloadPath, "--out", outputPath})
+			})
+			if exitCode != 0 {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+			select {
+			case requestBody := <-capture.bodies:
+				if !bytes.Equal(requestBody, payload) {
+					t.Fatalf("request bytes changed:\n got %x\nwant %x", requestBody, payload)
+				}
+			default:
+				t.Fatal("request body was not captured")
+			}
+
+			got, err := os.ReadFile(outputPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := append([]byte(`{"ok":true,"data":`), payload...)
+			want = append(want, '}')
+			if !bytes.Equal(got, want) {
+				t.Fatalf("--out bytes changed:\n got %x\nwant %x", got, want)
+			}
+			if bytes.HasPrefix(got, utf8BOM) {
+				t.Fatal("--out must be BOM-less UTF-8")
+			}
+		})
+	}
+}
+
+func TestRelayRejectsTwoResponseBOMsAcrossTextSinks(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	payload := []byte(`{"type":"ping"}`)
+	capture.response = func([]byte) []byte {
+		response := append(append([]byte{}, utf8BOM...), utf8BOM...)
+		return append(response, []byte(`{"ok":true,"data":{}}`)...)
+	}
+
+	for name, args := range map[string][]string{
+		"stdout": {"--data", string(payload)},
+		"out": {
+			"--data", string(payload),
+			"--out", filepath.Join(t.TempDir(), "response.json"),
+		},
+		"jq and out": {
+			"--data", string(payload),
+			"--jq", ".",
+			"--out", filepath.Join(t.TempDir(), "filtered.json"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			exitCode, output := captureCommandOutput(t, func() int {
+				return runRelayProxy(paths, "ws", args)
+			})
+			if exitCode != 1 || !strings.Contains(output, "more than one leading UTF-8 BOM") {
+				t.Fatalf("exit/output = %d, %q", exitCode, output)
+			}
+			if strings.ContainsRune(output, '\uFEFF') {
+				t.Fatalf("double BOM leaked to %s output: %q", name, output)
+			}
+			for index, arg := range args {
+				if arg == "--out" {
+					if _, err := os.Stat(args[index+1]); !os.IsNotExist(err) {
+						t.Fatalf("double-BOM response must not create --out file: %v", err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRelayOneResponseBOMWritesCleanStdout(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	response := []byte(`{"ok":true,"data":{"title":"Grüße 東京 😀"}}`)
+	capture.response = func([]byte) []byte {
+		return append(append([]byte{}, utf8BOM...), response...)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "ws", []string{"--data", `{"type":"ping"}`})
+	})
+	if exitCode != 0 || output != string(response)+"\n" {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+}
+
+func TestRelayHealthResponseUsesStrictUTF8Boundary(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	valid := []byte(`{"ok":true,"data":{"status":"ok","version":"0.7.1"}}`)
+
+	t.Run("one BOM is removed", func(t *testing.T) {
+		capture.response = func([]byte) []byte {
+			return append(append([]byte{}, utf8BOM...), valid...)
+		}
+		exitCode, output := captureCommandOutput(t, func() int {
+			return runHealth(paths, nil)
+		})
+		if exitCode != 0 || output != string(valid)+"\n" {
+			t.Fatalf("exit/output = %d, %q", exitCode, output)
+		}
+	})
+
+	t.Run("invalid UTF-8 is rejected", func(t *testing.T) {
+		capture.response = func([]byte) []byte {
+			return append([]byte(`{"ok":true,"data":"`), 0xDC)
+		}
+		exitCode, output := captureCommandOutput(t, func() int {
+			return runHealth(paths, nil)
+		})
+		if exitCode != 1 || !strings.Contains(output, "Relay health response is not valid UTF-8") || !strings.Contains(output, "already sent") {
+			t.Fatalf("exit/output = %d, %q", exitCode, output)
+		}
+	})
+
+	t.Run("two BOMs are rejected", func(t *testing.T) {
+		capture.response = func([]byte) []byte {
+			response := append(append([]byte{}, utf8BOM...), utf8BOM...)
+			return append(response, valid...)
+		}
+		exitCode, output := captureCommandOutput(t, func() int {
+			return runHealth(paths, nil)
+		})
+		if exitCode != 1 || !strings.Contains(output, "more than one leading UTF-8 BOM") || strings.ContainsRune(output, '\uFEFF') {
+			t.Fatalf("exit/output = %d, %q", exitCode, output)
+		}
+	})
+
+	t.Run("BOM only is rejected as empty", func(t *testing.T) {
+		capture.response = func([]byte) []byte {
+			return append([]byte{}, utf8BOM...)
+		}
+		exitCode, output := captureCommandOutput(t, func() int {
+			return runHealth(paths, nil)
+		})
+		if exitCode != 1 || !strings.Contains(output, "relay health check failed") {
+			t.Fatalf("exit/output = %d, %q", exitCode, output)
+		}
+	})
+}
+
+func TestRelayRejectsInvalidUTF8ResponseBeforeTextOutput(t *testing.T) {
+	paths, capture := setupStrictInputRelay(t)
+	capture.response = func([]byte) []byte {
+		return append([]byte(`{"ok":true,"data":"`), 0xDC)
+	}
+	dir := t.TempDir()
+	payloadPath := filepath.Join(dir, "payload.json")
+	outputPath := filepath.Join(dir, "response.json")
+	if err := os.WriteFile(payloadPath, []byte(`{"type":"ping"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode, output := captureCommandOutput(t, func() int {
+		return runRelayProxy(paths, "ws", []string{"--data-file", payloadPath, "--out", outputPath})
+	})
+	if exitCode != 1 || !strings.Contains(output, "already sent") || !strings.Contains(output, "not valid UTF-8") {
+		t.Fatalf("exit/output = %d, %q", exitCode, output)
+	}
+	if got := capture.requests.Load(); got != 1 {
+		t.Fatalf("request count = %d, want 1", got)
+	}
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("invalid UTF-8 response must not be written: %v", err)
+	}
+}
+
+func encodeASCIIUnits(input []byte, width, asciiOffset int) []byte {
+	output := make([]byte, len(input)*width)
+	for index, value := range input {
+		output[index*width+asciiOffset] = value
+	}
+	return output
+}
+
+func encodeUTF16(input string, byteOrder binary.ByteOrder, withBOM bool) []byte {
+	units := utf16.Encode([]rune(input))
+	output := make([]byte, 0, len(units)*2+2)
+	if withBOM {
+		if byteOrder == binary.LittleEndian {
+			output = append(output, 0xFF, 0xFE)
+		} else {
+			output = append(output, 0xFE, 0xFF)
+		}
+	}
+	for _, unit := range units {
+		encoded := make([]byte, 2)
+		byteOrder.PutUint16(encoded, unit)
+		output = append(output, encoded...)
+	}
+	return output
+}
+
+func encodeUTF32(input string, byteOrder binary.ByteOrder, withBOM bool) []byte {
+	output := make([]byte, 0, len([]rune(input))*4+4)
+	if withBOM {
+		if byteOrder == binary.LittleEndian {
+			output = append(output, 0xFF, 0xFE, 0x00, 0x00)
+		} else {
+			output = append(output, 0x00, 0x00, 0xFE, 0xFF)
+		}
+	}
+	for _, value := range []rune(input) {
+		encoded := make([]byte, 4)
+		byteOrder.PutUint32(encoded, uint32(value))
+		output = append(output, encoded...)
+	}
+	return output
+}

--- a/cli/strict_utf8_input_test.go
+++ b/cli/strict_utf8_input_test.go
@@ -2,14 +2,9 @@ package main
 
 import (
 	"bytes"
-	"fmt"
-	"io"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
 	"testing"
 )
 
@@ -33,16 +28,43 @@ func TestStrictJSONBytesPreservesUnicodeAndAcceptsOneBOM(t *testing.T) {
 }
 
 func TestStrictJSONBytesRejectsInvalidEncodingsBeforeJSON(t *testing.T) {
-	cases := map[string][]byte{
-		"active legacy code page byte": append(append([]byte(`{"title":"`), 0xDC), []byte(`bersicht"}`)...),
-		"truncated UTF-8":              append([]byte(`{"title":"`), 0xC3),
-		"UTF-16LE":                     {0xFF, 0xFE, '{', 0x00, '}', 0x00},
+	cases := map[string]struct {
+		input []byte
+		want  string
+	}{
+		"active legacy code page byte": {
+			input: append(append([]byte(`{"title":"`), 0xDC), []byte(`bersicht"}`)...),
+			want:  "unsupported or ambiguous",
+		},
+		"truncated UTF-8": {
+			input: append([]byte(`{"title":"`), 0xC3),
+			want:  "unsupported or ambiguous",
+		},
+		"UTF-16LE": {
+			input: []byte{0xFF, 0xFE, '{', 0x00, '}', 0x00},
+			want:  "detected UTF-16LE",
+		},
+		"UTF-16BE": {
+			input: []byte{0xFE, 0xFF, 0x00, '{', 0x00, '}'},
+			want:  "detected UTF-16BE",
+		},
+		"UTF-32LE": {
+			input: []byte{0xFF, 0xFE, 0x00, 0x00, '{', 0x00, 0x00, 0x00},
+			want:  "detected UTF-32LE",
+		},
+		"UTF-32BE": {
+			input: []byte{0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, '{'},
+			want:  "detected UTF-32BE",
+		},
 	}
-	for name, input := range cases {
+	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			_, err := strictJSONBytes(input, "test JSON")
+			_, err := strictJSONBytes(tc.input, "test JSON")
 			if err == nil || !strings.Contains(err.Error(), "not valid UTF-8") {
 				t.Fatalf("error = %v, want UTF-8 rejection", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
 		})
 	}
@@ -51,7 +73,6 @@ func TestStrictJSONBytesRejectsInvalidEncodingsBeforeJSON(t *testing.T) {
 		"malformed JSON": []byte(`{"title":`),
 		"empty":          nil,
 		"BOM only":       append([]byte{}, utf8BOM...),
-		"double BOM":     append(append(append([]byte{}, utf8BOM...), utf8BOM...), []byte(`{}`)...),
 	} {
 		t.Run(name, func(t *testing.T) {
 			_, err := strictJSONBytes(input, "test JSON")
@@ -59,6 +80,11 @@ func TestStrictJSONBytesRejectsInvalidEncodingsBeforeJSON(t *testing.T) {
 				t.Fatalf("error = %v, want JSON rejection", err)
 			}
 		})
+	}
+
+	doubleBOM := append(append(append([]byte{}, utf8BOM...), utf8BOM...), []byte(`{}`)...)
+	if _, err := strictJSONBytes(doubleBOM, "test JSON"); err == nil || !strings.Contains(err.Error(), "more than one leading UTF-8 BOM") {
+		t.Fatalf("double-BOM error = %v, want explicit rejection", err)
 	}
 }
 
@@ -73,7 +99,7 @@ func TestLoadRelayPayloadExplainsWindowsEncodingWithoutSending(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid UTF-8 to fail")
 	}
-	for _, want := range []string{path, "not valid UTF-8", "nothing was sent", "Set-Content -Encoding UTF8", "BOM is accepted"} {
+	for _, want := range []string{path, "not valid UTF-8", "nothing was sent", "System.IO.File", "System.Text.UTF8Encoding", "UTF-8 BOM is accepted"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error missing %q: %v", want, err)
 		}
@@ -352,44 +378,4 @@ func TestStoredUndoSnapshotRejectsInvalidUTF8(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "UTF-8") {
 		t.Fatalf("error = %v, want corrupt UTF-8 rejection", err)
 	}
-}
-
-type strictInputRelayCapture struct {
-	requests atomic.Int32
-	bodies   chan []byte
-}
-
-func setupStrictInputRelay(t *testing.T) (runtimePaths, *strictInputRelayCapture) {
-	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
-	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".test-relay-token"))
-	t.Setenv("HA_NOVA_NO_UPDATE_NUDGE", "1")
-
-	capture := &strictInputRelayCapture{bodies: make(chan []byte, 8)}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capture.requests.Add(1)
-		body, _ := io.ReadAll(r.Body)
-		capture.bodies <- body
-		w.Header().Set("content-type", "application/json")
-		_, _ = fmt.Fprint(w, `{"ok":true,"data":{}}`)
-	}))
-	t.Cleanup(server.Close)
-
-	paths, err := detectPaths()
-	if err != nil {
-		t.Fatalf("detectPaths: %v", err)
-	}
-	if err := saveConfig(paths, runtimeConfig{
-		HAHost:       "127.0.0.1",
-		HAURL:        "http://127.0.0.1:8123",
-		RelayBaseURL: server.URL,
-	}); err != nil {
-		t.Fatalf("saveConfig: %v", err)
-	}
-	if err := writeRelayAuthToken("test-token"); err != nil {
-		t.Fatalf("write relay token: %v", err)
-	}
-	return paths, capture
 }

--- a/cli/strict_utf8_test_helpers_test.go
+++ b/cli/strict_utf8_test_helpers_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+type strictInputRelayCapture struct {
+	requests atomic.Int32
+	bodies   chan []byte
+	response func([]byte) []byte
+}
+
+func setupStrictInputRelay(t *testing.T) (runtimePaths, *strictInputRelayCapture) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".test-relay-token"))
+	t.Setenv("HA_NOVA_NO_UPDATE_NUDGE", "1")
+
+	capture := &strictInputRelayCapture{bodies: make(chan []byte, 8)}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capture.requests.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		capture.bodies <- body
+		w.Header().Set("content-type", "application/json")
+		if capture.response != nil {
+			_, _ = w.Write(capture.response(body))
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"ok":true,"data":{}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths: %v", err)
+	}
+	if err := saveConfig(paths, runtimeConfig{
+		HAHost:       "127.0.0.1",
+		HAURL:        "http://127.0.0.1:8123",
+		RelayBaseURL: server.URL,
+	}); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+	if err := writeRelayAuthToken("test-token"); err != nil {
+		t.Fatalf("write relay token: %v", err)
+	}
+	return paths, capture
+}

--- a/cli/text_input.go
+++ b/cli/text_input.go
@@ -9,16 +9,70 @@ import (
 
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
+func detectedUnsupportedUnicodeEncoding(data []byte) string {
+	switch {
+	case bytes.HasPrefix(data, []byte{0x00, 0x00, 0xFE, 0xFF}):
+		return "UTF-32BE"
+	case bytes.HasPrefix(data, []byte{0xFF, 0xFE, 0x00, 0x00}):
+		return "UTF-32LE"
+	case bytes.HasPrefix(data, []byte{0xFE, 0xFF}):
+		return "UTF-16BE"
+	case bytes.HasPrefix(data, []byte{0xFF, 0xFE}):
+		return "UTF-16LE"
+	case looksLikeBOMLessUnicodeText(data, 4, 0):
+		return "BOM-less UTF-32LE"
+	case looksLikeBOMLessUnicodeText(data, 4, 3):
+		return "BOM-less UTF-32BE"
+	case looksLikeBOMLessUnicodeText(data, 2, 0):
+		return "BOM-less UTF-16LE"
+	case looksLikeBOMLessUnicodeText(data, 2, 1):
+		return "BOM-less UTF-16BE"
+	default:
+		return ""
+	}
+}
+
+// looksLikeBOMLessUnicodeText recognizes an unambiguous ASCII text prefix
+// encoded as UTF-16/32. It is deliberately conservative: arbitrary legacy
+// code pages cannot be identified reliably and must fall through to strict
+// UTF-8 validation.
+func looksLikeBOMLessUnicodeText(data []byte, width, asciiOffset int) bool {
+	if len(data) < width {
+		return false
+	}
+	unit := data[:width]
+	for byteIndex, value := range unit {
+		if byteIndex != asciiOffset && value != 0 {
+			return false
+		}
+	}
+	value := unit[asciiOffset]
+	return value == '\t' || value == '\n' || value == '\r' || (value >= 0x20 && value <= 0x7E)
+}
+
 // normalizeUTF8Bytes accepts one optional leading UTF-8 BOM and otherwise
 // preserves the input exactly. It never guesses or transcodes legacy code
 // pages: an ambiguous conversion would merely replace one silent corruption
 // path with another.
 func normalizeUTF8Bytes(data []byte, source string) ([]byte, error) {
 	normalized := bytes.TrimPrefix(data, utf8BOM)
+	if bytes.HasPrefix(normalized, utf8BOM) {
+		return nil, fmt.Errorf("%s contains more than one leading UTF-8 BOM; at most one is supported", source)
+	}
+	if encoding := detectedUnsupportedUnicodeEncoding(normalized); encoding != "" {
+		return nil, fmt.Errorf("%s is not valid UTF-8: detected %s; only UTF-8 is supported", source, encoding)
+	}
 	if !utf8.Valid(normalized) {
-		return nil, fmt.Errorf("%s is not valid UTF-8", source)
+		return nil, fmt.Errorf("%s is not valid UTF-8; its text encoding is unsupported or ambiguous", source)
 	}
 	return normalized, nil
+}
+
+func relayTextFileEncodingError(err error) error {
+	return fmt.Errorf(
+		"%w; nothing was sent. Windows PowerShell 5.1: read and write with System.IO.File plus an explicit System.Text.UTF8Encoding; a leading UTF-8 BOM is accepted, but default Get-Content/Set-Content, Out-File, and > are unsafe encoding boundaries",
+		err,
+	)
 }
 
 func validateUTF8String(value string, source string) error {

--- a/cli/text_output.go
+++ b/cli/text_output.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// writeRelayTextOutput writes bytes that the raw response boundary already
+// normalized. Go performs no platform transcoding, so the bytes stay BOM-less
+// UTF-8 on every operating system.
+func writeRelayTextOutput(path string, utf8Data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, utf8Data, 0o644)
+}

--- a/docs/work/2026-07-24-powershell-unicode-relay-spec.md
+++ b/docs/work/2026-07-24-powershell-unicode-relay-spec.md
@@ -1,0 +1,58 @@
+# PowerShell 5.1 Relay Unicode Round-Trip Spec
+
+Date: 2026-07-24
+Issue: #434
+
+## Goal
+
+Relay JSON file workflows preserve Unicode code points. Unsupported byte
+encodings fail before configuration lookup, authentication, or a network
+request. CLI-owned text output is deterministic UTF-8 without a BOM.
+
+## Contract
+
+- `--data-file`, `--body-file`, `--jq-file`, and other strict text inputs accept
+  UTF-8 with zero or one leading UTF-8 BOM.
+- A leading UTF-8 BOM is removed before JSON or jq parsing.
+- UTF-16LE, UTF-16BE, UTF-32LE, and UTF-32BE BOMs are rejected with the detected
+  encoding named. BOM-less UTF-16 JSON is rejected when its leading JSON bytes
+  have the characteristic alternating-NUL form.
+- Other invalid UTF-8 is rejected as an unsupported or ambiguous text encoding.
+  The error states that no request was sent and gives a PowerShell 5.1-safe
+  recovery.
+- Bytes that are already valid UTF-8 cannot reveal whether another tool
+  previously decoded them incorrectly. Documentation must therefore require an
+  explicit UTF-8 decoder when PowerShell 5.1 reads CLI output.
+- Relay text responses are validated as UTF-8 before stdout or `--out`.
+  `--out` removes one optional response BOM and writes the resulting bytes
+  directly, producing UTF-8 without a BOM on every operating system.
+- Shell redirection is outside CLI control. Agent guidance prefers `--out` and
+  warns that Windows PowerShell 5.1 `>`/`Out-File` writes UTF-16LE.
+
+## PowerShell 5.1 Guidance
+
+For read-modify-write:
+
+1. Retrieve with `ha-nova relay ... --out <file>`.
+2. Read bytes, remove at most one UTF-8 BOM explicitly, then decode with
+   `System.Text.UTF8Encoding(false, true)`. Do not use `ReadAllText`: its BOM
+   detection can override the supplied decoder.
+3. Serialize with `ConvertTo-Json`.
+4. Write with `System.IO.File.WriteAllText` and
+   `System.Text.UTF8Encoding(false)`.
+5. Submit with `--data-file` or `--body-file`.
+
+Do not use default `Get-Content`, `Set-Content`, `Out-File`, or `>` as an
+encoding boundary for mutation JSON in Windows PowerShell 5.1.
+
+## Verification
+
+- Byte-exact request and `--out` round trip using umlauts/eszett, accented
+  Latin, typographic punctuation, Japanese, and emoji.
+- Plain UTF-8 and UTF-8 BOM inputs produce identical request bytes.
+- UTF-16LE/BE with and without BOM, UTF-32 BOMs, and invalid UTF-8 produce zero
+  requests and actionable errors.
+- A non-UTF-8 Relay response is never written as text.
+- Documentation and agent-contract tests pin the safe PowerShell workflow.
+- The Windows job builds and invokes `ha-nova.exe`, checks a fixed expected
+  UTF-8 byte sequence, and rejects UTF-16LE/BE BOM files.

--- a/scripts/test/safe-core-files.json
+++ b/scripts/test/safe-core-files.json
@@ -74,6 +74,7 @@
   "tests/skills/integration-setup-contract.test.ts",
   "tests/skills/maintenance-contract.test.ts",
   "tests/skills/output-design-contract.test.ts",
+  "tests/skills/relay-unicode-contract.test.ts",
   "tests/skills/review-contract.test.ts",
   "tests/skills/scene-contract.test.ts",
   "tests/skills/service-call-contract.test.ts",

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -52,7 +52,32 @@ For agent-dispatched flows, use the CLI wrapper instead of raw curl:
 
 1. Write request JSON with the client's native file-writing tool.
    - POSIX heredocs are examples only; on Windows/PowerShell use the native file-writing equivalent while preserving the same JSON and jq file contents.
-   - Write JSON and jq files as UTF-8. One leading UTF-8 BOM is accepted. In Windows PowerShell 5.1, use `Set-Content -Encoding UTF8`: bare `Set-Content` uses the system's active ANSI code page and, on affected non-UTF-8 locales, can emit non-UTF-8 bytes, which are rejected before any Relay request is sent. `Out-File`/`>` emit UTF-16LE and are also rejected.
+   - Write JSON and jq files as UTF-8. One leading UTF-8 BOM is accepted. UTF-16 and invalid/ambiguous UTF-8 are rejected before configuration lookup, authentication, or a Relay request.
+   - Windows PowerShell 5.1 has inconsistent defaults: BOM-less `Get-Content` uses the active legacy code page, bare `Set-Content` uses that code page for a new file, and `Out-File`/`>` write UTF-16LE. A wrong read followed by a UTF-8 write produces valid but already-corrupted UTF-8 that no CLI can detect. For mutation JSON, do not use those default encoding boundaries.
+   - On Windows PowerShell 5.1, prefer `ha-nova relay ... --out <result-file>` over shell redirection. Read and write mutation JSON with explicit strict UTF-8:
+
+     ```powershell
+     $strictUtf8 = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false, $true
+     $bytes = [System.IO.File]::ReadAllBytes((Join-Path $PWD "result.json"))
+     $offset = 0
+     if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+         $offset = 3
+     }
+     if ($bytes.Length -ge ($offset + 3) -and $bytes[$offset] -eq 0xEF -and $bytes[$offset + 1] -eq 0xBB -and $bytes[$offset + 2] -eq 0xBF) {
+         throw "More than one leading UTF-8 BOM is unsupported"
+     }
+     $text = $strictUtf8.GetString($bytes, $offset, $bytes.Length - $offset)
+     $document = $text | ConvertFrom-Json
+     # Apply the intended in-memory change here.
+     $json = $document | ConvertTo-Json -Depth 100
+     $utf8NoBom = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+     [System.IO.File]::WriteAllText((Join-Path $PWD "payload.json"), $json, $utf8NoBom)
+     ```
+
+     `ReadAllText` is not strict enough here because .NET may honor a UTF-16/32
+     BOM instead of the supplied UTF-8 decoder. `--out` always writes BOM-less
+     UTF-8. PowerShell 7 defaults to BOM-less UTF-8, but the explicit file-based
+     contract remains preferred for cross-platform mutation work.
    - Write the final request body directly. Do not create placeholder payload templates such as `REPLACE_ENTITY_ID` and patch them later with `perl -0pi`, `sed -i`, or similar in-place rewrite commands.
 2. Use file-based relay flags as the default contract:
    - `ha-nova relay ws --data-file <payload-file>`

--- a/tests/skills/relay-unicode-contract.test.ts
+++ b/tests/skills/relay-unicode-contract.test.ts
@@ -40,10 +40,12 @@ describe("relay Unicode file contract", () => {
     expect(ci).toContain(
       "New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false, $true",
     );
-    expect(ci).toContain("PowerShell 5.1 changed Unicode code points");
     expect(ci).toContain(
-      "Workflow source changed the expected Unicode code points",
+      '$expected = $strictUtf8.GetString($expectedBytes)',
     );
+    expect(ci).not.toMatch(/[^\x00-\x7F]/);
+    expect(ci).toContain("PowerShell 5.1 changed Unicode code points");
+    expect(ci).toContain("UTF-8 test vector did not round-trip");
     expect(ci).toContain("Strict UTF-8 reader accepted");
     expect(ci).toContain("payload-bom.json");
     expect(ci).toContain("payload-double-bom.json");

--- a/tests/skills/relay-unicode-contract.test.ts
+++ b/tests/skills/relay-unicode-contract.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+describe("relay Unicode file contract", () => {
+  const relayApi = readFileSync("skills/ha-nova/relay-api.md", "utf8");
+  const relayApiNormalized = relayApi.replace(/\s+/g, " ");
+  const ci = readFileSync(".github/workflows/ci.yml", "utf8");
+
+  it("documents the strict cross-platform text boundary", () => {
+    expect(relayApi).toContain("One leading UTF-8 BOM is accepted.");
+    expect(relayApi).toContain(
+      "UTF-16 and invalid/ambiguous UTF-8 are rejected before configuration lookup, authentication, or a Relay request.",
+    );
+    expect(relayApi).toContain(
+      "prefer `ha-nova relay ... --out <result-file>` over shell redirection",
+    );
+    expect(relayApi).toContain(
+      "BOM-less `Get-Content` uses the active legacy code page",
+    );
+    expect(relayApi).toContain(
+      "A wrong read followed by a UTF-8 write produces valid but already-corrupted UTF-8 that no CLI can detect.",
+    );
+    expect(relayApi).toContain(
+      "New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false, $true",
+    );
+    expect(relayApi).toContain("System.IO.File]::ReadAllBytes");
+    expect(relayApi).toContain("$strictUtf8.GetString");
+    expect(relayApi).toContain("`ReadAllText` is not strict enough");
+    expect(relayApi).toContain("System.IO.File]::WriteAllText");
+    expect(relayApiNormalized).toContain(
+      "`--out` always writes BOM-less UTF-8.",
+    );
+  });
+
+  it("runs the documented round trip in Windows PowerShell 5.1", () => {
+    expect(ci).toContain("windows-powershell-unicode:");
+    expect(ci).toContain("runs-on: windows-latest");
+    expect(ci).toContain("$PSVersionTable.PSVersion.Major -ne 5");
+    expect(ci).toContain(
+      "New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false, $true",
+    );
+    expect(ci).toContain("PowerShell 5.1 changed Unicode code points");
+    expect(ci).toContain(
+      "Workflow source changed the expected Unicode code points",
+    );
+    expect(ci).toContain("Strict UTF-8 reader accepted");
+    expect(ci).toContain("payload-bom.json");
+    expect(ci).toContain("payload-double-bom.json");
+    expect(ci).toContain(
+      "Strict UTF-8 reader accepted more than one leading UTF-8 BOM",
+    );
+    expect(ci).toContain("go build -o ha-nova.exe .");
+    expect(ci).toContain("ha-nova.exe relay jq");
+    expect(ci).toContain("[Console]::OutputEncoding = $utf8NoBom");
+    expect(ci).toContain("$cliHex -cne $expectedHex");
+    expect(ci).toContain("Test(RelayUnicodeRoundTrip|RelayRejectsUTF16");
+  });
+});


### PR DESCRIPTION
## What changed

- enforce strict UTF-8 for Relay payload, jq, response, health, and text-output boundaries
- accept one leading UTF-8 BOM, reject UTF-16/32 and ambiguous/invalid text before requests
- write CLI-owned text output as deterministic BOM-less UTF-8
- add a real Windows PowerShell 5.1 Unicode round-trip CI job and regression coverage

## Root cause

Windows PowerShell 5.1 file defaults can read legacy code pages or write UTF-16LE. Relay file boundaries previously did not reject every unsupported encoding or validate every response sink, allowing silent Unicode corruption.

## Impact

Mutation payloads and Relay results preserve non-ASCII text across supported platforms. Invalid input fails before a request; invalid response text fails before output is written.

## Validation

- `npm run verify`
- pre-push suite: 113 files / 1081 tests
- Go Unicode proxy, health, jq, binary-output, BOM, UTF-16, and UTF-32 regressions
- PowerShell byte-array syntax and workflow YAML parsed locally

Closes #434
