### PR TITLE
test: verify disabled Cloud source-gate canary

### DIFF
--- a/docs/work/cloud-source-gate-disabled-canary.md
+++ b/docs/work/cloud-source-gate-disabled-canary.md
@@ -1,0 +1,7 @@
+# Disabled Cloud Source Gate Canary
+
+Temporary operational canary. Do not merge.
+
+Cloud Remote remains disabled. This pull request exists only to verify that
+the trusted default-branch broker reports `cloud-source-gate` through the
+repository-scoped GitHub App.


### PR DESCRIPTION
## Purpose

Zero-diff operational canary. Cloud Remote remains disabled. This PR exists only to prove that the trusted default-branch broker emits cloud-source-gate through private App ID 4400145 using the production environment credentials.

Do not merge. Close after recording the check identity and result.