### PR TITLE
fix(ci): tolerate PR merge materialization races

### DIFF
--- a/docs/work/2026-07-27-cloud-source-gate-efficiency-spec.md
+++ b/docs/work/2026-07-27-cloud-source-gate-efficiency-spec.md
@@ -30,6 +30,10 @@ notifications.
 - Duplicate deliveries and rerun attempts remain idempotent and attempt-bound.
 - Local tests cover completed, cancelled, stale, duplicate, rerun, missing-ref,
   and permission-boundary cases before one monitored remote canary is allowed.
+- The commit-association endpoint selects one current PR only. Security fields,
+  including `merge_commit_sha`, come from a subsequent full PR response.
+  Temporarily omitted or null merge materialization is retried inside the same
+  bounded run.
 
 ## Actions budget
 

--- a/scripts/release/cloud-source-consistency.mjs
+++ b/scripts/release/cloud-source-consistency.mjs
@@ -16,7 +16,7 @@ export function createCloudSourceConsistencyResolver({
       const pull = await currentPullRequest(headSHA);
       if (pull === undefined) {
         reason = "workflow run no longer identifies a current pull request";
-      } else if (pull.merge_commit_sha === null) {
+      } else if (pull.merge_commit_sha == null) {
         reason = "pull request merge commit is not materialized yet";
       } else {
         const mergeSHA = requireSHA(

--- a/scripts/release/run-cloud-source-check.mjs
+++ b/scripts/release/run-cloud-source-check.mjs
@@ -109,7 +109,24 @@ async function currentPullRequest(headSHA) {
     }
     fail("workflow run must identify exactly one current pull request");
   }
-  return matches[0];
+  const association = matches[0];
+  if (!Number.isSafeInteger(association.number) || association.number <= 0) {
+    fail("associated pull request number must be a positive integer");
+  }
+  const pull = await github(
+    `repos/${repository}/pulls/${association.number}`,
+    githubToken,
+  );
+  if (
+    pull.number !== association.number ||
+    pull.state !== "open" ||
+    pull.base?.ref !== "main" ||
+    pull.base?.repo?.full_name !== repository ||
+    pull.head?.sha !== headSHA
+  ) {
+    return undefined;
+  }
+  return pull;
 }
 
 function readEvent() {

--- a/tests/onboarding/cloud-source-check-lifecycle.test.ts
+++ b/tests/onboarding/cloud-source-check-lifecycle.test.ts
@@ -5,12 +5,14 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { registerCloudSourceMaterializationBehaviorTests } from "./cloud-source-materialization-behavior.js";
 import { registerCloudSourceRunnerBehaviorTests } from "./cloud-source-runner-behavior.js";
 
 const headSHA = "a".repeat(40);
 const appId = 42;
 
 registerCloudSourceRunnerBehaviorTests();
+registerCloudSourceMaterializationBehaviorTests();
 
 function check(runAttempt: number, status: "completed" | "in_progress") {
   return {

--- a/tests/onboarding/cloud-source-materialization-behavior.ts
+++ b/tests/onboarding/cloud-source-materialization-behavior.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { runSourceGate } from "./cloud-source-runner-behavior.js";
+
+export function registerCloudSourceMaterializationBehaviorTests(): void {
+  describe("Cloud source PR materialization", () => {
+    it("retries an absent full merge commit in one bounded run", () => {
+      const { result, trace } = runSourceGate({ mergeCommitSHA: null });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("merge commit is not materialized yet");
+      expect(trace.some((entry) => entry.method === "POST")).toBe(false);
+      expect(
+        trace.filter(
+          (entry) =>
+            entry.method === "GET" && entry.path.endsWith("/pulls/449"),
+        ),
+      ).toHaveLength(3);
+    });
+
+    it("reads merge materialization from the full pull-request resource", () => {
+      const { result, trace } = runSourceGate({
+        associationMergeCommitSHA: null,
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "GET" && entry.path.endsWith("/pulls/449"),
+        ),
+      ).toBe(true);
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "success",
+        ),
+      ).toBe(true);
+    });
+  });
+}

--- a/tests/onboarding/cloud-source-runner-behavior.ts
+++ b/tests/onboarding/cloud-source-runner-behavior.ts
@@ -11,12 +11,13 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-const headSHA = "a".repeat(40);
+export const headSHA = "a".repeat(40);
 const baseSHA = "b".repeat(40);
-const mergeSHA = "d".repeat(40);
+export const mergeSHA = "d".repeat(40);
 
-type RunOptions = {
+export type RunOptions = {
   action?: "completed" | "in_progress";
+  associationMergeCommitSHA?: null | string;
   bashExit?: number;
   conclusion?: "cancelled" | "failure" | "success";
   event?: "merge_group" | "pull_request";
@@ -28,7 +29,7 @@ type RunOptions = {
   workflowAPIStatus?: number;
 };
 
-function runSourceGate(options: RunOptions = {}) {
+export function runSourceGate(options: RunOptions = {}) {
   const root = mkdtempSync(join(tmpdir(), "ha-nova-source-runner-"));
   const bin = join(root, "bin");
   const eventPath = join(root, "event.json");
@@ -66,6 +67,10 @@ function runSourceGate(options: RunOptions = {}) {
   };
   const pulls = Array.from({ length: options.pullCount ?? 1 }, (_, index) => ({
     ...pull,
+    merge_commit_sha:
+      options.associationMergeCommitSHA === undefined
+        ? pull.merge_commit_sha
+        : options.associationMergeCommitSHA,
     number: pull.number + index,
   }));
 
@@ -99,6 +104,7 @@ exit "$MOCK_BASH_EXIT"
     `import { appendFileSync } from "node:fs";
 let checks = JSON.parse(process.env.MOCK_CHECKS);
 const pulls = JSON.parse(process.env.MOCK_PULLS);
+const fullPull = JSON.parse(process.env.MOCK_FULL_PULL);
 const workflowRun = JSON.parse(process.env.MOCK_WORKFLOW_RUN);
 globalThis.setTimeout = (callback) => {
   callback();
@@ -123,7 +129,7 @@ globalThis.fetch = async (url, init = {}) => {
     return response(pulls);
   }
   if (path.endsWith("/pulls/449")) {
-    return response(pulls[0]);
+    return response(fullPull);
   }
   if (path.endsWith("/check-runs") && method === "GET") {
     return response({ check_runs: checks, total_count: checks.length });
@@ -174,6 +180,7 @@ globalThis.fetch = async (url, init = {}) => {
               : headSHA
             : (options.gitSHA ?? ""),
         MOCK_PULLS: JSON.stringify(pulls),
+        MOCK_FULL_PULL: JSON.stringify(pull),
         MOCK_PATCH_STATUS: String(options.patchStatus ?? 200),
         MOCK_TRACE: tracePath,
         MOCK_WORKFLOW_RUN: JSON.stringify(workflowRun),
@@ -265,13 +272,6 @@ export function registerCloudSourceRunnerBehaviorTests(): void {
             entry.path.endsWith(`/commits/${headSHA}/pulls`),
         ),
       ).toHaveLength(3);
-    });
-
-    it("exits without a check while GitHub materializes the merge commit", () => {
-      const { result, trace } = runSourceGate({ mergeCommitSHA: null });
-      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-      expect(result.stdout).toContain("merge commit is not materialized yet");
-      expect(trace.some((entry) => entry.method === "POST")).toBe(false);
     });
 
     it("exits without a check while GitHub materializes the merge ref", () => {


### PR DESCRIPTION
## Summary

- use the commit association endpoint only to select one current pull request
- fetch the full PR resource before validating `merge_commit_sha` and source identity
- retry a temporarily null or omitted merge commit inside the existing bounded run
- cover reduced association responses and bounded full-resource retries

## Verification

- focused lifecycle/release contracts: 55 passed
- `npm run typecheck`
- `npm run verify:release-contracts`: 294 passed

## Rollout

The single-shot canary PR #453 was closed and deleted after exposing this race. Cloud Source Gate and Dependabot Safe Auto-Merge remain manually disabled. No release or feature activation is included.