### PR TITLE
docs: correct Cloud source reporter timeout

### DIFF
--- a/docs/work/2026-07-27-cloud-source-gate-efficiency-spec.md
+++ b/docs/work/2026-07-27-cloud-source-gate-efficiency-spec.md
@@ -60,7 +60,7 @@ and no rerun was used for debugging.
 
 GitHub API calls, remote-ref resolution, and policy subprocesses each have a
 finite deadline. The mode job has a three-minute limit; the reporter has a
-four-minute limit with cleanup margin. A failed fail-safe completion deletes
+ten-minute limit with cleanup margin. A failed fail-safe completion deletes
 the pending check before surfacing infrastructure failure.
 
 ## Dependabot trigger containment


### PR DESCRIPTION
## Summary

- correct the Cloud Source Gate efficiency spec from a four-minute reporter limit to the actual ten-minute workflow limit
- change no behavior, release metadata, or README claim

## Verification

- `npm run verify:docs` — 20/20
- `npx vitest run tests/onboarding/release-contract.test.ts` — 31/31
- `git diff --check`

Cloud Remote and the Cloud Source Gate remain disabled. No release, tag, or publish is included.