### PR TITLE
fix(deps-dev): patch PostCSS source map traversal

### DIFF
--- a/docs/work/2026-07-26-postcss-source-map-traversal-spec.md
+++ b/docs/work/2026-07-26-postcss-source-map-traversal-spec.md
@@ -1,0 +1,21 @@
+# PostCSS source-map traversal security fix
+
+## Context
+
+Dependabot alert 49 reports GHSA-r28c-9q8g-f849 in `postcss` versions through
+8.5.17. HA NOVA receives `postcss` only as a development-only transitive
+dependency through `vitest` and `vite`; no shipped runtime processes user CSS.
+
+## Decision
+
+- Update only the lockfile resolution from `postcss` 8.5.16 to the patched
+  8.5.18 release.
+- Do not add a direct dependency or change package manifests.
+- Keep this security maintenance separate from the Cloud Remote feature PR.
+- Do not add a README or release claim for an internal development dependency.
+
+## Verification
+
+- `npm ls postcss` resolves exactly 8.5.18.
+- `npm audit` reports no known vulnerabilities.
+- Typecheck, tests, build, and documentation fact-check pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2007,9 +2007,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- resolve Dependabot alert 49 / GHSA-r28c-9q8g-f849
- update only the transitive development lock resolution from postcss 8.5.16 to the first patched 8.5.18 release
- keep package manifests, runtime dependencies, README, and Cloud Remote PR unchanged

## Verification

- npm ci --ignore-scripts
- npm ls postcss --all (8.5.18)
- npm audit (0 vulnerabilities)
- npm run typecheck
- npm test (118 files, 1,135 tests)
- npm run build
- bash scripts/check-docs.sh

## Risk

Development-only transitive dependency through Vitest/Vite; no shipped runtime processes CSS.