### PR TITLE
fix(ci): harden Cloud source materialization races

### DIFF
--- a/.github/workflows/cloud-source-gate.yml
+++ b/.github/workflows/cloud-source-gate.yml
@@ -58,7 +58,7 @@ jobs:
     needs: cloud-source-mode
     if: needs.cloud-source-mode.outputs.should-run == 'true'
     runs-on: ubuntu-latest
-    # Covers the 60-second materialization window, bounded policy commands,
+    # Covers the 90-second materialization window, bounded policy commands,
     # network calls, and a final pending-check cleanup attempt.
     timeout-minutes: 10
     environment:

--- a/docs/work/2026-07-27-cloud-source-materialization-window-spec.md
+++ b/docs/work/2026-07-27-cloud-source-materialization-window-spec.md
@@ -1,0 +1,34 @@
+# Cloud Source Materialization Window Follow-up
+
+Status: locally implemented after the single-shot canary; no second canary run.
+
+## Problem
+
+Canary PR #457 reproduced the GitHub materialization race after PR #456. The
+completed broker started from trusted `main`, but GitHub did not expose the
+current pull request's merge commit and merge ref before the 60-second window
+expired. Both appeared immediately after the broker emitted its fail-closed
+rejection. The provisional App check was terminally rejected and no pending
+check remained.
+
+## Required behavior
+
+- Keep one bounded retry loop inside the existing completed broker run.
+- Use one 90-second acceptance deadline for current pull-request association,
+  the full pull-request merge commit, and the exact
+  `refs/pull/<number>/merge` ref.
+- Keep the three-second retry cadence and derive the attempt cap from the
+  window so both bounds cannot drift.
+- Measure the acceptance deadline with a monotonic clock.
+- Revalidate the CI attempt after materialization and immediately before
+  every terminal result. An older attempt only cleans up its own pending
+  checks, including when cleanup or policy execution fails.
+- Reconcile accepted check creation through a short bounded visibility window
+  when the GitHub API response is lost; repeat cleanup across that window when
+  creation remains ambiguous.
+- Preserve the existing fail-closed rejection, terminal immutability,
+  provisional cleanup, command/API deadlines, and ten-minute workflow cap.
+- Never accept a source that becomes consistent after the acceptance deadline.
+- Cover association, merge-commit, absent-ref, inconsistent-ref, deadline, and
+  rerun races after the previous 60-second attempt cap.
+- Do not rerun the remote canary from this change.

--- a/scripts/release/cloud-source-check-failure.mjs
+++ b/scripts/release/cloud-source-check-failure.mjs
@@ -1,0 +1,129 @@
+export async function handleCloudSourceCheckFailure({
+  activeWorkflowRun,
+  ambiguousMutation,
+  checkId,
+  completeCheck,
+  deletePendingAttemptChecks,
+  deletePendingAttemptChecksEventually,
+  deletePendingCheck,
+  reportedFailure,
+  requireTrustedCI,
+  staleAttemptObserved,
+  terminalCheckReported,
+}) {
+  if (reportedFailure) {
+    return 0;
+  }
+
+  async function cleanupActiveAttempt(context) {
+    if (activeWorkflowRun === undefined) {
+      return true;
+    }
+    try {
+      await deletePendingAttemptChecks(activeWorkflowRun);
+      return true;
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "unexpected pending-check cleanup failure";
+      console.error(`[run-cloud-source-check] ERROR: ${context}: ${message}`);
+      return false;
+    }
+  }
+
+  if (staleAttemptObserved) {
+    const cleaned = await cleanupActiveAttempt(
+      "cannot clean the stale CI attempt",
+    );
+    return cleaned ? 0 : 1;
+  }
+  if (ambiguousMutation) {
+    if (activeWorkflowRun !== undefined) {
+      try {
+        await deletePendingAttemptChecksEventually(activeWorkflowRun);
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "unexpected pending-check cleanup failure";
+        console.error(
+          `[run-cloud-source-check] ERROR: cannot reconcile pending state after an ambiguous mutation: ${message}`,
+        );
+      }
+    }
+    return 1;
+  }
+  if (checkId === undefined || terminalCheckReported) {
+    await cleanupActiveAttempt(
+      checkId === undefined
+        ? "cannot clean pending state after a pre-check failure"
+        : "terminal result reported, but pending sibling cleanup failed",
+    );
+    return 1;
+  }
+
+  let failureCI;
+  try {
+    failureCI = await requireTrustedCI(activeWorkflowRun);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "unexpected CI lifecycle refresh failure";
+    console.error(
+      `[run-cloud-source-check] ERROR: cannot refresh CI before rejection: ${message}`,
+    );
+    await cleanupActiveAttempt(
+      "cannot clean pending state after CI refresh failure",
+    );
+    return 1;
+  }
+  if (failureCI.staleAttempt) {
+    const cleaned = await cleanupActiveAttempt(
+      "cannot clean the stale CI attempt before rejection",
+    );
+    return cleaned ? 0 : 1;
+  }
+
+  try {
+    await completeCheck(
+      checkId,
+      "failure",
+      "Trusted source verification failed. Inspect the linked workflow run.",
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "unexpected source-check reporting failure";
+    console.error(
+      `[run-cloud-source-check] ERROR: cannot report rejection: ${message}`,
+    );
+    try {
+      await deletePendingCheck(checkId);
+    } catch (cleanupError) {
+      const cleanupMessage =
+        cleanupError instanceof Error
+          ? cleanupError.message
+          : "unexpected pending-check cleanup failure";
+      console.error(
+        `[run-cloud-source-check] ERROR: cannot delete pending rejection: ${cleanupMessage}`,
+      );
+    }
+    return 1;
+  }
+  try {
+    await deletePendingAttemptChecks(activeWorkflowRun, checkId);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "unexpected pending-check cleanup failure";
+    console.error(
+      `[run-cloud-source-check] ERROR: rejection reported, but pending sibling cleanup failed: ${message}`,
+    );
+    return 1;
+  }
+  return 0;
+}

--- a/scripts/release/cloud-source-check-mutation.mjs
+++ b/scripts/release/cloud-source-check-mutation.mjs
@@ -1,0 +1,86 @@
+const reconcileAttempts = 3;
+const reconcileDelayMs = 1_000;
+
+function wait(delay = reconcileDelayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
+export class AmbiguousSourceCheckMutationError extends Error {}
+
+export async function createCheckWithReconciliation({
+  cleanupPending,
+  create,
+  listMatches,
+}) {
+  let creationError;
+  try {
+    return await create();
+  } catch (error) {
+    creationError = error;
+  }
+
+  let reconciledPending;
+  let reconciledTerminal;
+  for (let attempt = 1; attempt <= reconcileAttempts; attempt += 1) {
+    let matches;
+    try {
+      matches = await listMatches();
+    } catch (error) {
+      creationError = error;
+      matches = [];
+    }
+    if (matches.length === 1) {
+      const [match] = matches;
+      if (match.status === "completed") {
+        reconciledTerminal = match;
+      } else {
+        reconciledPending = match;
+      }
+    }
+    if (matches.length > 1) {
+      const terminals = matches.filter(
+        (candidate) => candidate.status === "completed",
+      );
+      if (terminals.length === 1) {
+        await cleanupPending();
+        return terminals[0];
+      }
+      throw new AmbiguousSourceCheckMutationError(
+        "ambiguous source-check creation produced multiple matching checks",
+        { cause: creationError },
+      );
+    }
+    if (attempt < reconcileAttempts) {
+      await wait();
+    }
+  }
+  if (reconciledTerminal !== undefined) {
+    await cleanupPending();
+    return reconciledTerminal;
+  }
+  if (reconciledPending !== undefined) {
+    return reconciledPending;
+  }
+  throw new AmbiguousSourceCheckMutationError(
+    "source-check creation remained invisible after bounded reconciliation",
+    { cause: creationError },
+  );
+}
+
+export async function retryPendingCleanup(cleanupPending) {
+  let finalError;
+  for (let attempt = 1; attempt <= reconcileAttempts; attempt += 1) {
+    try {
+      await cleanupPending();
+      finalError = undefined;
+    } catch (error) {
+      finalError = error;
+    }
+    if (attempt < reconcileAttempts) {
+      await wait();
+    }
+  }
+  if (finalError !== undefined) {
+    throw finalError;
+  }
+}

--- a/scripts/release/cloud-source-check-mutation.mjs
+++ b/scripts/release/cloud-source-check-mutation.mjs
@@ -11,6 +11,8 @@ export async function createCheckWithReconciliation({
   cleanupPending,
   create,
   listMatches,
+  retainPendingOnTerminalConflict = false,
+  waitFor = wait,
 }) {
   let creationError;
   try {
@@ -19,8 +21,8 @@ export async function createCheckWithReconciliation({
     creationError = error;
   }
 
-  let reconciledPending;
-  let reconciledTerminal;
+  const observedMatches = new Map();
+  const observedTerminalConclusions = new Set();
   for (let attempt = 1; attempt <= reconcileAttempts; attempt += 1) {
     let matches;
     try {
@@ -29,37 +31,46 @@ export async function createCheckWithReconciliation({
       creationError = error;
       matches = [];
     }
-    if (matches.length === 1) {
-      const [match] = matches;
+    for (const match of matches) {
       if (match.status === "completed") {
-        reconciledTerminal = match;
-      } else {
-        reconciledPending = match;
+        observedTerminalConclusions.add(match.conclusion);
       }
-    }
-    if (matches.length > 1) {
-      const terminals = matches.filter(
-        (candidate) => candidate.status === "completed",
-      );
-      if (terminals.length === 1) {
-        await cleanupPending();
-        return terminals[0];
+      const observed = observedMatches.get(match.id);
+      if (observed?.status !== "completed" || match.status === "completed") {
+        observedMatches.set(match.id, match);
       }
-      throw new AmbiguousSourceCheckMutationError(
-        "ambiguous source-check creation produced multiple matching checks",
-        { cause: creationError },
-      );
     }
     if (attempt < reconcileAttempts) {
-      await wait();
+      await waitFor();
     }
   }
-  if (reconciledTerminal !== undefined) {
+  const observed = [...observedMatches.values()];
+  const terminals = observed
+    .filter((candidate) => candidate.status === "completed")
+    .sort((left, right) => left.id - right.id);
+  const pending = observed.filter(
+    (candidate) => candidate.status !== "completed",
+  );
+  const terminalConclusions = observedTerminalConclusions;
+  if (terminals.length > 0 && terminalConclusions.size === 1) {
     await cleanupPending();
-    return reconciledTerminal;
+    return terminals.at(-1);
   }
-  if (reconciledPending !== undefined) {
-    return reconciledPending;
+  if (
+    retainPendingOnTerminalConflict &&
+    terminalConclusions.size > 1 &&
+    pending.length === 1
+  ) {
+    return pending[0];
+  }
+  if (terminalConclusions.size > 1 || pending.length > 1) {
+    throw new AmbiguousSourceCheckMutationError(
+      "ambiguous source-check creation produced multiple matching checks",
+      { cause: creationError },
+    );
+  }
+  if (pending.length === 1) {
+    return pending[0];
   }
   throw new AmbiguousSourceCheckMutationError(
     "source-check creation remained invisible after bounded reconciliation",

--- a/scripts/release/cloud-source-check-reporter.mjs
+++ b/scripts/release/cloud-source-check-reporter.mjs
@@ -207,7 +207,7 @@ export function createCloudSourceCheckReporter({
     workflowRun,
     targetSHA,
     summary,
-    beforeTerminalMutation = async () => {},
+    beforeTerminalMutation,
   ) {
     const checks = await sourceChecks(workflowRun, targetSHA);
     const terminals = checks.filter(
@@ -243,7 +243,7 @@ export function createCloudSourceCheckReporter({
     await deletePendingAttemptChecks(workflowRun);
   }
 
-  async function hasTerminalAttemptResult(workflowRun) {
+  async function hasTerminalAttemptResult(workflowRun, beforeTerminalMutation) {
     const prefix = attemptPrefix(workflowRun);
     const terminals = (await sourceCheckRuns(workflowRun)).filter(
       (candidate) =>
@@ -261,6 +261,7 @@ export function createCloudSourceCheckReporter({
           workflowRun,
           workflowRun.head_sha,
           "Conflicting terminal source checks were detected for this CI attempt.",
+          beforeTerminalMutation,
         );
       }
       failReported("source checks have conflicting terminal conclusions");
@@ -338,7 +339,7 @@ export function createCloudSourceCheckReporter({
     workflowRun,
     targetSHA,
     summary,
-    beforeTerminalMutation = async () => {},
+    beforeTerminalMutation,
   ) {
     const failed = await createCheck(workflowRun, targetSHA);
     if (
@@ -364,7 +365,11 @@ export function createCloudSourceCheckReporter({
     return failed;
   }
 
-  async function ensurePendingCheck(workflowRun, targetSHA) {
+  async function ensurePendingCheck(
+    workflowRun,
+    targetSHA,
+    beforeTerminalMutation,
+  ) {
     let checks = await sourceChecks(workflowRun, targetSHA);
     const terminals = checks
       .filter((candidate) => candidate.status === "completed")
@@ -394,6 +399,7 @@ export function createCloudSourceCheckReporter({
           workflowRun,
           targetSHA,
           "Conflicting terminal source checks were detected for this exact target.",
+          beforeTerminalMutation,
         );
       }
       failReported("source checks have conflicting terminal conclusions");
@@ -439,6 +445,7 @@ export function createCloudSourceCheckReporter({
             workflowRun,
             targetSHA,
             "A terminal source check raced pending-check creation.",
+            beforeTerminalMutation,
           );
         }
         failReported("terminal source check raced pending-check creation");

--- a/scripts/release/cloud-source-check-reporter.mjs
+++ b/scripts/release/cloud-source-check-reporter.mjs
@@ -1,3 +1,11 @@
+import {
+  AmbiguousSourceCheckMutationError,
+  createCheckWithReconciliation,
+  retryPendingCleanup,
+} from "./cloud-source-check-mutation.mjs";
+
+export { AmbiguousSourceCheckMutationError };
+
 const apiVersion = "2026-03-10";
 const apiTimeoutMs = 10_000;
 const checkName = "cloud-source-gate";
@@ -7,8 +15,6 @@ function fail(message) {
 }
 
 export class ReportedSourceCheckError extends Error {}
-
-export class AmbiguousSourceCheckMutationError extends Error {}
 
 function failReported(message) {
   throw new ReportedSourceCheckError(message);
@@ -59,19 +65,28 @@ export function createCloudSourceCheckReporter({
   }
 
   async function createCheck(workflowRun, targetSHA) {
-    return github(`repos/${repository}/check-runs`, {
-      method: "POST",
-      body: JSON.stringify({
-        name: checkName,
-        head_sha: workflowRun.head_sha,
-        status: "in_progress",
-        external_id: sourceExternalId(workflowRun, targetSHA),
-        details_url: `https://github.com/${repository}/actions/runs/${runId}`,
-        output: {
-          title: "Home Assistant Cloud source verification",
-          summary: "Trusted default-branch verification is running.",
-        },
-      }),
+    const externalId = sourceExternalId(workflowRun, targetSHA);
+    return createCheckWithReconciliation({
+      cleanupPending: () => deletePendingAttemptChecksEventually(workflowRun),
+      create: () =>
+        github(`repos/${repository}/check-runs`, {
+          method: "POST",
+          body: JSON.stringify({
+            name: checkName,
+            head_sha: workflowRun.head_sha,
+            status: "in_progress",
+            external_id: externalId,
+            details_url: `https://github.com/${repository}/actions/runs/${runId}`,
+            output: {
+              title: "Home Assistant Cloud source verification",
+              summary: "Trusted default-branch verification is running.",
+            },
+          }),
+        }),
+      listMatches: async () =>
+        (await sourceCheckRuns(workflowRun)).filter(
+          (candidate) => candidate.external_id === externalId,
+        ),
     });
   }
 
@@ -175,6 +190,10 @@ export function createCloudSourceCheckReporter({
     }
   }
 
+  async function deletePendingAttemptChecksEventually(workflowRun) {
+    await retryPendingCleanup(() => deletePendingAttemptChecks(workflowRun));
+  }
+
   async function deletePendingTargetChecks(workflowRun, targetSHA) {
     const pending = (await sourceChecks(workflowRun, targetSHA)).filter(
       (candidate) => candidate.status !== "completed",
@@ -184,7 +203,12 @@ export function createCloudSourceCheckReporter({
     }
   }
 
-  async function rejectTargetCheck(workflowRun, targetSHA, summary) {
+  async function rejectTargetCheck(
+    workflowRun,
+    targetSHA,
+    summary,
+    beforeTerminalMutation = async () => {},
+  ) {
     const checks = await sourceChecks(workflowRun, targetSHA);
     const terminals = checks.filter(
       (candidate) => candidate.status === "completed",
@@ -201,9 +225,15 @@ export function createCloudSourceCheckReporter({
       await deleteCheck(candidate.id);
     }
     if (check === undefined) {
-      await createFailSafeCheck(workflowRun, targetSHA, summary);
+      await createFailSafeCheck(
+        workflowRun,
+        targetSHA,
+        summary,
+        beforeTerminalMutation,
+      );
     } else {
       try {
+        await beforeTerminalMutation();
         await completeCheck(check.id, "failure", summary);
       } catch (error) {
         await deletePendingCheck(check.id);
@@ -304,7 +334,12 @@ export function createCloudSourceCheckReporter({
     await deleteCheck(checkId);
   }
 
-  async function createFailSafeCheck(workflowRun, targetSHA, summary) {
+  async function createFailSafeCheck(
+    workflowRun,
+    targetSHA,
+    summary,
+    beforeTerminalMutation = async () => {},
+  ) {
     const failed = await createCheck(workflowRun, targetSHA);
     if (
       !Number.isSafeInteger(failed.id) ||
@@ -313,7 +348,14 @@ export function createCloudSourceCheckReporter({
     ) {
       fail("dedicated GitHub App returned an invalid fail-safe check run");
     }
+    if (failed.status === "completed") {
+      if (failed.conclusion === "failure") {
+        return failed;
+      }
+      failReported("terminal source check raced fail-safe creation");
+    }
     try {
+      await beforeTerminalMutation();
       await completeCheck(failed.id, "failure", summary);
     } catch (error) {
       await deletePendingCheck(failed.id);
@@ -423,6 +465,7 @@ export function createCloudSourceCheckReporter({
     deleteCheck,
     deletePendingCheck,
     deletePendingAttemptChecks,
+    deletePendingAttemptChecksEventually,
     deletePendingTargetChecks,
     ensurePendingCheck,
     hasTerminalAttemptResult,

--- a/scripts/release/cloud-source-check-reporter.mjs
+++ b/scripts/release/cloud-source-check-reporter.mjs
@@ -64,7 +64,11 @@ export function createCloudSourceCheckReporter({
     return `workflow-run:${workflowRun.id}:attempt:${workflowRun.run_attempt}:target:${requireSHA(targetSHA, "source check target SHA")}`;
   }
 
-  async function createCheck(workflowRun, targetSHA) {
+  async function createCheck(
+    workflowRun,
+    targetSHA,
+    retainPendingOnTerminalConflict = false,
+  ) {
     const externalId = sourceExternalId(workflowRun, targetSHA);
     return createCheckWithReconciliation({
       cleanupPending: () => deletePendingAttemptChecksEventually(workflowRun),
@@ -87,6 +91,7 @@ export function createCloudSourceCheckReporter({
         (await sourceCheckRuns(workflowRun)).filter(
           (candidate) => candidate.external_id === externalId,
         ),
+      retainPendingOnTerminalConflict,
     });
   }
 
@@ -341,7 +346,7 @@ export function createCloudSourceCheckReporter({
     summary,
     beforeTerminalMutation,
   ) {
-    const failed = await createCheck(workflowRun, targetSHA);
+    const failed = await createCheck(workflowRun, targetSHA, true);
     if (
       !Number.isSafeInteger(failed.id) ||
       failed.id <= 0 ||

--- a/scripts/release/cloud-source-consistency.mjs
+++ b/scripts/release/cloud-source-consistency.mjs
@@ -1,8 +1,7 @@
-const pullRequestAttempts = 21;
-const pullRequestAssociationAttempts = 3;
 const queueAttempts = 3;
 const delayMs = 3_000;
-const pullRequestWindowMs = 60_000;
+const pullRequestWindowMs = 90_000;
+const pullRequestAttempts = Math.floor(pullRequestWindowMs / delayMs) + 1;
 
 function wait(delay = delayMs) {
   return new Promise((resolve) => setTimeout(resolve, delay));
@@ -10,26 +9,24 @@ function wait(delay = delayMs) {
 
 export function createCloudSourceConsistencyResolver({
   currentPullRequest,
+  now = () => performance.now(),
   requireSHA,
   resolveRemoteRef,
+  waitFor = wait,
 }) {
   async function resolvePullRequestSource(headSHA) {
-    const deadline = Date.now() + pullRequestWindowMs;
+    const deadline = now() + pullRequestWindowMs;
     let reason = "workflow run no longer identifies a current pull request";
-    let associationMisses = 0;
     for (let attempt = 1; attempt <= pullRequestAttempts; attempt += 1) {
+      if (attempt > 1 && now() >= deadline) {
+        break;
+      }
       const pull = await currentPullRequest(headSHA);
       if (pull === undefined) {
         reason = "workflow run no longer identifies a current pull request";
-        associationMisses += 1;
-        if (associationMisses >= pullRequestAssociationAttempts) {
-          return { kind: "stale", reason };
-        }
       } else if (pull.merge_commit_sha == null) {
-        associationMisses = 0;
         reason = "pull request merge commit is not materialized yet";
       } else {
-        associationMisses = 0;
         const mergeSHA = requireSHA(
           pull.merge_commit_sha,
           "pull request merge commit SHA",
@@ -41,13 +38,16 @@ export function createCloudSourceConsistencyResolver({
         } else if (refSHA !== mergeSHA) {
           reason =
             "pull request API and merge ref are temporarily inconsistent";
+        } else if (now() > deadline) {
+          reason =
+            "pull request source materialized after the bounded deadline";
         } else {
           return { pull, sourceRef, targetSHA: refSHA };
         }
       }
-      const remainingMs = deadline - Date.now();
+      const remainingMs = deadline - now();
       if (attempt < pullRequestAttempts && remainingMs > 0) {
-        await wait(Math.min(delayMs, remainingMs));
+        await waitFor(Math.min(delayMs, remainingMs));
       } else {
         break;
       }

--- a/scripts/release/cloud-source-consistency.mjs
+++ b/scripts/release/cloud-source-consistency.mjs
@@ -18,7 +18,7 @@ export function createCloudSourceConsistencyResolver({
     const deadline = now() + pullRequestWindowMs;
     let reason = "workflow run no longer identifies a current pull request";
     for (let attempt = 1; attempt <= pullRequestAttempts; attempt += 1) {
-      if (attempt > 1 && now() >= deadline) {
+      if (attempt > 1 && now() > deadline) {
         break;
       }
       const pull = await currentPullRequest(headSHA);

--- a/scripts/release/run-cloud-source-check.mjs
+++ b/scripts/release/run-cloud-source-check.mjs
@@ -8,6 +8,7 @@ import {
   createCloudSourceCheckReporter,
   ReportedSourceCheckError,
 } from "./cloud-source-check-reporter.mjs";
+import { handleCloudSourceCheckFailure } from "./cloud-source-check-failure.mjs";
 import { createCloudSourceConsistencyResolver } from "./cloud-source-consistency.mjs";
 import { createTrustedCIResolver } from "./cloud-source-workflow-run.mjs";
 
@@ -183,6 +184,7 @@ const {
   completeCheck,
   deletePendingCheck,
   deletePendingAttemptChecks,
+  deletePendingAttemptChecksEventually,
   deletePendingTargetChecks,
   ensurePendingCheck,
   hasTerminalAttemptResult,
@@ -196,6 +198,15 @@ const {
 
 let checkId;
 let activeWorkflowRun;
+let staleAttemptObserved = false;
+let terminalCheckReported = false;
+
+async function discardStaleAttempt(workflowRun) {
+  staleAttemptObserved = true;
+  await deletePendingAttemptChecks(workflowRun);
+  noCheck("workflow lifecycle delivery belongs to an older CI attempt");
+}
+
 try {
   const { action, workflowRun } = readEvent();
   const event = workflowRun.event;
@@ -203,10 +214,10 @@ try {
   if (event !== "pull_request" && event !== "merge_group") {
     fail(`unsupported triggering event ${String(event)}`);
   }
+  activeWorkflowRun = workflowRun;
   const trustedCI = await requireTrustedCI(workflowRun);
   if (trustedCI.staleAttempt) {
-    await deletePendingAttemptChecks(workflowRun);
-    noCheck("workflow lifecycle delivery belongs to an older CI attempt");
+    await discardStaleAttempt(workflowRun);
   }
   const currentWorkflowRun = trustedCI.current;
   activeWorkflowRun = currentWorkflowRun;
@@ -227,8 +238,7 @@ try {
     }
     const refreshedCI = await requireTrustedCI(workflowRun);
     if (refreshedCI.staleAttempt) {
-      await deletePendingAttemptChecks(workflowRun);
-      noCheck("workflow lifecycle delivery belongs to an older CI attempt");
+      await discardStaleAttempt(workflowRun);
     }
     const refreshedWorkflowRun = refreshedCI.current;
     if (refreshedWorkflowRun.status === "completed") {
@@ -261,6 +271,10 @@ try {
 
   if (event === "pull_request") {
     const resolved = await resolvePullRequestSource(headSHA);
+    const refreshedSourceCI = await requireTrustedCI(workflowRun);
+    if (refreshedSourceCI.staleAttempt) {
+      await discardStaleAttempt(workflowRun);
+    }
     if ("reason" in resolved) {
       if (resolved.kind === "stale") {
         await deletePendingAttemptChecks(currentWorkflowRun);
@@ -269,6 +283,12 @@ try {
           currentWorkflowRun,
           headSHA,
           "GitHub did not materialize the current pull-request source before the bounded deadline. Re-run CI once; the Cloud Source Gate will follow automatically.",
+          async () => {
+            const rejectionCI = await requireTrustedCI(workflowRun);
+            if (rejectionCI.staleAttempt) {
+              await discardStaleAttempt(workflowRun);
+            }
+          },
         );
       }
       noCheck(resolved.reason);
@@ -362,65 +382,33 @@ try {
       fail("pull request identity changed after final source verification");
     }
   }
+  const finalTrustedCI = await requireTrustedCI(workflowRun);
+  if (finalTrustedCI.staleAttempt) {
+    await discardStaleAttempt(currentWorkflowRun);
+  }
   await completeCheck(
     checkId,
     "success",
     "Trusted default-branch code verified the current source state.",
   );
+  terminalCheckReported = true;
   await deletePendingAttemptChecks(currentWorkflowRun, checkId);
 } catch (error) {
   const message =
     error instanceof Error ? error.message : "unexpected source-gate failure";
   console.error(`[run-cloud-source-check] ERROR: ${message}`);
-  if (error instanceof ReportedSourceCheckError) {
-    process.exit(0);
-  }
-  if (error instanceof AmbiguousSourceCheckMutationError) {
-    process.exit(1);
-  }
-  if (checkId !== undefined) {
-    try {
-      await completeCheck(
-        checkId,
-        "failure",
-        "Trusted source verification failed. Inspect the linked workflow run.",
-      );
-    } catch (reportError) {
-      const reportMessage =
-        reportError instanceof Error
-          ? reportError.message
-          : "unexpected source-check reporting failure";
-      console.error(
-        `[run-cloud-source-check] ERROR: cannot report rejection: ${reportMessage}`,
-      );
-      try {
-        await deletePendingCheck(checkId);
-      } catch (cleanupError) {
-        const cleanupMessage =
-          cleanupError instanceof Error
-            ? cleanupError.message
-            : "unexpected pending-check cleanup failure";
-        console.error(
-          `[run-cloud-source-check] ERROR: cannot delete pending rejection: ${cleanupMessage}`,
-        );
-      }
-      process.exit(1);
-    }
-    try {
-      if (activeWorkflowRun !== undefined) {
-        await deletePendingAttemptChecks(activeWorkflowRun, checkId);
-      }
-    } catch (cleanupError) {
-      const cleanupMessage =
-        cleanupError instanceof Error
-          ? cleanupError.message
-          : "unexpected pending-check cleanup failure";
-      console.error(
-        `[run-cloud-source-check] ERROR: rejection reported, but pending sibling cleanup failed: ${cleanupMessage}`,
-      );
-      process.exit(1);
-    }
-    process.exit(0);
-  }
-  process.exit(1);
+  const exitCode = await handleCloudSourceCheckFailure({
+    activeWorkflowRun,
+    ambiguousMutation: error instanceof AmbiguousSourceCheckMutationError,
+    checkId,
+    completeCheck,
+    deletePendingAttemptChecks,
+    deletePendingAttemptChecksEventually,
+    deletePendingCheck,
+    reportedFailure: error instanceof ReportedSourceCheckError,
+    requireTrustedCI,
+    staleAttemptObserved,
+    terminalCheckReported,
+  });
+  process.exit(exitCode);
 }

--- a/scripts/release/run-cloud-source-check.mjs
+++ b/scripts/release/run-cloud-source-check.mjs
@@ -221,17 +221,29 @@ try {
   }
   const currentWorkflowRun = trustedCI.current;
   activeWorkflowRun = currentWorkflowRun;
+  async function revalidateCurrentAttempt() {
+    const mutationCI = await requireTrustedCI(workflowRun);
+    if (mutationCI.staleAttempt) {
+      await discardStaleAttempt(currentWorkflowRun);
+    }
+  }
   if (action === "in_progress") {
     if (currentWorkflowRun.status === "completed") {
       noCheck("upstream CI already completed; provisional check not emitted");
     }
-    if (await hasTerminalAttemptResult(currentWorkflowRun)) {
+    if (
+      await hasTerminalAttemptResult(
+        currentWorkflowRun,
+        revalidateCurrentAttempt,
+      )
+    ) {
       await deletePendingTargetChecks(currentWorkflowRun, headSHA);
       noCheck("source check attempt already has a terminal result");
     }
     const { check, terminalResult } = await ensurePendingCheck(
       currentWorkflowRun,
       headSHA,
+      revalidateCurrentAttempt,
     );
     if (terminalResult) {
       process.exit(0);
@@ -244,7 +256,12 @@ try {
     if (refreshedWorkflowRun.status === "completed") {
       if (event === "pull_request") {
         await deletePendingTargetChecks(refreshedWorkflowRun, headSHA);
-      } else if (await hasTerminalAttemptResult(refreshedWorkflowRun)) {
+      } else if (
+        await hasTerminalAttemptResult(
+          refreshedWorkflowRun,
+          revalidateCurrentAttempt,
+        )
+      ) {
         await deletePendingAttemptChecks(refreshedWorkflowRun);
       }
     }
@@ -259,7 +276,9 @@ try {
       "upstream CI did not complete successfully; no source check emitted",
     );
   }
-  if (await hasTerminalAttemptResult(currentWorkflowRun)) {
+  if (
+    await hasTerminalAttemptResult(currentWorkflowRun, revalidateCurrentAttempt)
+  ) {
     await deletePendingAttemptChecks(currentWorkflowRun);
     noCheck("source check attempt already has a terminal result");
   }
@@ -283,12 +302,7 @@ try {
           currentWorkflowRun,
           headSHA,
           "GitHub did not materialize the current pull-request source before the bounded deadline. Re-run CI once; the Cloud Source Gate will follow automatically.",
-          async () => {
-            const rejectionCI = await requireTrustedCI(workflowRun);
-            if (rejectionCI.staleAttempt) {
-              await discardStaleAttempt(workflowRun);
-            }
-          },
+          revalidateCurrentAttempt,
         );
       }
       noCheck(resolved.reason);
@@ -330,6 +344,7 @@ try {
   const { check, terminalResult } = await ensurePendingCheck(
     currentWorkflowRun,
     verifiedTargetSHA,
+    revalidateCurrentAttempt,
   );
   checkId = check.id;
   await deletePendingAttemptChecks(currentWorkflowRun, checkId);

--- a/tests/onboarding/cloud-release-gate-contract.ts
+++ b/tests/onboarding/cloud-release-gate-contract.ts
@@ -252,8 +252,9 @@ export function registerCloudReleaseGateContractTests(): void {
       '`workflow-run:${workflowRun.id}:attempt:${workflowRun.run_attempt}:target:${requireSHA(targetSHA, "source check target SHA")}`',
     );
     expect(reporter).toContain(
-      "ensurePendingCheck(\n    currentWorkflowRun,\n    verifiedTargetSHA,\n  )",
+      "ensurePendingCheck(\n    currentWorkflowRun,\n    verifiedTargetSHA,\n    revalidateCurrentAttempt,\n  )",
     );
+    expect(reporterHelper).not.toContain("beforeTerminalMutation =");
     expect(reporter).toContain("terminalResult");
     expect(reporterHelper).toContain(
       "source checks have conflicting terminal conclusions",

--- a/tests/onboarding/cloud-source-check-lifecycle.test.ts
+++ b/tests/onboarding/cloud-source-check-lifecycle.test.ts
@@ -62,6 +62,7 @@ const reporter = createCloudSourceCheckReporter({
 await reporter.ensurePendingCheck(
   JSON.parse(process.env.MOCK_WORKFLOW_RUN),
   process.env.MOCK_TARGET_SHA,
+  async () => {},
 );
 `,
     "utf8",

--- a/tests/onboarding/cloud-source-check-lifecycle.test.ts
+++ b/tests/onboarding/cloud-source-check-lifecycle.test.ts
@@ -6,14 +6,16 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { registerCloudSourceMaterializationBehaviorTests } from "./cloud-source-materialization-behavior.js";
+import { registerCloudSourceMaterializationWindowBehaviorTests } from "./cloud-source-materialization-window-behavior.js";
 import { registerCloudSourceRejectionBehaviorTests } from "./cloud-source-rejection-behavior.js";
-import { registerCloudSourceRunnerBehaviorTests } from "./cloud-source-runner-behavior.js";
+import { registerCloudSourceRunnerLifecycleBehaviorTests } from "./cloud-source-runner-lifecycle-behavior.js";
 
 const headSHA = "a".repeat(40);
 const appId = 42;
 
-registerCloudSourceRunnerBehaviorTests();
+registerCloudSourceRunnerLifecycleBehaviorTests();
 registerCloudSourceMaterializationBehaviorTests();
+registerCloudSourceMaterializationWindowBehaviorTests();
 registerCloudSourceRejectionBehaviorTests();
 
 function check(runAttempt: number, status: "completed" | "in_progress") {
@@ -253,10 +255,7 @@ describe("Cloud source check lifecycle", () => {
       conclusion: "failure",
       id: 902,
     };
-    const { result, trace } = runLifecycle(1, [], [
-      racedSuccess,
-      racedFailure,
-    ]);
+    const { result, trace } = runLifecycle(1, [], [racedSuccess, racedFailure]);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain(
       "terminal source check raced pending-check creation",

--- a/tests/onboarding/cloud-source-check-lifecycle.test.ts
+++ b/tests/onboarding/cloud-source-check-lifecycle.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { registerCloudSourceCheckMutationBehaviorTests } from "./cloud-source-check-mutation-behavior.js";
 import { registerCloudSourceMaterializationBehaviorTests } from "./cloud-source-materialization-behavior.js";
 import { registerCloudSourceMaterializationWindowBehaviorTests } from "./cloud-source-materialization-window-behavior.js";
 import { registerCloudSourceRejectionBehaviorTests } from "./cloud-source-rejection-behavior.js";
@@ -17,6 +18,7 @@ registerCloudSourceRunnerLifecycleBehaviorTests();
 registerCloudSourceMaterializationBehaviorTests();
 registerCloudSourceMaterializationWindowBehaviorTests();
 registerCloudSourceRejectionBehaviorTests();
+registerCloudSourceCheckMutationBehaviorTests();
 
 function check(runAttempt: number, status: "completed" | "in_progress") {
   return {

--- a/tests/onboarding/cloud-source-check-mutation-behavior.ts
+++ b/tests/onboarding/cloud-source-check-mutation-behavior.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+
+type Candidate = ReturnType<typeof reconciliationCandidate>;
+type Scan = Candidate[] | Error;
+type ReconciliationOptions = {
+  cleanupPending: () => Promise<void>;
+  create: () => Promise<Candidate>;
+  listMatches: () => Promise<Candidate[]>;
+  retainPendingOnTerminalConflict?: boolean;
+  waitFor?: () => Promise<void>;
+};
+
+function reconciliationCandidate(
+  id: number,
+  status: "completed" | "in_progress",
+  conclusion: "failure" | "success" | null = null,
+) {
+  return { conclusion, id, status };
+}
+
+const mutationModulePath: string =
+  "../../scripts/release/cloud-source-check-mutation.mjs";
+const { AmbiguousSourceCheckMutationError, createCheckWithReconciliation } =
+  (await import(mutationModulePath)) as {
+    AmbiguousSourceCheckMutationError: typeof Error;
+    createCheckWithReconciliation: (
+      options: ReconciliationOptions,
+    ) => Promise<Candidate>;
+  };
+
+async function reconcileSequence(
+  sequence: Scan[],
+  retainPendingOnTerminalConflict = false,
+) {
+  let cleanupCount = 0;
+  let listCount = 0;
+  const result = await createCheckWithReconciliation({
+    cleanupPending: async () => {
+      cleanupCount += 1;
+    },
+    create: async () => {
+      throw new Error("mock accepted POST response loss");
+    },
+    listMatches: async () => {
+      const scan = sequence[Math.min(listCount++, sequence.length - 1)] ?? [];
+      if (scan instanceof Error) {
+        throw scan;
+      }
+      return scan;
+    },
+    retainPendingOnTerminalConflict,
+    waitFor: async () => {},
+  });
+  return { cleanupCount, listCount, result };
+}
+
+export function registerCloudSourceCheckMutationBehaviorTests(): void {
+  describe("Cloud source check mutation reconciliation", () => {
+    const failure = reconciliationCandidate(701, "completed", "failure");
+    const success = reconciliationCandidate(702, "completed", "success");
+    const pending = reconciliationCandidate(900, "in_progress");
+
+    it("retains one conflict fail-safe after terminals appear", async () => {
+      const reconciled = await reconcileSequence(
+        [[pending], [failure, success, pending], [failure, success, pending]],
+        true,
+      );
+      expect(reconciled).toMatchObject({
+        cleanupCount: 0,
+        listCount: 3,
+        result: pending,
+      });
+    });
+
+    it("waits for a second terminal before choosing conflict precedence", async () => {
+      const reconciled = await reconcileSequence(
+        [
+          [failure, pending],
+          [failure, success, pending],
+          [failure, success, pending],
+        ],
+        true,
+      );
+      expect(reconciled).toMatchObject({
+        cleanupCount: 0,
+        listCount: 3,
+        result: pending,
+      });
+    });
+
+    it("rejects terminal conflict during normal pending creation", async () => {
+      await expect(
+        reconcileSequence([[failure, success, pending], [pending], [pending]]),
+      ).rejects.toBeInstanceOf(AmbiguousSourceCheckMutationError);
+    });
+
+    it.each([
+      [
+        "terminal then stale pending",
+        [
+          [reconciliationCandidate(900, "completed", "success")],
+          [pending],
+          [pending],
+        ],
+      ],
+      [
+        "pending then terminal then stale pending",
+        [
+          [pending],
+          [reconciliationCandidate(900, "completed", "success")],
+          [pending],
+        ],
+      ],
+    ] as const)(
+      "keeps terminal observation sticky: %s",
+      async (_label, scans) => {
+        const reconciled = await reconcileSequence(
+          scans.map((scan) => [...scan]),
+        );
+        expect(reconciled).toMatchObject({
+          cleanupCount: 1,
+          listCount: 3,
+          result: reconciliationCandidate(900, "completed", "success"),
+        });
+      },
+    );
+
+    it("retains conflicting conclusions observed for the same terminal ID", async () => {
+      const changedFailure = reconciliationCandidate(
+        900,
+        "completed",
+        "failure",
+      );
+      const changedSuccess = reconciliationCandidate(
+        900,
+        "completed",
+        "success",
+      );
+      await expect(
+        reconcileSequence([
+          [changedFailure],
+          [changedSuccess],
+          [changedSuccess],
+        ]),
+      ).rejects.toBeInstanceOf(AmbiguousSourceCheckMutationError);
+    });
+
+    it("keeps the latest immutable terminal when conclusions agree", async () => {
+      const latestFailure = reconciliationCandidate(
+        703,
+        "completed",
+        "failure",
+      );
+      const reconciled = await reconcileSequence([
+        [failure, pending],
+        [failure, latestFailure, pending],
+        [failure, latestFailure, pending],
+      ]);
+      expect(reconciled).toMatchObject({
+        cleanupCount: 1,
+        listCount: 3,
+        result: latestFailure,
+      });
+    });
+
+    it("lets a terminal supersede multiple observed pending checks", async () => {
+      const duplicate = reconciliationCandidate(901, "in_progress");
+      const reconciled = await reconcileSequence([
+        [pending, duplicate],
+        [pending, duplicate, success],
+        [pending, duplicate, success],
+      ]);
+      expect(reconciled).toMatchObject({
+        cleanupCount: 1,
+        listCount: 3,
+        result: success,
+      });
+    });
+
+    it.each([0, 1, 2])(
+      "tolerates a transient list failure on scan %i",
+      async (failureIndex) => {
+        const scans: Scan[] = [[pending], [pending], [pending]];
+        scans[failureIndex] = new Error("transient list failure");
+        const reconciled = await reconcileSequence(scans);
+        expect(reconciled).toMatchObject({
+          cleanupCount: 0,
+          listCount: 3,
+          result: pending,
+        });
+      },
+    );
+
+    it.each([
+      ["conflicting terminals", [failure, success]],
+      [
+        "multiple pending checks",
+        [pending, reconciliationCandidate(901, "in_progress")],
+      ],
+      [
+        "conflicting terminals and multiple pending checks",
+        [
+          failure,
+          success,
+          pending,
+          reconciliationCandidate(901, "in_progress"),
+        ],
+      ],
+    ])("rejects unresolved ambiguity: %s", async (_label, matches) => {
+      await expect(reconcileSequence([matches])).rejects.toBeInstanceOf(
+        AmbiguousSourceCheckMutationError,
+      );
+    });
+  });
+}

--- a/tests/onboarding/cloud-source-materialization-behavior.ts
+++ b/tests/onboarding/cloud-source-materialization-behavior.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  headSHA,
-  runSourceGate,
-} from "./cloud-source-runner-behavior.js";
+import { headSHA, runSourceGate } from "./cloud-source-runner-behavior.js";
 
 export function registerCloudSourceMaterializationBehaviorTests(): void {
   describe("Cloud source PR materialization", () => {
@@ -27,7 +24,10 @@ export function registerCloudSourceMaterializationBehaviorTests(): void {
           (entry) =>
             entry.method === "GET" && entry.path.endsWith("/pulls/449"),
         ),
-      ).toHaveLength(21);
+      ).toHaveLength(30);
+      const retryDelays = trace.filter((entry) => entry.method === "TIMER");
+      expect(retryDelays).toHaveLength(30);
+      expect(retryDelays.every((entry) => entry.path === "3000")).toBe(true);
       expect(
         trace.some(
           (entry) =>
@@ -45,42 +45,13 @@ export function registerCloudSourceMaterializationBehaviorTests(): void {
     it("creates one fail-safe rejection without a provisional check", () => {
       const { result, trace } = runSourceGate({ mergeCommitSHA: null });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-      expect(
-        trace.filter((entry) => entry.method === "POST"),
-      ).toHaveLength(1);
+      expect(trace.filter((entry) => entry.method === "POST")).toHaveLength(1);
       expect(
         trace.filter(
           (entry) =>
             entry.method === "PATCH" && entry.body?.conclusion === "failure",
         ),
       ).toHaveLength(1);
-    });
-
-    it("accepts a merge commit materialized near the bounded deadline", () => {
-      const { result, trace } = runSourceGate({
-        mergeCommitSHASequence: [
-          ...Array<null>(19).fill(null),
-          "d".repeat(40),
-        ],
-      });
-      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-      const exactCheckIndex = trace.findIndex(
-        (entry) => entry.method === "POST",
-      );
-      expect(
-        trace
-          .slice(0, exactCheckIndex)
-          .filter(
-            (entry) =>
-              entry.method === "GET" && entry.path.endsWith("/pulls/449"),
-          ),
-      ).toHaveLength(20);
-      expect(
-        trace.some(
-          (entry) =>
-            entry.method === "PATCH" && entry.body?.conclusion === "success",
-        ),
-      ).toBe(true);
     });
 
     it("does not recreate a provisional check after CI completed", () => {
@@ -112,8 +83,7 @@ export function registerCloudSourceMaterializationBehaviorTests(): void {
       expect(
         trace.some(
           (entry) =>
-            entry.method === "DELETE" &&
-            entry.path.endsWith("/check-runs/900"),
+            entry.method === "DELETE" && entry.path.endsWith("/check-runs/900"),
         ),
       ).toBe(true);
     });
@@ -150,10 +120,7 @@ export function registerCloudSourceMaterializationBehaviorTests(): void {
           false,
           true,
         ],
-        mergeCommitSHASequence: [
-          ...Array<null>(18).fill(null),
-          "d".repeat(40),
-        ],
+        mergeCommitSHASequence: [...Array<null>(18).fill(null), "d".repeat(40)],
       });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
       expect(
@@ -192,8 +159,7 @@ export function registerCloudSourceMaterializationBehaviorTests(): void {
       expect(
         trace.some(
           (entry) =>
-            entry.method === "DELETE" &&
-            entry.path.endsWith("/check-runs/900"),
+            entry.method === "DELETE" && entry.path.endsWith("/check-runs/900"),
         ),
       ).toBe(true);
     });
@@ -267,7 +233,7 @@ export function registerCloudSourceMaterializationBehaviorTests(): void {
       ).toBe(true);
     });
 
-    it("exits without a new check for a stale pull-request head", () => {
+    it("rejects when current pull-request association stays absent", () => {
       const provisional = {
         app: { id: 42 },
         external_id: `workflow-run:123:attempt:1:target:${headSHA}`,
@@ -292,8 +258,9 @@ export function registerCloudSourceMaterializationBehaviorTests(): void {
       expect(
         trace.some(
           (entry) =>
-            entry.method === "DELETE" &&
-            entry.path.endsWith(`/check-runs/${provisional.id}`),
+            entry.method === "PATCH" &&
+            entry.path.endsWith(`/check-runs/${provisional.id}`) &&
+            entry.body?.conclusion === "failure",
         ),
       ).toBe(true);
       expect(
@@ -309,7 +276,7 @@ export function registerCloudSourceMaterializationBehaviorTests(): void {
             entry.method === "GET" &&
             entry.path.endsWith(`/commits/${headSHA}/pulls`),
         ),
-      ).toHaveLength(3);
+      ).toHaveLength(30);
     });
 
     it("reports a fail-safe rejection when the merge ref stays absent", () => {

--- a/tests/onboarding/cloud-source-materialization-behavior.ts
+++ b/tests/onboarding/cloud-source-materialization-behavior.ts
@@ -24,7 +24,7 @@ export function registerCloudSourceMaterializationBehaviorTests(): void {
           (entry) =>
             entry.method === "GET" && entry.path.endsWith("/pulls/449"),
         ),
-      ).toHaveLength(30);
+      ).toHaveLength(31);
       const retryDelays = trace.filter((entry) => entry.method === "TIMER");
       expect(retryDelays).toHaveLength(30);
       expect(retryDelays.every((entry) => entry.path === "3000")).toBe(true);
@@ -276,7 +276,7 @@ export function registerCloudSourceMaterializationBehaviorTests(): void {
             entry.method === "GET" &&
             entry.path.endsWith(`/commits/${headSHA}/pulls`),
         ),
-      ).toHaveLength(30);
+      ).toHaveLength(31);
     });
 
     it("reports a fail-safe rejection when the merge ref stays absent", () => {

--- a/tests/onboarding/cloud-source-materialization-window-behavior.ts
+++ b/tests/onboarding/cloud-source-materialization-window-behavior.ts
@@ -8,9 +8,9 @@ import {
 
 export function registerCloudSourceMaterializationWindowBehaviorTests(): void {
   describe("Cloud source PR materialization window", () => {
-    it("accepts a PR association materialized after the prior attempt cap", () => {
+    it("accepts a PR association materialized at the deadline", () => {
       const { result, trace } = runSourceGate({
-        associationPresentSequence: [...Array<boolean>(21).fill(false), true],
+        associationPresentSequence: [...Array<boolean>(30).fill(false), true],
       });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
       const exactCheckIndex = trace.findIndex(
@@ -24,7 +24,7 @@ export function registerCloudSourceMaterializationWindowBehaviorTests(): void {
               entry.method === "GET" &&
               entry.path.endsWith(`/commits/${headSHA}/pulls`),
           ),
-      ).toHaveLength(22);
+      ).toHaveLength(31);
       expect(
         trace.some(
           (entry) =>
@@ -33,9 +33,9 @@ export function registerCloudSourceMaterializationWindowBehaviorTests(): void {
       ).toBe(true);
     });
 
-    it("accepts a merge commit materialized after the prior attempt cap", () => {
+    it("accepts a merge commit materialized at the deadline", () => {
       const { result, trace } = runSourceGate({
-        mergeCommitSHASequence: [...Array<null>(21).fill(null), mergeSHA],
+        mergeCommitSHASequence: [...Array<null>(30).fill(null), mergeSHA],
       });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
       const exactCheckIndex = trace.findIndex(
@@ -48,7 +48,7 @@ export function registerCloudSourceMaterializationWindowBehaviorTests(): void {
             (entry) =>
               entry.method === "GET" && entry.path.endsWith("/pulls/449"),
           ),
-      ).toHaveLength(22);
+      ).toHaveLength(31);
       expect(
         trace.some(
           (entry) =>
@@ -61,11 +61,11 @@ export function registerCloudSourceMaterializationWindowBehaviorTests(): void {
       ["absent", null],
       ["inconsistent", "c".repeat(40)],
     ] as const)(
-      "accepts a merge ref that becomes consistent after the prior attempt cap: %s",
+      "accepts a merge ref that becomes consistent at the deadline: %s",
       (_name, delayedRef) => {
         const { result, trace } = runSourceGate({
           gitSHASequence: [
-            ...Array<null | string>(21).fill(delayedRef),
+            ...Array<null | string>(30).fill(delayedRef),
             mergeSHA,
             mergeSHA,
           ],
@@ -193,7 +193,7 @@ export function registerCloudSourceMaterializationWindowBehaviorTests(): void {
     it.each([
       ["pending during reconciliation after terminal", 2, 1],
       ["pending during cleanup after terminal", 2, 4],
-      ["terminal during reconciliation after pending", 3, 0],
+      ["terminal during final reconciliation scan after pending", 4, 0],
     ] as const)(
       "cleans an accepted hidden POST beside a late terminal success %s",
       (_label, lateVisibleChecksDelay, postVisibilityDelay) => {

--- a/tests/onboarding/cloud-source-materialization-window-behavior.ts
+++ b/tests/onboarding/cloud-source-materialization-window-behavior.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  headSHA,
+  mergeSHA,
+  runSourceGate,
+} from "./cloud-source-runner-behavior.js";
+
+export function registerCloudSourceMaterializationWindowBehaviorTests(): void {
+  describe("Cloud source PR materialization window", () => {
+    it("accepts a PR association materialized after the prior attempt cap", () => {
+      const { result, trace } = runSourceGate({
+        associationPresentSequence: [...Array<boolean>(21).fill(false), true],
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      const exactCheckIndex = trace.findIndex(
+        (entry) => entry.method === "POST",
+      );
+      expect(
+        trace
+          .slice(0, exactCheckIndex)
+          .filter(
+            (entry) =>
+              entry.method === "GET" &&
+              entry.path.endsWith(`/commits/${headSHA}/pulls`),
+          ),
+      ).toHaveLength(22);
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "success",
+        ),
+      ).toBe(true);
+    });
+
+    it("accepts a merge commit materialized after the prior attempt cap", () => {
+      const { result, trace } = runSourceGate({
+        mergeCommitSHASequence: [...Array<null>(21).fill(null), mergeSHA],
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      const exactCheckIndex = trace.findIndex(
+        (entry) => entry.method === "POST",
+      );
+      expect(
+        trace
+          .slice(0, exactCheckIndex)
+          .filter(
+            (entry) =>
+              entry.method === "GET" && entry.path.endsWith("/pulls/449"),
+          ),
+      ).toHaveLength(22);
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "success",
+        ),
+      ).toBe(true);
+    });
+
+    it.each([
+      ["absent", null],
+      ["inconsistent", "c".repeat(40)],
+    ] as const)(
+      "accepts a merge ref that becomes consistent after the prior attempt cap: %s",
+      (_name, delayedRef) => {
+        const { result, trace } = runSourceGate({
+          gitSHASequence: [
+            ...Array<null | string>(21).fill(delayedRef),
+            mergeSHA,
+            mergeSHA,
+          ],
+        });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(
+          trace.some(
+            (entry) =>
+              entry.method === "PATCH" && entry.body?.conclusion === "success",
+          ),
+        ).toBe(true);
+      },
+    );
+
+    it("never accepts source consistency after the bounded deadline", () => {
+      const { result, trace } = runSourceGate({
+        monotonicNowSequence: [0, 90_001, 90_001],
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain(
+        "source materialized after the bounded deadline",
+      );
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "failure",
+        ),
+      ).toBe(true);
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "success",
+        ),
+      ).toBe(false);
+    });
+
+    it("reconciles an exact pending check after its POST response times out", () => {
+      const { result, trace } = runSourceGate({
+        postThrowsAfterApply: true,
+        postVisibilityDelay: 2,
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "success",
+        ),
+      ).toBe(true);
+      expect(trace.some((entry) => entry.method === "DELETE")).toBe(false);
+    });
+
+    it("retries a transient list failure during POST reconciliation", () => {
+      const { result, trace } = runSourceGate({
+        postReconcileListStatusSequence: [500, 200],
+        postThrowsAfterApply: true,
+        postVisibilityDelay: 1,
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "success",
+        ),
+      ).toBe(true);
+    });
+
+    it("reconciles a fail-safe check after its POST response times out", () => {
+      const { result, trace } = runSourceGate({
+        mergeCommitSHA: null,
+        postThrowsAfterApply: true,
+        postVisibilityDelay: 2,
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "failure",
+        ),
+      ).toBe(true);
+      expect(trace.some((entry) => entry.method === "DELETE")).toBe(false);
+    });
+
+    it("eventually deletes a delayed pending check after unresolved POST ambiguity", () => {
+      const { result, trace } = runSourceGate({
+        deleteStatusSequence: [500, 204],
+        postThrowsAfterApply: true,
+        postVisibilityDelay: 4,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        "source-check creation remained invisible",
+      );
+      expect(
+        trace.filter(
+          (entry) =>
+            entry.method === "DELETE" && entry.path.endsWith("/check-runs/900"),
+        ),
+      ).toHaveLength(2);
+      expect(trace.some((entry) => entry.method === "PATCH")).toBe(false);
+    });
+
+    it("never overwrites terminal success found during POST reconciliation", () => {
+      const terminalSuccess = {
+        app: { id: 42 },
+        conclusion: "success",
+        external_id: `workflow-run:123:attempt:1:target:${headSHA}`,
+        id: 701,
+        name: "cloud-source-gate",
+        status: "completed",
+      };
+      const { result, trace } = runSourceGate({
+        lateVisibleChecks: [terminalSuccess],
+        lateVisibleChecksDelay: 2,
+        mergeCommitSHA: null,
+        postThrowsBeforeApply: true,
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stderr).toContain(
+        "terminal source check raced fail-safe creation",
+      );
+      expect(trace.some((entry) => entry.method === "PATCH")).toBe(false);
+      expect(trace.some((entry) => entry.method === "DELETE")).toBe(false);
+    });
+
+    it.each([
+      ["pending during reconciliation after terminal", 2, 1],
+      ["pending during cleanup after terminal", 2, 4],
+      ["terminal during reconciliation after pending", 3, 0],
+    ] as const)(
+      "cleans an accepted hidden POST beside a late terminal success %s",
+      (_label, lateVisibleChecksDelay, postVisibilityDelay) => {
+        const terminalSuccess = {
+          app: { id: 42 },
+          conclusion: "success",
+          external_id: `workflow-run:123:attempt:1:target:${headSHA}`,
+          id: 701,
+          name: "cloud-source-gate",
+          status: "completed",
+        };
+        const { result, trace } = runSourceGate({
+          lateVisibleChecks: [terminalSuccess],
+          lateVisibleChecksDelay,
+          mergeCommitSHA: null,
+          postThrowsAfterApply: true,
+          postVisibilityDelay,
+        });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(
+          trace.some(
+            (entry) =>
+              entry.method === "DELETE" &&
+              entry.path.endsWith("/check-runs/900"),
+          ),
+        ).toBe(true);
+        expect(
+          trace.some(
+            (entry) =>
+              entry.method === "DELETE" &&
+              entry.path.endsWith(`/check-runs/${terminalSuccess.id}`),
+          ),
+        ).toBe(false);
+        expect(trace.some((entry) => entry.method === "PATCH")).toBe(false);
+      },
+    );
+
+    it("cleans a provisional check when the post-window CI refresh fails", () => {
+      const provisional = {
+        app: { id: 42 },
+        external_id: `workflow-run:123:attempt:1:target:${headSHA}`,
+        id: 700,
+        name: "cloud-source-gate",
+        status: "in_progress",
+      };
+      const { result, trace } = runSourceGate({
+        initialChecks: [provisional],
+        mergeCommitSHA: null,
+        workflowAPIStatusSequence: [200, 500],
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("returned HTTP 500");
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "DELETE" &&
+            entry.path.endsWith(`/check-runs/${provisional.id}`),
+        ),
+      ).toBe(true);
+      expect(trace.some((entry) => entry.method === "PATCH")).toBe(false);
+    });
+
+    it("drops a timeout rejection after a newer CI attempt starts", () => {
+      const provisional = {
+        app: { id: 42 },
+        external_id: `workflow-run:123:attempt:1:target:${headSHA}`,
+        id: 700,
+        name: "cloud-source-gate",
+        status: "in_progress",
+      };
+      const { result, trace } = runSourceGate({
+        currentWorkflowAttemptSequence: [1, 2],
+        currentWorkflowStatusSequence: ["completed", "in_progress"],
+        initialChecks: [provisional],
+        mergeCommitSHA: null,
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("older CI attempt");
+      expect(trace.some((entry) => entry.method === "PATCH")).toBe(false);
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "DELETE" &&
+            entry.path.endsWith(`/check-runs/${provisional.id}`),
+        ),
+      ).toBe(true);
+    });
+
+    it.each([
+      ["reused provisional", true],
+      ["new fail-safe", false],
+    ] as const)(
+      "drops %s when a newer CI attempt starts during rejection",
+      (_label, reuseProvisional) => {
+        const provisional = {
+          app: { id: 42 },
+          external_id: `workflow-run:123:attempt:1:target:${headSHA}`,
+          id: 700,
+          name: "cloud-source-gate",
+          status: "in_progress",
+        };
+        const { result, trace } = runSourceGate({
+          currentWorkflowAttemptSequence: [1, 1, 2],
+          currentWorkflowStatusSequence: [
+            "completed",
+            "completed",
+            "in_progress",
+          ],
+          initialChecks: reuseProvisional ? [provisional] : [],
+          mergeCommitSHA: null,
+        });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(trace.some((entry) => entry.method === "PATCH")).toBe(false);
+        expect(
+          trace.some(
+            (entry) =>
+              entry.method === "DELETE" &&
+              entry.path.endsWith(
+                `/check-runs/${reuseProvisional ? provisional.id : 900}`,
+              ),
+          ),
+        ).toBe(true);
+      },
+    );
+
+    it("does not reject or delete a newer attempt after policy failure", () => {
+      const newerAttempt = {
+        app: { id: 42 },
+        external_id: `workflow-run:123:attempt:2:target:${mergeSHA}`,
+        id: 702,
+        name: "cloud-source-gate",
+        status: "in_progress",
+      };
+      const { result, trace } = runSourceGate({
+        bashExit: 1,
+        currentWorkflowAttemptSequence: [1, 1, 2],
+        currentWorkflowStatusSequence: [
+          "completed",
+          "completed",
+          "in_progress",
+        ],
+        initialChecks: [newerAttempt],
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "DELETE" && entry.path.endsWith("/check-runs/900"),
+        ),
+      ).toBe(true);
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "DELETE" &&
+            entry.path.endsWith(`/check-runs/${newerAttempt.id}`),
+        ),
+      ).toBe(false);
+      expect(trace.some((entry) => entry.method === "PATCH")).toBe(false);
+    });
+
+    it("never converts stale cleanup failure into terminal rejection", () => {
+      const { result, trace } = runSourceGate({
+        bashExit: 1,
+        currentWorkflowAttemptSequence: [1, 1, 2],
+        currentWorkflowStatusSequence: [
+          "completed",
+          "completed",
+          "in_progress",
+        ],
+        deleteStatus: 500,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("cannot clean the stale CI attempt");
+      expect(trace.some((entry) => entry.method === "PATCH")).toBe(false);
+    });
+
+    it("removes exact pending state when a newer attempt starts before success", () => {
+      const { result, trace } = runSourceGate({
+        currentWorkflowAttemptSequence: [1, 1, 2],
+        currentWorkflowStatusSequence: [
+          "completed",
+          "completed",
+          "in_progress",
+        ],
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("older CI attempt");
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "DELETE" && entry.path.endsWith("/check-runs/900"),
+        ),
+      ).toBe(true);
+      expect(
+        trace.some(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "success",
+        ),
+      ).toBe(false);
+    });
+  });
+}

--- a/tests/onboarding/cloud-source-rejection-behavior.ts
+++ b/tests/onboarding/cloud-source-rejection-behavior.ts
@@ -55,6 +55,53 @@ export function registerCloudSourceRejectionBehaviorTests(): void {
       ).toBe(true);
     });
 
+    it.each([0, 1, 2])(
+      "preserves a conflict fail-safe when its accepted POST stays hidden for %i scans",
+      (postVisibilityDelay) => {
+        const headSHA = "a".repeat(40);
+        const externalId = `workflow-run:123:attempt:1:target:${headSHA}`;
+        const { result, trace } = runSourceGate({
+          event: "merge_group",
+          initialChecks: [
+            {
+              app: { id: 42 },
+              conclusion: "failure",
+              external_id: externalId,
+              id: 701,
+              name: "cloud-source-gate",
+              status: "completed",
+            },
+            {
+              app: { id: 42 },
+              conclusion: "success",
+              external_id: externalId,
+              id: 702,
+              name: "cloud-source-gate",
+              status: "completed",
+            },
+          ],
+          postThrowsAfterApply: true,
+          postVisibilityDelay,
+        });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(
+          trace.filter(
+            (entry) =>
+              entry.method === "PATCH" &&
+              entry.path.endsWith("/check-runs/900") &&
+              entry.body?.conclusion === "failure",
+          ),
+        ).toHaveLength(1);
+        expect(
+          trace.some(
+            (entry) =>
+              entry.method === "DELETE" &&
+              entry.path.endsWith("/check-runs/900"),
+          ),
+        ).toBe(false);
+      },
+    );
+
     it("keeps App-check reporting failures visible as workflow failures", () => {
       const { result, trace } = runSourceGate({
         bashExit: 1,

--- a/tests/onboarding/cloud-source-runner-behavior.ts
+++ b/tests/onboarding/cloud-source-runner-behavior.ts
@@ -9,8 +9,6 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
-
 export const headSHA = "a".repeat(40);
 const baseSHA = "b".repeat(40);
 export const mergeSHA = "d".repeat(40);
@@ -23,24 +21,38 @@ export type RunOptions = {
   conclusion?: "cancelled" | "failure" | "success";
   event?: "merge_group" | "pull_request";
   gitSHA?: null | string;
+  gitSHASequence?: Array<null | string>;
   initialChecks?: unknown[];
   mergeCommitSHA?: null | string;
   mergeCommitSHASequence?: Array<null | string>;
+  monotonicNowSequence?: number[];
   checkListStatusAfterPatch?: number;
   checkReadStatus?: number;
+  deleteStatus?: number;
+  deleteStatusSequence?: number[];
+  lateVisibleChecks?: unknown[];
+  lateVisibleChecksDelay?: number;
   patchStatus?: number;
   patchThrowsAfterApply?: boolean;
+  postReconcileListStatusSequence?: number[];
+  postThrowsBeforeApply?: boolean;
+  postThrowsAfterApply?: boolean;
+  postVisibilityDelay?: number;
   pullCount?: number;
   currentWorkflowStatus?: "completed" | "in_progress";
   currentWorkflowAttempt?: number;
+  currentWorkflowAttemptSequence?: number[];
   currentWorkflowStatusSequence?: Array<"completed" | "in_progress">;
   workflowAPIStatus?: number;
+  workflowAPIStatusSequence?: number[];
 };
 
 export function runSourceGate(options: RunOptions = {}) {
   const root = mkdtempSync(join(tmpdir(), "ha-nova-source-runner-"));
   const bin = join(root, "bin");
   const eventPath = join(root, "event.json");
+  const gitIndexPath = join(root, "git-index");
+  const gitSequencePath = join(root, "git-sequence");
   const preloadPath = join(root, "mock-fetch.mjs");
   const tracePath = join(root, "trace.jsonl");
   mkdirSync(bin);
@@ -91,8 +103,16 @@ export function runSourceGate(options: RunOptions = {}) {
   writeFileSync(
     join(bin, "git"),
     `#!/bin/sh
-if [ -n "$MOCK_GIT_SHA" ]; then
-  printf '%s\\t%s\\n' "$MOCK_GIT_SHA" "$4"
+index="$(cat "$MOCK_GIT_INDEX_FILE")"
+index="$((index + 1))"
+printf '%s' "$index" > "$MOCK_GIT_INDEX_FILE"
+count="$(wc -l < "$MOCK_GIT_SEQUENCE_FILE" | tr -d ' ')"
+if [ "$index" -gt "$count" ]; then
+  index="$count"
+fi
+mock_sha="$(sed -n "\${index}p" "$MOCK_GIT_SEQUENCE_FILE")"
+if [ -n "$mock_sha" ]; then
+  printf '%s\\t%s\\n' "$mock_sha" "$4"
 fi
 `,
     "utf8",
@@ -106,20 +126,73 @@ exit "$MOCK_BASH_EXIT"
   );
   chmodSync(join(bin, "git"), 0o755);
   chmodSync(join(bin, "bash"), 0o755);
+  const defaultGitSHA =
+    options.gitSHA === undefined
+      ? event === "pull_request"
+        ? (pull.merge_commit_sha ?? "")
+        : headSHA
+      : (options.gitSHA ?? "");
+  writeFileSync(gitIndexPath, "0", "utf8");
+  writeFileSync(
+    gitSequencePath,
+    `${(options.gitSHASequence ?? [defaultGitSHA])
+      .map((sha) => sha ?? "")
+      .join("\n")}\n`,
+    "utf8",
+  );
 
   writeFileSync(
     preloadPath,
     `import { appendFileSync } from "node:fs";
 let checks = JSON.parse(process.env.MOCK_CHECKS);
+let hiddenChecks = [];
+let postVisibilityScansRemaining = Number(
+  process.env.MOCK_POST_VISIBILITY_DELAY,
+);
+let lateVisibleChecks = JSON.parse(process.env.MOCK_LATE_VISIBLE_CHECKS);
+let lateVisibleScansRemaining = Number(
+  process.env.MOCK_LATE_VISIBLE_CHECKS_DELAY,
+);
+const monotonicNowSequence = JSON.parse(
+  process.env.MOCK_MONOTONIC_NOW_SEQUENCE,
+);
+let monotonicNowIndex = 0;
+let monotonicNow = 0;
+Object.defineProperty(globalThis.performance, "now", {
+  value: () => {
+    if (monotonicNowSequence.length === 0) {
+      return monotonicNow;
+    }
+    return monotonicNowSequence[
+      Math.min(monotonicNowIndex++, monotonicNowSequence.length - 1)
+    ];
+  },
+});
 const pulls = JSON.parse(process.env.MOCK_PULLS);
 const fullPulls = JSON.parse(process.env.MOCK_FULL_PULLS);
 let fullPullIndex = 0;
 let terminalPatchCompleted = false;
+let postAttempted = false;
+const postReconcileListStatuses = JSON.parse(
+  process.env.MOCK_POST_RECONCILE_LIST_STATUSES,
+);
+let postReconcileListStatusIndex = 0;
+const deleteStatuses = JSON.parse(process.env.MOCK_DELETE_STATUSES);
+let deleteStatusIndex = 0;
 const associationPresent = JSON.parse(process.env.MOCK_ASSOCIATION_PRESENT);
 let associationIndex = 0;
 const workflowRuns = JSON.parse(process.env.MOCK_WORKFLOW_RUNS);
 let workflowRunIndex = 0;
-globalThis.setTimeout = (callback) => {
+const workflowAPIStatuses = JSON.parse(
+  process.env.MOCK_WORKFLOW_API_STATUSES,
+);
+let workflowAPIStatusIndex = 0;
+globalThis.setTimeout = (callback, delay = 0) => {
+  monotonicNow += delay;
+  appendFileSync(
+    process.env.MOCK_TRACE,
+    JSON.stringify({ method: "TIMER", path: String(delay), body: null }) + "\\n",
+  );
   callback();
   return 0;
 };
@@ -138,7 +211,9 @@ globalThis.fetch = async (url, init = {}) => {
   if (path.endsWith("/actions/runs/123")) {
     return response(
       workflowRuns[Math.min(workflowRunIndex++, workflowRuns.length - 1)],
-      Number(process.env.MOCK_WORKFLOW_API_STATUS),
+      workflowAPIStatuses[
+        Math.min(workflowAPIStatusIndex++, workflowAPIStatuses.length - 1)
+      ],
     );
   }
   if (path.endsWith("/commits/${headSHA}/pulls")) {
@@ -152,15 +227,57 @@ globalThis.fetch = async (url, init = {}) => {
     return response(fullPulls[Math.min(fullPullIndex++, fullPulls.length - 1)]);
   }
   if (path.endsWith("/check-runs") && method === "GET") {
+    if (hiddenChecks.length > 0) {
+      if (postVisibilityScansRemaining === 0) {
+        checks.push(...hiddenChecks);
+        hiddenChecks = [];
+      } else {
+        postVisibilityScansRemaining -= 1;
+      }
+    }
+    if (lateVisibleChecks.length > 0) {
+      if (lateVisibleScansRemaining === 0) {
+        checks.push(...lateVisibleChecks);
+        lateVisibleChecks = [];
+      } else {
+        lateVisibleScansRemaining -= 1;
+      }
+    }
+    const postReconcileStatus =
+      postAttempted && postReconcileListStatuses.length > 0
+        ? postReconcileListStatuses[
+            Math.min(
+              postReconcileListStatusIndex++,
+              postReconcileListStatuses.length - 1,
+            )
+          ]
+        : undefined;
     return response(
       { check_runs: checks, total_count: checks.length },
-      terminalPatchCompleted
-        ? Number(process.env.MOCK_CHECK_LIST_STATUS_AFTER_PATCH)
-        : 200,
+      postReconcileStatus ??
+        (terminalPatchCompleted
+          ? Number(process.env.MOCK_CHECK_LIST_STATUS_AFTER_PATCH)
+          : 200),
     );
   }
   if (path.endsWith("/check-runs") && method === "POST") {
-    const created = { ...body, app: { id: 42 }, id: 900 };
+    postAttempted = true;
+    if (process.env.MOCK_POST_THROWS_BEFORE_APPLY === "true") {
+      throw new DOMException("mock response timeout", "TimeoutError");
+    }
+    const created = {
+      ...body,
+      app: { id: 42 },
+      id: 900,
+    };
+    if (process.env.MOCK_POST_THROWS_AFTER_APPLY === "true") {
+      if (postVisibilityScansRemaining > 0) {
+        hiddenChecks.push(created);
+      } else {
+        checks.push(created);
+      }
+      throw new DOMException("mock response timeout", "TimeoutError");
+    }
     checks.push(created);
     return response(created, 201);
   }
@@ -193,8 +310,12 @@ globalThis.fetch = async (url, init = {}) => {
   }
   if (path.includes("/check-runs/") && method === "DELETE") {
     const id = Number(path.split("/").at(-1));
-    checks = checks.filter((candidate) => candidate.id !== id);
-    return response({}, 204);
+    const deleteStatus =
+      deleteStatuses[Math.min(deleteStatusIndex++, deleteStatuses.length - 1)];
+    if (deleteStatus === 204) {
+      checks = checks.filter((candidate) => candidate.id !== id);
+    }
+    return response({}, deleteStatus);
   }
   return response({ message: "unexpected request" }, 500);
 };
@@ -226,12 +347,20 @@ globalThis.fetch = async (url, init = {}) => {
         ),
         MOCK_CHECK_READ_STATUS: String(options.checkReadStatus ?? 200),
         MOCK_CHECKS: JSON.stringify(options.initialChecks ?? []),
-        MOCK_GIT_SHA:
-          options.gitSHA === undefined
-            ? event === "pull_request"
-              ? (pull.merge_commit_sha ?? "")
-              : headSHA
-            : (options.gitSHA ?? ""),
+        MOCK_DELETE_STATUSES: JSON.stringify(
+          options.deleteStatusSequence ?? [options.deleteStatus ?? 204],
+        ),
+        MOCK_GIT_INDEX_FILE: gitIndexPath,
+        MOCK_GIT_SEQUENCE_FILE: gitSequencePath,
+        MOCK_MONOTONIC_NOW_SEQUENCE: JSON.stringify(
+          options.monotonicNowSequence ?? [],
+        ),
+        MOCK_LATE_VISIBLE_CHECKS: JSON.stringify(
+          options.lateVisibleChecks ?? [],
+        ),
+        MOCK_LATE_VISIBLE_CHECKS_DELAY: String(
+          options.lateVisibleChecksDelay ?? 0,
+        ),
         MOCK_PULLS: JSON.stringify(pulls),
         MOCK_FULL_PULLS: JSON.stringify(
           (options.mergeCommitSHASequence ?? [pull.merge_commit_sha]).map(
@@ -242,20 +371,39 @@ globalThis.fetch = async (url, init = {}) => {
         MOCK_PATCH_THROWS_AFTER_APPLY: String(
           options.patchThrowsAfterApply ?? false,
         ),
+        MOCK_POST_RECONCILE_LIST_STATUSES: JSON.stringify(
+          options.postReconcileListStatusSequence ?? [],
+        ),
+        MOCK_POST_THROWS_BEFORE_APPLY: String(
+          options.postThrowsBeforeApply ?? false,
+        ),
+        MOCK_POST_THROWS_AFTER_APPLY: String(
+          options.postThrowsAfterApply ?? false,
+        ),
+        MOCK_POST_VISIBILITY_DELAY: String(options.postVisibilityDelay ?? 0),
         MOCK_TRACE: tracePath,
         MOCK_WORKFLOW_RUNS: JSON.stringify(
           (
             options.currentWorkflowStatusSequence ?? [
               options.currentWorkflowStatus ?? workflowRun.status,
             ]
-          ).map((status) => ({
-            ...workflowRun,
-            run_attempt:
+          ).map((status, index) => {
+            const attemptSequence = options.currentWorkflowAttemptSequence ?? [
               options.currentWorkflowAttempt ?? workflowRun.run_attempt,
-            status,
-          })),
+            ];
+            return {
+              ...workflowRun,
+              run_attempt:
+                attemptSequence[Math.min(index, attemptSequence.length - 1)],
+              status,
+            };
+          }),
         ),
-        MOCK_WORKFLOW_API_STATUS: String(options.workflowAPIStatus ?? 200),
+        MOCK_WORKFLOW_API_STATUSES: JSON.stringify(
+          options.workflowAPIStatusSequence ?? [
+            options.workflowAPIStatus ?? 200,
+          ],
+        ),
         PATH: `${bin}:${process.env.PATH ?? ""}`,
       },
     },
@@ -273,96 +421,4 @@ globalThis.fetch = async (url, init = {}) => {
         },
     );
   return { result, trace };
-}
-
-export function registerCloudSourceRunnerBehaviorTests(): void {
-  describe("Cloud source runner behavior", () => {
-    it("creates only a provisional pending check while CI is in progress", () => {
-      const { result, trace } = runSourceGate({ action: "in_progress" });
-      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-      expect(result.stdout).toContain(
-        "provisional source check recorded for active CI",
-      );
-      const post = trace.find((entry) => entry.method === "POST");
-      expect(post?.body?.external_id).toBe(
-        `workflow-run:123:attempt:1:target:${headSHA}`,
-      );
-      expect(
-        trace.some((entry) => entry.path.includes(`/commits/${headSHA}/pulls`)),
-      ).toBe(false);
-    });
-
-    it("replaces the provisional check only after the exact check is pending", () => {
-      const provisional = {
-        app: { id: 42 },
-        external_id: `workflow-run:123:attempt:1:target:${headSHA}`,
-        id: 700,
-        name: "cloud-source-gate",
-        status: "in_progress",
-      };
-      const { result, trace } = runSourceGate({
-        initialChecks: [provisional],
-      });
-      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-      const exactPostIndex = trace.findIndex(
-        (entry) =>
-          entry.method === "POST" &&
-          entry.body?.external_id ===
-            `workflow-run:123:attempt:1:target:${mergeSHA}`,
-      );
-      const provisionalDeleteIndex = trace.findIndex(
-        (entry) =>
-          entry.method === "DELETE" &&
-          entry.path.endsWith(`/check-runs/${provisional.id}`),
-      );
-      expect(exactPostIndex).toBeGreaterThanOrEqual(0);
-      expect(provisionalDeleteIndex).toBeGreaterThan(exactPostIndex);
-    });
-
-    it.each(["cancelled", "failure"] as const)(
-      "exits without a check after %s CI",
-      (conclusion) => {
-        const { result, trace } = runSourceGate({ conclusion });
-        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-        expect(result.stdout).toContain("no source check emitted");
-        expect(trace.some((entry) => entry.method === "POST")).toBe(false);
-      },
-    );
-
-    it("keeps infrastructure failures before check creation visible", () => {
-      const { result, trace } = runSourceGate({ workflowAPIStatus: 500 });
-      expect(result.status).not.toBe(0);
-      expect(result.stderr).toContain("returned HTTP 500");
-      expect(trace.some((entry) => entry.method === "POST")).toBe(false);
-    });
-
-    it.each([
-      [null, "no longer current"],
-      ["c".repeat(40), "moved before source verification"],
-    ] as const)(
-      "exits without a check when the merge-queue ref is stale: %s",
-      (gitSHA, message) => {
-        const { result, trace } = runSourceGate({
-          event: "merge_group",
-          gitSHA,
-        });
-        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-        expect(result.stdout).toContain(message);
-        expect(trace.some((entry) => entry.method === "POST")).toBe(false);
-      },
-    );
-
-    it("reports successful completed verification once", () => {
-      const { result, trace } = runSourceGate({ event: "merge_group" });
-      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-      expect(trace.filter((entry) => entry.method === "POST")).toHaveLength(1);
-      expect(
-        trace.filter(
-          (entry) =>
-            entry.method === "PATCH" && entry.body?.conclusion === "success",
-        ),
-      ).toHaveLength(1);
-    });
-
-  });
 }

--- a/tests/onboarding/cloud-source-runner-lifecycle-behavior.ts
+++ b/tests/onboarding/cloud-source-runner-lifecycle-behavior.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  headSHA,
+  mergeSHA,
+  runSourceGate,
+} from "./cloud-source-runner-behavior.js";
+
+export function registerCloudSourceRunnerLifecycleBehaviorTests(): void {
+  describe("Cloud source runner behavior", () => {
+    it("creates only a provisional pending check while CI is in progress", () => {
+      const { result, trace } = runSourceGate({ action: "in_progress" });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain(
+        "provisional source check recorded for active CI",
+      );
+      const post = trace.find((entry) => entry.method === "POST");
+      expect(post?.body?.external_id).toBe(
+        `workflow-run:123:attempt:1:target:${headSHA}`,
+      );
+      expect(
+        trace.some((entry) => entry.path.includes(`/commits/${headSHA}/pulls`)),
+      ).toBe(false);
+    });
+
+    it("replaces the provisional check only after the exact check is pending", () => {
+      const provisional = {
+        app: { id: 42 },
+        external_id: `workflow-run:123:attempt:1:target:${headSHA}`,
+        id: 700,
+        name: "cloud-source-gate",
+        status: "in_progress",
+      };
+      const { result, trace } = runSourceGate({
+        initialChecks: [provisional],
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      const exactPostIndex = trace.findIndex(
+        (entry) =>
+          entry.method === "POST" &&
+          entry.body?.external_id ===
+            `workflow-run:123:attempt:1:target:${mergeSHA}`,
+      );
+      const provisionalDeleteIndex = trace.findIndex(
+        (entry) =>
+          entry.method === "DELETE" &&
+          entry.path.endsWith(`/check-runs/${provisional.id}`),
+      );
+      expect(exactPostIndex).toBeGreaterThanOrEqual(0);
+      expect(provisionalDeleteIndex).toBeGreaterThan(exactPostIndex);
+    });
+
+    it.each(["cancelled", "failure"] as const)(
+      "exits without a check after %s CI",
+      (conclusion) => {
+        const { result, trace } = runSourceGate({ conclusion });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(result.stdout).toContain("no source check emitted");
+        expect(trace.some((entry) => entry.method === "POST")).toBe(false);
+      },
+    );
+
+    it("keeps infrastructure failures before check creation visible", () => {
+      const { result, trace } = runSourceGate({ workflowAPIStatus: 500 });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("returned HTTP 500");
+      expect(trace.some((entry) => entry.method === "POST")).toBe(false);
+    });
+
+    it.each([
+      [null, "no longer current"],
+      ["c".repeat(40), "moved before source verification"],
+    ] as const)(
+      "exits without a check when the merge-queue ref is stale: %s",
+      (gitSHA, message) => {
+        const { result, trace } = runSourceGate({
+          event: "merge_group",
+          gitSHA,
+        });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(result.stdout).toContain(message);
+        expect(trace.some((entry) => entry.method === "POST")).toBe(false);
+      },
+    );
+
+    it("reports successful completed verification once", () => {
+      const { result, trace } = runSourceGate({ event: "merge_group" });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(trace.filter((entry) => entry.method === "POST")).toHaveLength(1);
+      expect(
+        trace.filter(
+          (entry) =>
+            entry.method === "PATCH" && entry.body?.conclusion === "success",
+        ),
+      ).toHaveLength(1);
+    });
+  });
+}

--- a/tests/onboarding/cloud-source-runner-lifecycle-behavior.ts
+++ b/tests/onboarding/cloud-source-runner-lifecycle-behavior.ts
@@ -6,6 +6,78 @@ import {
   runSourceGate,
 } from "./cloud-source-runner-behavior.js";
 
+function terminalConflict(targetSHA: string) {
+  const externalId = `workflow-run:123:attempt:1:target:${targetSHA}`;
+  return [
+    {
+      app: { id: 42 },
+      conclusion: "failure",
+      external_id: externalId,
+      id: 701,
+      name: "cloud-source-gate",
+      status: "completed",
+    },
+    {
+      app: { id: 42 },
+      conclusion: "success",
+      external_id: externalId,
+      id: 702,
+      name: "cloud-source-gate",
+      status: "completed",
+    },
+  ];
+}
+
+function newerPending(targetSHA: string) {
+  return {
+    app: { id: 42 },
+    external_id: `workflow-run:123:attempt:2:target:${targetSHA}`,
+    id: 703,
+    name: "cloud-source-gate",
+    status: "in_progress",
+  };
+}
+
+function expectStaleConflictCleanup(
+  result: ReturnType<typeof runSourceGate>["result"],
+  trace: ReturnType<typeof runSourceGate>["trace"],
+  expectedPostCount: number,
+) {
+  expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  expect(result.stdout).toContain("older CI attempt");
+  expect(trace.some((entry) => entry.method === "PATCH")).toBe(false);
+  const posts = trace.filter((entry) => entry.method === "POST");
+  expect(posts).toHaveLength(expectedPostCount);
+  expect(
+    posts.every((entry) =>
+      String(entry.body?.external_id).startsWith(
+        "workflow-run:123:attempt:1:target:",
+      ),
+    ),
+  ).toBe(true);
+  expect(
+    trace.filter(
+      (entry) =>
+        entry.method === "DELETE" && entry.path.endsWith("/check-runs/900"),
+    ),
+  ).toHaveLength(expectedPostCount);
+  expect(
+    trace.some(
+      (entry) =>
+        entry.method === "DELETE" && entry.path.endsWith("/check-runs/703"),
+    ),
+  ).toBe(false);
+  expect(
+    trace.some(
+      (entry) =>
+        entry.method === "DELETE" &&
+        ["/check-runs/701", "/check-runs/702"].some((suffix) =>
+          entry.path.endsWith(suffix),
+        ),
+    ),
+  ).toBe(false);
+}
+
 export function registerCloudSourceRunnerLifecycleBehaviorTests(): void {
   describe("Cloud source runner behavior", () => {
     it("creates only a provisional pending check while CI is in progress", () => {
@@ -93,6 +165,45 @@ export function registerCloudSourceRunnerLifecycleBehaviorTests(): void {
             entry.method === "PATCH" && entry.body?.conclusion === "success",
         ),
       ).toHaveLength(1);
+    });
+
+    it("drops an attempt-wide conflict fail-safe after a newer attempt starts", () => {
+      const { result, trace } = runSourceGate({
+        currentWorkflowAttemptSequence: [1, 2],
+        currentWorkflowStatusSequence: ["completed", "in_progress"],
+        initialChecks: [...terminalConflict(headSHA), newerPending(headSHA)],
+      });
+      expectStaleConflictCleanup(result, trace, 1);
+    });
+
+    it("drops an exact-target conflict fail-safe after a newer attempt starts", () => {
+      const { result, trace } = runSourceGate({
+        currentWorkflowAttemptSequence: [1, 1, 2],
+        currentWorkflowStatusSequence: [
+          "completed",
+          "completed",
+          "in_progress",
+        ],
+        initialChecks: [newerPending(mergeSHA)],
+        lateVisibleChecks: terminalConflict(mergeSHA),
+        lateVisibleChecksDelay: 1,
+      });
+      expectStaleConflictCleanup(result, trace, 1);
+    });
+
+    it("drops a raced conflict fail-safe after a newer attempt starts", () => {
+      const { result, trace } = runSourceGate({
+        currentWorkflowAttemptSequence: [1, 1, 2],
+        currentWorkflowStatusSequence: [
+          "completed",
+          "completed",
+          "in_progress",
+        ],
+        initialChecks: [newerPending(mergeSHA)],
+        lateVisibleChecks: terminalConflict(mergeSHA),
+        lateVisibleChecksDelay: 2,
+      });
+      expectStaleConflictCleanup(result, trace, 2);
     });
   });
 }


### PR DESCRIPTION
## Summary

- extend the Cloud source materialization window from 60 to 90 seconds using a monotonic deadline
- revalidate workflow-attempt ownership before every terminal mutation
- reconcile ambiguous GitHub check creation and cleanup without overwriting terminal success
- add regression coverage for association, merge-ref, stale-attempt, visibility-order, and transient API races

## Evidence

The single controlled canary in #457 reproduced PR merge-ref materialization immediately after the previous 60-second window expired. It confirmed the cleanup and terminal-reporting behavior from #456, but not the prior timeout threshold. No canary was rerun.

## Verification

- `npm run typecheck`
- `npm test` — 136 files, 1418 tests passed
- `npm run build`
- `npm run docs:check`
- three-pass adversarial pre-PR review — clean

The Cloud Source Gate remains manually disabled. This PR does not enable Cloud support, publish, tag, or release anything.