### PR TITLE
fix(ci): make Cloud source gate lifecycle efficient

### DIFF
--- a/.github/workflows/cloud-source-gate.yml
+++ b/.github/workflows/cloud-source-gate.yml
@@ -6,8 +6,6 @@ on:
       - CI
     types:
       - completed
-      - in_progress
-      - requested
 
 permissions:
   actions: read

--- a/.github/workflows/cloud-source-gate.yml
+++ b/.github/workflows/cloud-source-gate.yml
@@ -6,6 +6,7 @@ on:
       - CI
     types:
       - completed
+      - in_progress
 
 permissions:
   actions: read

--- a/.github/workflows/dependabot-safe-auto-merge.yml
+++ b/.github/workflows/dependabot-safe-auto-merge.yml
@@ -21,6 +21,12 @@ permissions: {}
 
 jobs:
   resolve-trigger:
+    if: >-
+      github.event_name == 'repository_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/')) ||
+      (github.event_name == 'check_run' &&
+      github.event.check_run.name == 'cloud-source-gate')
     permissions:
       actions: read
       contents: read
@@ -45,8 +51,9 @@ jobs:
             gh api "repos/${GITHUB_REPOSITORY}/commits/${POLICY_REF}" --jq '.sha'
           )"
           [[ "${trusted_ref}" =~ ^[0-9a-f]{40}$ ]]
-          POLICY_FILE="$(mktemp)"
-          TRIGGER_SCRIPT="$(mktemp)"
+          TRIGGER_DIR="$(mktemp -d)"
+          POLICY_FILE="${TRIGGER_DIR}/repo-policy.json"
+          TRIGGER_SCRIPT="${TRIGGER_DIR}/resolve-dependabot-auto-merge-trigger.mjs"
           gh api "repos/${GITHUB_REPOSITORY}/contents/.github/policy/repo-policy.json?ref=${trusted_ref}" \
             --jq '.content' \
             | tr -d '\n' \

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -174,12 +174,14 @@ The required `cloud-source-gate` is emitted by the dedicated
 `ha-nova-cloud-source-gate` GitHub App after a trusted
 default-branch `workflow_run`. The broker runs after `CI` for pull requests and
 merge groups, including Dependabot runs; it never reads upstream artifacts or
-caches, checks out PR code, or executes a target path. It independently
-creates or reuses one App check for each exact successful, completed upstream
-run ID and attempt. Reruns produce a new attempt-bound check. Cancelled or
-failed CI, stale pull requests, and GitHub races before a merge ref is
-materialized exit without a check; the missing required context remains
-fail-closed without producing duplicate workflow failures. It
+caches, checks out PR code, or executes a target path. An `in_progress`
+delivery creates only an attempt-bound provisional pending App check; this
+invalidates prior success during initial runs and reruns without resolving a
+merge ref or executing policy code. A successful `completed` delivery creates
+the exact target-bound pending check before retiring the provisional check.
+Cancelled or failed CI retires its provisional check because CI itself remains
+failed. Stale pull requests and GitHub races before a merge ref is materialized
+exit without an exact check and remain fail-closed. The broker
 resolves the current PR head and base, fetches GitHub's merge ref, verifies its
 two parents, and materializes only its three release metadata files for
 parsing. The first resolved merge SHA is passed to the verifier as an exact

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -175,9 +175,11 @@ The required `cloud-source-gate` is emitted by the dedicated
 default-branch `workflow_run`. The broker runs after `CI` for pull requests and
 merge groups, including Dependabot runs; it never reads upstream artifacts or
 caches, checks out PR code, or executes a target path. It independently
-creates or reuses one pending App check for each exact upstream run ID and
-attempt on `requested` or `in_progress`; this also covers reruns, where GitHub
-does not emit `requested`. Only `completed` performs source verification. It
+creates or reuses one App check for each exact successful, completed upstream
+run ID and attempt. Reruns produce a new attempt-bound check. Cancelled or
+failed CI, stale pull requests, and GitHub races before a merge ref is
+materialized exit without a check; the missing required context remains
+fail-closed without producing duplicate workflow failures. It
 resolves the current PR head and base, fetches GitHub's merge ref, verifies its
 two parents, and materializes only its three release metadata files for
 parsing. The first resolved merge SHA is passed to the verifier as an exact

--- a/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
+++ b/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
@@ -688,11 +688,13 @@ as the expected status source. Every success requires strict up-to-date branch
 protection and the exact App binding. The broker binds the first fetched PR or
 merge-queue ref to the verifier, re-fetches that ref immediately before
 success, and then resolves the current PR identity and merge commit once more.
-Each successful completed CI lifecycle event idempotently creates one App
-check per upstream run ID, attempt, and exact synthetic merge target, then
-verifies and finishes it. Failed or cancelled CI, stale pull requests, and
-temporarily absent merge refs emit no check, which remains fail-closed when the
-context is required. Terminal success is idempotent, terminal failure is
+Each in-progress CI lifecycle event idempotently creates an attempt-bound
+provisional pending App check without resolving or executing the target. A
+successful completed event creates the exact synthetic-target check before
+retiring that provisional check, closing the old-success rerun window. Failed
+or cancelled CI retires its provisional check because CI remains failed.
+Stale pull requests and temporarily absent merge refs emit no exact check and
+remain fail-closed. Terminal success is idempotent, terminal failure is
 retryable, and conflicting duplicate conclusions fail closed. A
 read-only trigger job authenticates the exact check name, App ID, and slug
 before its completion may re-evaluate Dependabot.
@@ -715,8 +717,9 @@ marker recovery, while human-owned native auto-merge is never changed.
 The single dedicated source App is the complete MVP trust boundary. GitHub
 requires a successful check on the latest candidate SHA, and strict branch
 protection requires the branch to be current with its base. The trusted
-default-branch broker creates an App check for each successful completed CI run
-ID, attempt, and exact synthetic merge target before reporting success. The
+default-branch broker first creates a provisional pending check for each active
+CI attempt, then replaces it with the exact synthetic-target check before
+reporting success. The
 direct merger additionally rejects a source success whose external ID names
 another merge target, any active current-head CI run, or any changed PR,
 head, base, or merge ref. A second external invalidator service would duplicate

--- a/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
+++ b/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
@@ -688,10 +688,12 @@ as the expected status source. Every success requires strict up-to-date branch
 protection and the exact App binding. The broker binds the first fetched PR or
 merge-queue ref to the verifier, re-fetches that ref immediately before
 success, and then resolves the current PR identity and merge commit once more.
-Requested and in-progress CI lifecycle events idempotently create one pending
-App check per upstream run ID, attempt, and exact synthetic merge target; only
-completion verifies and finishes it. Terminal success is idempotent, terminal
-failure is retryable, and conflicting duplicate conclusions fail closed. A
+Each successful completed CI lifecycle event idempotently creates one App
+check per upstream run ID, attempt, and exact synthetic merge target, then
+verifies and finishes it. Failed or cancelled CI, stale pull requests, and
+temporarily absent merge refs emit no check, which remains fail-closed when the
+context is required. Terminal success is idempotent, terminal failure is
+retryable, and conflicting duplicate conclusions fail closed. A
 read-only trigger job authenticates the exact check name, App ID, and slug
 before its completion may re-evaluate Dependabot.
 
@@ -713,8 +715,8 @@ marker recovery, while human-owned native auto-merge is never changed.
 The single dedicated source App is the complete MVP trust boundary. GitHub
 requires a successful check on the latest candidate SHA, and strict branch
 protection requires the branch to be current with its base. The trusted
-default-branch broker creates a pending App check for each CI run ID, attempt,
-and exact synthetic merge target before completion can report success. The
+default-branch broker creates an App check for each successful completed CI run
+ID, attempt, and exact synthetic merge target before reporting success. The
 direct merger additionally rejects a source success whose external ID names
 another merge target, any active current-head CI run, or any changed PR,
 head, base, or merge ref. A second external invalidator service would duplicate

--- a/docs/work/2026-07-27-cloud-source-gate-efficiency-spec.md
+++ b/docs/work/2026-07-27-cloud-source-gate-efficiency-spec.md
@@ -30,3 +30,15 @@ notifications.
 No push or rerun may be used as a debugging loop. A remote canary is
 single-shot, is cancelled at its first unexpected result, and must leave no
 active workflows after closure.
+
+## Dependabot trigger containment
+
+The local PR canary exposed an existing failure in the Dependabot safe
+auto-merge trigger:
+
+- Downloaded ES modules must retain a `.mjs` filename before Node executes
+  them.
+- Human branches and unrelated check names must skip the resolver job before
+  it downloads policy or script files.
+- These prefilters only reject irrelevant events. The trusted default-branch
+  resolver remains the authorization boundary for every accepted event.

--- a/docs/work/2026-07-27-cloud-source-gate-efficiency-spec.md
+++ b/docs/work/2026-07-27-cloud-source-gate-efficiency-spec.md
@@ -12,7 +12,13 @@ notifications.
 
 ## Required behavior
 
-- Trigger the broker only for a completed `CI` workflow run.
+- Trigger the broker for `in_progress` and `completed` CI deliveries. Never use
+  `requested`, because GitHub does not emit it consistently for reruns.
+- `in_progress` creates only an attempt-bound provisional pending App check on
+  the CI head. It does not resolve a PR, fetch a merge ref, or run policy code.
+- `completed` creates the exact target-bound pending check before deleting the
+  provisional check. It repeats provisional cleanup after terminal success so
+  a delayed early delivery cannot strand state.
 - A non-successful upstream CI run, stale pull request, missing merge ref, or
   temporarily absent pull-request merge SHA exits successfully without
   creating an App check. The missing required check remains fail-closed.

--- a/docs/work/2026-07-27-cloud-source-gate-efficiency-spec.md
+++ b/docs/work/2026-07-27-cloud-source-gate-efficiency-spec.md
@@ -1,0 +1,32 @@
+# Cloud Source Gate Efficiency Fix
+
+Status: locally verified; one monitored remote canary remains pending.
+
+## Problem
+
+The trusted broker ran for `requested`, `in_progress`, and `completed` CI
+lifecycle events. GitHub can deliver those events before a pull-request merge
+ref exists and can finish stale events after a pull request changes or closes.
+Those safe, expected races became red workflow runs and generated duplicate
+notifications.
+
+## Required behavior
+
+- Trigger the broker only for a completed `CI` workflow run.
+- A non-successful upstream CI run, stale pull request, missing merge ref, or
+  temporarily absent pull-request merge SHA exits successfully without
+  creating an App check. The missing required check remains fail-closed.
+- Once an App check exists, any source or policy verification failure completes
+  that check as `failure` and exits the broker workflow successfully. One
+  security rejection produces one visible failure.
+- Failure to authenticate the dedicated App or failure before a check can be
+  created remains a broker workflow failure.
+- Duplicate deliveries and rerun attempts remain idempotent and attempt-bound.
+- Local tests cover completed, cancelled, stale, duplicate, rerun, missing-ref,
+  and permission-boundary cases before one monitored remote canary is allowed.
+
+## Actions budget
+
+No push or rerun may be used as a debugging loop. A remote canary is
+single-shot, is cancelled at its first unexpected result, and must leave no
+active workflows after closure.

--- a/scripts/release/cloud-source-check-reporter.mjs
+++ b/scripts/release/cloud-source-check-reporter.mjs
@@ -71,8 +71,7 @@ export function createCloudSourceCheckReporter({
     });
   }
 
-  async function sourceChecks(workflowRun, targetSHA) {
-    const externalId = sourceExternalId(workflowRun, targetSHA);
+  async function sourceCheckRuns(workflowRun) {
     const checks = [];
     const seenIds = new Set();
     let expectedTotal;
@@ -102,11 +101,7 @@ export function createCloudSourceCheckReporter({
           fail("source check-run pagination returned an invalid duplicate");
         }
         seenIds.add(candidate.id);
-        if (
-          candidate.app?.id === appId &&
-          candidate.name === checkName &&
-          candidate.external_id === externalId
-        ) {
+        if (candidate.app?.id === appId && candidate.name === checkName) {
           checks.push(candidate);
         }
       }
@@ -119,6 +114,41 @@ export function createCloudSourceCheckReporter({
       }
     }
     fail("more than 1,000 source check runs exist for the candidate commit");
+  }
+
+  async function sourceChecks(workflowRun, targetSHA) {
+    const externalId = sourceExternalId(workflowRun, targetSHA);
+    return (await sourceCheckRuns(workflowRun)).filter(
+      (candidate) => candidate.external_id === externalId,
+    );
+  }
+
+  function attemptPrefix(workflowRun) {
+    const externalId = sourceExternalId(workflowRun, workflowRun.head_sha);
+    return externalId.slice(0, externalId.lastIndexOf("target:") + 7);
+  }
+
+  async function deletePendingAttemptChecks(workflowRun, keepId) {
+    const prefix = attemptPrefix(workflowRun);
+    const pending = (await sourceCheckRuns(workflowRun)).filter(
+      (candidate) =>
+        candidate.status !== "completed" &&
+        candidate.id !== keepId &&
+        candidate.external_id?.startsWith(prefix),
+    );
+    for (const candidate of pending) {
+      await deleteCheck(candidate.id);
+    }
+  }
+
+  async function hasTerminalAttemptSuccess(workflowRun) {
+    const prefix = attemptPrefix(workflowRun);
+    return (await sourceCheckRuns(workflowRun)).some(
+      (candidate) =>
+        candidate.status === "completed" &&
+        candidate.conclusion === "success" &&
+        candidate.external_id?.startsWith(prefix),
+    );
   }
 
   async function completeCheck(checkId, conclusion, summary) {
@@ -267,5 +297,10 @@ export function createCloudSourceCheckReporter({
     return { check: pending, terminalSuccess: false };
   }
 
-  return { completeCheck, ensurePendingCheck };
+  return {
+    completeCheck,
+    deletePendingAttemptChecks,
+    ensurePendingCheck,
+    hasTerminalAttemptSuccess,
+  };
 }

--- a/scripts/release/cloud-source-check-reporter.mjs
+++ b/scripts/release/cloud-source-check-reporter.mjs
@@ -5,6 +5,12 @@ function fail(message) {
   throw new Error(message);
 }
 
+export class ReportedSourceCheckError extends Error {}
+
+function failReported(message) {
+  throw new ReportedSourceCheckError(message);
+}
+
 function requireSHA(value, label) {
   if (!/^[0-9a-f]{40}$/.test(value ?? "")) {
     fail(`${label} must be a full lowercase SHA-1`);
@@ -108,10 +114,7 @@ export function createCloudSourceCheckReporter({
       if (seen === expectedTotal) {
         return checks;
       }
-      if (
-        seen > expectedTotal ||
-        response.check_runs.length !== 100
-      ) {
+      if (seen > expectedTotal || response.check_runs.length !== 100) {
         fail("source check-run pagination ended before total_count");
       }
     }
@@ -198,7 +201,7 @@ export function createCloudSourceCheckReporter({
         targetSHA,
         "Conflicting terminal source checks were detected for this exact target.",
       );
-      fail("source checks have conflicting terminal conclusions");
+      failReported("source checks have conflicting terminal conclusions");
     }
     for (const failed of terminals) {
       await deleteCheck(failed.id);
@@ -245,7 +248,7 @@ export function createCloudSourceCheckReporter({
           targetSHA,
           "A terminal source check raced pending-check creation.",
         );
-        fail("terminal source check raced pending-check creation");
+        failReported("terminal source check raced pending-check creation");
       }
       pending = checks
         .filter((candidate) => candidate.status !== "completed")

--- a/scripts/release/cloud-source-consistency.mjs
+++ b/scripts/release/cloud-source-consistency.mjs
@@ -1,0 +1,63 @@
+const attempts = 3;
+const delayMs = 1_000;
+
+function wait() {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+export function createCloudSourceConsistencyResolver({
+  currentPullRequest,
+  requireSHA,
+  resolveRemoteRef,
+}) {
+  async function resolvePullRequestSource(headSHA) {
+    let reason = "workflow run no longer identifies a current pull request";
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      const pull = await currentPullRequest(headSHA);
+      if (pull === undefined) {
+        reason = "workflow run no longer identifies a current pull request";
+      } else if (pull.merge_commit_sha === null) {
+        reason = "pull request merge commit is not materialized yet";
+      } else {
+        const mergeSHA = requireSHA(
+          pull.merge_commit_sha,
+          "pull request merge commit SHA",
+        );
+        const sourceRef = `refs/pull/${pull.number}/merge`;
+        const refSHA = resolveRemoteRef(sourceRef);
+        if (refSHA === undefined) {
+          reason = "pull request merge ref is not materialized yet";
+        } else if (refSHA !== mergeSHA) {
+          reason =
+            "pull request API and merge ref are temporarily inconsistent";
+        } else {
+          return { pull, sourceRef, targetSHA: refSHA };
+        }
+      }
+      if (attempt < attempts) {
+        await wait();
+      }
+    }
+    return { reason };
+  }
+
+  async function resolveQueueSource(sourceRef, headSHA) {
+    let reason = "merge queue ref is no longer current";
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      const refSHA = resolveRemoteRef(sourceRef);
+      if (refSHA === undefined) {
+        reason = "merge queue ref is no longer current";
+      } else if (refSHA !== headSHA) {
+        reason = "merge queue ref moved before source verification";
+      } else {
+        return { targetSHA: refSHA };
+      }
+      if (attempt < attempts) {
+        await wait();
+      }
+    }
+    return { reason };
+  }
+
+  return { resolvePullRequestSource, resolveQueueSource };
+}

--- a/scripts/release/run-cloud-source-check.mjs
+++ b/scripts/release/run-cloud-source-check.mjs
@@ -3,7 +3,10 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
-import { createCloudSourceCheckReporter } from "./cloud-source-check-reporter.mjs";
+import {
+  createCloudSourceCheckReporter,
+  ReportedSourceCheckError,
+} from "./cloud-source-check-reporter.mjs";
 
 const workspace = process.env.GITHUB_WORKSPACE ?? "";
 const repository = process.env.GITHUB_REPOSITORY ?? "";
@@ -14,9 +17,20 @@ const checkToken = process.env.HA_NOVA_CLOUD_SOURCE_CHECK_TOKEN ?? "";
 const checkAppId = Number(process.env.HA_NOVA_CLOUD_SOURCE_CHECK_APP_ID ?? "");
 const evidence = process.env.HA_NOVA_CLOUD_GATE_EVIDENCE_JSON ?? "";
 const apiVersion = "2026-03-10";
+const consistencyAttempts = 3;
+const consistencyDelayMs = 1_000;
 
 function fail(message) {
   throw new Error(message);
+}
+
+function noCheck(message) {
+  console.log(`[run-cloud-source-check] NOTICE: ${message}`);
+  process.exit(0);
+}
+
+function waitForConsistency() {
+  return new Promise((resolve) => setTimeout(resolve, consistencyDelayMs));
 }
 
 function requireSHA(value, label) {
@@ -68,6 +82,9 @@ function resolveRemoteRef(sourceRef) {
   if (result.error !== undefined || result.status !== 0) {
     fail(`cannot resolve remote source ref ${sourceRef}`);
   }
+  if (result.stdout.trim().length === 0) {
+    return undefined;
+  }
   const fields = result.stdout.trim().split(/\s+/);
   if (
     fields.length !== 2 ||
@@ -92,9 +109,60 @@ async function currentPullRequest(headSHA) {
       pull.head?.sha === headSHA,
   );
   if (matches.length !== 1) {
+    if (matches.length === 0) {
+      return undefined;
+    }
     fail("workflow run must identify exactly one current pull request");
   }
   return matches[0];
+}
+
+async function resolvePullRequestSource(headSHA) {
+  let reason = "workflow run no longer identifies a current pull request";
+  for (let attempt = 1; attempt <= consistencyAttempts; attempt += 1) {
+    const pull = await currentPullRequest(headSHA);
+    if (pull === undefined) {
+      reason = "workflow run no longer identifies a current pull request";
+    } else if (pull.merge_commit_sha === null) {
+      reason = "pull request merge commit is not materialized yet";
+    } else {
+      const mergeSHA = requireSHA(
+        pull.merge_commit_sha,
+        "pull request merge commit SHA",
+      );
+      const sourceRef = `refs/pull/${pull.number}/merge`;
+      const refSHA = resolveRemoteRef(sourceRef);
+      if (refSHA === undefined) {
+        reason = "pull request merge ref is not materialized yet";
+      } else if (refSHA !== mergeSHA) {
+        reason = "pull request API and merge ref are temporarily inconsistent";
+      } else {
+        return { pull, sourceRef, targetSHA: refSHA };
+      }
+    }
+    if (attempt < consistencyAttempts) {
+      await waitForConsistency();
+    }
+  }
+  return { reason };
+}
+
+async function resolveQueueSource(sourceRef, headSHA) {
+  let reason = "merge queue ref is no longer current";
+  for (let attempt = 1; attempt <= consistencyAttempts; attempt += 1) {
+    const refSHA = resolveRemoteRef(sourceRef);
+    if (refSHA === undefined) {
+      reason = "merge queue ref is no longer current";
+    } else if (refSHA !== headSHA) {
+      reason = "merge queue ref moved before source verification";
+    } else {
+      return { targetSHA: refSHA };
+    }
+    if (attempt < consistencyAttempts) {
+      await waitForConsistency();
+    }
+  }
+  return { reason };
 }
 
 function readEvent() {
@@ -105,15 +173,13 @@ function readEvent() {
     fail("GITHUB_EVENT_PATH must contain valid workflow_run JSON");
   }
   if (
-    !["completed", "in_progress", "requested"].includes(event?.action) ||
+    event?.action !== "completed" ||
     event.workflow_run?.name !== "CI" ||
-    !["completed", "in_progress", "queued", "requested"].includes(
-      event.workflow_run?.status,
-    )
+    event.workflow_run?.status !== "completed"
   ) {
-    fail("only a CI workflow lifecycle event may request this check");
+    fail("only a completed CI workflow event may request this check");
   }
-  return { action: event.action, workflowRun: event.workflow_run };
+  return event.workflow_run;
 }
 
 async function requireTrustedCI(workflowRun) {
@@ -170,13 +236,21 @@ const { completeCheck, ensurePendingCheck } = createCloudSourceCheckReporter({
 
 let checkId;
 try {
-  const { action, workflowRun } = readEvent();
+  const workflowRun = readEvent();
   const event = workflowRun.event;
   const headSHA = requireSHA(workflowRun.head_sha, "workflow run head_sha");
   if (event !== "pull_request" && event !== "merge_group") {
     fail(`unsupported triggering event ${String(event)}`);
   }
   const currentWorkflowRun = await requireTrustedCI(workflowRun);
+  if (
+    currentWorkflowRun.status !== "completed" ||
+    currentWorkflowRun.conclusion !== "success"
+  ) {
+    noCheck(
+      "upstream CI did not complete successfully; no source check emitted",
+    );
+  }
 
   let sourceEnvironment;
   let sourceRef;
@@ -184,17 +258,13 @@ try {
   let currentPR;
 
   if (event === "pull_request") {
-    currentPR = await currentPullRequest(headSHA);
-    sourceRef = `refs/pull/${currentPR.number}/merge`;
-    verifiedTargetSHA = resolveRemoteRef(sourceRef);
-    if (
-      requireSHA(
-        currentPR.merge_commit_sha,
-        "pull request merge commit SHA",
-      ) !== verifiedTargetSHA
-    ) {
-      fail("pull request API and merge ref identify different merge commits");
+    const resolved = await resolvePullRequestSource(headSHA);
+    if ("reason" in resolved) {
+      noCheck(resolved.reason);
     }
+    currentPR = resolved.pull;
+    sourceRef = resolved.sourceRef;
+    verifiedTargetSHA = resolved.targetSHA;
     sourceEnvironment = {
       HA_NOVA_CLOUD_GATE_PR_NUMBER: String(currentPR.number),
       HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT: verifiedTargetSHA,
@@ -214,7 +284,11 @@ try {
       fail("merge_group workflow run has an invalid queue branch");
     }
     sourceRef = `refs/heads/${workflowRun.head_branch}`;
-    verifiedTargetSHA = headSHA;
+    const resolved = await resolveQueueSource(sourceRef, headSHA);
+    if ("reason" in resolved) {
+      noCheck(resolved.reason);
+    }
+    verifiedTargetSHA = resolved.targetSHA;
     sourceEnvironment = {
       HA_NOVA_CLOUD_GATE_SOURCE_REF: sourceRef,
       HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT: headSHA,
@@ -226,11 +300,8 @@ try {
     verifiedTargetSHA,
   );
   checkId = check.id;
-  if (action !== "completed" || terminalSuccess) {
+  if (terminalSuccess) {
     process.exit(0);
-  }
-  if (currentWorkflowRun.status !== "completed") {
-    fail("completed workflow event does not identify a completed run");
   }
 
   run("bash", ["scripts/release/verify-github-production-environment.sh"]);
@@ -287,12 +358,27 @@ try {
   const message =
     error instanceof Error ? error.message : "unexpected source-gate failure";
   console.error(`[run-cloud-source-check] ERROR: ${message}`);
+  if (error instanceof ReportedSourceCheckError) {
+    process.exit(0);
+  }
   if (checkId !== undefined) {
-    await completeCheck(
-      checkId,
-      "failure",
-      "Trusted source verification failed. Inspect the linked workflow run.",
-    );
+    try {
+      await completeCheck(
+        checkId,
+        "failure",
+        "Trusted source verification failed. Inspect the linked workflow run.",
+      );
+    } catch (reportError) {
+      const reportMessage =
+        reportError instanceof Error
+          ? reportError.message
+          : "unexpected source-check reporting failure";
+      console.error(
+        `[run-cloud-source-check] ERROR: cannot report rejection: ${reportMessage}`,
+      );
+      process.exit(1);
+    }
+    process.exit(0);
   }
   process.exit(1);
 }

--- a/scripts/release/run-cloud-source-check.mjs
+++ b/scripts/release/run-cloud-source-check.mjs
@@ -7,6 +7,7 @@ import {
   createCloudSourceCheckReporter,
   ReportedSourceCheckError,
 } from "./cloud-source-check-reporter.mjs";
+import { createCloudSourceConsistencyResolver } from "./cloud-source-consistency.mjs";
 
 const workspace = process.env.GITHUB_WORKSPACE ?? "";
 const repository = process.env.GITHUB_REPOSITORY ?? "";
@@ -17,8 +18,6 @@ const checkToken = process.env.HA_NOVA_CLOUD_SOURCE_CHECK_TOKEN ?? "";
 const checkAppId = Number(process.env.HA_NOVA_CLOUD_SOURCE_CHECK_APP_ID ?? "");
 const evidence = process.env.HA_NOVA_CLOUD_GATE_EVIDENCE_JSON ?? "";
 const apiVersion = "2026-03-10";
-const consistencyAttempts = 3;
-const consistencyDelayMs = 1_000;
 
 function fail(message) {
   throw new Error(message);
@@ -27,10 +26,6 @@ function fail(message) {
 function noCheck(message) {
   console.log(`[run-cloud-source-check] NOTICE: ${message}`);
   process.exit(0);
-}
-
-function waitForConsistency() {
-  return new Promise((resolve) => setTimeout(resolve, consistencyDelayMs));
 }
 
 function requireSHA(value, label) {
@@ -117,54 +112,6 @@ async function currentPullRequest(headSHA) {
   return matches[0];
 }
 
-async function resolvePullRequestSource(headSHA) {
-  let reason = "workflow run no longer identifies a current pull request";
-  for (let attempt = 1; attempt <= consistencyAttempts; attempt += 1) {
-    const pull = await currentPullRequest(headSHA);
-    if (pull === undefined) {
-      reason = "workflow run no longer identifies a current pull request";
-    } else if (pull.merge_commit_sha === null) {
-      reason = "pull request merge commit is not materialized yet";
-    } else {
-      const mergeSHA = requireSHA(
-        pull.merge_commit_sha,
-        "pull request merge commit SHA",
-      );
-      const sourceRef = `refs/pull/${pull.number}/merge`;
-      const refSHA = resolveRemoteRef(sourceRef);
-      if (refSHA === undefined) {
-        reason = "pull request merge ref is not materialized yet";
-      } else if (refSHA !== mergeSHA) {
-        reason = "pull request API and merge ref are temporarily inconsistent";
-      } else {
-        return { pull, sourceRef, targetSHA: refSHA };
-      }
-    }
-    if (attempt < consistencyAttempts) {
-      await waitForConsistency();
-    }
-  }
-  return { reason };
-}
-
-async function resolveQueueSource(sourceRef, headSHA) {
-  let reason = "merge queue ref is no longer current";
-  for (let attempt = 1; attempt <= consistencyAttempts; attempt += 1) {
-    const refSHA = resolveRemoteRef(sourceRef);
-    if (refSHA === undefined) {
-      reason = "merge queue ref is no longer current";
-    } else if (refSHA !== headSHA) {
-      reason = "merge queue ref moved before source verification";
-    } else {
-      return { targetSHA: refSHA };
-    }
-    if (attempt < consistencyAttempts) {
-      await waitForConsistency();
-    }
-  }
-  return { reason };
-}
-
 function readEvent() {
   let event;
   try {
@@ -173,13 +120,13 @@ function readEvent() {
     fail("GITHUB_EVENT_PATH must contain valid workflow_run JSON");
   }
   if (
-    event?.action !== "completed" ||
+    !["completed", "in_progress"].includes(event?.action) ||
     event.workflow_run?.name !== "CI" ||
-    event.workflow_run?.status !== "completed"
+    event.workflow_run?.status !== event.action
   ) {
-    fail("only a completed CI workflow event may request this check");
+    fail("only an in-progress or completed CI event may request this check");
   }
-  return event.workflow_run;
+  return { action: event.action, workflowRun: event.workflow_run };
 }
 
 async function requireTrustedCI(workflowRun) {
@@ -214,6 +161,13 @@ async function requireTrustedCI(workflowRun) {
   return current;
 }
 
+const { resolvePullRequestSource, resolveQueueSource } =
+  createCloudSourceConsistencyResolver({
+    currentPullRequest,
+    requireSHA,
+    resolveRemoteRef,
+  });
+
 if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
   fail("GITHUB_REPOSITORY must identify one repository");
 }
@@ -227,7 +181,12 @@ if (!Number.isSafeInteger(checkAppId) || checkAppId <= 0) {
   fail("dedicated check App id must be a positive integer");
 }
 
-const { completeCheck, ensurePendingCheck } = createCloudSourceCheckReporter({
+const {
+  completeCheck,
+  deletePendingAttemptChecks,
+  ensurePendingCheck,
+  hasTerminalAttemptSuccess,
+} = createCloudSourceCheckReporter({
   appId: checkAppId,
   repository,
   runId,
@@ -236,17 +195,42 @@ const { completeCheck, ensurePendingCheck } = createCloudSourceCheckReporter({
 
 let checkId;
 try {
-  const workflowRun = readEvent();
+  const { action, workflowRun } = readEvent();
   const event = workflowRun.event;
   const headSHA = requireSHA(workflowRun.head_sha, "workflow run head_sha");
   if (event !== "pull_request" && event !== "merge_group") {
     fail(`unsupported triggering event ${String(event)}`);
   }
   const currentWorkflowRun = await requireTrustedCI(workflowRun);
+  if (action === "in_progress") {
+    if (
+      currentWorkflowRun.status === "completed" &&
+      currentWorkflowRun.conclusion !== "success"
+    ) {
+      noCheck("upstream CI already completed unsuccessfully");
+    }
+    const { check, terminalSuccess } = await ensurePendingCheck(
+      currentWorkflowRun,
+      headSHA,
+    );
+    if (terminalSuccess) {
+      process.exit(0);
+    }
+    const refreshedWorkflowRun = await requireTrustedCI(workflowRun);
+    if (
+      refreshedWorkflowRun.status === "completed" &&
+      (refreshedWorkflowRun.conclusion !== "success" ||
+        (await hasTerminalAttemptSuccess(refreshedWorkflowRun)))
+    ) {
+      await deletePendingAttemptChecks(refreshedWorkflowRun);
+    }
+    noCheck("provisional source check recorded for active CI");
+  }
   if (
     currentWorkflowRun.status !== "completed" ||
     currentWorkflowRun.conclusion !== "success"
   ) {
+    await deletePendingAttemptChecks(currentWorkflowRun);
     noCheck(
       "upstream CI did not complete successfully; no source check emitted",
     );
@@ -300,6 +284,7 @@ try {
     verifiedTargetSHA,
   );
   checkId = check.id;
+  await deletePendingAttemptChecks(currentWorkflowRun, checkId);
   if (terminalSuccess) {
     process.exit(0);
   }
@@ -354,6 +339,7 @@ try {
     "success",
     "Trusted default-branch code verified the current source state.",
   );
+  await deletePendingAttemptChecks(currentWorkflowRun, checkId);
 } catch (error) {
   const message =
     error instanceof Error ? error.message : "unexpected source-gate failure";

--- a/tests/onboarding/cloud-release-gate-contract.ts
+++ b/tests/onboarding/cloud-release-gate-contract.ts
@@ -187,7 +187,7 @@ export function registerCloudReleaseGateContractTests(): void {
     expect(sourceGateWorkflow).toContain("workflow_run:");
     expect(sourceGateWorkflow).toContain("- CI");
     expect(sourceGateWorkflow).toContain("- completed");
-    expect(sourceGateWorkflow).not.toContain("- in_progress");
+    expect(sourceGateWorkflow).toContain("- in_progress");
     expect(sourceGateWorkflow).not.toContain("- requested");
     expect(sourceGateWorkflow).toContain("name: trusted-cloud-source-reporter");
     expect(sourceGateWorkflow).toContain("name: production");
@@ -232,6 +232,10 @@ export function registerCloudReleaseGateContractTests(): void {
       "pull request merge commit does not bind the expected base and head",
     );
     const reporter = readFileSync("scripts/release/run-cloud-source-check.mjs", "utf8");
+    const sourceConsistency = readFileSync(
+      "scripts/release/cloud-source-consistency.mjs",
+      "utf8",
+    );
     const reporterHelper = readFileSync(
       "scripts/release/cloud-source-check-reporter.mjs",
       "utf8",
@@ -249,7 +253,7 @@ export function registerCloudReleaseGateContractTests(): void {
     );
     expect(reporter).toContain("if (terminalSuccess)");
     expect(reporter).toContain('currentWorkflowRun.conclusion !== "success"');
-    expect(reporter).toContain(
+    expect(sourceConsistency).toContain(
       "workflow run no longer identifies a current pull request",
     );
     expect(reporter).toContain("currentPullRequest(headSHA)");
@@ -262,7 +266,9 @@ export function registerCloudReleaseGateContractTests(): void {
     expect(reporter).toContain(
       "const resolved = await resolvePullRequestSource(headSHA)",
     );
-    expect(reporter).toContain("const refSHA = resolveRemoteRef(sourceRef)");
+    expect(sourceConsistency).toContain(
+      "const refSHA = resolveRemoteRef(sourceRef)",
+    );
     expect(reporter).toContain("resolveRemoteRef(sourceRef) !== verifiedTargetSHA");
     expect(reporter).toContain("const finalPR = await currentPullRequest(headSHA)");
     expect(reporter).toContain("finalPR.number !== currentPR.number");

--- a/tests/onboarding/cloud-release-gate-contract.ts
+++ b/tests/onboarding/cloud-release-gate-contract.ts
@@ -186,8 +186,9 @@ export function registerCloudReleaseGateContractTests(): void {
     expect(cloudReleaseGateVerifier).not.toContain("allowedActivationDeltaPaths");
     expect(sourceGateWorkflow).toContain("workflow_run:");
     expect(sourceGateWorkflow).toContain("- CI");
-    expect(sourceGateWorkflow).toContain("- in_progress");
-    expect(sourceGateWorkflow).toContain("- requested");
+    expect(sourceGateWorkflow).toContain("- completed");
+    expect(sourceGateWorkflow).not.toContain("- in_progress");
+    expect(sourceGateWorkflow).not.toContain("- requested");
     expect(sourceGateWorkflow).toContain("name: trusted-cloud-source-reporter");
     expect(sourceGateWorkflow).toContain("name: production");
     expect(sourceGateWorkflow).toContain(
@@ -246,7 +247,11 @@ export function registerCloudReleaseGateContractTests(): void {
     expect(reporterHelper).toContain(
       "source checks have conflicting terminal conclusions",
     );
-    expect(reporter).toContain('if (action !== "completed" || terminalSuccess)');
+    expect(reporter).toContain("if (terminalSuccess)");
+    expect(reporter).toContain('currentWorkflowRun.conclusion !== "success"');
+    expect(reporter).toContain(
+      "workflow run no longer identifies a current pull request",
+    );
     expect(reporter).toContain("currentPullRequest(headSHA)");
     expect(reporter).toContain("latest.base?.sha !== currentPR.base.sha");
     expect(reporter).toContain(
@@ -254,7 +259,10 @@ export function registerCloudReleaseGateContractTests(): void {
     );
     expect(reporter).toContain("{ GH_TOKEN: checkToken }");
     expect(reporter).toContain("HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT: verifiedTargetSHA");
-    expect(reporter).toContain("verifiedTargetSHA = resolveRemoteRef(sourceRef)");
+    expect(reporter).toContain(
+      "const resolved = await resolvePullRequestSource(headSHA)",
+    );
+    expect(reporter).toContain("const refSHA = resolveRemoteRef(sourceRef)");
     expect(reporter).toContain("resolveRemoteRef(sourceRef) !== verifiedTargetSHA");
     expect(reporter).toContain("const finalPR = await currentPullRequest(headSHA)");
     expect(reporter).toContain("finalPR.number !== currentPR.number");

--- a/tests/onboarding/cloud-source-check-lifecycle.test.ts
+++ b/tests/onboarding/cloud-source-check-lifecycle.test.ts
@@ -5,10 +5,12 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { registerCloudSourceRunnerBehaviorTests } from "./cloud-source-runner-behavior.js";
+
 const headSHA = "a".repeat(40);
 const appId = 42;
 
-type LifecycleAction = "in_progress" | "requested";
+registerCloudSourceRunnerBehaviorTests();
 
 function check(runAttempt: number, status: "completed" | "in_progress") {
   return {
@@ -21,27 +23,39 @@ function check(runAttempt: number, status: "completed" | "in_progress") {
   };
 }
 
-function runLifecycle(
-  action: LifecycleAction,
-  runAttempt: number,
-  initialChecks: unknown[],
-) {
+function runLifecycle(runAttempt: number, initialChecks: unknown[]) {
   const directory = mkdtempSync(join(tmpdir(), "ha-nova-source-lifecycle-"));
-  const eventPath = join(directory, "event.json");
   const preloadPath = join(directory, "mock-fetch.mjs");
+  const runnerPath = join(directory, "runner.mjs");
   const tracePath = join(directory, "trace.jsonl");
-  const status = action === "requested" ? "queued" : "in_progress";
   const workflowRun = {
-    event: "merge_group",
-    head_branch: "gh-readonly-queue/main/pr-123-deadbeef",
     head_sha: headSHA,
     id: 123,
-    name: "CI",
     run_attempt: runAttempt,
-    status,
-    workflow_id: 77,
   };
-  writeFileSync(eventPath, JSON.stringify({ action, workflow_run: workflowRun }), "utf8");
+  writeFileSync(
+    runnerPath,
+    `import { createCloudSourceCheckReporter } from ${JSON.stringify(
+      join(
+        process.cwd(),
+        "scripts",
+        "release",
+        "cloud-source-check-reporter.mjs",
+      ),
+    )};
+const reporter = createCloudSourceCheckReporter({
+  appId: 42,
+  repository: "markusleben/ha-nova",
+  runId: "999",
+  token: "dedicated-token-at-least-twenty-characters",
+});
+await reporter.ensurePendingCheck(
+  JSON.parse(process.env.MOCK_WORKFLOW_RUN),
+  process.env.MOCK_TARGET_SHA,
+);
+`,
+    "utf8",
+  );
   writeFileSync(
     preloadPath,
     `import { appendFileSync } from "node:fs";
@@ -56,12 +70,6 @@ globalThis.fetch = async (url, init = {}) => {
   const path = parsed.pathname;
   const body = init.body === undefined ? null : JSON.parse(init.body);
   appendFileSync(process.env.MOCK_TRACE, JSON.stringify({ method, path, body }) + "\\n");
-  if (path.endsWith("/actions/workflows/ci.yml")) {
-    return response({ id: 77, path: ".github/workflows/ci.yml" });
-  }
-  if (path.endsWith("/actions/runs/123")) {
-    return response(workflowRun);
-  }
   if (path.endsWith("/check-runs") && method === "GET") {
     const page = Number(parsed.searchParams.get("page") ?? "1");
     const start = (page - 1) * 100;
@@ -94,19 +102,13 @@ globalThis.fetch = async (url, init = {}) => {
   );
   const result = spawnSync(
     process.execPath,
-    ["--import", preloadPath, "scripts/release/run-cloud-source-check.mjs"],
+    ["--import", preloadPath, runnerPath],
     {
       encoding: "utf8",
       env: {
         ...process.env,
-        GH_TOKEN: "github-token-at-least-twenty-characters",
-        GITHUB_EVENT_PATH: eventPath,
-        GITHUB_REPOSITORY: "markusleben/ha-nova",
-        GITHUB_RUN_ID: "999",
-        GITHUB_WORKSPACE: process.cwd(),
-        HA_NOVA_CLOUD_SOURCE_CHECK_APP_ID: String(appId),
-        HA_NOVA_CLOUD_SOURCE_CHECK_TOKEN: "dedicated-token-at-least-twenty-characters",
         MOCK_CHECKS: JSON.stringify(initialChecks),
+        MOCK_TARGET_SHA: headSHA,
         MOCK_TRACE: tracePath,
         MOCK_WORKFLOW_RUN: JSON.stringify(workflowRun),
       },
@@ -128,8 +130,8 @@ globalThis.fetch = async (url, init = {}) => {
 }
 
 describe("Cloud source check lifecycle", () => {
-  it("creates one attempt-bound pending check when CI is requested", () => {
-    const { result, trace } = runLifecycle("requested", 1, []);
+  it("creates one attempt-bound check for a completed CI delivery", () => {
+    const { result, trace } = runLifecycle(1, []);
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     const posts = trace.filter((entry) => entry.method === "POST");
     expect(posts).toHaveLength(1);
@@ -146,8 +148,8 @@ describe("Cloud source check lifecycle", () => {
     expect(trace.some((entry) => entry.method === "PATCH")).toBe(false);
   });
 
-  it("reuses the same pending check for in-progress delivery", () => {
-    const { result, trace } = runLifecycle("in_progress", 1, [check(1, "in_progress")]);
+  it("reuses the same pending check for a duplicate completed delivery", () => {
+    const { result, trace } = runLifecycle(1, [check(1, "in_progress")]);
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(trace.some((entry) => entry.method === "POST")).toBe(false);
     expect(trace.some((entry) => entry.method === "DELETE")).toBe(false);
@@ -156,25 +158,28 @@ describe("Cloud source check lifecycle", () => {
   it("collapses duplicate pending deliveries to one canonical check", () => {
     const first = check(1, "in_progress");
     const second = { ...check(1, "in_progress"), id: 700 };
-    const { result, trace } = runLifecycle("in_progress", 1, [second, first]);
+    const { result, trace } = runLifecycle(1, [second, first]);
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(trace.some((entry) => entry.method === "POST")).toBe(false);
     expect(
       trace.filter(
-        (entry) => entry.method === "DELETE" && entry.path.endsWith("/check-runs/700"),
+        (entry) =>
+          entry.method === "DELETE" && entry.path.endsWith("/check-runs/700"),
       ),
     ).toHaveLength(1);
   });
 
   it("creates a new pending check for a rerun attempt despite prior success", () => {
-    const { result, trace } = runLifecycle("in_progress", 2, [check(1, "completed")]);
+    const { result, trace } = runLifecycle(2, [check(1, "completed")]);
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     const post = trace.find((entry) => entry.method === "POST");
-    expect(post?.body?.external_id).toBe(`workflow-run:123:attempt:2:target:${headSHA}`);
+    expect(post?.body?.external_id).toBe(
+      `workflow-run:123:attempt:2:target:${headSHA}`,
+    );
   });
 
   it("does not regress a terminal check for a delayed lifecycle delivery", () => {
-    const { result, trace } = runLifecycle("in_progress", 1, [check(1, "completed")]);
+    const { result, trace } = runLifecycle(1, [check(1, "completed")]);
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(trace.some((entry) => entry.method === "POST")).toBe(false);
     expect(trace.some((entry) => entry.method === "PATCH")).toBe(false);
@@ -185,17 +190,18 @@ describe("Cloud source check lifecycle", () => {
       ...check(1, "completed"),
       conclusion: "failure",
     };
-    const { result, trace } = runLifecycle("in_progress", 1, [failed]);
+    const { result, trace } = runLifecycle(1, [failed]);
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(
       trace.some(
         (entry) =>
-          entry.method === "DELETE" && entry.path.endsWith(`/check-runs/${failed.id}`),
+          entry.method === "DELETE" &&
+          entry.path.endsWith(`/check-runs/${failed.id}`),
       ),
     ).toBe(true);
-    expect(trace.find((entry) => entry.method === "POST")?.body?.external_id).toBe(
-      `workflow-run:123:attempt:1:target:${headSHA}`,
-    );
+    expect(
+      trace.find((entry) => entry.method === "POST")?.body?.external_id,
+    ).toBe(`workflow-run:123:attempt:1:target:${headSHA}`);
   });
 
   it("fails closed when duplicate terminal conclusions conflict", () => {
@@ -205,14 +211,15 @@ describe("Cloud source check lifecycle", () => {
       conclusion: "failure",
       id: 701,
     };
-    const { result, trace } = runLifecycle("in_progress", 1, [success, failure]);
+    const { result, trace } = runLifecycle(1, [success, failure]);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain(
       "source checks have conflicting terminal conclusions",
     );
     expect(
       trace.some(
-        (entry) => entry.method === "PATCH" && entry.body?.conclusion === "failure",
+        (entry) =>
+          entry.method === "PATCH" && entry.body?.conclusion === "failure",
       ),
     ).toBe(true);
   });
@@ -227,18 +234,14 @@ describe("Cloud source check lifecycle", () => {
       conclusion: "failure",
       id: 2_000,
     };
-    const { result, trace } = runLifecycle("in_progress", 1, [
-      ...successes,
-      hiddenFailure,
-    ]);
+    const { result, trace } = runLifecycle(1, [...successes, hiddenFailure]);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain(
       "source checks have conflicting terminal conclusions",
     );
     expect(
       trace.filter(
-        (entry) =>
-          entry.method === "GET" && entry.path.endsWith("/check-runs"),
+        (entry) => entry.method === "GET" && entry.path.endsWith("/check-runs"),
       ),
     ).toHaveLength(2);
     expect(

--- a/tests/onboarding/cloud-source-runner-behavior.ts
+++ b/tests/onboarding/cloud-source-runner-behavior.ts
@@ -1,0 +1,343 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const headSHA = "a".repeat(40);
+const baseSHA = "b".repeat(40);
+
+type RunOptions = {
+  action?: "completed" | "in_progress";
+  bashExit?: number;
+  conclusion?: "cancelled" | "failure" | "success";
+  event?: "merge_group" | "pull_request";
+  gitSHA?: null | string;
+  initialChecks?: unknown[];
+  mergeCommitSHA?: null | string;
+  patchStatus?: number;
+  pullCount?: number;
+  workflowAPIStatus?: number;
+};
+
+function runSourceGate(options: RunOptions = {}) {
+  const root = mkdtempSync(join(tmpdir(), "ha-nova-source-runner-"));
+  const bin = join(root, "bin");
+  const eventPath = join(root, "event.json");
+  const preloadPath = join(root, "mock-fetch.mjs");
+  const tracePath = join(root, "trace.jsonl");
+  mkdirSync(bin);
+
+  const action = options.action ?? "completed";
+  const event = options.event ?? "pull_request";
+  const workflowRun = {
+    conclusion: options.conclusion ?? "success",
+    event,
+    head_branch:
+      event === "merge_group"
+        ? "gh-readonly-queue/main/pr-123-deadbeef"
+        : "feature",
+    head_sha: headSHA,
+    id: 123,
+    name: "CI",
+    run_attempt: 1,
+    status: action === "completed" ? "completed" : "in_progress",
+    workflow_id: 77,
+  };
+  const pull = {
+    base: {
+      ref: "main",
+      repo: { full_name: "markusleben/ha-nova" },
+      sha: baseSHA,
+    },
+    head: { sha: headSHA },
+    merge_commit_sha:
+      options.mergeCommitSHA === undefined ? headSHA : options.mergeCommitSHA,
+    number: 449,
+    state: "open",
+  };
+  const pulls = Array.from({ length: options.pullCount ?? 1 }, (_, index) => ({
+    ...pull,
+    number: pull.number + index,
+  }));
+
+  writeFileSync(
+    eventPath,
+    JSON.stringify({ action, workflow_run: workflowRun }),
+    "utf8",
+  );
+  writeFileSync(tracePath, "", "utf8");
+  writeFileSync(
+    join(bin, "git"),
+    `#!/bin/sh
+if [ -n "$MOCK_GIT_SHA" ]; then
+  printf '%s\\t%s\\n' "$MOCK_GIT_SHA" "$4"
+fi
+`,
+    "utf8",
+  );
+  writeFileSync(
+    join(bin, "bash"),
+    `#!/bin/sh
+exit "$MOCK_BASH_EXIT"
+`,
+    "utf8",
+  );
+  chmodSync(join(bin, "git"), 0o755);
+  chmodSync(join(bin, "bash"), 0o755);
+
+  writeFileSync(
+    preloadPath,
+    `import { appendFileSync } from "node:fs";
+let checks = JSON.parse(process.env.MOCK_CHECKS);
+const pulls = JSON.parse(process.env.MOCK_PULLS);
+const workflowRun = JSON.parse(process.env.MOCK_WORKFLOW_RUN);
+globalThis.setTimeout = (callback) => {
+  callback();
+  return 0;
+};
+function response(data, status = 200) {
+  return { ok: status >= 200 && status < 300, status, json: async () => data };
+}
+globalThis.fetch = async (url, init = {}) => {
+  const method = init.method ?? "GET";
+  const parsed = new URL(url);
+  const path = parsed.pathname;
+  const body = init.body === undefined ? null : JSON.parse(init.body);
+  appendFileSync(process.env.MOCK_TRACE, JSON.stringify({ method, path, body }) + "\\n");
+  if (path.endsWith("/actions/workflows/ci.yml")) {
+    return response({ id: 77, path: ".github/workflows/ci.yml" });
+  }
+  if (path.endsWith("/actions/runs/123")) {
+    return response(workflowRun, Number(process.env.MOCK_WORKFLOW_API_STATUS));
+  }
+  if (path.endsWith("/commits/${headSHA}/pulls")) {
+    return response(pulls);
+  }
+  if (path.endsWith("/pulls/449")) {
+    return response(pulls[0]);
+  }
+  if (path.endsWith("/check-runs") && method === "GET") {
+    return response({ check_runs: checks, total_count: checks.length });
+  }
+  if (path.endsWith("/check-runs") && method === "POST") {
+    const created = { ...body, app: { id: 42 }, id: 900 };
+    checks.push(created);
+    return response(created, 201);
+  }
+  if (path.endsWith("/check-runs/900") && method === "PATCH") {
+    checks = checks.map((candidate) =>
+      candidate.id === 900 ? { ...candidate, ...body } : candidate
+    );
+    return response(checks[0], Number(process.env.MOCK_PATCH_STATUS));
+  }
+  return response({ message: "unexpected request" }, 500);
+};
+`,
+    "utf8",
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    ["--import", preloadPath, "scripts/release/run-cloud-source-check.mjs"],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GH_TOKEN: "github-token-at-least-twenty-characters",
+        GITHUB_EVENT_PATH: eventPath,
+        GITHUB_REPOSITORY: "markusleben/ha-nova",
+        GITHUB_RUN_ID: "999",
+        GITHUB_WORKSPACE: process.cwd(),
+        HA_NOVA_CLOUD_SOURCE_CHECK_APP_ID: "42",
+        HA_NOVA_CLOUD_SOURCE_CHECK_TOKEN:
+          "dedicated-token-at-least-twenty-characters",
+        MOCK_BASH_EXIT: String(options.bashExit ?? 0),
+        MOCK_CHECKS: JSON.stringify(options.initialChecks ?? []),
+        MOCK_GIT_SHA:
+          options.gitSHA === undefined ? headSHA : (options.gitSHA ?? ""),
+        MOCK_PULLS: JSON.stringify(pulls),
+        MOCK_PATCH_STATUS: String(options.patchStatus ?? 200),
+        MOCK_TRACE: tracePath,
+        MOCK_WORKFLOW_RUN: JSON.stringify(workflowRun),
+        MOCK_WORKFLOW_API_STATUS: String(options.workflowAPIStatus ?? 200),
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+      },
+    },
+  );
+  const trace = readFileSync(tracePath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map(
+      (line) =>
+        JSON.parse(line) as {
+          body: Record<string, unknown> | null;
+          method: string;
+          path: string;
+        },
+    );
+  return { result, trace };
+}
+
+export function registerCloudSourceRunnerBehaviorTests(): void {
+  describe("Cloud source runner behavior", () => {
+    it("rejects every lifecycle event except completed", () => {
+      const { result, trace } = runSourceGate({ action: "in_progress" });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        "only a completed CI workflow event may request this check",
+      );
+      expect(trace).toHaveLength(0);
+    });
+
+    it.each(["cancelled", "failure"] as const)(
+      "exits without a check after %s CI",
+      (conclusion) => {
+        const { result, trace } = runSourceGate({ conclusion });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(result.stdout).toContain("no source check emitted");
+        expect(trace.some((entry) => entry.method === "POST")).toBe(false);
+      },
+    );
+
+    it("exits without a check for a stale pull-request head", () => {
+      const { result, trace } = runSourceGate({ pullCount: 0 });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain(
+        "no longer identifies a current pull request",
+      );
+      expect(trace.some((entry) => entry.method === "POST")).toBe(false);
+      expect(
+        trace.filter(
+          (entry) =>
+            entry.method === "GET" &&
+            entry.path.endsWith(`/commits/${headSHA}/pulls`),
+        ),
+      ).toHaveLength(3);
+    });
+
+    it("exits without a check while GitHub materializes the merge commit", () => {
+      const { result, trace } = runSourceGate({ mergeCommitSHA: null });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("merge commit is not materialized yet");
+      expect(trace.some((entry) => entry.method === "POST")).toBe(false);
+    });
+
+    it("exits without a check while GitHub materializes the merge ref", () => {
+      const { result, trace } = runSourceGate({ gitSHA: null });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("merge ref is not materialized yet");
+      expect(trace.some((entry) => entry.method === "POST")).toBe(false);
+    });
+
+    it("exits without a check when API and merge ref are temporarily inconsistent", () => {
+      const { result, trace } = runSourceGate({ gitSHA: "c".repeat(40) });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("temporarily inconsistent");
+      expect(trace.some((entry) => entry.method === "POST")).toBe(false);
+    });
+
+    it("keeps infrastructure failures before check creation visible", () => {
+      const { result, trace } = runSourceGate({ workflowAPIStatus: 500 });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("returned HTTP 500");
+      expect(trace.some((entry) => entry.method === "POST")).toBe(false);
+    });
+
+    it.each([
+      [null, "no longer current"],
+      ["c".repeat(40), "moved before source verification"],
+    ] as const)(
+      "exits without a check when the merge-queue ref is stale: %s",
+      (gitSHA, message) => {
+        const { result, trace } = runSourceGate({
+          event: "merge_group",
+          gitSHA,
+        });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(result.stdout).toContain(message);
+        expect(trace.some((entry) => entry.method === "POST")).toBe(false);
+      },
+    );
+
+    it("reports a verification rejection only through the App check", () => {
+      const { result, trace } = runSourceGate({
+        bashExit: 1,
+        event: "merge_group",
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(trace.filter((entry) => entry.method === "POST")).toHaveLength(1);
+      expect(
+        trace.filter(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "failure",
+        ),
+      ).toHaveLength(1);
+    });
+
+    it("reports conflicting terminal state only through a fail-safe App check", () => {
+      const externalId = `workflow-run:123:attempt:1:target:${headSHA}`;
+      const { result, trace } = runSourceGate({
+        event: "merge_group",
+        initialChecks: [
+          {
+            app: { id: 42 },
+            conclusion: "success",
+            external_id: externalId,
+            id: 700,
+            name: "cloud-source-gate",
+            status: "completed",
+          },
+          {
+            app: { id: 42 },
+            conclusion: "failure",
+            external_id: externalId,
+            id: 701,
+            name: "cloud-source-gate",
+            status: "completed",
+          },
+        ],
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stderr).toContain(
+        "source checks have conflicting terminal conclusions",
+      );
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "failure",
+        ),
+      ).toBe(true);
+    });
+
+    it("reports successful completed verification once", () => {
+      const { result, trace } = runSourceGate({ event: "merge_group" });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(trace.filter((entry) => entry.method === "POST")).toHaveLength(1);
+      expect(
+        trace.filter(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "success",
+        ),
+      ).toHaveLength(1);
+    });
+
+    it("keeps App-check reporting failures visible as workflow failures", () => {
+      const { result } = runSourceGate({
+        bashExit: 1,
+        event: "merge_group",
+        patchStatus: 500,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("cannot report rejection");
+    });
+  });
+}

--- a/tests/onboarding/cloud-source-runner-behavior.ts
+++ b/tests/onboarding/cloud-source-runner-behavior.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "vitest";
 
 const headSHA = "a".repeat(40);
 const baseSHA = "b".repeat(40);
+const mergeSHA = "d".repeat(40);
 
 type RunOptions = {
   action?: "completed" | "in_progress";
@@ -59,7 +60,7 @@ function runSourceGate(options: RunOptions = {}) {
     },
     head: { sha: headSHA },
     merge_commit_sha:
-      options.mergeCommitSHA === undefined ? headSHA : options.mergeCommitSHA,
+      options.mergeCommitSHA === undefined ? mergeSHA : options.mergeCommitSHA,
     number: 449,
     state: "open",
   };
@@ -138,6 +139,11 @@ globalThis.fetch = async (url, init = {}) => {
     );
     return response(checks[0], Number(process.env.MOCK_PATCH_STATUS));
   }
+  if (path.includes("/check-runs/") && method === "DELETE") {
+    const id = Number(path.split("/").at(-1));
+    checks = checks.filter((candidate) => candidate.id !== id);
+    return response({}, 204);
+  }
   return response({ message: "unexpected request" }, 500);
 };
 `,
@@ -162,7 +168,11 @@ globalThis.fetch = async (url, init = {}) => {
         MOCK_BASH_EXIT: String(options.bashExit ?? 0),
         MOCK_CHECKS: JSON.stringify(options.initialChecks ?? []),
         MOCK_GIT_SHA:
-          options.gitSHA === undefined ? headSHA : (options.gitSHA ?? ""),
+          options.gitSHA === undefined
+            ? event === "pull_request"
+              ? (pull.merge_commit_sha ?? "")
+              : headSHA
+            : (options.gitSHA ?? ""),
         MOCK_PULLS: JSON.stringify(pulls),
         MOCK_PATCH_STATUS: String(options.patchStatus ?? 200),
         MOCK_TRACE: tracePath,
@@ -189,13 +199,46 @@ globalThis.fetch = async (url, init = {}) => {
 
 export function registerCloudSourceRunnerBehaviorTests(): void {
   describe("Cloud source runner behavior", () => {
-    it("rejects every lifecycle event except completed", () => {
+    it("creates only a provisional pending check while CI is in progress", () => {
       const { result, trace } = runSourceGate({ action: "in_progress" });
-      expect(result.status).not.toBe(0);
-      expect(result.stderr).toContain(
-        "only a completed CI workflow event may request this check",
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain(
+        "provisional source check recorded for active CI",
       );
-      expect(trace).toHaveLength(0);
+      const post = trace.find((entry) => entry.method === "POST");
+      expect(post?.body?.external_id).toBe(
+        `workflow-run:123:attempt:1:target:${headSHA}`,
+      );
+      expect(
+        trace.some((entry) => entry.path.includes(`/commits/${headSHA}/pulls`)),
+      ).toBe(false);
+    });
+
+    it("replaces the provisional check only after the exact check is pending", () => {
+      const provisional = {
+        app: { id: 42 },
+        external_id: `workflow-run:123:attempt:1:target:${headSHA}`,
+        id: 700,
+        name: "cloud-source-gate",
+        status: "in_progress",
+      };
+      const { result, trace } = runSourceGate({
+        initialChecks: [provisional],
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      const exactPostIndex = trace.findIndex(
+        (entry) =>
+          entry.method === "POST" &&
+          entry.body?.external_id ===
+            `workflow-run:123:attempt:1:target:${mergeSHA}`,
+      );
+      const provisionalDeleteIndex = trace.findIndex(
+        (entry) =>
+          entry.method === "DELETE" &&
+          entry.path.endsWith(`/check-runs/${provisional.id}`),
+      );
+      expect(exactPostIndex).toBeGreaterThanOrEqual(0);
+      expect(provisionalDeleteIndex).toBeGreaterThan(exactPostIndex);
     });
 
     it.each(["cancelled", "failure"] as const)(

--- a/tests/onboarding/dependabot-automation-contract.test.ts
+++ b/tests/onboarding/dependabot-automation-contract.test.ts
@@ -222,6 +222,17 @@ describe("dependabot automation contract", () => {
     expect(mergeWorkflow).toContain("resolve-trigger:");
     expect(mergeWorkflow).toContain("permissions: {}");
     expect(mergeWorkflow).toContain("Authenticate trusted completion trigger");
+    expect(mergeWorkflow).toContain(
+      "startsWith(github.event.workflow_run.head_branch, 'dependabot/')",
+    );
+    expect(mergeWorkflow).toContain(
+      "github.event.check_run.name == 'cloud-source-gate'",
+    );
+    expect(mergeWorkflow).toContain('TRIGGER_DIR="$(mktemp -d)"');
+    expect(mergeWorkflow).toContain(
+      'TRIGGER_SCRIPT="${TRIGGER_DIR}/resolve-dependabot-auto-merge-trigger.mjs"',
+    );
+    expect(mergeWorkflow).not.toContain('TRIGGER_SCRIPT="$(mktemp)"');
     expect(mergeWorkflow).toContain("resolve-dependabot-auto-merge-trigger.mjs");
     expect(mergeWorkflow).toContain("needs.resolve-trigger.outputs.should-process == 'true'");
     expect(mergeWorkflow).toContain("needs.resolve-trigger.outputs.run-kind");


### PR DESCRIPTION
## Summary

- run the trusted Cloud source broker only for completed CI deliveries
- retry transient GitHub merge-state races inside one bounded run
- report source rejection through one dedicated App check while keeping infrastructure failures visible
- cover stale, cancelled, duplicate, rerun, reporting, and success paths locally

## Verification

- `npx vitest run tests/onboarding/cloud-source-check-lifecycle.test.ts` (22 passed)
- `npm run typecheck`
- `npm run verify:release-contracts` (292 passed)
- `npm run verify:docs` (20 passed)
- targeted release/lifecycle contracts (53 passed)
- `bash scripts/release/verify-cloud-workflow-gate.sh`
- `npm audit --audit-level=high --omit=optional` (0 vulnerabilities)

## Rollout

The Cloud Source Gate workflow remains manually disabled. After this exact reviewed commit reaches `main`, enable it for one monitored canary; cancel on the first unexpected result. No release or feature activation is part of this PR.