### PR TITLE
fix: select current Census rollback deployment

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -199,6 +199,10 @@ release changes the census Worker.
    Cloudflare Access must already protect `/stats*`, the Worker must have
    `ACCESS_TEAM_DOMAIN` and `ACCESS_AUD`, and the release shell must provide
    the Access service-token credentials documented in `census-worker/README.md`.
+   Treat the Census deploy as a serialized single-writer operation: do not
+   deploy the Worker from another shell, workflow, or the Cloudflare dashboard
+   while this wrapper runs. When Wrangler identifies this run's deployed
+   version, cleanup refuses to overwrite a different active version.
    A maintainer must also complete a fresh browser login to `/stats` and only
    then set `HA_NOVA_CENSUS_BROWSER_ACCESS_VERIFIED=1` in that release shell.
    The fail-closed wrapper requires Node.js 22 or newer, a clean exact-SHA

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -202,7 +202,9 @@ release changes the census Worker.
    Treat the Census deploy as a serialized single-writer operation: do not
    deploy the Worker from another shell, workflow, or the Cloudflare dashboard
    while this wrapper runs. When Wrangler identifies this run's deployed
-   version, cleanup refuses to overwrite a different active version.
+   version, cleanup refuses to overwrite a different active version. Cleanup
+   also waits through a bounded settlement window before treating a failed
+   deploy as unchanged.
    A maintainer must also complete a fresh browser login to `/stats` and only
    then set `HA_NOVA_CENSUS_BROWSER_ACCESS_VERIFIED=1` in that release shell.
    The fail-closed wrapper requires Node.js 22 or newer, a clean exact-SHA

--- a/docs/work/2026-07-25-census-deploy-rollback-selection-spec.md
+++ b/docs/work/2026-07-25-census-deploy-rollback-selection-spec.md
@@ -14,6 +14,8 @@ serving immediately before the attempted deploy.
   `deployments status --json` command instead of inferring it from list order.
 - Use the same current-state command to verify the restored deployment.
 - Require exactly one status object with one safe 100-percent version ID.
+- Keep deployment-state parsing in a focused helper so the release wrapper
+  remains below the repository's approximate 400-line limit.
 - Skip rollback when production never changed, and refuse rollback when a
   different deployment became active after this process deployed.
 - Add a regression fixture matching Wrangler 4.113.0's oldest-first list

--- a/docs/work/2026-07-25-census-deploy-rollback-selection-spec.md
+++ b/docs/work/2026-07-25-census-deploy-rollback-selection-spec.md
@@ -29,7 +29,9 @@ serving immediately before the attempted deploy.
 - The restored deployment must be the newest 100-percent deployment and match
   the selected rollback version.
 - A failed deploy that leaves production unchanged does not create a rollback
-  deployment.
+  deployment after the baseline stays active for the settlement window.
+- A failed deploy that becomes active during the settlement window is rolled
+  back instead of being mistaken for an unchanged deployment.
 - A deploy that changes production but loses or malforms local output still
   restores the baseline under the required single-writer invariant.
 - When Wrangler identifies this run's deployed version, cleanup does not

--- a/docs/work/2026-07-25-census-deploy-rollback-selection-spec.md
+++ b/docs/work/2026-07-25-census-deploy-rollback-selection-spec.md
@@ -1,0 +1,43 @@
+# Census Deploy Rollback Selection
+
+Date: 2026-07-25
+Status: active
+
+## Goal
+
+Ensure a failed Census Worker deployment rolls back to the deployment that was
+serving immediately before the attempted deploy.
+
+## Scope
+
+- Read the active deployment through Wrangler's dedicated
+  `deployments status --json` command instead of inferring it from list order.
+- Use the same current-state command to verify the restored deployment.
+- Require exactly one status object with one safe 100-percent version ID.
+- Skip rollback when production never changed, and refuse rollback when a
+  different deployment became active after this process deployed.
+- Add a regression fixture matching Wrangler 4.113.0's oldest-first list
+  order.
+
+## Acceptance
+
+- The rollback path does not use the oldest-first deployment list.
+- The current 100-percent version comes from `deployments status --json`.
+- A post-deploy verification failure rolls back to that version.
+- The restored deployment must be the newest 100-percent deployment and match
+  the selected rollback version.
+- A failed deploy that leaves production unchanged does not create a rollback
+  deployment.
+- A deploy that changes production but loses or malforms local output still
+  restores the baseline under the required single-writer invariant.
+- When Wrangler identifies this run's deployed version, cleanup does not
+  overwrite a different active version.
+- Existing release-gate behavior remains green.
+
+## Non-goals
+
+- No Worker runtime or Census data changes.
+- No Wrangler version change.
+- No production deployment.
+- No distributed deployment lock; correctness for indistinguishable
+  concurrent writes depends on the documented single-writer operation.

--- a/scripts/release/census-deployment-state.sh
+++ b/scripts/release/census-deployment-state.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+census_single_deployment_version_id() {
+  jq -ser '
+    select(length == 1)
+    | .[0]
+    | select(type == "object")
+    | .versions
+    | select(
+        type == "array"
+        and length == 1
+        and .[0].percentage == 100
+        and (
+          .[0].version_id
+          | type == "string"
+            and test("^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$")
+        )
+      )
+    | .[0].version_id
+  '
+}
+
+census_deployment_output_version_id() {
+  jq -ser '
+    [.[] | select(.type == "deploy")]
+    | select(length == 1)
+    | .[0].version_id
+    | select(
+        type == "string"
+        and test("^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$")
+      )
+  ' "$1"
+}
+
+census_read_current_deployment() {
+  local account_id="$1"
+  local worker_dir="$2"
+  local config_file="$3"
+  local worker_name="$4"
+
+  CLOUDFLARE_ENV='' CLOUDFLARE_ACCOUNT_ID="$account_id" \
+    npx --yes wrangler@4.113.0 deployments status \
+      --cwd "$worker_dir" \
+      --config "$config_file" \
+      --name "$worker_name" \
+      --json
+}

--- a/scripts/release/census-deployment-state.sh
+++ b/scripts/release/census-deployment-state.sh
@@ -45,3 +45,29 @@ census_read_current_deployment() {
       --name "$worker_name" \
       --json
 }
+
+census_wait_for_settled_current_version() {
+  local baseline_version="$1"
+  local account_id="$2"
+  local worker_dir="$3"
+  local config_file="$4"
+  local worker_name="$5"
+  local attempt deployment version
+
+  # A failed Wrangler process can leave a Cloudflare deploy in flight. Require
+  # the baseline to stay active for a bounded settlement window before treating
+  # the failed command as a no-op.
+  for ((attempt = 1; attempt <= 15; attempt++)); do
+    deployment="$(
+      census_read_current_deployment \
+        "$account_id" "$worker_dir" "$config_file" "$worker_name"
+    )" || return 1
+    version="$(census_single_deployment_version_id <<<"$deployment")" \
+      || return 1
+    if [[ "$version" != "$baseline_version" || "$attempt" -eq 15 ]]; then
+      printf '%s\n' "$version"
+      return 0
+    fi
+    sleep 2
+  done
+}

--- a/scripts/release/deploy-census-worker.sh
+++ b/scripts/release/deploy-census-worker.sh
@@ -22,6 +22,38 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
 }
 
+single_deployment_version_id() {
+  jq -ser '
+    select(length == 1)
+    | .[0]
+    | select(type == "object")
+    | .versions
+    | select(
+        type == "array"
+        and length == 1
+        and .[0].percentage == 100
+        and (
+          .[0].version_id
+          | type == "string"
+            and test("^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$")
+        )
+      )
+    | .[0].version_id
+  '
+}
+
+deployment_output_version_id() {
+  jq -ser '
+    [.[] | select(.type == "deploy")]
+    | select(length == 1)
+    | .[0].version_id
+    | select(
+        type == "string"
+        and test("^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$")
+      )
+  ' "$1"
+}
+
 if [[ "$#" -ne 1 ]]; then
   usage
   exit 2
@@ -61,6 +93,16 @@ temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/ha-nova-census-release.XXXXXX")"
 dev_pid=""
 rollback_armed=0
 rollback_version=""
+deployed_version=""
+read_current_deployment() {
+  CLOUDFLARE_ENV='' CLOUDFLARE_ACCOUNT_ID="$expected_account" \
+    npx --yes wrangler@4.113.0 deployments status \
+      --cwd "$worker_dir" \
+      --config "$config_file" \
+      --name "$expected_worker" \
+      --json
+}
+
 cleanup() {
   cleanup_status=$?
   if [[ -n "$dev_pid" ]] && kill -0 "$dev_pid" 2>/dev/null; then
@@ -68,33 +110,43 @@ cleanup() {
     wait "$dev_pid" 2>/dev/null || true
   fi
   if [[ "$rollback_armed" -eq 1 && -n "$rollback_version" ]]; then
-    echo "[deploy-census-worker] restoring previous Worker version ${rollback_version}" >&2
-    if ! CLOUDFLARE_ENV='' CLOUDFLARE_ACCOUNT_ID="$expected_account" \
-      npx --yes wrangler@4.113.0 rollback "$rollback_version" \
-        --cwd "$worker_dir" \
-        --config "$config_file" \
-        --name "$expected_worker" \
-        --message "Automatic rollback after failed HA NOVA Census verification" \
-        --yes; then
-      echo "[deploy-census-worker] ERROR: automatic Worker rollback failed" >&2
+    if [[ -z "$deployed_version" && -n "${wrangler_output:-}" && -s "$wrangler_output" ]]; then
+      deployed_version="$(deployment_output_version_id "$wrangler_output")" \
+        || deployed_version=""
+    fi
+    current_deployment="$(read_current_deployment)" || current_deployment=""
+    current_version="$(
+      single_deployment_version_id <<<"$current_deployment"
+    )" || current_version=""
+    if [[ "$current_version" == "$rollback_version" ]]; then
+      echo "[deploy-census-worker] production stayed on ${rollback_version}; rollback not needed" >&2
+    elif [[ -z "$current_version" ]]; then
+      echo "[deploy-census-worker] ERROR: could not determine the active Worker version; refusing automatic rollback" >&2
+      cleanup_status=1
+    elif [[ -n "$deployed_version" && "$current_version" != "$deployed_version" ]]; then
+      echo "[deploy-census-worker] ERROR: active Worker version changed outside this deploy; refusing automatic rollback" >&2
       cleanup_status=1
     else
-      restored_deployments="$(
-        CLOUDFLARE_ENV='' CLOUDFLARE_ACCOUNT_ID="$expected_account" \
-          npx --yes wrangler@4.113.0 deployments list \
-            --cwd "$worker_dir" \
-            --config "$config_file" \
-            --name "$expected_worker" \
-            --json
-      )" || restored_deployments=""
-      if ! jq -e --arg version "$rollback_version" '
-        .[0].versions
-        | length == 1
-          and .[0].percentage == 100
-          and .[0].version_id == $version
-      ' >/dev/null <<<"$restored_deployments"; then
-        echo "[deploy-census-worker] ERROR: could not verify the restored Worker version" >&2
+      echo "[deploy-census-worker] restoring previous Worker version ${rollback_version}" >&2
+      if ! CLOUDFLARE_ENV='' CLOUDFLARE_ACCOUNT_ID="$expected_account" \
+        npx --yes wrangler@4.113.0 rollback "$rollback_version" \
+          --cwd "$worker_dir" \
+          --config "$config_file" \
+          --name "$expected_worker" \
+          --message "Automatic rollback after failed HA NOVA Census verification" \
+          --yes; then
+        echo "[deploy-census-worker] ERROR: automatic Worker rollback failed" >&2
         cleanup_status=1
+      else
+        restored_deployment="$(read_current_deployment)" \
+          || restored_deployment=""
+        restored_version="$(
+          single_deployment_version_id <<<"$restored_deployment"
+        )" || restored_version=""
+        if [[ "$restored_version" != "$rollback_version" ]]; then
+          echo "[deploy-census-worker] ERROR: could not verify the restored Worker version" >&2
+          cleanup_status=1
+        fi
       fi
     fi
   fi
@@ -325,20 +377,13 @@ actual_sha="$(git -C "$root_dir" rev-parse HEAD)"
 [[ "$actual_sha" == "$reviewed_sha" ]] \
   || fail "HEAD changed during local proof (${actual_sha}); refusing to deploy"
 
-previous_deployments="$(
-  CLOUDFLARE_ENV='' CLOUDFLARE_ACCOUNT_ID="$expected_account" \
-    npx --yes wrangler@4.113.0 deployments list \
-      --cwd "$worker_dir" \
-      --config "$config_file" \
-      --name "$expected_worker" \
-      --json
-)" || fail "could not read the current production Worker deployment"
-rollback_version="$(jq -er '
-  .[0].versions
-  | select(length == 1 and .[0].percentage == 100)
-  | .[0].version_id
-' <<<"$previous_deployments")" \
+previous_deployment="$(read_current_deployment)" \
+  || fail "could not read the current production Worker deployment"
+rollback_version="$(single_deployment_version_id <<<"$previous_deployment")" \
   || fail "current Worker is not a single 100-percent version; refuse an ambiguous rollback target"
+# Census deploys are a serialized single-writer operation. When Wrangler
+# identifies this run's deployed version, cleanup refuses to overwrite a
+# different active version.
 rollback_armed=1
 
 wrangler_output="${temp_dir}/wrangler-output.ndjson"
@@ -355,6 +400,8 @@ WRANGLER_OUTPUT_FILE_PATH="$wrangler_output" \
     --no-autoconfig
 
 [[ -s "$wrangler_output" ]] || fail "Wrangler wrote no structured deployment output"
+deployed_version="$(deployment_output_version_id "$wrangler_output")" \
+  || fail "Wrangler output did not identify exactly one safe deployed version"
 deploy_record="$({
   jq -sce \
     --arg worker "$expected_worker" \
@@ -363,11 +410,17 @@ deploy_record="$({
       | ($deploys | length) == 1
       and $deploys[0].worker_name == $worker
       and $deploys[0].targets == [$target]
-      and ($deploys[0].version_id | type == "string" and length > 0)
+      and (
+        $deploys[0].version_id
+        | type == "string"
+          and test("^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$")
+      )
       | if . then $deploys[0] else error("unexpected deployment target") end
     ' "$wrangler_output"
 })" || fail "Wrangler output did not attest exactly ${expected_worker} at ${expected_target}"
 version_id="$(jq -er '.version_id' <<<"$deploy_record")"
+[[ "$version_id" == "$deployed_version" ]] \
+  || fail "Wrangler deployment output reported inconsistent version IDs"
 
 HA_NOVA_CENSUS_ACCESS_CLIENT_ID="$access_id" \
 HA_NOVA_CENSUS_ACCESS_CLIENT_SECRET="$access_secret" \

--- a/scripts/release/deploy-census-worker.sh
+++ b/scripts/release/deploy-census-worker.sh
@@ -74,12 +74,10 @@ cleanup() {
       deployed_version="$(census_deployment_output_version_id "$wrangler_output")" \
         || deployed_version=""
     fi
-    current_deployment="$(
-      census_read_current_deployment \
-        "$expected_account" "$worker_dir" "$config_file" "$expected_worker"
-    )" || current_deployment=""
     current_version="$(
-      census_single_deployment_version_id <<<"$current_deployment"
+      census_wait_for_settled_current_version \
+        "$rollback_version" \
+        "$expected_account" "$worker_dir" "$config_file" "$expected_worker"
     )" || current_version=""
     if [[ "$current_version" == "$rollback_version" ]]; then
       echo "[deploy-census-worker] production stayed on ${rollback_version}; rollback not needed" >&2

--- a/scripts/release/deploy-census-worker.sh
+++ b/scripts/release/deploy-census-worker.sh
@@ -22,38 +22,6 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
 }
 
-single_deployment_version_id() {
-  jq -ser '
-    select(length == 1)
-    | .[0]
-    | select(type == "object")
-    | .versions
-    | select(
-        type == "array"
-        and length == 1
-        and .[0].percentage == 100
-        and (
-          .[0].version_id
-          | type == "string"
-            and test("^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$")
-        )
-      )
-    | .[0].version_id
-  '
-}
-
-deployment_output_version_id() {
-  jq -ser '
-    [.[] | select(.type == "deploy")]
-    | select(length == 1)
-    | .[0].version_id
-    | select(
-        type == "string"
-        and test("^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$")
-      )
-  ' "$1"
-}
-
 if [[ "$#" -ne 1 ]]; then
   usage
   exit 2
@@ -94,14 +62,6 @@ dev_pid=""
 rollback_armed=0
 rollback_version=""
 deployed_version=""
-read_current_deployment() {
-  CLOUDFLARE_ENV='' CLOUDFLARE_ACCOUNT_ID="$expected_account" \
-    npx --yes wrangler@4.113.0 deployments status \
-      --cwd "$worker_dir" \
-      --config "$config_file" \
-      --name "$expected_worker" \
-      --json
-}
 
 cleanup() {
   cleanup_status=$?
@@ -111,12 +71,15 @@ cleanup() {
   fi
   if [[ "$rollback_armed" -eq 1 && -n "$rollback_version" ]]; then
     if [[ -z "$deployed_version" && -n "${wrangler_output:-}" && -s "$wrangler_output" ]]; then
-      deployed_version="$(deployment_output_version_id "$wrangler_output")" \
+      deployed_version="$(census_deployment_output_version_id "$wrangler_output")" \
         || deployed_version=""
     fi
-    current_deployment="$(read_current_deployment)" || current_deployment=""
+    current_deployment="$(
+      census_read_current_deployment \
+        "$expected_account" "$worker_dir" "$config_file" "$expected_worker"
+    )" || current_deployment=""
     current_version="$(
-      single_deployment_version_id <<<"$current_deployment"
+      census_single_deployment_version_id <<<"$current_deployment"
     )" || current_version=""
     if [[ "$current_version" == "$rollback_version" ]]; then
       echo "[deploy-census-worker] production stayed on ${rollback_version}; rollback not needed" >&2
@@ -138,10 +101,12 @@ cleanup() {
         echo "[deploy-census-worker] ERROR: automatic Worker rollback failed" >&2
         cleanup_status=1
       else
-        restored_deployment="$(read_current_deployment)" \
-          || restored_deployment=""
+        restored_deployment="$(
+          census_read_current_deployment \
+            "$expected_account" "$worker_dir" "$config_file" "$expected_worker"
+        )" || restored_deployment=""
         restored_version="$(
-          single_deployment_version_id <<<"$restored_deployment"
+          census_single_deployment_version_id <<<"$restored_deployment"
         )" || restored_version=""
         if [[ "$restored_version" != "$rollback_version" ]]; then
           echo "[deploy-census-worker] ERROR: could not verify the restored Worker version" >&2
@@ -173,6 +138,9 @@ node_major="$(node -p 'Number(process.versions.node.split(".")[0])')"
 [[ -z "$(git -C "$root_dir" status --porcelain)" ]] || fail "checkout is dirty; deploy only the exact reviewed merge"
 actual_sha="$(git -C "$root_dir" rev-parse HEAD)"
 [[ "$actual_sha" == "$reviewed_sha" ]] || fail "HEAD ${actual_sha} does not match reviewed SHA ${reviewed_sha}"
+# Source only after proving the helper belongs to this clean reviewed checkout.
+# shellcheck source=scripts/release/census-deployment-state.sh
+source "${script_dir}/census-deployment-state.sh"
 gh auth status --hostname github.com >/dev/null 2>&1 \
   || fail "gh is not authenticated for github.com"
 active_github_user="$(gh api --hostname github.com user --jq .login)" \
@@ -377,9 +345,11 @@ actual_sha="$(git -C "$root_dir" rev-parse HEAD)"
 [[ "$actual_sha" == "$reviewed_sha" ]] \
   || fail "HEAD changed during local proof (${actual_sha}); refusing to deploy"
 
-previous_deployment="$(read_current_deployment)" \
-  || fail "could not read the current production Worker deployment"
-rollback_version="$(single_deployment_version_id <<<"$previous_deployment")" \
+previous_deployment="$(
+  census_read_current_deployment \
+    "$expected_account" "$worker_dir" "$config_file" "$expected_worker"
+)" || fail "could not read the current production Worker deployment"
+rollback_version="$(census_single_deployment_version_id <<<"$previous_deployment")" \
   || fail "current Worker is not a single 100-percent version; refuse an ambiguous rollback target"
 # Census deploys are a serialized single-writer operation. When Wrangler
 # identifies this run's deployed version, cleanup refuses to overwrite a
@@ -400,7 +370,7 @@ WRANGLER_OUTPUT_FILE_PATH="$wrangler_output" \
     --no-autoconfig
 
 [[ -s "$wrangler_output" ]] || fail "Wrangler wrote no structured deployment output"
-deployed_version="$(deployment_output_version_id "$wrangler_output")" \
+deployed_version="$(census_deployment_output_version_id "$wrangler_output")" \
   || fail "Wrangler output did not identify exactly one safe deployed version"
 deploy_record="$({
   jq -sce \

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -25,6 +25,10 @@ describe("release contract", () => {
     "scripts/release/deploy-census-worker.sh",
     "utf8",
   );
+  const censusDeploymentState = readFileSync(
+    "scripts/release/census-deployment-state.sh",
+    "utf8",
+  );
   const releaseWorkflow = readFileSync(".github/workflows/release.yml", "utf8");
   const rcWorkflow = readFileSync(
     ".github/workflows/release-candidate.yml",
@@ -392,17 +396,29 @@ describe("release contract", () => {
     );
     expect(censusDeployer).toContain("WRANGLER_OUTPUT_FILE_PATH");
     expect(censusDeployer).toContain("$deploys[0].targets == [$target]");
-    expect(censusDeployer).toContain("single_deployment_version_id");
-    expect(censusDeployer).toContain("deployment_output_version_id");
-    expect(censusDeployer).toContain("select(length == 1)");
+    expect(censusDeployer).toContain("census_single_deployment_version_id");
     expect(censusDeployer).toContain(
+      "census_deployment_output_version_id",
+    );
+    expect(censusDeployer).toContain("census-deployment-state.sh");
+    expect(censusDeploymentState).toContain("select(length == 1)");
+    expect(censusDeploymentState).toContain(
       'test("^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$")',
     );
-    expect(censusDeployer).toContain("wrangler@4.113.0 deployments status");
-    expect(censusDeployer).not.toContain(
+    expect(censusDeploymentState).toContain(
+      "wrangler@4.113.0 deployments status",
+    );
+    const censusDeploymentScripts = `${censusDeployer}\n${censusDeploymentState}`;
+    expect(censusDeploymentScripts).not.toContain(
       "wrangler@4.113.0 deployments list",
     );
-    expect(censusDeployer).not.toContain(".[0].versions");
+    expect(censusDeploymentScripts).not.toContain(".[0].versions");
+    expect(
+      censusDeployer.trimEnd().split("\n").length,
+    ).toBeLessThanOrEqual(400);
+    expect(
+      censusDeploymentState.trimEnd().split("\n").length,
+    ).toBeLessThanOrEqual(400);
     expect(censusDeployer).toContain("rollback not needed");
     expect(censusDeployer).toContain(
       "active Worker version changed outside this deploy",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -392,6 +392,22 @@ describe("release contract", () => {
     );
     expect(censusDeployer).toContain("WRANGLER_OUTPUT_FILE_PATH");
     expect(censusDeployer).toContain("$deploys[0].targets == [$target]");
+    expect(censusDeployer).toContain("single_deployment_version_id");
+    expect(censusDeployer).toContain("deployment_output_version_id");
+    expect(censusDeployer).toContain("select(length == 1)");
+    expect(censusDeployer).toContain(
+      'test("^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$")',
+    );
+    expect(censusDeployer).toContain("wrangler@4.113.0 deployments status");
+    expect(censusDeployer).not.toContain(
+      "wrangler@4.113.0 deployments list",
+    );
+    expect(censusDeployer).not.toContain(".[0].versions");
+    expect(censusDeployer).toContain("rollback not needed");
+    expect(censusDeployer).toContain(
+      "active Worker version changed outside this deploy",
+    );
+    expect(releasing).toContain("serialized single-writer operation");
     expect(censusDeployer).toContain('--tag "$reviewed_sha"');
     expect(censusDeployer).toContain("--strict");
     expect(censusDeployer).toContain("--no-autoconfig");

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -401,7 +401,12 @@ describe("release contract", () => {
       "census_deployment_output_version_id",
     );
     expect(censusDeployer).toContain("census-deployment-state.sh");
+    expect(censusDeployer).toContain(
+      "census_wait_for_settled_current_version",
+    );
     expect(censusDeploymentState).toContain("select(length == 1)");
+    expect(censusDeploymentState).toContain("attempt <= 15");
+    expect(censusDeploymentState).toContain("sleep 2");
     expect(censusDeploymentState).toContain(
       'test("^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$")',
     );

--- a/tests/onboarding/release-gates-behavior.test.ts
+++ b/tests/onboarding/release-gates-behavior.test.ts
@@ -58,6 +58,10 @@ function releaseFixture(): {
   const script = join(releaseDir, "deploy-census-worker.sh");
   copyFileSync("scripts/release/deploy-census-worker.sh", script);
   copyFileSync(
+    "scripts/release/census-deployment-state.sh",
+    join(releaseDir, "census-deployment-state.sh"),
+  );
+  copyFileSync(
     "scripts/release/verify-census-deployment.sh",
     join(releaseDir, "verify-census-deployment.sh"),
   );

--- a/tests/onboarding/release-gates-behavior.test.ts
+++ b/tests/onboarding/release-gates-behavior.test.ts
@@ -45,6 +45,7 @@ function releaseFixture(): {
   script: string;
   fakeBin: string;
   callLog: string;
+  deploymentState: string;
 } {
   const root = mkdtempSync(join(tmpdir(), "ha-nova-release-gates-"));
   const releaseDir = join(root, "scripts", "release");
@@ -71,6 +72,11 @@ function releaseFixture(): {
     mkdtempSync(join(tmpdir(), "ha-nova-release-call-log-")),
     "calls.log",
   );
+  const deploymentState = join(
+    mkdtempSync(join(tmpdir(), "ha-nova-release-deployment-state-")),
+    "version",
+  );
+  writeFileSync(deploymentState, "previous-version\n", "utf8");
   writeExecutable(
     join(fakeBin, "node"),
     `#!/usr/bin/env bash
@@ -107,19 +113,58 @@ case " $* " in
     exec /bin/sleep 300
     ;;
   *" wrangler@4.113.0 deployments list "*)
-    printf '[{"versions":[{"version_id":"previous-version","percentage":100}]}]\n'
+    printf '%s\n' '[{"created_on":"2026-07-22T10:00:00Z","versions":[{"version_id":"oldest-version","percentage":100}]},{"created_on":"2026-07-24T10:00:00Z","versions":[{"version_id":"previous-version","percentage":100}]}]'
+    ;;
+  *" wrangler@4.113.0 deployments status "*)
+    if [[ "\${FAKE_MODE:-valid}" == "malformed_current_deployment" ]]; then
+      printf '%s\n' '{}'
+    elif [[ "\${FAKE_MODE:-valid}" == "multiple_current_deployments" ]]; then
+      printf '%s\n%s\n' \
+        '{"versions":[{"version_id":"previous-version","percentage":100}]}' \
+        '{"versions":[{"version_id":"other-version","percentage":100}]}'
+    elif [[ "\${FAKE_MODE:-valid}" == "split_current_deployment" ]]; then
+      printf '%s\n' '{"created_on":"2026-07-24T10:00:00Z","versions":[{"version_id":"previous-version","percentage":50},{"version_id":"other-version","percentage":50}]}'
+    elif [[ "\${FAKE_MODE:-valid}" == "unsafe_current_deployment" ]]; then
+      printf '%s\n' '{"versions":[{"version_id":"--help","percentage":100}]}'
+    elif [[ "\${FAKE_MODE:-valid}" == "cleanup_status_unavailable" && "$(<"$FAKE_DEPLOYMENT_STATE")" == "$TEST_VERSION_ID" ]]; then
+      exit 42
+    else
+      current_version="$(<"$FAKE_DEPLOYMENT_STATE")"
+      if [[ "\${FAKE_MODE:-valid}" == "concurrent_after_deploy" && "$current_version" == "$TEST_VERSION_ID" ]]; then
+        current_version="concurrent-version"
+      fi
+      printf '{"versions":[{"version_id":"%s","percentage":100}]}\n' "$current_version"
+    fi
     ;;
   *" wrangler@4.113.0 rollback "*)
+    rollback_target="$4"
+    if [[ "\${FAKE_MODE:-valid}" == "rollback_status_mismatch" ]]; then
+      printf 'wrong-restored-version\n' > "$FAKE_DEPLOYMENT_STATE"
+    else
+      printf '%s\n' "$rollback_target" > "$FAKE_DEPLOYMENT_STATE"
+    fi
     printf 'rollback ok\n'
     ;;
   *" wrangler@4.113.0 deploy "*)
     [[ "\${FAKE_MODE:-valid}" != "deploy_fail" ]] || exit 42
+    printf '%s\n' "$TEST_VERSION_ID" > "$FAKE_DEPLOYMENT_STATE"
+    if [[ "\${FAKE_MODE:-valid}" == "remote_fail_without_output" ]]; then
+      : > "$WRANGLER_OUTPUT_FILE_PATH"
+      exit 42
+    elif [[ "\${FAKE_MODE:-valid}" == "missing_deploy_output" ]]; then
+      : > "$WRANGLER_OUTPUT_FILE_PATH"
+      exit 0
+    elif [[ "\${FAKE_MODE:-valid}" == "malformed_deploy_output" ]]; then
+      printf '%s\n' '{"type":"unexpected"}' > "$WRANGLER_OUTPUT_FILE_PATH"
+      exit 0
+    fi
     target="https://ha-nova-census.markusleben.workers.dev"
     [[ "\${FAKE_MODE:-valid}" != "wrong_target" ]] || target="https://ha-nova-census-wrong.example.workers.dev"
     targets="[\\\"$target\\\"]"
     [[ "\${FAKE_MODE:-valid}" != "extra_target" ]] || targets="[\\\"$target\\\",\\\"https://extra.example.test\\\"]"
     printf '{"type":"deploy","version":1,"worker_name":"ha-nova-census","version_id":"%s","targets":%s}\n' \
       "$TEST_VERSION_ID" "$targets" > "$WRANGLER_OUTPUT_FILE_PATH"
+    [[ "\${FAKE_MODE:-valid}" != "deploy_fail_after_upload" ]] || exit 42
     ;;
   *) exit 2 ;;
 esac
@@ -218,7 +263,11 @@ relay_analytics='{"status":"available","source":"https://analytics.home-assistan
 [[ "\${FAKE_MODE:-valid}" != "malformed_relay_analytics" ]] || relay_analytics='{"status":"unavailable","source":"https://analytics.home-assistant.io/addons.json","slug":"2368fcfa_ha_nova_relay"}'
 [[ "\${FAKE_MODE:-valid}" != "stale_relay_analytics" ]] || relay_analytics='{"status":"unavailable","source":"https://analytics.home-assistant.io/addons.json","slug":"2368fcfa_ha_nova_relay","error":"upstream timeout","total":9,"by_version":{"0.7.0":9}}'
 payload="{\\"schema\\":2,\\"generated_at\\":\\"2026-07-23T00:00:00Z\\",\\"client_installations\\":{\\"active_21_days\\":$active_count,\\"known_60_days\\":$active_count,\\"release_smoke_installations\\":$smoke_count,\\"by_os\\":{\\"linux\\":$active_count},\\"by_version\\":{\\"other\\":$active_count},\\"relay_versions\\":{},\\"relay_not_recently_observed\\":$active_count,\\"new_installation_rejections_today\\":0},\\"relay_app_installations\\":$relay_analytics,\\"legacy_ping_activity\\":{\\"weekly\\":[]}}"
-[[ "\${FAKE_MODE:-valid}" != "wrong_public_sha" ]] || public_sha="0000000000000000000000000000000000000000"
+case "\${FAKE_MODE:-valid}" in
+  wrong_public_sha|rollback_status_mismatch|concurrent_after_deploy|cleanup_status_unavailable)
+    public_sha="0000000000000000000000000000000000000000"
+    ;;
+esac
 [[ "\${FAKE_MODE:-valid}" != "wrong_public_version" ]] || public_version="wrong-version"
 [[ "\${FAKE_MODE:-valid}" != "malformed_public_stats" ]] || payload='{"schema":2}'
 printf 'HTTP/2 200\\r\\nX-HA-NOVA-Deployment-SHA: %s\\r\\nX-HA-NOVA-Version-ID: %s\\r\\n\\r\\n' \
@@ -243,7 +292,7 @@ printf '200'
     cwd: root,
     encoding: "utf8",
   }).trim();
-  return { root, sha, script, fakeBin, callLog };
+  return { root, sha, script, fakeBin, callLog, deploymentState };
 }
 
 function runGate(
@@ -259,6 +308,7 @@ function runGate(
       ...process.env,
       PATH: `${fixture.fakeBin}:${process.env.PATH ?? ""}`,
       FAKE_CALL_LOG: fixture.callLog,
+      FAKE_DEPLOYMENT_STATE: fixture.deploymentState,
       FAKE_MODE: mode,
       TEST_SHA: fixture.sha,
       TEST_VERSION_ID: VERSION_ID,
@@ -323,6 +373,21 @@ describe("release gate behavior", () => {
     expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
   });
 
+  it.each([
+    "malformed_current_deployment",
+    "multiple_current_deployments",
+    "split_current_deployment",
+    "unsafe_current_deployment",
+  ])("rejects unsafe current state before deploy in %s mode", (mode) => {
+    const fixture = releaseFixture();
+    const result = runGate(fixture, mode);
+    expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+    const calls = readFileSync(fixture.callLog, "utf8");
+    expect(calls).toContain("wrangler@4.113.0 deployments status");
+    expect(calls).not.toContain("wrangler@4.113.0 deploy --cwd");
+    expect(calls).not.toContain("wrangler@4.113.0 rollback");
+  });
+
   it.each(["valid", "analytics_unavailable", "unrelated_linux_install"])(
     "accepts the exact deployment chain in %s mode",
     (mode) => {
@@ -344,12 +409,92 @@ describe("release gate behavior", () => {
     expect(calls).toContain("/withdraw");
   });
 
-  it("rolls production back after any post-deploy verification failure", () => {
+  it("rolls back to the newest deployment when Wrangler lists oldest first", () => {
     const fixture = releaseFixture();
     const result = runGate(fixture, "wrong_public_sha");
     expect(result.status).not.toBe(0);
-    expect(readFileSync(fixture.callLog, "utf8")).toContain(
+    const calls = readFileSync(fixture.callLog, "utf8");
+    expect(calls).toContain(
       "wrangler@4.113.0 rollback previous-version",
+    );
+    expect(calls).not.toContain("wrangler@4.113.0 rollback oldest-version");
+    expect(calls).toContain("wrangler@4.113.0 deployments status");
+    expect(calls).not.toContain("wrangler@4.113.0 deployments list");
+    expect(result.stderr).not.toContain(
+      "could not verify the restored Worker version",
+    );
+    expect(readFileSync(fixture.deploymentState, "utf8").trim()).toBe(
+      "previous-version",
+    );
+  });
+
+  it("does not create a rollback deployment when deploy fails unchanged", () => {
+    const fixture = releaseFixture();
+    const result = runGate(fixture, "deploy_fail");
+    expect(result.status).not.toBe(0);
+    const calls = readFileSync(fixture.callLog, "utf8");
+    expect(calls).not.toContain("wrangler@4.113.0 rollback");
+    expect(result.stderr).toContain("rollback not needed");
+  });
+
+  it("rolls back when a failed deploy emitted its deployed version", () => {
+    const fixture = releaseFixture();
+    const result = runGate(fixture, "deploy_fail_after_upload");
+    expect(result.status).not.toBe(0);
+    const calls = readFileSync(fixture.callLog, "utf8");
+    expect(calls).toContain(
+      "wrangler@4.113.0 rollback previous-version",
+    );
+    expect(readFileSync(fixture.deploymentState, "utf8").trim()).toBe(
+      "previous-version",
+    );
+  });
+
+  it.each([
+    "remote_fail_without_output",
+    "missing_deploy_output",
+    "malformed_deploy_output",
+  ])("rolls back a changed single-writer deployment in %s mode", (mode) => {
+    const fixture = releaseFixture();
+    const result = runGate(fixture, mode);
+    expect(result.status).not.toBe(0);
+    const calls = readFileSync(fixture.callLog, "utf8");
+    expect(calls).toContain(
+      "wrangler@4.113.0 rollback previous-version",
+    );
+    expect(readFileSync(fixture.deploymentState, "utf8").trim()).toBe(
+      "previous-version",
+    );
+  });
+
+  it("fails when rollback does not restore the selected version", () => {
+    const fixture = releaseFixture();
+    const result = runGate(fixture, "rollback_status_mismatch");
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "could not verify the restored Worker version",
+    );
+  });
+
+  it("does not overwrite a deployment that became active later", () => {
+    const fixture = releaseFixture();
+    const result = runGate(fixture, "concurrent_after_deploy");
+    expect(result.status).not.toBe(0);
+    const calls = readFileSync(fixture.callLog, "utf8");
+    expect(calls).not.toContain("wrangler@4.113.0 rollback");
+    expect(result.stderr).toContain(
+      "active Worker version changed outside this deploy",
+    );
+  });
+
+  it("does not roll back when cleanup cannot read the active version", () => {
+    const fixture = releaseFixture();
+    const result = runGate(fixture, "cleanup_status_unavailable");
+    expect(result.status).not.toBe(0);
+    const calls = readFileSync(fixture.callLog, "utf8");
+    expect(calls).not.toContain("wrangler@4.113.0 rollback");
+    expect(result.stderr).toContain(
+      "could not determine the active Worker version",
     );
   });
 

--- a/tests/onboarding/release-gates-behavior.test.ts
+++ b/tests/onboarding/release-gates-behavior.test.ts
@@ -46,6 +46,8 @@ function releaseFixture(): {
   fakeBin: string;
   callLog: string;
   deploymentState: string;
+  deploymentPending: string;
+  deploymentPolls: string;
 } {
   const root = mkdtempSync(join(tmpdir(), "ha-nova-release-gates-"));
   const releaseDir = join(root, "scripts", "release");
@@ -81,6 +83,10 @@ function releaseFixture(): {
     "version",
   );
   writeFileSync(deploymentState, "previous-version\n", "utf8");
+  const deploymentPending = join(root, "deployment-pending");
+  const deploymentPolls = join(root, "deployment-polls");
+  writeFileSync(deploymentPending, "none\n", "utf8");
+  writeFileSync(deploymentPolls, "0\n", "utf8");
   writeExecutable(
     join(fakeBin, "node"),
     `#!/usr/bin/env bash
@@ -120,6 +126,14 @@ case " $* " in
     printf '%s\n' '[{"created_on":"2026-07-22T10:00:00Z","versions":[{"version_id":"oldest-version","percentage":100}]},{"created_on":"2026-07-24T10:00:00Z","versions":[{"version_id":"previous-version","percentage":100}]}]'
     ;;
   *" wrangler@4.113.0 deployments status "*)
+    if [[ "\${FAKE_MODE:-valid}" == "delayed_deploy_failure" && "$(<"$FAKE_DEPLOYMENT_PENDING")" == "pending" ]]; then
+      poll_count="$(( $(<"$FAKE_DEPLOYMENT_POLLS") + 1 ))"
+      printf '%s\n' "$poll_count" > "$FAKE_DEPLOYMENT_POLLS"
+      if [[ "$poll_count" -ge 3 ]]; then
+        printf '%s\n' "$TEST_VERSION_ID" > "$FAKE_DEPLOYMENT_STATE"
+        printf 'settled\n' > "$FAKE_DEPLOYMENT_PENDING"
+      fi
+    fi
     if [[ "\${FAKE_MODE:-valid}" == "malformed_current_deployment" ]]; then
       printf '%s\n' '{}'
     elif [[ "\${FAKE_MODE:-valid}" == "multiple_current_deployments" ]]; then
@@ -151,6 +165,10 @@ case " $* " in
     ;;
   *" wrangler@4.113.0 deploy "*)
     [[ "\${FAKE_MODE:-valid}" != "deploy_fail" ]] || exit 42
+    if [[ "\${FAKE_MODE:-valid}" == "delayed_deploy_failure" ]]; then
+      printf 'pending\n' > "$FAKE_DEPLOYMENT_PENDING"
+      exit 42
+    fi
     printf '%s\n' "$TEST_VERSION_ID" > "$FAKE_DEPLOYMENT_STATE"
     if [[ "\${FAKE_MODE:-valid}" == "remote_fail_without_output" ]]; then
       : > "$WRANGLER_OUTPUT_FILE_PATH"
@@ -296,7 +314,16 @@ printf '200'
     cwd: root,
     encoding: "utf8",
   }).trim();
-  return { root, sha, script, fakeBin, callLog, deploymentState };
+  return {
+    root,
+    sha,
+    script,
+    fakeBin,
+    callLog,
+    deploymentState,
+    deploymentPending,
+    deploymentPolls,
+  };
 }
 
 function runGate(
@@ -313,6 +340,8 @@ function runGate(
       PATH: `${fixture.fakeBin}:${process.env.PATH ?? ""}`,
       FAKE_CALL_LOG: fixture.callLog,
       FAKE_DEPLOYMENT_STATE: fixture.deploymentState,
+      FAKE_DEPLOYMENT_PENDING: fixture.deploymentPending,
+      FAKE_DEPLOYMENT_POLLS: fixture.deploymentPolls,
       FAKE_MODE: mode,
       TEST_SHA: fixture.sha,
       TEST_VERSION_ID: VERSION_ID,
@@ -439,6 +468,23 @@ describe("release gate behavior", () => {
     const calls = readFileSync(fixture.callLog, "utf8");
     expect(calls).not.toContain("wrangler@4.113.0 rollback");
     expect(result.stderr).toContain("rollback not needed");
+    expect(
+      calls.match(/wrangler@4\.113\.0 deployments status/g),
+    ).toHaveLength(16);
+  });
+
+  it("waits for a failed in-flight deploy to settle before rollback", () => {
+    const fixture = releaseFixture();
+    const result = runGate(fixture, "delayed_deploy_failure");
+    expect(result.status).not.toBe(0);
+    const calls = readFileSync(fixture.callLog, "utf8");
+    expect(calls).toContain(
+      "wrangler@4.113.0 rollback previous-version",
+    );
+    expect(readFileSync(fixture.deploymentPolls, "utf8").trim()).toBe("3");
+    expect(readFileSync(fixture.deploymentState, "utf8").trim()).toBe(
+      "previous-version",
+    );
   });
 
   it("rolls back when a failed deploy emitted its deployed version", () => {


### PR DESCRIPTION
## Summary

- derive the rollback target from `wrangler deployments status` instead of the oldest entry returned by `deployments list`
- validate current/deployed version IDs and fail closed for ambiguous or concurrent deployment state
- add stateful regression coverage for rollback, unchanged production, malformed output, unavailable status, and concurrent deploys
- document the required serialized single-writer deployment invariant

## Verification

- `npm run verify` (94 release-contract tests)
- pre-push hook: 1,134 tests, typecheck, build, documentation fact-check
- `npx vitest run tests/onboarding/release-gates-behavior.test.ts tests/onboarding/release-contract.test.ts` (66 tests)
- `shellcheck scripts/release/deploy-census-worker.sh`
- `bash -n scripts/release/deploy-census-worker.sh`
- `git diff --check`

No production deployment is part of this PR.