### PR TITLE
ci: provision Cloud source-gate App ID

### DIFF
--- a/.github/policy/repo-policy.json
+++ b/.github/policy/repo-policy.json
@@ -81,7 +81,7 @@
   "cloud_source_gate": {
     "check_name": "cloud-source-gate",
     "reporter_app_slug": "ha-nova-cloud-source-gate",
-    "reporter_app_id": 0,
+    "reporter_app_id": 4400145,
     "sensitive_workflows": [
       ".github/workflows/cloud-source-gate.yml",
       ".github/workflows/ci.yml",

--- a/tests/onboarding/dependabot-automation-contract.test.ts
+++ b/tests/onboarding/dependabot-automation-contract.test.ts
@@ -325,7 +325,7 @@ describe("dependabot automation contract", () => {
     expect(policy.cloud_source_gate.check_name).toBe("cloud-source-gate");
     expect(policy.cloud_source_gate.reporter_app_slug).toBe("ha-nova-cloud-source-gate");
     expect(policy.cloud_source_gate.reporter_app_slug.length).toBeLessThanOrEqual(34);
-    expect(policy.cloud_source_gate.reporter_app_id).toBe(0);
+    expect(policy.cloud_source_gate.reporter_app_id).toBe(4400145);
     expect(protectionScript).toContain("repo-policy.json");
     expect(protectionScript).toContain(".main_branch_protection.required_status_checks | sort");
     expect(protectionScript).toContain(".main_branch_protection.required_status_check_apps");


### PR DESCRIPTION
## Summary

- pin the already-created private ha-nova-cloud-source-gate App ID in repository policy
- keep Cloud Remote disabled and keep cloud-source-gate outside required branch checks
- update the policy contract test to pin the reviewed App ID

## Verification

- 20 targeted policy/workflow tests passed
- live main protection verifier passed
- production environment contains both source-gate secret names

## Rollout boundary

After merge, a separate disabled test PR must prove the real broker check is emitted by App ID 4400145. Only after that can live branch protection require cloud-source-gate. No Cloud activation, tag, release, or README change is included.