### PR TITLE
fix(cli): prevent macOS Keychain password prompts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,15 @@ jobs:
           go-version: "1.26.5"
           cache-dependency-path: cli/go.sum
 
+      - name: Verify macOS Keychain no-UI policy
+        run: |
+          cd cli
+          /usr/bin/sandbox-exec \
+            -p '(version 1)(allow default)(deny process-exec (literal "/usr/bin/security"))' \
+            go test -count=1 \
+              -run '^(TestDecodeDarwinGoKeyringValue|TestNativeSecretWorkerAcceptsRelayTokenKey|Test(Read|Set|Delete)DarwinKeychainSecretInProcess.*|TestDarwin(KeychainNoUI.*|Device.*|RelayToken.*|Interactive.*|ExplicitPair.*|PairCommand.*|DoctorResume.*))$' \
+              .
+
       - name: Reject a non-hardened executable
         run: |
           cd cli

--- a/cli/cmd_pair.go
+++ b/cli/cmd_pair.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Hook so the pair command's config seeding can be tested without a live relay.
-var runSecurePairingForPairCmd = runSecurePairing
+var runSecurePairingForPairCmd = runSecurePairingAfterInteractivePreflight
 
 // runPairCommand pairs this install with a NOVA Relay using a one-time code from
 // the NOVA owner page. The passwordless secure flow: OPAQUE over the bootstrap
@@ -79,6 +79,7 @@ func runPairCommand(paths runtimePaths, args []string) int {
 		printErr("--credential-store supports only the value \"file\" (got %q)", credentialStore)
 		return 1
 	}
+	pairCommandUI := pairCommandSecretStoreUIPolicy(credentialStore)
 	if serverNameSet {
 		if err := validateUTF8String(serverName, "server profile name"); err != nil {
 			printErr("%s; nothing was paired", err)
@@ -211,12 +212,13 @@ func runPairCommand(paths runtimePaths, args []string) int {
 	// overwrite it. Valid incomplete profiles recovered above retain their
 	// pending endpoints, so they use the same recovery path.
 	var resumeErr error
-	resumedActivation, resumeErr = resumeInterruptedPairingForDoctor(
+	resumedActivation, resumeErr = resumeInterruptedPairingForPairCommand(
 		paths,
 		&cfg,
 		pairLifecycleGeneration,
 		configSnapshot,
 		hadConfigSnapshot,
+		pairCommandUI,
 	)
 	if resumeErr != nil {
 		printPendingActivationResumeError(resumeErr)
@@ -265,7 +267,10 @@ func runPairCommand(paths runtimePaths, args []string) int {
 		if err := guardPairMutation(); err != nil {
 			return err
 		}
-		return validateLocalDeviceReplacementAllowed(cfg)
+		return validateLocalDeviceReplacementAllowedWithPolicy(
+			cfg,
+			pairCommandUI,
+		)
 	})
 	if guardErr != nil {
 		printErr("Pairing cannot start: %s", guardErr)
@@ -310,7 +315,7 @@ func runPairCommand(paths runtimePaths, args []string) int {
 			return err
 		}
 		var err error
-		probe, err = probeDeviceCredentialStorage()
+		probe, err = probePairCommandDeviceStorage(pairCommandUI)
 		return err
 	})
 	if probeErr != nil {

--- a/cli/device_credential_storage.go
+++ b/cli/device_credential_storage.go
@@ -116,6 +116,18 @@ func deviceSecretFileExists(service string) bool {
 // keyring is unreachable (headless). Resume uses it to prefer a real keyring
 // pending over an orphan .pending FILE from an aborted earlier headless attempt.
 func readKeyringDeviceSecret(service string) (string, bool, error) {
+	return readKeyringDeviceSecretWithPolicy(
+		context.Background(),
+		service,
+		SecretStoreForbidUI,
+	)
+}
+
+func readKeyringDeviceSecretWithPolicy(
+	ctx context.Context,
+	service string,
+	ui SecretStoreUIPolicy,
+) (string, bool, error) {
 	if dir, ok := testSecretDir(); ok {
 		data, err := os.ReadFile(testSecretPath(dir, service))
 		if err != nil {
@@ -126,14 +138,11 @@ func readKeyringDeviceSecret(service string) (string, bool, error) {
 		}
 		return strings.TrimSpace(string(data)), true, nil
 	}
-	ctx, cancel := boundedNativeOAuthSecretContext(
-		context.Background(),
-		SecretStoreForbidUI,
-	)
+	ctx, cancel := boundedNativeOAuthSecretContext(ctx, ui)
 	defer cancel()
 	if err := deviceCredentialPreflightWithContext(
 		ctx,
-		SecretStoreForbidUI,
+		ui,
 	); err != nil {
 		return "", false, err
 	}
@@ -141,7 +150,7 @@ func readKeyringDeviceSecret(service string) (string, bool, error) {
 		ctx,
 		service,
 		secretUser(),
-		SecretStoreForbidUI,
+		ui,
 	)
 	if err != nil {
 		if errors.Is(err, keyring.ErrNotFound) {

--- a/cli/device_credential_storage_probe.go
+++ b/cli/device_credential_storage_probe.go
@@ -12,6 +12,7 @@ import (
 
 // Test seams: the canaries hit the real OS keyring / filesystem by default.
 var deviceStorageKeyringCanary = keyringStorageCanary
+var deviceStorageKeyringCanaryForPolicy = keyringStorageCanaryWithPolicy
 var deviceStorageFileCanary = fileStorageCanary
 
 // deviceCredentialStorageViable reports whether a device credential can be
@@ -38,7 +39,7 @@ func probeDeviceCredentialStorageWithPolicy(
 	ui SecretStoreUIPolicy,
 ) (deviceStorageProbe, error) {
 	return probeDeviceCredentialStorageWithCanary(func() error {
-		return keyringStorageCanaryWithPolicy(ctx, ui)
+		return deviceStorageKeyringCanaryForPolicy(ctx, ui)
 	})
 }
 

--- a/cli/device_credential_storage_test.go
+++ b/cli/device_credential_storage_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -44,10 +45,22 @@ func withDeviceStorageTestHome(t *testing.T) string {
 
 func stubStorageCanaries(t *testing.T, keyringErr error) {
 	t.Helper()
-	prevK, prevF := deviceStorageKeyringCanary, deviceStorageFileCanary
+	prevK := deviceStorageKeyringCanary
+	prevPolicy := deviceStorageKeyringCanaryForPolicy
+	prevF := deviceStorageFileCanary
 	deviceStorageKeyringCanary = func() error { return keyringErr }
+	deviceStorageKeyringCanaryForPolicy = func(
+		context.Context,
+		SecretStoreUIPolicy,
+	) error {
+		return keyringErr
+	}
 	deviceStorageFileCanary = fileStorageCanary
-	t.Cleanup(func() { deviceStorageKeyringCanary, deviceStorageFileCanary = prevK, prevF })
+	t.Cleanup(func() {
+		deviceStorageKeyringCanary = prevK
+		deviceStorageKeyringCanaryForPolicy = prevPolicy
+		deviceStorageFileCanary = prevF
+	})
 }
 
 func TestProbeFallsBackToFilesWhenNoDesktopSession(t *testing.T) {

--- a/cli/doctor_pairing_resume.go
+++ b/cli/doctor_pairing_resume.go
@@ -7,6 +7,68 @@ func resumeInterruptedPairingForDoctor(
 	configSnapshot []byte,
 	hadConfigSnapshot bool,
 ) (bool, error) {
+	return resumeInterruptedPairing(
+		paths,
+		cfg,
+		lifecycleGeneration,
+		configSnapshot,
+		hadConfigSnapshot,
+		resumePendingActivationAfterRetirementGuard,
+	)
+}
+
+func resumeInterruptedPairingForExplicitPair(
+	paths runtimePaths,
+	cfg *runtimeConfig,
+	lifecycleGeneration []byte,
+	configSnapshot []byte,
+	hadConfigSnapshot bool,
+) (bool, error) {
+	return resumeInterruptedPairingForPairCommand(
+		paths,
+		cfg,
+		lifecycleGeneration,
+		configSnapshot,
+		hadConfigSnapshot,
+		SecretStoreAllowUI,
+	)
+}
+
+func resumeInterruptedPairingForPairCommand(
+	paths runtimePaths,
+	cfg *runtimeConfig,
+	lifecycleGeneration []byte,
+	configSnapshot []byte,
+	hadConfigSnapshot bool,
+	ui SecretStoreUIPolicy,
+) (bool, error) {
+	resume := resumePendingActivationAfterRetirementGuard
+	if ui == SecretStoreAllowUI {
+		resume =
+			resumePendingActivationForExplicitPairAfterRetirementGuard
+	}
+	return resumeInterruptedPairing(
+		paths,
+		cfg,
+		lifecycleGeneration,
+		configSnapshot,
+		hadConfigSnapshot,
+		resume,
+	)
+}
+
+func resumeInterruptedPairing(
+	paths runtimePaths,
+	cfg *runtimeConfig,
+	lifecycleGeneration []byte,
+	configSnapshot []byte,
+	hadConfigSnapshot bool,
+	resume func(
+		runtimePaths,
+		*runtimeConfig,
+		func(*runtimeConfig) error,
+	) (bool, error),
+) (bool, error) {
 	if cfg == nil ||
 		cfg.PendingSecureBaseURL == "" ||
 		cfg.PendingSpkiPin == "" {
@@ -28,7 +90,7 @@ func resumeInterruptedPairingForDoctor(
 			return err
 		}
 		var err error
-		resumed, err = resumePendingActivationAfterRetirementGuard(
+		resumed, err = resume(
 			paths,
 			cfg,
 			func(value *runtimeConfig) error {

--- a/cli/keyring_darwin.go
+++ b/cli/keyring_darwin.go
@@ -7,10 +7,8 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"os/exec"
 	"os/user"
 	"strings"
-	"time"
 
 	"github.com/zalando/go-keyring"
 )
@@ -20,9 +18,19 @@ func init() {
 	secretKeyringSetWithPolicy = darwinDeviceSecretSet
 	secretKeyringDeleteWithPolicy = darwinDeviceSecretDelete
 	deviceCredentialPreflightWithContext = darwinDeviceCredentialPreflight
+	explicitPairingSecretStoreUIPolicy = func() SecretStoreUIPolicy {
+		return SecretStoreAllowUI
+	}
+	snapshotRelayAuthTokenForSetupPersistence =
+		snapshotDarwinRelayAuthTokenForSetupPersistence
 }
 
-var macOSDeviceCredentialKeychainAvailableNoUI = macOSKeychainAvailableNoUI
+var darwinDeviceSecureStorageBoundaryAvailable = platformCloudRemoteSecureStorageBoundaryAvailable
+var readDarwinSecretInProcess = readDarwinKeychainSecretInProcess
+var setDarwinSecretInProcess = setDarwinKeychainSecretInProcess
+var deleteDarwinSecretInProcess = deleteDarwinKeychainSecretInProcess
+var readDarwinSecretThroughBoundary = readDarwinKeychainSecret
+var runNativeSecretWorkerForDarwinDevice = runNativeSecretWorkerProcess
 
 func darwinDeviceCredentialPreflight(
 	ctx context.Context,
@@ -35,14 +43,6 @@ func darwinDeviceCredentialPreflight(
 		if !deviceCredentialPromptSessionAvailable() {
 			return deviceCredentialPromptUnavailableError()
 		}
-		return nil
-	}
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	if err := macOSDeviceCredentialKeychainAvailableNoUI(ctx); err != nil {
-		return desktopKeyringLockedError(
-			"the login keychain is locked or unavailable",
-		)
 	}
 	return nil
 }
@@ -52,13 +52,26 @@ func darwinDeviceSecretGet(
 	service, account string,
 	ui SecretStoreUIPolicy,
 ) (string, error) {
-	if !platformCloudRemoteSecureStorageBoundaryAvailable() {
+	if !darwinDeviceSecureStorageBoundaryAvailable() {
 		if err := ctx.Err(); err != nil {
 			return "", err
 		}
-		return keyring.Get(service, account)
+		value, found, err := readDarwinSecretInProcess(
+			ctx,
+			service,
+			account,
+			ui,
+			"read device credential",
+		)
+		if err != nil {
+			return "", err
+		}
+		if !found {
+			return "", keyring.ErrNotFound
+		}
+		return decodeDarwinGoKeyringValue(value)
 	}
-	value, found, err := readDarwinKeychainSecret(
+	value, found, err := readDarwinSecretThroughBoundary(
 		ctx,
 		service,
 		account,
@@ -79,11 +92,40 @@ func darwinDeviceSecretSet(
 	service, account, value string,
 	ui SecretStoreUIPolicy,
 ) error {
-	if !platformCloudRemoteSecureStorageBoundaryAvailable() {
+	if ui == SecretStoreAllowUI {
+		if err := darwinDeviceSecretDelete(
+			ctx,
+			service,
+			account,
+			ui,
+		); err != nil {
+			return fmt.Errorf(
+				"replace macOS Keychain device credential: %w",
+				err,
+			)
+		}
+	}
+	if !darwinDeviceSecureStorageBoundaryAvailable() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		return keyring.Set(service, account, value)
+		expected := []byte(value)
+		defer zeroSecretBytes(expected)
+		err := setDarwinSecretInProcess(
+			ctx,
+			service,
+			account,
+			value,
+			ui,
+			"write device credential",
+		)
+		return reconcileDarwinInProcessSet(
+			ctx,
+			service,
+			account,
+			expected,
+			err,
+		)
 	}
 	raw := []byte(value)
 	defer zeroSecretBytes(raw)
@@ -97,7 +139,7 @@ func darwinDeviceSecretSet(
 		Account:       account,
 		Value:         raw,
 	}
-	_, err := runNativeSecretWorkerProcess(operationCtx, request)
+	_, err := runNativeSecretWorkerForDarwinDevice(operationCtx, request)
 	return reconcileNativeSecretSet(ctx, request, err)
 }
 
@@ -106,11 +148,23 @@ func darwinDeviceSecretDelete(
 	service, account string,
 	ui SecretStoreUIPolicy,
 ) error {
-	if !platformCloudRemoteSecureStorageBoundaryAvailable() {
+	if !darwinDeviceSecureStorageBoundaryAvailable() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		return keyring.Delete(service, account)
+		err := deleteDarwinSecretInProcess(
+			ctx,
+			service,
+			account,
+			ui,
+			"delete device credential",
+		)
+		return reconcileDarwinInProcessDelete(
+			ctx,
+			service,
+			account,
+			err,
+		)
 	}
 	operationCtx, cancel := boundedNativeOAuthSecretContext(ctx, ui)
 	defer cancel()
@@ -121,7 +175,7 @@ func darwinDeviceSecretDelete(
 		Service:       service,
 		Account:       account,
 	}
-	_, err := runNativeSecretWorkerProcess(operationCtx, request)
+	_, err := runNativeSecretWorkerForDarwinDevice(operationCtx, request)
 	return reconcileNativeSecretDelete(ctx, request, err)
 }
 
@@ -134,6 +188,7 @@ func decodeDarwinGoKeyringValue(value string) (string, error) {
 	switch {
 	case strings.HasPrefix(value, hexPrefix):
 		decoded, err := hex.DecodeString(strings.TrimPrefix(value, hexPrefix))
+		defer zeroSecretBytes(decoded)
 		if err != nil {
 			return "", fmt.Errorf("decode macOS Keychain device credential: %w", err)
 		}
@@ -142,6 +197,7 @@ func decodeDarwinGoKeyringValue(value string) (string, error) {
 		decoded, err := base64.StdEncoding.DecodeString(
 			strings.TrimPrefix(value, base64Prefix),
 		)
+		defer zeroSecretBytes(decoded)
 		if err != nil {
 			return "", fmt.Errorf("decode macOS Keychain device credential: %w", err)
 		}
@@ -151,15 +207,16 @@ func decodeDarwinGoKeyringValue(value string) (string, error) {
 	}
 }
 
-func macOSKeychainAvailableNoUI(ctx context.Context) error {
-	return exec.CommandContext(
-		ctx,
-		"/usr/bin/security",
-		"show-keychain-info",
-	).Run()
+func readRelayAuthToken() (string, error) {
+	return readRelayAuthTokenWithPolicy(SecretStoreForbidUI)
 }
 
-func readRelayAuthToken() (string, error) {
+func readRelayAuthTokenWithPolicy(
+	ui SecretStoreUIPolicy,
+) (string, error) {
+	if err := validateSecretUIPolicy(ui); err != nil {
+		return "", err
+	}
 	if token, overridden, err := readRelayAuthTokenOverride(); overridden {
 		if err != nil {
 			if isNotExist(err) {
@@ -178,21 +235,54 @@ func readRelayAuthToken() (string, error) {
 	}
 	service := relayAuthTokenServiceName()
 
-	// Read through go-keyring so the base64 envelope its writer (keyring.Set)
-	// adds is decoded back to the raw token. Reading the item with raw
-	// `security ... -w` returns the encoded `go-keyring-base64:...` value, which
-	// would authenticate every relay call with the wrong bearer token.
-	token, err := keyring.Get(service, u.Username)
+	ctx, cancel := boundedNativeOAuthSecretContext(
+		context.Background(),
+		ui,
+	)
+	defer cancel()
+	var token string
+	var found bool
+	if darwinDeviceSecureStorageBoundaryAvailable() {
+		token, found, err = readDarwinSecretThroughBoundary(
+			ctx,
+			service,
+			u.Username,
+			ui,
+			"read relay auth token",
+		)
+	} else {
+		token, found, err = readDarwinSecretInProcess(
+			ctx,
+			service,
+			u.Username,
+			ui,
+			"read relay auth token",
+		)
+	}
 	if err != nil {
-		if err == keyring.ErrNotFound {
-			return "", missingRelayAuthTokenError(service)
-		}
 		return "", relayAuthTokenReadError(service, err)
 	}
-	return token, nil
+	if !found {
+		return "", missingRelayAuthTokenError(service)
+	}
+	token, err = decodeDarwinGoKeyringValue(token)
+	if err != nil {
+		return "", relayAuthTokenReadError(service, err)
+	}
+	return strings.TrimSpace(token), nil
 }
 
 func writeRelayAuthToken(token string) error {
+	return writeRelayAuthTokenWithPolicy(token, SecretStoreForbidUI)
+}
+
+func writeRelayAuthTokenWithPolicy(
+	token string,
+	ui SecretStoreUIPolicy,
+) error {
+	if err := validateSecretUIPolicy(ui); err != nil {
+		return err
+	}
 	if overridden, err := writeRelayAuthTokenOverride(token); overridden {
 		if err != nil {
 			return fmt.Errorf("cannot write relay auth token: %w", err)
@@ -208,19 +298,42 @@ func writeRelayAuthToken(token string) error {
 	}
 	service := relayAuthTokenServiceName()
 
-	// Write via go-keyring, whose macOS backend pipes the command through
-	// `security -i` (stdin) instead of passing the secret as a CLI argument — so
-	// the token never appears in the process argv (visible to `ps`). go-keyring
-	// base64-wraps the stored value, so the read path MUST use keyring.Get
-	// (above) to decode it; delete matches by `-s <service> -a <user>` and needs
-	// no value, so it carries no argv exposure.
-	if err := keyring.Set(service, u.Username, token); err != nil {
-		return fmt.Errorf("cannot write relay auth token: %w", err)
+	ctx, cancel := boundedNativeOAuthSecretContext(
+		context.Background(),
+		ui,
+	)
+	defer cancel()
+	var writeErr error
+	if ui == SecretStoreAllowUI {
+		writeErr = replaceDarwinRelayAuthToken(
+			ctx,
+			service,
+			u.Username,
+			token,
+		)
+	} else {
+		writeErr = setDarwinRelayAuthToken(
+			ctx,
+			service,
+			u.Username,
+			token,
+			ui,
+		)
+	}
+	if writeErr != nil {
+		return fmt.Errorf("cannot write relay auth token: %w", writeErr)
 	}
 	return nil
 }
 
 func deleteRelayAuthToken() error {
+	return deleteRelayAuthTokenWithPolicy(SecretStoreForbidUI)
+}
+
+func deleteRelayAuthTokenWithPolicy(ui SecretStoreUIPolicy) error {
+	if err := validateSecretUIPolicy(ui); err != nil {
+		return err
+	}
 	if overridden, err := deleteRelayAuthTokenOverride(); overridden {
 		if err != nil {
 			return fmt.Errorf("cannot delete relay auth token: %w", err)
@@ -236,17 +349,19 @@ func deleteRelayAuthToken() error {
 	}
 	service := relayAuthTokenServiceName()
 
-	cmd := exec.Command(
-		"security", "delete-generic-password",
-		"-a", u.Username,
-		"-s", service,
+	ctx, cancel := boundedNativeOAuthSecretContext(
+		context.Background(),
+		ui,
 	)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		text := strings.TrimSpace(string(output))
-		if strings.Contains(text, "could not be found") {
-			return nil
-		}
-		return fmt.Errorf("cannot delete relay auth token: %w (%s)", err, text)
+	defer cancel()
+	deleteErr := deleteDarwinRelayAuthToken(
+		ctx,
+		service,
+		u.Username,
+		ui,
+	)
+	if deleteErr != nil {
+		return fmt.Errorf("cannot delete relay auth token: %w", deleteErr)
 	}
 	return nil
 }

--- a/cli/keyring_darwin_interaction.go
+++ b/cli/keyring_darwin_interaction.go
@@ -1,0 +1,315 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var errDarwinKeychainInteractionRestore = errors.New(
+	"macOS Keychain interaction restoration failed",
+)
+
+var darwinKeychainInteractionSemaphore = make(chan struct{}, 1)
+var loadDarwinKeychainSecurity = loadDarwinOAuthSecurity
+var setDarwinKeychainInteraction = setDarwinOAuthInteraction
+var restoreDarwinKeychainInteraction = func(previous uint8) darwinOAuthOSStatus {
+	return darwinOAuthSecurity.setInteraction(previous)
+}
+var getDarwinKeychainSecret = darwinOAuthGet
+var setDarwinKeychainSecret = darwinOAuthSet
+var deleteDarwinKeychainSecret = darwinOAuthDelete
+
+func readDarwinKeychainSecretInProcess(
+	ctx context.Context,
+	service, account string,
+	ui SecretStoreUIPolicy,
+	operation string,
+) (string, bool, error) {
+	if !validNativeSecretWorkerKey(service, account) {
+		return "", false, newCloudError(
+			CloudErrInvalidInput,
+			operation,
+			nil,
+		)
+	}
+
+	var raw []byte
+	var found bool
+	err := withDarwinKeychainInteraction(
+		ctx,
+		operation,
+		ui,
+		false,
+		func() error {
+			var status darwinOAuthOSStatus
+			raw, found, status = getDarwinKeychainSecret(service, account)
+			if status == darwinOAuthSuccess {
+				return nil
+			}
+			return newCloudError(
+				darwinOAuthErrorCode(status, ui),
+				operation,
+				fmt.Errorf("OSStatus %d", status),
+			)
+		},
+	)
+	if err != nil {
+		zeroSecretBytes(raw)
+		return "", false, err
+	}
+	defer zeroSecretBytes(raw)
+	if !found {
+		return "", false, nil
+	}
+	return string(raw), true, nil
+}
+
+func setDarwinKeychainSecretInProcess(
+	ctx context.Context,
+	service, account, value string,
+	ui SecretStoreUIPolicy,
+	operation string,
+) error {
+	if !validNativeSecretWorkerKey(service, account) || value == "" {
+		return newCloudError(CloudErrInvalidInput, operation, nil)
+	}
+	raw := []byte(value)
+	defer zeroSecretBytes(raw)
+	return withDarwinKeychainInteraction(
+		ctx,
+		operation,
+		ui,
+		true,
+		func() error {
+			status := setDarwinKeychainSecret(service, account, raw)
+			if status == darwinOAuthSuccess {
+				return nil
+			}
+			return newCloudError(
+				darwinOAuthErrorCode(status, ui),
+				operation,
+				fmt.Errorf("OSStatus %d", status),
+			)
+		},
+	)
+}
+
+func deleteDarwinKeychainSecretInProcess(
+	ctx context.Context,
+	service, account string,
+	ui SecretStoreUIPolicy,
+	operation string,
+) error {
+	if !validNativeSecretWorkerKey(service, account) {
+		return newCloudError(CloudErrInvalidInput, operation, nil)
+	}
+	return withDarwinKeychainInteraction(
+		ctx,
+		operation,
+		ui,
+		true,
+		func() error {
+			status := deleteDarwinKeychainSecret(service, account)
+			if status == darwinOAuthSuccess ||
+				status == darwinOAuthItemNotFound {
+				return nil
+			}
+			return newCloudError(
+				darwinOAuthErrorCode(status, ui),
+				operation,
+				fmt.Errorf("OSStatus %d", status),
+			)
+		},
+	)
+}
+
+func reconcileDarwinInProcessSet(
+	ctx context.Context,
+	service, account string,
+	expected []byte,
+	mutationErr error,
+) error {
+	reconciled := reconcileSecretSetWithRead(
+		ctx,
+		expected,
+		mutationErr,
+		darwinInProcessReconciliationRead(service, account),
+	)
+	if reconciled == nil &&
+		errors.Is(mutationErr, errDarwinKeychainInteractionRestore) {
+		return mutationErr
+	}
+	return reconciled
+}
+
+func reconcileDarwinInProcessDelete(
+	ctx context.Context,
+	service, account string,
+	mutationErr error,
+) error {
+	reconciled := reconcileSecretDeleteWithRead(
+		ctx,
+		mutationErr,
+		darwinInProcessReconciliationRead(service, account),
+	)
+	if reconciled == nil &&
+		errors.Is(mutationErr, errDarwinKeychainInteractionRestore) {
+		return mutationErr
+	}
+	return reconciled
+}
+
+func darwinInProcessReconciliationRead(
+	service, account string,
+) nativeSecretReconciliationRead {
+	return func(readCtx context.Context) ([]byte, bool, error) {
+		value, found, err := readDarwinSecretInProcess(
+			readCtx,
+			service,
+			account,
+			SecretStoreForbidUI,
+			"reconcile macOS Keychain mutation",
+		)
+		return []byte(value), found, err
+	}
+}
+
+func withDarwinKeychainInteraction(
+	ctx context.Context,
+	operation string,
+	ui SecretStoreUIPolicy,
+	mutating bool,
+	run func() error,
+) (resultErr error) {
+	if err := validateSecretUIPolicy(ui); err != nil {
+		return err
+	}
+	if ui == SecretStoreAllowUI &&
+		!deviceCredentialPromptSessionAvailable() {
+		return deviceCredentialPromptUnavailableError()
+	}
+	if err := ctx.Err(); err != nil {
+		return newCloudError(CloudErrTimeout, operation, err)
+	}
+	select {
+	case darwinKeychainInteractionSemaphore <- struct{}{}:
+		defer func() { <-darwinKeychainInteractionSemaphore }()
+	case <-ctx.Done():
+		return newCloudError(CloudErrTimeout, operation, ctx.Err())
+	}
+	if err := ctx.Err(); err != nil {
+		return newCloudError(CloudErrTimeout, operation, err)
+	}
+
+	// SecKeychainSetUserInteractionAllowed is process-wide. Signed production
+	// builds isolate this policy in a verified worker. Development/ad-hoc builds
+	// serialize the short in-process operation and restore the prior policy.
+	if err := loadDarwinKeychainSecurity(); err != nil {
+		return newCloudError(
+			CloudErrSecretStore,
+			"load macOS Keychain",
+			err,
+		)
+	}
+	previous, err := setDarwinKeychainInteraction(ui)
+	if err != nil {
+		return newCloudError(
+			CloudErrSecretStore,
+			"set macOS Keychain interaction policy",
+			err,
+		)
+	}
+	defer func() {
+		panicValue := recover()
+		restoreErr := restoreDarwinKeychainPolicy(previous)
+		switch {
+		case panicValue != nil:
+			code := CloudErrSecretStore
+			if mutating {
+				code = CloudErrSecretOutcomeUnknown
+			}
+			panicErr := newCloudError(
+				code,
+				operation,
+				fmt.Errorf("macOS Keychain operation panicked"),
+			)
+			if restoreErr != nil {
+				resultErr = errors.Join(panicErr, restoreErr)
+			} else {
+				resultErr = panicErr
+			}
+		case restoreErr != nil && resultErr != nil:
+			resultErr = errors.Join(resultErr, restoreErr)
+		case restoreErr != nil && mutating:
+			resultErr = newCloudError(
+				CloudErrSecretOutcomeUnknown,
+				operation,
+				restoreErr,
+			)
+		case restoreErr != nil:
+			resultErr = restoreErr
+		}
+	}()
+	resultErr = run()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		code := CloudErrTimeout
+		if mutating {
+			code = CloudErrSecretOutcomeUnknown
+		}
+		resultErr = newCloudError(code, operation, ctxErr)
+	}
+	return resultErr
+}
+
+func restoreDarwinKeychainPolicy(previous uint8) error {
+	status, panicValue := callDarwinKeychainRestore(previous)
+	if panicValue != nil {
+		return newCloudError(
+			CloudErrSecretStore,
+			"restore macOS Keychain interaction policy",
+			fmt.Errorf(
+				"%w: restore panicked",
+				errDarwinKeychainInteractionRestore,
+			),
+		)
+	}
+	if status == darwinOAuthSuccess {
+		return nil
+	}
+	status, panicValue = callDarwinKeychainRestore(previous)
+	if panicValue == nil && status == darwinOAuthSuccess {
+		return nil
+	}
+	if panicValue != nil {
+		return newCloudError(
+			CloudErrSecretStore,
+			"restore macOS Keychain interaction policy",
+			fmt.Errorf(
+				"%w: restore panicked",
+				errDarwinKeychainInteractionRestore,
+			),
+		)
+	}
+	return newCloudError(
+		CloudErrSecretStore,
+		"restore macOS Keychain interaction policy",
+		fmt.Errorf(
+			"%w: OSStatus %d",
+			errDarwinKeychainInteractionRestore,
+			status,
+		),
+	)
+}
+
+func callDarwinKeychainRestore(
+	previous uint8,
+) (status darwinOAuthOSStatus, panicValue any) {
+	defer func() {
+		panicValue = recover()
+	}()
+	status = restoreDarwinKeychainInteraction(previous)
+	return status, nil
+}

--- a/cli/keyring_darwin_interaction_delete_test.go
+++ b/cli/keyring_darwin_interaction_delete_test.go
@@ -1,0 +1,84 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDeleteDarwinKeychainSecretInProcessNoUIRestoresPolicy(
+	t *testing.T,
+) {
+	installDarwinKeychainNoUITestSeams(t)
+	var policy SecretStoreUIPolicy
+	var restored uint8
+	setDarwinKeychainInteraction = func(
+		ui SecretStoreUIPolicy,
+	) (uint8, error) {
+		policy = ui
+		return 1, nil
+	}
+	restoreDarwinKeychainInteraction = func(
+		previous uint8,
+	) darwinOAuthOSStatus {
+		restored = previous
+		return darwinOAuthSuccess
+	}
+	deleteCalls := 0
+	deleteDarwinKeychainSecret = func(
+		service, account string,
+	) darwinOAuthOSStatus {
+		if service != deviceCredentialService || account != secretUser() {
+			t.Fatalf("unexpected Keychain key: %q / %q", service, account)
+		}
+		deleteCalls++
+		return darwinOAuthSuccess
+	}
+
+	err := deleteDarwinKeychainSecretInProcess(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+		"delete test credential",
+	)
+	if err != nil ||
+		policy != SecretStoreForbidUI ||
+		restored != 1 ||
+		deleteCalls != 1 {
+		t.Fatalf(
+			"delete err=%v policy=%q restored=%d calls=%d",
+			err,
+			policy,
+			restored,
+			deleteCalls,
+		)
+	}
+}
+
+func TestDeleteDarwinKeychainSecretInProcessRejectsUnsafePromptSession(
+	t *testing.T,
+) {
+	installDarwinKeychainNoUITestSeams(t)
+	deviceCredentialPromptSessionAvailable = func() bool { return false }
+	deleteCalls := 0
+	deleteDarwinKeychainSecret = func(
+		_, _ string,
+	) darwinOAuthOSStatus {
+		deleteCalls++
+		return darwinOAuthSuccess
+	}
+
+	err := deleteDarwinKeychainSecretInProcess(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreAllowUI,
+		"delete test credential",
+	)
+	if !IsCloudErrorCode(err, CloudErrSecretUIForbidden) ||
+		deleteCalls != 0 {
+		t.Fatalf("unsafe prompt error=%v calls=%d", err, deleteCalls)
+	}
+}

--- a/cli/keyring_darwin_interaction_test.go
+++ b/cli/keyring_darwin_interaction_test.go
@@ -1,0 +1,355 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestReadDarwinKeychainSecretInProcessNoUIRestoresPolicy(t *testing.T) {
+	installDarwinKeychainNoUITestSeams(t)
+	var restored uint8
+	restoreDarwinKeychainInteraction = func(
+		previous uint8,
+	) darwinOAuthOSStatus {
+		restored = previous
+		return darwinOAuthSuccess
+	}
+	getDarwinKeychainSecret = func(
+		service, account string,
+	) ([]byte, bool, darwinOAuthOSStatus) {
+		if service != deviceCredentialService || account != secretUser() {
+			t.Fatalf("unexpected Keychain key: %q / %q", service, account)
+		}
+		return []byte("credential"), true, darwinOAuthSuccess
+	}
+	value, found, err := readDarwinKeychainSecretInProcess(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+		"read test credential",
+	)
+	if err != nil || !found || value != "credential" {
+		t.Fatalf("no-UI native read = (%q, %v, %v)", value, found, err)
+	}
+	if restored != 1 {
+		t.Fatalf("restored interaction policy = %d, want 1", restored)
+	}
+}
+
+func TestReadDarwinKeychainSecretInProcessNoUIFailsWithoutPrompt(
+	t *testing.T,
+) {
+	installDarwinKeychainNoUITestSeams(t)
+	restoreCalls := 0
+	restoreDarwinKeychainInteraction = func(
+		uint8,
+	) darwinOAuthOSStatus {
+		restoreCalls++
+		return darwinOAuthSuccess
+	}
+	getDarwinKeychainSecret = func(
+		_, _ string,
+	) ([]byte, bool, darwinOAuthOSStatus) {
+		return nil, false, darwinOAuthInteractionNotAllowed
+	}
+	_, _, err := readDarwinKeychainSecretInProcess(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+		"read test credential",
+	)
+	if !IsCloudErrorCode(err, CloudErrSecretUIForbidden) {
+		t.Fatalf("interaction-required read error = %v", err)
+	}
+	if restoreCalls != 1 {
+		t.Fatalf("restore calls = %d, want 1", restoreCalls)
+	}
+}
+
+func TestReadDarwinKeychainSecretInProcessNoUIRetriesRestoreStatus(
+	t *testing.T,
+) {
+	installDarwinKeychainNoUITestSeams(t)
+	restoreCalls := 0
+	restoreDarwinKeychainInteraction = func(
+		uint8,
+	) darwinOAuthOSStatus {
+		restoreCalls++
+		if restoreCalls == 1 {
+			return darwinOAuthAuthFailed
+		}
+		return darwinOAuthSuccess
+	}
+	getDarwinKeychainSecret = func(
+		_, _ string,
+	) ([]byte, bool, darwinOAuthOSStatus) {
+		return []byte("credential"), true, darwinOAuthSuccess
+	}
+	value, found, err := readDarwinKeychainSecretInProcess(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+		"read test credential",
+	)
+	if err != nil || !found || value != "credential" || restoreCalls != 2 {
+		t.Fatalf(
+			"restore retry = (%q, %v, %v), calls=%d",
+			value,
+			found,
+			err,
+			restoreCalls,
+		)
+	}
+}
+
+func TestReadDarwinKeychainSecretInProcessNoUIZerosAfterRestorePanic(
+	t *testing.T,
+) {
+	installDarwinKeychainNoUITestSeams(t)
+	raw := []byte("credential")
+	restoreCalls := 0
+	getDarwinKeychainSecret = func(
+		_, _ string,
+	) ([]byte, bool, darwinOAuthOSStatus) {
+		return raw, true, darwinOAuthSuccess
+	}
+	restoreDarwinKeychainInteraction = func(
+		uint8,
+	) darwinOAuthOSStatus {
+		restoreCalls++
+		panic("restore panic")
+	}
+
+	value, found, err := readDarwinKeychainSecretInProcess(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+		"read test credential",
+	)
+	if value != "" || found || !IsCloudErrorCode(err, CloudErrSecretStore) {
+		t.Fatalf("restore panic = (%q, %v, %v)", value, found, err)
+	}
+	if restoreCalls != 1 {
+		t.Fatalf("restore calls = %d, want 1", restoreCalls)
+	}
+	for index, value := range raw {
+		if value != 0 {
+			t.Fatalf("raw[%d] was not zeroed", index)
+		}
+	}
+}
+
+func TestDarwinKeychainNoUIWaitHonorsContext(t *testing.T) {
+	installDarwinKeychainNoUITestSeams(t)
+	darwinKeychainInteractionSemaphore <- struct{}{}
+	t.Cleanup(func() {
+		select {
+		case <-darwinKeychainInteractionSemaphore:
+		default:
+		}
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	getCalls := 0
+	getDarwinKeychainSecret = func(
+		_, _ string,
+	) ([]byte, bool, darwinOAuthOSStatus) {
+		getCalls++
+		return nil, false, darwinOAuthSuccess
+	}
+
+	_, _, err := readDarwinKeychainSecretInProcess(
+		ctx,
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+		"read test credential",
+	)
+	if !IsCloudErrorCode(err, CloudErrTimeout) || getCalls != 0 {
+		t.Fatalf("canceled wait err=%v getCalls=%d", err, getCalls)
+	}
+}
+
+func TestSetDarwinKeychainSecretInProcessUsesRequestedPolicy(t *testing.T) {
+	installDarwinKeychainNoUITestSeams(t)
+	var policy SecretStoreUIPolicy
+	setDarwinKeychainInteraction = func(
+		ui SecretStoreUIPolicy,
+	) (uint8, error) {
+		policy = ui
+		return 1, nil
+	}
+	var stored string
+	setDarwinKeychainSecret = func(
+		service, account string,
+		value []byte,
+	) darwinOAuthOSStatus {
+		if service != deviceCredentialService || account != secretUser() {
+			t.Fatalf("unexpected Keychain key: %q / %q", service, account)
+		}
+		stored = string(value)
+		return darwinOAuthSuccess
+	}
+
+	err := setDarwinKeychainSecretInProcess(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		"credential",
+		SecretStoreAllowUI,
+		"write test credential",
+	)
+	if err != nil || stored != "credential" ||
+		policy != SecretStoreAllowUI {
+		t.Fatalf("native write err=%v stored=%q policy=%q", err, stored, policy)
+	}
+}
+
+func TestSetDarwinKeychainSecretInProcessRejectsUnsafePromptSession(
+	t *testing.T,
+) {
+	installDarwinKeychainNoUITestSeams(t)
+	deviceCredentialPromptSessionAvailable = func() bool { return false }
+	setCalls := 0
+	setDarwinKeychainSecret = func(
+		_, _ string,
+		_ []byte,
+	) darwinOAuthOSStatus {
+		setCalls++
+		return darwinOAuthSuccess
+	}
+
+	err := setDarwinKeychainSecretInProcess(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		"credential",
+		SecretStoreAllowUI,
+		"write test credential",
+	)
+	if !IsCloudErrorCode(err, CloudErrSecretUIForbidden) || setCalls != 0 {
+		t.Fatalf("unsafe prompt session error=%v setCalls=%d", err, setCalls)
+	}
+}
+
+func TestSetDarwinKeychainSecretInProcessPanicIsOutcomeUnknown(
+	t *testing.T,
+) {
+	installDarwinKeychainNoUITestSeams(t)
+	var raw []byte
+	setDarwinKeychainSecret = func(
+		_, _ string,
+		value []byte,
+	) darwinOAuthOSStatus {
+		raw = value
+		panic("write panic")
+	}
+
+	err := setDarwinKeychainSecretInProcess(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		"credential",
+		SecretStoreForbidUI,
+		"write test credential",
+	)
+	if !IsCloudErrorCode(err, CloudErrSecretOutcomeUnknown) {
+		t.Fatalf("write panic error = %v", err)
+	}
+	for index, value := range raw {
+		if value != 0 {
+			t.Fatalf("raw[%d] was not zeroed", index)
+		}
+	}
+}
+
+func TestSetDarwinKeychainSecretInProcessPanicPreservesRestoreFailure(
+	t *testing.T,
+) {
+	installDarwinKeychainNoUITestSeams(t)
+	setDarwinKeychainSecret = func(
+		_, _ string,
+		_ []byte,
+	) darwinOAuthOSStatus {
+		panic("write panic")
+	}
+	restoreDarwinKeychainInteraction = func(
+		uint8,
+	) darwinOAuthOSStatus {
+		panic("restore panic")
+	}
+
+	err := setDarwinKeychainSecretInProcess(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		"credential",
+		SecretStoreForbidUI,
+		"write test credential",
+	)
+	if !IsCloudErrorCode(err, CloudErrSecretOutcomeUnknown) ||
+		!errors.Is(err, errDarwinKeychainInteractionRestore) {
+		t.Fatalf("combined panic error = %v", err)
+	}
+}
+
+func TestReadDarwinKeychainSecretInProcessRejectsExpiredResult(t *testing.T) {
+	installDarwinKeychainNoUITestSeams(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	raw := []byte("credential")
+	getDarwinKeychainSecret = func(
+		_, _ string,
+	) ([]byte, bool, darwinOAuthOSStatus) {
+		cancel()
+		return raw, true, darwinOAuthSuccess
+	}
+
+	value, found, err := readDarwinKeychainSecretInProcess(
+		ctx,
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+		"read test credential",
+	)
+	if value != "" || found || !IsCloudErrorCode(err, CloudErrTimeout) {
+		t.Fatalf("expired read = (%q, %v, %v)", value, found, err)
+	}
+	for index, value := range raw {
+		if value != 0 {
+			t.Fatalf("raw[%d] was not zeroed", index)
+		}
+	}
+}
+
+func TestSetDarwinKeychainSecretInProcessRestoreFailureIsOutcomeUnknown(
+	t *testing.T,
+) {
+	installDarwinKeychainNoUITestSeams(t)
+	restoreDarwinKeychainInteraction = func(
+		uint8,
+	) darwinOAuthOSStatus {
+		return darwinOAuthAuthFailed
+	}
+
+	err := setDarwinKeychainSecretInProcess(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		"credential",
+		SecretStoreForbidUI,
+		"write test credential",
+	)
+	if !IsCloudErrorCode(err, CloudErrSecretOutcomeUnknown) {
+		t.Fatalf("restore failure error = %v", err)
+	}
+	if !errors.Is(err, errDarwinKeychainInteractionRestore) {
+		t.Fatalf("restore marker missing from error = %v", err)
+	}
+}

--- a/cli/keyring_darwin_interaction_test_helpers_test.go
+++ b/cli/keyring_darwin_interaction_test_helpers_test.go
@@ -1,0 +1,56 @@
+//go:build darwin
+
+package main
+
+import "testing"
+
+func installDarwinKeychainNoUITestSeams(t *testing.T) {
+	t.Helper()
+	originalLoad := loadDarwinKeychainSecurity
+	originalSetInteraction := setDarwinKeychainInteraction
+	originalRestore := restoreDarwinKeychainInteraction
+	originalGet := getDarwinKeychainSecret
+	originalSet := setDarwinKeychainSecret
+	originalDelete := deleteDarwinKeychainSecret
+	originalPrompt := deviceCredentialPromptSessionAvailable
+	loadDarwinKeychainSecurity = func() error { return nil }
+	setDarwinKeychainInteraction = func(
+		ui SecretStoreUIPolicy,
+	) (uint8, error) {
+		if ui != SecretStoreForbidUI {
+			t.Fatalf("interaction policy = %q", ui)
+		}
+		return 1, nil
+	}
+	restoreDarwinKeychainInteraction = func(
+		uint8,
+	) darwinOAuthOSStatus {
+		return darwinOAuthSuccess
+	}
+	getDarwinKeychainSecret = func(
+		_, _ string,
+	) ([]byte, bool, darwinOAuthOSStatus) {
+		return nil, false, darwinOAuthSuccess
+	}
+	setDarwinKeychainSecret = func(
+		_, _ string,
+		_ []byte,
+	) darwinOAuthOSStatus {
+		return darwinOAuthSuccess
+	}
+	deleteDarwinKeychainSecret = func(
+		_, _ string,
+	) darwinOAuthOSStatus {
+		return darwinOAuthSuccess
+	}
+	deviceCredentialPromptSessionAvailable = func() bool { return true }
+	t.Cleanup(func() {
+		loadDarwinKeychainSecurity = originalLoad
+		setDarwinKeychainInteraction = originalSetInteraction
+		restoreDarwinKeychainInteraction = originalRestore
+		getDarwinKeychainSecret = originalGet
+		setDarwinKeychainSecret = originalSet
+		deleteDarwinKeychainSecret = originalDelete
+		deviceCredentialPromptSessionAvailable = originalPrompt
+	})
+}

--- a/cli/keyring_darwin_policy_test.go
+++ b/cli/keyring_darwin_policy_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"testing"
+
+	"github.com/zalando/go-keyring"
 )
 
 func TestDecodeDarwinGoKeyringValue(t *testing.T) {
@@ -33,15 +35,9 @@ func TestDecodeDarwinGoKeyringValue(t *testing.T) {
 
 func TestDarwinDeviceCredentialPreflightAllowsExplicitPrompt(t *testing.T) {
 	originalPrompt := deviceCredentialPromptSessionAvailable
-	originalNoUI := macOSDeviceCredentialKeychainAvailableNoUI
 	deviceCredentialPromptSessionAvailable = func() bool { return true }
-	macOSDeviceCredentialKeychainAvailableNoUI = func(context.Context) error {
-		t.Fatal("explicit prompt preflight ran the no-UI keychain probe")
-		return nil
-	}
 	t.Cleanup(func() {
 		deviceCredentialPromptSessionAvailable = originalPrompt
-		macOSDeviceCredentialKeychainAvailableNoUI = originalNoUI
 	})
 
 	if err := darwinDeviceCredentialPreflight(
@@ -54,15 +50,9 @@ func TestDarwinDeviceCredentialPreflightAllowsExplicitPrompt(t *testing.T) {
 
 func TestDarwinDeviceCredentialPreflightRejectsUnsafePromptSession(t *testing.T) {
 	originalPrompt := deviceCredentialPromptSessionAvailable
-	originalNoUI := macOSDeviceCredentialKeychainAvailableNoUI
 	deviceCredentialPromptSessionAvailable = func() bool { return false }
-	macOSDeviceCredentialKeychainAvailableNoUI = func(context.Context) error {
-		t.Fatal("unsafe prompt session reached the no-UI keychain probe")
-		return nil
-	}
 	t.Cleanup(func() {
 		deviceCredentialPromptSessionAvailable = originalPrompt
-		macOSDeviceCredentialKeychainAvailableNoUI = originalNoUI
 	})
 
 	err := darwinDeviceCredentialPreflight(
@@ -74,26 +64,227 @@ func TestDarwinDeviceCredentialPreflightRejectsUnsafePromptSession(t *testing.T)
 	}
 }
 
-func TestDarwinDeviceCredentialPreflightForbidUIFailsLocked(t *testing.T) {
+func TestDarwinDeviceCredentialPreflightForbidUIDoesNotProbe(t *testing.T) {
 	originalPrompt := deviceCredentialPromptSessionAvailable
-	originalNoUI := macOSDeviceCredentialKeychainAvailableNoUI
 	deviceCredentialPromptSessionAvailable = func() bool {
 		t.Fatal("no-UI preflight consulted interactive prompt state")
 		return false
 	}
-	macOSDeviceCredentialKeychainAvailableNoUI = func(context.Context) error {
-		return errors.New("locked")
-	}
 	t.Cleanup(func() {
 		deviceCredentialPromptSessionAvailable = originalPrompt
-		macOSDeviceCredentialKeychainAvailableNoUI = originalNoUI
 	})
 
 	err := darwinDeviceCredentialPreflight(
 		context.Background(),
 		SecretStoreForbidUI,
 	)
-	if !isDesktopKeyringLockedError(err) {
-		t.Fatalf("no-UI locked preflight error = %v", err)
+	if err != nil {
+		t.Fatalf("no-UI preflight error = %v", err)
+	}
+}
+
+func TestDarwinDeviceSecretGetUsesNoUIPathWithoutHardenedBoundary(
+	t *testing.T,
+) {
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalRead := readDarwinSecretInProcess
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return false }
+	calls := 0
+	readDarwinSecretInProcess = func(
+		_ context.Context,
+		service, account string,
+		ui SecretStoreUIPolicy,
+		operation string,
+	) (string, bool, error) {
+		calls++
+		if service != deviceCredentialService || account != secretUser() {
+			t.Fatalf("unexpected Keychain key: %q / %q", service, account)
+		}
+		if ui != SecretStoreForbidUI || operation == "" {
+			t.Fatalf("unexpected policy/operation: %q / %q", ui, operation)
+		}
+		return "go-keyring-base64:" +
+			base64.StdEncoding.EncodeToString([]byte("credential")), true, nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		readDarwinSecretInProcess = originalRead
+	})
+
+	value, err := darwinDeviceSecretGet(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+	)
+	if err != nil || value != "credential" || calls != 1 {
+		t.Fatalf("no-UI read = (%q, %v), calls=%d", value, err, calls)
+	}
+}
+
+func TestDarwinDeviceSecretGetNoUIReportsMissingItem(t *testing.T) {
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalRead := readDarwinSecretInProcess
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return false }
+	readDarwinSecretInProcess = func(
+		context.Context,
+		string, string, SecretStoreUIPolicy, string,
+	) (string, bool, error) {
+		return "", false, nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		readDarwinSecretInProcess = originalRead
+	})
+
+	_, err := darwinDeviceSecretGet(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+	)
+	if !errors.Is(err, keyring.ErrNotFound) {
+		t.Fatalf("missing no-UI read error = %v", err)
+	}
+}
+
+func TestDarwinDeviceSecretMutationsUseNoUIPathWithoutHardenedBoundary(
+	t *testing.T,
+) {
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalSet := setDarwinSecretInProcess
+	originalDelete := deleteDarwinSecretInProcess
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return false }
+	var calls []string
+	setDarwinSecretInProcess = func(
+		_ context.Context,
+		service, account, value string,
+		ui SecretStoreUIPolicy,
+		operation string,
+	) error {
+		if service != deviceCredentialService ||
+			account != secretUser() ||
+			value != "credential" ||
+			ui != SecretStoreForbidUI {
+			t.Fatalf("unexpected no-UI set input")
+		}
+		calls = append(calls, operation)
+		return nil
+	}
+	deleteDarwinSecretInProcess = func(
+		_ context.Context,
+		service, account string,
+		ui SecretStoreUIPolicy,
+		operation string,
+	) error {
+		if service != deviceCredentialService ||
+			account != secretUser() ||
+			ui != SecretStoreForbidUI {
+			t.Fatalf("unexpected no-UI delete input")
+		}
+		calls = append(calls, operation)
+		return nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		setDarwinSecretInProcess = originalSet
+		deleteDarwinSecretInProcess = originalDelete
+	})
+
+	if err := darwinDeviceSecretSet(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		"credential",
+		SecretStoreForbidUI,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := darwinDeviceSecretDelete(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 2 || calls[0] == "" || calls[1] == "" {
+		t.Fatalf("no-UI mutation calls = %v", calls)
+	}
+}
+
+func TestDarwinDeviceSecretUsesWorkerPathWithHardenedBoundary(
+	t *testing.T,
+) {
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalRead := readDarwinSecretThroughBoundary
+	originalWorker := runNativeSecretWorkerForDarwinDevice
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return true }
+	readDarwinSecretThroughBoundary = func(
+		_ context.Context,
+		service, account string,
+		ui SecretStoreUIPolicy,
+		operation string,
+	) (string, bool, error) {
+		if service != deviceCredentialService ||
+			account != secretUser() ||
+			ui != SecretStoreForbidUI ||
+			operation == "" {
+			t.Fatalf("unexpected hardened read input")
+		}
+		return "go-keyring-base64:" +
+			base64.StdEncoding.EncodeToString([]byte("credential")), true, nil
+	}
+	var operations []nativeSecretOperation
+	runNativeSecretWorkerForDarwinDevice = func(
+		_ context.Context,
+		request nativeSecretWorkerRequest,
+	) (nativeSecretWorkerResponse, error) {
+		if request.Service != deviceCredentialService ||
+			request.Account != secretUser() ||
+			request.UI != SecretStoreForbidUI {
+			t.Fatalf("unexpected hardened worker request: %+v", request)
+		}
+		operations = append(operations, request.Operation)
+		return nativeSecretWorkerResponse{
+			SchemaVersion: nativeSecretWorkerSchema,
+		}, nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		readDarwinSecretThroughBoundary = originalRead
+		runNativeSecretWorkerForDarwinDevice = originalWorker
+	})
+
+	value, err := darwinDeviceSecretGet(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+	)
+	if err != nil || value != "credential" {
+		t.Fatalf("hardened read = %q, %v", value, err)
+	}
+	if err := darwinDeviceSecretSet(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		"credential",
+		SecretStoreForbidUI,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := darwinDeviceSecretDelete(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if len(operations) != 2 ||
+		operations[0] != nativeSecretSet ||
+		operations[1] != nativeSecretDelete {
+		t.Fatalf("hardened worker operations = %v", operations)
 	}
 }

--- a/cli/keyring_darwin_reconcile_test.go
+++ b/cli/keyring_darwin_reconcile_test.go
@@ -1,0 +1,137 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestDarwinDeviceSecretSetReconcilesUnknownOutcome(t *testing.T) {
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalSet := setDarwinSecretInProcess
+	originalRead := readDarwinSecretInProcess
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return false }
+	setDarwinSecretInProcess = func(
+		context.Context,
+		string, string, string, SecretStoreUIPolicy, string,
+	) error {
+		return newCloudError(
+			CloudErrSecretOutcomeUnknown,
+			"write test credential",
+			nil,
+		)
+	}
+	readDarwinSecretInProcess = func(
+		_ context.Context,
+		_, _ string,
+		ui SecretStoreUIPolicy,
+		_ string,
+	) (string, bool, error) {
+		if ui != SecretStoreForbidUI {
+			t.Fatalf("reconciliation policy = %q", ui)
+		}
+		return "credential", true, nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		setDarwinSecretInProcess = originalSet
+		readDarwinSecretInProcess = originalRead
+	})
+
+	err := darwinDeviceSecretSet(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		"credential",
+		SecretStoreForbidUI,
+	)
+	if err != nil {
+		t.Fatalf("reconciled write error = %v", err)
+	}
+}
+
+func TestDarwinDeviceSecretSetPreservesRestoreFailureAfterReconciliation(
+	t *testing.T,
+) {
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalSet := setDarwinSecretInProcess
+	originalRead := readDarwinSecretInProcess
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return false }
+	restoreErr := fmt.Errorf(
+		"%w: test restore",
+		errDarwinKeychainInteractionRestore,
+	)
+	setDarwinSecretInProcess = func(
+		context.Context,
+		string, string, string, SecretStoreUIPolicy, string,
+	) error {
+		return newCloudError(
+			CloudErrSecretOutcomeUnknown,
+			"write test credential",
+			restoreErr,
+		)
+	}
+	readDarwinSecretInProcess = func(
+		context.Context,
+		string, string, SecretStoreUIPolicy, string,
+	) (string, bool, error) {
+		return "credential", true, nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		setDarwinSecretInProcess = originalSet
+		readDarwinSecretInProcess = originalRead
+	})
+
+	err := darwinDeviceSecretSet(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		"credential",
+		SecretStoreForbidUI,
+	)
+	if !errors.Is(err, errDarwinKeychainInteractionRestore) {
+		t.Fatalf("reconciled write lost restore failure: %v", err)
+	}
+}
+
+func TestDarwinDeviceSecretDeleteReconcilesUnknownOutcome(t *testing.T) {
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalDelete := deleteDarwinSecretInProcess
+	originalRead := readDarwinSecretInProcess
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return false }
+	deleteDarwinSecretInProcess = func(
+		context.Context,
+		string, string, SecretStoreUIPolicy, string,
+	) error {
+		return newCloudError(
+			CloudErrSecretOutcomeUnknown,
+			"delete test credential",
+			nil,
+		)
+	}
+	readDarwinSecretInProcess = func(
+		context.Context,
+		string, string, SecretStoreUIPolicy, string,
+	) (string, bool, error) {
+		return "", false, nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		deleteDarwinSecretInProcess = originalDelete
+		readDarwinSecretInProcess = originalRead
+	})
+
+	err := darwinDeviceSecretDelete(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		SecretStoreForbidUI,
+	)
+	if err != nil {
+		t.Fatalf("reconciled delete error = %v", err)
+	}
+}

--- a/cli/keyring_darwin_relay_token.go
+++ b/cli/keyring_darwin_relay_token.go
@@ -1,0 +1,168 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+func replaceDarwinRelayAuthToken(
+	ctx context.Context,
+	service, account, token string,
+) error {
+	var previous string
+	var found bool
+	var err error
+	if darwinDeviceSecureStorageBoundaryAvailable() {
+		previous, found, err = readDarwinSecretThroughBoundary(
+			ctx,
+			service,
+			account,
+			SecretStoreAllowUI,
+			"read relay auth token before replacement",
+		)
+	} else {
+		previous, found, err = readDarwinSecretInProcess(
+			ctx,
+			service,
+			account,
+			SecretStoreAllowUI,
+			"read relay auth token before replacement",
+		)
+	}
+	if err != nil {
+		return err
+	}
+	if found {
+		if err := deleteDarwinRelayAuthToken(
+			ctx,
+			service,
+			account,
+			SecretStoreAllowUI,
+		); err != nil {
+			return err
+		}
+	}
+	if err := setDarwinRelayAuthToken(
+		ctx,
+		service,
+		account,
+		token,
+		SecretStoreAllowUI,
+	); err != nil {
+		if found {
+			restoreCtx, cancelRestore :=
+				boundedNativeOAuthSecretContext(
+					context.Background(),
+					SecretStoreAllowUI,
+				)
+			defer cancelRestore()
+			restoreErr := setDarwinRelayAuthToken(
+				restoreCtx,
+				service,
+				account,
+				previous,
+				SecretStoreAllowUI,
+			)
+			if restoreErr != nil {
+				return errors.Join(
+					err,
+					fmt.Errorf(
+						"restore previous relay auth token: %w",
+						restoreErr,
+					),
+				)
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func snapshotDarwinRelayAuthTokenForSetupPersistence(
+	previousToken string,
+	hadPreviousToken bool,
+) (string, bool, error) {
+	if hadPreviousToken {
+		return previousToken, true, nil
+	}
+	token, err := readRelayAuthTokenWithPolicy(SecretStoreAllowUI)
+	if err == nil {
+		return token, true, nil
+	}
+	if isMissingRelayAuthTokenError(err) {
+		return "", false, nil
+	}
+	return previousToken, hadPreviousToken, err
+}
+
+func setDarwinRelayAuthToken(
+	ctx context.Context,
+	service, account, token string,
+	ui SecretStoreUIPolicy,
+) error {
+	if darwinDeviceSecureStorageBoundaryAvailable() {
+		raw := []byte(token)
+		defer zeroSecretBytes(raw)
+		request := nativeSecretWorkerRequest{
+			SchemaVersion: nativeSecretWorkerSchema,
+			Operation:     nativeSecretSet,
+			UI:            ui,
+			Service:       service,
+			Account:       account,
+			Value:         raw,
+		}
+		_, err := runNativeSecretWorkerForDarwinDevice(ctx, request)
+		return reconcileNativeSecretSet(ctx, request, err)
+	}
+	expected := []byte(token)
+	defer zeroSecretBytes(expected)
+	err := setDarwinSecretInProcess(
+		ctx,
+		service,
+		account,
+		token,
+		ui,
+		"write relay auth token",
+	)
+	return reconcileDarwinInProcessSet(
+		ctx,
+		service,
+		account,
+		expected,
+		err,
+	)
+}
+
+func deleteDarwinRelayAuthToken(
+	ctx context.Context,
+	service, account string,
+	ui SecretStoreUIPolicy,
+) error {
+	if darwinDeviceSecureStorageBoundaryAvailable() {
+		request := nativeSecretWorkerRequest{
+			SchemaVersion: nativeSecretWorkerSchema,
+			Operation:     nativeSecretDelete,
+			UI:            ui,
+			Service:       service,
+			Account:       account,
+		}
+		_, err := runNativeSecretWorkerForDarwinDevice(ctx, request)
+		return reconcileNativeSecretDelete(ctx, request, err)
+	}
+	err := deleteDarwinSecretInProcess(
+		ctx,
+		service,
+		account,
+		ui,
+		"delete relay auth token",
+	)
+	return reconcileDarwinInProcessDelete(
+		ctx,
+		service,
+		account,
+		err,
+	)
+}

--- a/cli/keyring_darwin_relay_token_policy_test.go
+++ b/cli/keyring_darwin_relay_token_policy_test.go
@@ -1,0 +1,370 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+)
+
+func TestDarwinRelayTokenReadUsesNoUIPath(t *testing.T) {
+	withDeviceStorageTestHome(t)
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalRead := readDarwinSecretInProcess
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return false }
+	readDarwinSecretInProcess = func(
+		_ context.Context,
+		service, account string,
+		ui SecretStoreUIPolicy,
+		operation string,
+	) (string, bool, error) {
+		if service != relayAuthTokenServiceName() ||
+			account != secretUser() ||
+			ui != SecretStoreForbidUI ||
+			operation == "" {
+			t.Fatalf("unexpected relay-token read")
+		}
+		return "go-keyring-base64:" +
+			base64.StdEncoding.EncodeToString([]byte("relay-token")), true, nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		readDarwinSecretInProcess = originalRead
+	})
+
+	token, err := readRelayAuthToken()
+	if err != nil || token != "relay-token" {
+		t.Fatalf("relay token = %q, %v", token, err)
+	}
+}
+
+func TestDarwinRelayTokenInteractiveWriteUsesMatchingNativePath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", "")
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalRead := readDarwinSecretInProcess
+	originalSet := setDarwinSecretInProcess
+	originalDelete := deleteDarwinSecretInProcess
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return false }
+	var operations []string
+	readDarwinSecretInProcess = func(
+		_ context.Context,
+		service, account string,
+		ui SecretStoreUIPolicy,
+		operation string,
+	) (string, bool, error) {
+		if service != relayAuthTokenServiceName() ||
+			account != secretUser() ||
+			ui != SecretStoreAllowUI ||
+			operation == "" {
+			t.Fatalf("unexpected relay-token replacement read")
+		}
+		operations = append(operations, "read")
+		return "previous-token", true, nil
+	}
+	deleteDarwinSecretInProcess = func(
+		_ context.Context,
+		service, account string,
+		ui SecretStoreUIPolicy,
+		operation string,
+	) error {
+		if service != relayAuthTokenServiceName() ||
+			account != secretUser() ||
+			ui != SecretStoreAllowUI ||
+			operation == "" {
+			t.Fatalf("unexpected relay-token replacement delete")
+		}
+		operations = append(operations, "delete")
+		return nil
+	}
+	setDarwinSecretInProcess = func(
+		_ context.Context,
+		service, account, value string,
+		ui SecretStoreUIPolicy,
+		operation string,
+	) error {
+		if service != relayAuthTokenServiceName() ||
+			account != secretUser() ||
+			value != "relay-token" ||
+			ui != SecretStoreAllowUI ||
+			operation == "" {
+			t.Fatalf("unexpected relay-token write")
+		}
+		operations = append(operations, "set")
+		return nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		readDarwinSecretInProcess = originalRead
+		setDarwinSecretInProcess = originalSet
+		deleteDarwinSecretInProcess = originalDelete
+	})
+
+	if err := writeRelayAuthTokenInteractive("relay-token"); err != nil {
+		t.Fatal(err)
+	}
+	if len(operations) != 3 ||
+		operations[0] != "read" ||
+		operations[1] != "delete" ||
+		operations[2] != "set" {
+		t.Fatalf("interactive replacement operations = %v", operations)
+	}
+}
+
+func TestDarwinRelayTokenBackgroundMutationsForbidUI(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", "")
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalSet := setDarwinSecretInProcess
+	originalDelete := deleteDarwinSecretInProcess
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return false }
+	var policies []SecretStoreUIPolicy
+	deleteDarwinSecretInProcess = func(
+		_ context.Context,
+		_, _ string,
+		ui SecretStoreUIPolicy,
+		_ string,
+	) error {
+		policies = append(policies, ui)
+		return nil
+	}
+	setDarwinSecretInProcess = func(
+		_ context.Context,
+		_, _, _ string,
+		ui SecretStoreUIPolicy,
+		_ string,
+	) error {
+		policies = append(policies, ui)
+		return nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		setDarwinSecretInProcess = originalSet
+		deleteDarwinSecretInProcess = originalDelete
+	})
+
+	if err := writeRelayAuthToken("relay-token"); err != nil {
+		t.Fatal(err)
+	}
+	if err := deleteRelayAuthToken(); err != nil {
+		t.Fatal(err)
+	}
+	if len(policies) != 2 ||
+		policies[0] != SecretStoreForbidUI ||
+		policies[1] != SecretStoreForbidUI {
+		t.Fatalf("background mutation policies = %v", policies)
+	}
+}
+
+func TestDarwinRelayTokenInteractiveReplacementRestoresOnWriteFailure(
+	t *testing.T,
+) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", "")
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalRead := readDarwinSecretInProcess
+	originalSet := setDarwinSecretInProcess
+	originalDelete := deleteDarwinSecretInProcess
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return false }
+	readDarwinSecretInProcess = func(
+		context.Context,
+		string, string, SecretStoreUIPolicy, string,
+	) (string, bool, error) {
+		return "previous-token", true, nil
+	}
+	deleteDarwinSecretInProcess = func(
+		context.Context,
+		string, string, SecretStoreUIPolicy, string,
+	) error {
+		return nil
+	}
+	writeErr := errors.New("new token write failed")
+	var values []string
+	var cancelReplacement context.CancelFunc
+	setDarwinSecretInProcess = func(
+		ctx context.Context,
+		_, _, value string,
+		_ SecretStoreUIPolicy,
+		_ string,
+	) error {
+		values = append(values, value)
+		if value == "new-token" {
+			cancelReplacement()
+			return writeErr
+		}
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("rollback reused failed context: %v", err)
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		readDarwinSecretInProcess = originalRead
+		setDarwinSecretInProcess = originalSet
+		deleteDarwinSecretInProcess = originalDelete
+	})
+
+	replacementCtx, cancel := context.WithCancel(
+		context.Background(),
+	)
+	defer cancel()
+	cancelReplacement = cancel
+	err := replaceDarwinRelayAuthToken(
+		replacementCtx,
+		relayAuthTokenServiceName(),
+		secretUser(),
+		"new-token",
+	)
+	if !errors.Is(err, writeErr) ||
+		len(values) != 2 ||
+		values[0] != "new-token" ||
+		values[1] != "previous-token" {
+		t.Fatalf("replacement error=%v values=%v", err, values)
+	}
+}
+
+func TestDarwinRelayTokenUsesHardenedWorker(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", "")
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalRead := readDarwinSecretThroughBoundary
+	originalWorker := runNativeSecretWorkerForDarwinDevice
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return true }
+	var readPolicies []SecretStoreUIPolicy
+	readDarwinSecretThroughBoundary = func(
+		_ context.Context,
+		service, account string,
+		ui SecretStoreUIPolicy,
+		operation string,
+	) (string, bool, error) {
+		if service != relayAuthTokenServiceName() ||
+			account != secretUser() ||
+			operation == "" {
+			t.Fatalf("unexpected hardened relay-token read")
+		}
+		readPolicies = append(readPolicies, ui)
+		return "relay-token", true, nil
+	}
+	var requests []nativeSecretWorkerRequest
+	runNativeSecretWorkerForDarwinDevice = func(
+		_ context.Context,
+		request nativeSecretWorkerRequest,
+	) (nativeSecretWorkerResponse, error) {
+		requests = append(requests, request)
+		return nativeSecretWorkerResponse{
+			SchemaVersion: nativeSecretWorkerSchema,
+		}, nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		readDarwinSecretThroughBoundary = originalRead
+		runNativeSecretWorkerForDarwinDevice = originalWorker
+	})
+
+	if token, err := readRelayAuthToken(); err != nil || token != "relay-token" {
+		t.Fatalf("hardened relay-token read = %q, %v", token, err)
+	}
+	if err := writeRelayAuthToken("relay-token"); err != nil {
+		t.Fatal(err)
+	}
+	if err := deleteRelayAuthToken(); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRelayAuthTokenInteractive("replacement-token"); err != nil {
+		t.Fatal(err)
+	}
+	if len(readPolicies) != 2 ||
+		readPolicies[0] != SecretStoreForbidUI ||
+		readPolicies[1] != SecretStoreAllowUI {
+		t.Fatalf("hardened relay-token read policies = %v", readPolicies)
+	}
+	if len(requests) != 4 ||
+		requests[0].Operation != nativeSecretSet ||
+		requests[1].Operation != nativeSecretDelete ||
+		requests[2].Operation != nativeSecretDelete ||
+		requests[3].Operation != nativeSecretSet {
+		t.Fatalf("hardened relay-token requests = %+v", requests)
+	}
+	for index, request := range requests {
+		wantUI := SecretStoreForbidUI
+		if index >= 2 {
+			wantUI = SecretStoreAllowUI
+		}
+		if request.Service != relayAuthTokenServiceName() ||
+			request.Account != secretUser() ||
+			request.UI != wantUI {
+			t.Fatalf("unexpected hardened relay-token request: %+v", request)
+		}
+	}
+}
+
+func TestDarwinInteractiveCurrentCredentialRecreatesKeychainItem(
+	t *testing.T,
+) {
+	originalBoundary := darwinDeviceSecureStorageBoundaryAvailable
+	originalSet := setDarwinSecretInProcess
+	originalDelete := deleteDarwinSecretInProcess
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return false }
+	var operations []string
+	deleteDarwinSecretInProcess = func(
+		_ context.Context,
+		service, _ string,
+		ui SecretStoreUIPolicy,
+		_ string,
+	) error {
+		if service != deviceCredentialService || ui != SecretStoreAllowUI {
+			t.Fatalf("unexpected interactive delete: %q / %q", service, ui)
+		}
+		operations = append(operations, "delete")
+		return nil
+	}
+	setDarwinSecretInProcess = func(
+		_ context.Context,
+		service, _, _ string,
+		ui SecretStoreUIPolicy,
+		_ string,
+	) error {
+		if service != deviceCredentialService || ui != SecretStoreAllowUI {
+			t.Fatalf("unexpected interactive set: %q / %q", service, ui)
+		}
+		operations = append(operations, "set")
+		return nil
+	}
+	t.Cleanup(func() {
+		darwinDeviceSecureStorageBoundaryAvailable = originalBoundary
+		setDarwinSecretInProcess = originalSet
+		deleteDarwinSecretInProcess = originalDelete
+	})
+
+	err := darwinDeviceSecretSet(
+		context.Background(),
+		deviceCredentialService,
+		secretUser(),
+		"credential",
+		SecretStoreAllowUI,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(operations) != 2 ||
+		operations[0] != "delete" ||
+		operations[1] != "set" {
+		t.Fatalf("interactive replacement operations = %v", operations)
+	}
+}
+
+func TestNativeSecretWorkerAcceptsRelayTokenKey(t *testing.T) {
+	service := relayAuthTokenServiceName()
+	if !validNativeSecretWorkerKey(service, secretUser()) {
+		t.Fatalf("relay-token key rejected: %q / %q", service, secretUser())
+	}
+	if validNativeSecretWorkerKey(service, secretUser()+".other") {
+		t.Fatal("relay-token key accepted for another account")
+	}
+}

--- a/cli/keyring_darwin_test_backend_test.go
+++ b/cli/keyring_darwin_test_backend_test.go
@@ -1,0 +1,63 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/zalando/go-keyring"
+)
+
+// Darwin production code uses Security.framework directly. Package tests use
+// go-keyring's in-memory mock, so keep ordinary storage tests isolated from the
+// user's real login Keychain. Policy tests call the native core through seams.
+func init() {
+	// Install the mock during package initialization, before TestMain and before
+	// any helper subprocess can reach a package-level test hook. Waiting for
+	// TestMain leaves an initialization window where go-keyring still owns its
+	// production /usr/bin/security provider.
+	keyring.MockInit()
+	darwinDeviceSecureStorageBoundaryAvailable = func() bool { return false }
+	readDarwinSecretInProcess = func(
+		ctx context.Context,
+		service, account string,
+		_ SecretStoreUIPolicy,
+		_ string,
+	) (string, bool, error) {
+		if err := ctx.Err(); err != nil {
+			return "", false, err
+		}
+		value, err := keyring.Get(service, account)
+		if errors.Is(err, keyring.ErrNotFound) {
+			return "", false, nil
+		}
+		return value, err == nil, err
+	}
+	setDarwinSecretInProcess = func(
+		ctx context.Context,
+		service, account, value string,
+		_ SecretStoreUIPolicy,
+		_ string,
+	) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return keyring.Set(service, account, value)
+	}
+	deleteDarwinSecretInProcess = func(
+		ctx context.Context,
+		service, account string,
+		_ SecretStoreUIPolicy,
+		_ string,
+	) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := keyring.Delete(service, account)
+		if errors.Is(err, keyring.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+}

--- a/cli/native_secret_worker.go
+++ b/cli/native_secret_worker.go
@@ -252,6 +252,9 @@ func validNativeSecretWorkerKey(service, account string) bool {
 	if account != secretUser() {
 		return false
 	}
+	if service == relayAuthTokenServiceName() {
+		return validSecretText(service, 256)
+	}
 	if service == deviceCredentialProbeService ||
 		service == deviceCredentialService ||
 		service == deviceCredentialPendingService {

--- a/cli/pairing_flow.go
+++ b/cli/pairing_flow.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -45,16 +46,38 @@ func defaultPairingClientInfo() pairingClientInfo {
 // Test seams so the pairing orchestration can be exercised without a live relay.
 var pairDeviceV1ForPairing = pairDeviceV1
 var activateDeviceV1ForPairing = activateDeviceV1
+var explicitPairingSecretStoreUIPolicy = func() SecretStoreUIPolicy {
+	return SecretStoreForbidUI
+}
 
-func runSecurePairing(bootstrapURL, code string, cfg *runtimeConfig, saveCfg func(*runtimeConfig) error, info pairingClientInfo) (string, error) {
-	if err := validateLocalDeviceReplacementAllowed(*cfg); err != nil {
+func runSecurePairingWithValidationPolicy(
+	bootstrapURL, code string,
+	cfg *runtimeConfig,
+	saveCfg func(*runtimeConfig) error,
+	info pairingClientInfo,
+	validationUI SecretStoreUIPolicy,
+) (string, error) {
+	pairingUI := explicitPairingSecretStoreUIPolicy()
+	if err := validateLocalDeviceReplacementAllowedWithPolicy(
+		*cfg,
+		validationUI,
+	); err != nil {
 		return "", err
 	}
 	// Prove credential storage works BEFORE talking to the relay: /pair/v1/finish
 	// consumes the owner's one-time code, so a broken keyring discovered after the
 	// fact would burn the code with nothing stored. Callers probe earlier for the
 	// user-facing message; this guard keeps the invariant for every caller.
-	if _, err := probeDeviceCredentialStorage(); err != nil {
+	probeCtx, cancelProbe := boundedNativeOAuthSecretContext(
+		context.Background(),
+		pairingUI,
+	)
+	_, err := probeDeviceCredentialStorageWithPolicy(
+		probeCtx,
+		pairingUI,
+	)
+	cancelProbe()
+	if err != nil {
 		return "", fmt.Errorf("cannot store a device credential on this system (the code was not used): %w", err)
 	}
 	installID, err := getOrCreateClientInstallID(cfg, saveCfg)
@@ -74,7 +97,17 @@ func runSecurePairing(bootstrapURL, code string, cfg *runtimeConfig, saveCfg fun
 
 	// Local-first: persist the pending credential BEFORE activating, so a crash
 	// after activation can still resume (the credential is not lost).
-	if err := writePendingDeviceCredential(prov.Credential); err != nil {
+	pendingCtx, cancelPending := boundedNativeOAuthSecretContext(
+		context.Background(),
+		pairingUI,
+	)
+	err = writePendingDeviceCredentialWithPolicy(
+		pendingCtx,
+		prov.Credential,
+		pairingUI,
+	)
+	cancelPending()
+	if err != nil {
 		return "", fmt.Errorf("could not store the new credential securely: %w", err)
 	}
 
@@ -125,7 +158,16 @@ func runSecurePairing(bootstrapURL, code string, cfg *runtimeConfig, saveCfg fun
 	if err := saveCfg(cfg); err != nil {
 		return "", fmt.Errorf("could not save the secure endpoint: %w", err)
 	}
-	if err := promotePendingDeviceCredential(); err != nil {
+	promoteCtx, cancelPromote := boundedNativeOAuthSecretContext(
+		context.Background(),
+		pairingUI,
+	)
+	err = promotePendingDeviceCredentialWithPolicy(
+		promoteCtx,
+		pairingUI,
+	)
+	cancelPromote()
+	if err != nil {
 		return "", fmt.Errorf("activated but could not finalize the credential: %w", err)
 	}
 	// Credential + live endpoint are now durable and working; clearing the stale
@@ -138,12 +180,30 @@ func runSecurePairing(bootstrapURL, code string, cfg *runtimeConfig, saveCfg fun
 }
 
 func validateLocalDeviceReplacementAllowed(cfg runtimeConfig) error {
+	return validateLocalDeviceReplacementAllowedWithPolicy(
+		cfg,
+		SecretStoreForbidUI,
+	)
+}
+
+func validateLocalDeviceReplacementAllowedWithPolicy(
+	cfg runtimeConfig,
+	ui SecretStoreUIPolicy,
+) error {
 	if cfg.Cloud != nil {
 		return fmt.Errorf(
 			"Home Assistant Cloud access is configured; remove it before replacing the local device pairing (the code was not used)",
 		)
 	}
-	if pending, exists, err := readPendingDeviceCredentialRecord(); err != nil {
+	ctx, cancel := boundedNativeOAuthSecretContext(
+		context.Background(),
+		ui,
+	)
+	defer cancel()
+	if pending, exists, err := readPendingDeviceCredentialRecordWithPolicy(
+		ctx,
+		ui,
+	); err != nil {
 		return fmt.Errorf(
 			"cannot inspect the pending device credential before local pairing: %w",
 			err,
@@ -169,6 +229,21 @@ func validateLocalDeviceReplacementAllowed(cfg runtimeConfig) error {
 // already stored pending (e.g. a crash between activate and promote). Safe to
 // call at setup/doctor start; a no-op when there is no pending credential.
 func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) error) (bool, error) {
+	return resumePendingActivationWithPolicy(
+		cfg,
+		saveCfg,
+		SecretStoreForbidUI,
+	)
+}
+
+func resumePendingActivationWithPolicy(
+	cfg *runtimeConfig,
+	saveCfg func(*runtimeConfig) error,
+	ui SecretStoreUIPolicy,
+) (bool, error) {
+	if err := validateSecretUIPolicy(ui); err != nil {
+		return false, err
+	}
 	base, pin := cfg.PendingSecureBaseURL, cfg.PendingSpkiPin
 	if base == "" || pin == "" {
 		// No interrupted pairing to resume (cheap check first, before any keyring
@@ -219,7 +294,11 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 		// orphan file) or a headless-interrupted pairing whose marker is not
 		// written until promotion. Prefer a real keyring pending over an orphan
 		// file; only an absent/empty keyring falls back to the file.
-		kp, kok, kerr := readKeyringDeviceSecret(pendingService)
+		kp, kok, kerr := readKeyringDeviceSecretWithPolicy(
+			context.Background(),
+			pendingService,
+			ui,
+		)
 		switch {
 		case kok:
 			record, decodeErr := decodePendingDeviceCredentialRecord(kp)
@@ -284,10 +363,15 @@ func resumePendingActivation(cfg *runtimeConfig, saveCfg func(*runtimeConfig) er
 		// Keyring-backed: promote the pending we already read and drop the keyring
 		// pending slot. An orphan .pending FILE (if any) is left untouched — it is
 		// harmless residue that marker-based reads never consult.
-		if err := writeDeviceCredential(pending); err != nil {
+		ctx, cancel := boundedNativeOAuthSecretContext(
+			context.Background(),
+			ui,
+		)
+		defer cancel()
+		if err := writeDeviceCredentialWithPolicy(ctx, pending, ui); err != nil {
 			return false, err
 		}
-		if err := deletePendingDeviceCredential(); err != nil {
+		if err := deletePendingDeviceCredentialWithPolicy(ctx, ui); err != nil {
 			return false, err
 		}
 	}

--- a/cli/pairing_policy.go
+++ b/cli/pairing_policy.go
@@ -1,0 +1,55 @@
+package main
+
+import "context"
+
+func runSecurePairing(
+	bootstrapURL, code string,
+	cfg *runtimeConfig,
+	saveCfg func(*runtimeConfig) error,
+	info pairingClientInfo,
+) (string, error) {
+	return runSecurePairingWithValidationPolicy(
+		bootstrapURL,
+		code,
+		cfg,
+		saveCfg,
+		info,
+		explicitPairingSecretStoreUIPolicy(),
+	)
+}
+
+func runSecurePairingAfterInteractivePreflight(
+	bootstrapURL, code string,
+	cfg *runtimeConfig,
+	saveCfg func(*runtimeConfig) error,
+	info pairingClientInfo,
+) (string, error) {
+	return runSecurePairingWithValidationPolicy(
+		bootstrapURL,
+		code,
+		cfg,
+		saveCfg,
+		info,
+		SecretStoreForbidUI,
+	)
+}
+
+func pairCommandSecretStoreUIPolicy(
+	credentialStore string,
+) SecretStoreUIPolicy {
+	if credentialStore == "file" {
+		return SecretStoreForbidUI
+	}
+	return explicitPairingSecretStoreUIPolicy()
+}
+
+func probePairCommandDeviceStorage(
+	ui SecretStoreUIPolicy,
+) (deviceStorageProbe, error) {
+	ctx, cancel := boundedNativeOAuthSecretContext(
+		context.Background(),
+		ui,
+	)
+	defer cancel()
+	return probeDeviceCredentialStorageWithPolicy(ctx, ui)
+}

--- a/cli/pairing_policy_darwin_test.go
+++ b/cli/pairing_policy_darwin_test.go
@@ -1,0 +1,367 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+type darwinDevicePolicyEvent struct {
+	operation string
+	service   string
+	ui        SecretStoreUIPolicy
+}
+
+func installDarwinDevicePolicyRecorder(
+	t *testing.T,
+) (map[string]string, *[]darwinDevicePolicyEvent) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("HA_NOVA_TEST_SECRET_DIR", "")
+	previousForced := deviceCredentialFileModeForced
+	previousExplicit := deviceCredentialFileModeExplicit
+	deviceCredentialFileModeForced = false
+	deviceCredentialFileModeExplicit = false
+
+	slots := map[string]string{}
+	events := []darwinDevicePolicyEvent{}
+	previousPreflight := deviceCredentialPreflightWithContext
+	previousGet := secretKeyringGetWithPolicy
+	previousSet := secretKeyringSetWithPolicy
+	previousDelete := secretKeyringDeleteWithPolicy
+	deviceCredentialPreflightWithContext = func(
+		ctx context.Context,
+		ui SecretStoreUIPolicy,
+	) error {
+		events = append(events, darwinDevicePolicyEvent{
+			operation: "preflight",
+			ui:        ui,
+		})
+		return validateDeviceCredentialPreflightRequest(ctx, ui)
+	}
+	secretKeyringGetWithPolicy = func(
+		_ context.Context,
+		service, _ string,
+		ui SecretStoreUIPolicy,
+	) (string, error) {
+		events = append(events, darwinDevicePolicyEvent{
+			operation: "get",
+			service:   service,
+			ui:        ui,
+		})
+		value, exists := slots[service]
+		if !exists {
+			return "", keyring.ErrNotFound
+		}
+		return value, nil
+	}
+	secretKeyringSetWithPolicy = func(
+		_ context.Context,
+		service, _, value string,
+		ui SecretStoreUIPolicy,
+	) error {
+		events = append(events, darwinDevicePolicyEvent{
+			operation: "set",
+			service:   service,
+			ui:        ui,
+		})
+		slots[service] = value
+		return nil
+	}
+	secretKeyringDeleteWithPolicy = func(
+		_ context.Context,
+		service, _ string,
+		ui SecretStoreUIPolicy,
+	) error {
+		events = append(events, darwinDevicePolicyEvent{
+			operation: "delete",
+			service:   service,
+			ui:        ui,
+		})
+		if _, exists := slots[service]; !exists {
+			return keyring.ErrNotFound
+		}
+		delete(slots, service)
+		return nil
+	}
+	t.Cleanup(func() {
+		deviceCredentialFileModeForced = previousForced
+		deviceCredentialFileModeExplicit = previousExplicit
+		deviceCredentialPreflightWithContext = previousPreflight
+		secretKeyringGetWithPolicy = previousGet
+		secretKeyringSetWithPolicy = previousSet
+		secretKeyringDeleteWithPolicy = previousDelete
+	})
+	return slots, &events
+}
+
+func TestDarwinExplicitPairingUsesInteractiveDevicePolicy(t *testing.T) {
+	slots, events := installDarwinDevicePolicyRecorder(t)
+	credential := validCredential(210)
+	previousPair := pairDeviceV1ForPairing
+	previousActivate := activateDeviceV1ForPairing
+	pairDeviceV1ForPairing = func(
+		*http.Client,
+		string,
+		string,
+		deviceMetadata,
+	) (*provisionedCredential, error) {
+		return &provisionedCredential{
+			DeviceID:   deviceIDOf(credential),
+			Credential: credential,
+			SpkiPin:    "pin",
+			SecurePort: 8792,
+		}, nil
+	}
+	activateDeviceV1ForPairing = func(string, string, string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		pairDeviceV1ForPairing = previousPair
+		activateDeviceV1ForPairing = previousActivate
+	})
+
+	cfg := runtimeConfig{ClientInstallID: "inst-policy-test"}
+	if _, err := runSecurePairing(
+		"http://relay:8791",
+		"123456",
+		&cfg,
+		func(*runtimeConfig) error { return nil },
+		defaultPairingClientInfo(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if slots[activeDeviceCredentialService()] != credential {
+		t.Fatal("explicit pairing did not promote the credential")
+	}
+	assertDarwinCredentialSlotPolicy(
+		t,
+		*events,
+		SecretStoreAllowUI,
+	)
+}
+
+func TestDarwinDoctorResumeForbidsDeviceKeychainUI(t *testing.T) {
+	slots, events := installDarwinDevicePolicyRecorder(t)
+	credential := validCredential(211)
+	slots[activeDeviceCredentialPendingService()] = credential
+	previousActivate := activateDeviceV1ForPairing
+	activateDeviceV1ForPairing = func(string, string, string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		activateDeviceV1ForPairing = previousActivate
+	})
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := runtimeConfig{
+		ProfileID:            "profile-doctor-policy",
+		PendingSecureBaseURL: "https://relay:8792",
+		PendingSpkiPin:       "pin",
+	}
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, hadSnapshot, err := readOptionalFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resumed, err := resumeInterruptedPairingForDoctor(
+		paths,
+		&cfg,
+		nil,
+		snapshot,
+		hadSnapshot,
+	)
+	if err != nil || !resumed {
+		t.Fatalf("Doctor resume=%v err=%v", resumed, err)
+	}
+	assertAllDarwinPolicies(t, *events, SecretStoreForbidUI)
+}
+
+func TestDarwinExplicitPairResumeAllowsDeviceKeychainUI(t *testing.T) {
+	slots, events := installDarwinDevicePolicyRecorder(t)
+	credential := validCredential(212)
+	slots[activeDeviceCredentialPendingService()] = credential
+	previousActivate := activateDeviceV1ForPairing
+	activateDeviceV1ForPairing = func(string, string, string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		activateDeviceV1ForPairing = previousActivate
+	})
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := runtimeConfig{
+		ProfileID:            "profile-pair-policy",
+		PendingSecureBaseURL: "https://relay:8792",
+		PendingSpkiPin:       "pin",
+	}
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, hadSnapshot, err := readOptionalFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resumed, err := resumeInterruptedPairingForExplicitPair(
+		paths,
+		&cfg,
+		nil,
+		snapshot,
+		hadSnapshot,
+	)
+	if err != nil || !resumed {
+		t.Fatalf("explicit pair resume=%v err=%v", resumed, err)
+	}
+	assertAllDarwinPolicies(t, *events, SecretStoreAllowUI)
+}
+
+func TestDarwinInteractiveSetupResumeAllowsDeviceKeychainUI(t *testing.T) {
+	slots, events := installDarwinDevicePolicyRecorder(t)
+	credential := validCredential(213)
+	slots[activeDeviceCredentialPendingService()] = credential
+	previousActivate := activateDeviceV1ForPairing
+	activateDeviceV1ForPairing = func(string, string, string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		activateDeviceV1ForPairing = previousActivate
+	})
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := runtimeConfig{
+		ProfileID:            "profile-setup-policy",
+		PendingSecureBaseURL: "https://relay:8792",
+		PendingSpkiPin:       "pin",
+	}
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatal(err)
+	}
+	resumed, err := resumeInteractiveSetupPendingActivation(
+		paths,
+		&cfg,
+	)
+	if err != nil || !resumed {
+		t.Fatalf("interactive setup resume=%v err=%v", resumed, err)
+	}
+	assertAllDarwinPolicies(t, *events, SecretStoreAllowUI)
+}
+
+func TestDarwinPairCommandFileModeForbidsKeychainUI(t *testing.T) {
+	slots, events := installDarwinDevicePolicyRecorder(t)
+	previousPrompt := deviceCredentialPromptSessionAvailable
+	deviceCredentialPromptSessionAvailable = func() bool { return false }
+	deviceCredentialPreflightWithContext = func(
+		ctx context.Context,
+		ui SecretStoreUIPolicy,
+	) error {
+		*events = append(*events, darwinDevicePolicyEvent{
+			operation: "preflight",
+			ui:        ui,
+		})
+		return darwinDeviceCredentialPreflight(ctx, ui)
+	}
+	t.Cleanup(func() {
+		deviceCredentialPromptSessionAvailable = previousPrompt
+	})
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	credential := validCredential(214)
+	slots[activeDeviceCredentialPendingService()] = credential
+	if err := saveConfig(
+		paths,
+		runtimeConfig{
+			RelayBaseURL:         "http://relay:8791",
+			PendingSecureBaseURL: "https://relay:8792",
+			PendingSpkiPin:       "pin",
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	previousActivate := activateDeviceV1ForPairing
+	activateDeviceV1ForPairing = func(
+		_, _, got string,
+	) error {
+		if got != credential {
+			t.Fatalf("resume credential = %q", got)
+		}
+		return nil
+	}
+	previousPair := runSecurePairingForPairCmd
+	runSecurePairingForPairCmd = func(
+		string,
+		string,
+		*runtimeConfig,
+		func(*runtimeConfig) error,
+		pairingClientInfo,
+	) (string, error) {
+		t.Fatal("resumed file-mode pairing asked for a new code")
+		return "", nil
+	}
+	t.Cleanup(func() {
+		activateDeviceV1ForPairing = previousActivate
+		runSecurePairingForPairCmd = previousPair
+	})
+
+	if code := runPairCommand(
+		paths,
+		[]string{
+			"--code", "123456",
+			"--credential-store", "file",
+		},
+	); code != 0 {
+		t.Fatalf("file-backed pair exit = %d", code)
+	}
+	assertAllDarwinPolicies(t, *events, SecretStoreForbidUI)
+}
+
+func assertDarwinCredentialSlotPolicy(
+	t *testing.T,
+	events []darwinDevicePolicyEvent,
+	want SecretStoreUIPolicy,
+) {
+	t.Helper()
+	checked := 0
+	for _, event := range events {
+		if event.service != activeDeviceCredentialService() &&
+			event.service != activeDeviceCredentialPendingService() {
+			continue
+		}
+		checked++
+		if event.ui != want {
+			t.Fatalf("credential event %+v; want UI policy %q", event, want)
+		}
+	}
+	if checked < 4 {
+		t.Fatalf("only %d credential-slot policy events: %+v", checked, events)
+	}
+}
+
+func assertAllDarwinPolicies(
+	t *testing.T,
+	events []darwinDevicePolicyEvent,
+	want SecretStoreUIPolicy,
+) {
+	t.Helper()
+	if len(events) == 0 {
+		t.Fatal("no secure-storage policy events recorded")
+	}
+	for _, event := range events {
+		if event.ui != want {
+			t.Fatalf("secure-storage event %+v; want UI policy %q", event, want)
+		}
+	}
+}

--- a/cli/pending_activation_retirement.go
+++ b/cli/pending_activation_retirement.go
@@ -4,10 +4,51 @@ import "strings"
 
 // Test seam for the activation reached only through the retirement guard.
 var resumePendingActivationAfterRetirementCheck = resumePendingActivation
+var resumePendingActivationForExplicitPairAfterRetirementCheck = func(
+	cfg *runtimeConfig,
+	save func(*runtimeConfig) error,
+) (bool, error) {
+	return resumePendingActivationWithPolicy(
+		cfg,
+		save,
+		explicitPairingSecretStoreUIPolicy(),
+	)
+}
 
 func resumeSetupPendingActivation(
 	paths runtimePaths,
 	cfg *runtimeConfig,
+	lifecycleMarker ...[]byte,
+) (bool, error) {
+	return resumeSetupPendingActivationWithGuard(
+		paths,
+		cfg,
+		resumePendingActivationAfterRetirementGuard,
+		lifecycleMarker...,
+	)
+}
+
+func resumeInteractiveSetupPendingActivation(
+	paths runtimePaths,
+	cfg *runtimeConfig,
+	lifecycleMarker ...[]byte,
+) (bool, error) {
+	return resumeSetupPendingActivationWithGuard(
+		paths,
+		cfg,
+		resumePendingActivationForExplicitPairAfterRetirementGuard,
+		lifecycleMarker...,
+	)
+}
+
+func resumeSetupPendingActivationWithGuard(
+	paths runtimePaths,
+	cfg *runtimeConfig,
+	resume func(
+		runtimePaths,
+		*runtimeConfig,
+		func(*runtimeConfig) error,
+	) (bool, error),
 	lifecycleMarker ...[]byte,
 ) (bool, error) {
 	if cfg == nil ||
@@ -18,7 +59,7 @@ func resumeSetupPendingActivation(
 	resumed := false
 	err := withSetupLifecycleLock(paths, lifecycleMarker, func() error {
 		var err error
-		resumed, err = resumePendingActivationAfterRetirementGuard(
+		resumed, err = resume(
 			paths,
 			cfg,
 			func(value *runtimeConfig) error {
@@ -64,4 +105,26 @@ func resumePendingActivationAfterRetirementGuard(
 		return false, err
 	}
 	return resumePendingActivationAfterRetirementCheck(cfg, save)
+}
+
+func resumePendingActivationForExplicitPairAfterRetirementGuard(
+	paths runtimePaths,
+	cfg *runtimeConfig,
+	save func(*runtimeConfig) error,
+) (bool, error) {
+	if cfg == nil ||
+		strings.TrimSpace(cfg.PendingSecureBaseURL) == "" ||
+		strings.TrimSpace(cfg.PendingSpkiPin) == "" {
+		return false, nil
+	}
+	if err := requireSettledDeviceCredentialRetirement(
+		paths,
+		activeServerProfile(),
+	); err != nil {
+		return false, err
+	}
+	return resumePendingActivationForExplicitPairAfterRetirementCheck(
+		cfg,
+		save,
+	)
 }

--- a/cli/relay_token_policy.go
+++ b/cli/relay_token_policy.go
@@ -1,0 +1,22 @@
+package main
+
+func writeRelayAuthTokenInteractive(token string) error {
+	return writeRelayAuthTokenWithPolicy(token, SecretStoreAllowUI)
+}
+
+func deleteRelayAuthTokenInteractive() error {
+	return deleteRelayAuthTokenWithPolicy(SecretStoreAllowUI)
+}
+
+func restoreRelayAuthTokenInteractive(
+	previousToken string,
+	hadPreviousToken, tokenChanged bool,
+) error {
+	if !tokenChanged {
+		return nil
+	}
+	if hadPreviousToken {
+		return writeRelayAuthTokenInteractive(previousToken)
+	}
+	return deleteRelayAuthTokenInteractive()
+}

--- a/cli/relay_token_policy_other.go
+++ b/cli/relay_token_policy_other.go
@@ -1,0 +1,20 @@
+//go:build !darwin
+
+package main
+
+func writeRelayAuthTokenWithPolicy(
+	token string,
+	ui SecretStoreUIPolicy,
+) error {
+	if err := validateSecretUIPolicy(ui); err != nil {
+		return err
+	}
+	return writeRelayAuthToken(token)
+}
+
+func deleteRelayAuthTokenWithPolicy(ui SecretStoreUIPolicy) error {
+	if err := validateSecretUIPolicy(ui); err != nil {
+		return err
+	}
+	return deleteRelayAuthToken()
+}

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -218,7 +218,7 @@ func interactiveSetup(paths runtimePaths, cfg runtimeConfig, state installState,
 		return 0
 	}
 	resumedActivation, resumeActivationErr :=
-		resumeSetupPendingActivation(
+		resumeInteractiveSetupPendingActivation(
 			paths,
 			&cfg,
 			lifecycleMarker...,

--- a/cli/setup_pairing.go
+++ b/cli/setup_pairing.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,7 +30,7 @@ var errSetupDevicePaired = errors.New("device paired securely")
 // v1 flow first and falls back to the legacy code exchange, so a relay without
 // /pair/v1 (or a test with no v1 endpoint) transparently uses the old path.
 var probePairingV1ForSetup = probePairingV1
-var securePairForSetup = runSecurePairing
+var securePairForSetup = runSecurePairingAfterInteractivePreflight
 var probePairingV1DetailedForSetup = probePairingV1Detailed
 
 type relayPairingRateLimitError struct {
@@ -224,7 +225,10 @@ func runSetupPairingFlow(reader *bufio.Reader, out io.Writer, paths runtimePaths
 		if err := guardPairingMutation(); err != nil {
 			return err
 		}
-		return validateLocalDeviceReplacementAllowed(*cfg)
+		return validateLocalDeviceReplacementAllowedWithPolicy(
+			*cfg,
+			explicitPairingSecretStoreUIPolicy(),
+		)
 	})
 	if guardErr != nil {
 		renderSetupErrorLine(
@@ -239,8 +243,17 @@ func runSetupPairingFlow(reader *bufio.Reader, out io.Writer, paths runtimePaths
 	// fallback here, with a visible note.
 	var probe deviceStorageProbe
 	probeErr := withSetupLifecycleLock(paths, lifecycleMarker, func() error {
+		ui := explicitPairingSecretStoreUIPolicy()
+		ctx, cancel := boundedNativeOAuthSecretContext(
+			context.Background(),
+			ui,
+		)
+		defer cancel()
 		var err error
-		probe, err = probeDeviceCredentialStorage()
+		probe, err = probeDeviceCredentialStorageWithPolicy(
+			ctx,
+			ui,
+		)
 		return err
 	})
 	if probeErr != nil {

--- a/cli/setup_persistence.go
+++ b/cli/setup_persistence.go
@@ -7,7 +7,14 @@ import (
 
 var saveConfigForSetupPersistence = saveConfig
 var saveStateForSetupPersistence = saveState
-var writeRelayAuthTokenForSetupPersistence = writeRelayAuthToken
+var writeRelayAuthTokenForSetupPersistence = writeRelayAuthTokenInteractive
+var restoreRelayAuthTokenForSetupPersistence = restoreRelayAuthTokenInteractive
+var snapshotRelayAuthTokenForSetupPersistence = func(
+	previousToken string,
+	hadPreviousToken bool,
+) (string, bool, error) {
+	return previousToken, hadPreviousToken, nil
+}
 
 func persistInteractiveSetupState(paths runtimePaths, cfg runtimeConfig, state *installState, previousToken string, hadPreviousToken bool, token string, lifecycleMarker ...[]byte) error {
 	return persistInteractiveSetupStateWithMode(paths, cfg, state, previousToken, hadPreviousToken, token, false, lifecycleMarker...)
@@ -105,13 +112,21 @@ func persistInteractiveSetupStateUnlocked(paths runtimePaths, cfg runtimeConfig,
 
 	tokenChanged := token != previousToken
 	if tokenChanged {
+		previousToken, hadPreviousToken, err =
+			snapshotRelayAuthTokenForSetupPersistence(
+				previousToken,
+				hadPreviousToken,
+			)
+		if err != nil {
+			return relayAuthTokenSetupSaveError(err)
+		}
 		if err := writeRelayAuthTokenForSetupPersistence(token); err != nil {
 			return relayAuthTokenSetupSaveError(err)
 		}
 	}
 	if err := saveConfigForSetupPersistence(paths, cfg); err != nil {
 		rollbackErr := errors.Join(
-			restoreRelayAuthToken(previousToken, hadPreviousToken, tokenChanged),
+			restoreRelayAuthTokenForSetupPersistence(previousToken, hadPreviousToken, tokenChanged),
 			restoreOptionalFile(paths.ConfigFile, configSnapshot, hadConfigSnapshot),
 			restoreOptionalFile(paths.StateFile, stateSnapshot, hadStateSnapshot),
 		)
@@ -122,7 +137,7 @@ func persistInteractiveSetupStateUnlocked(paths runtimePaths, cfg runtimeConfig,
 	state.InstallSource = detectInstallSource(paths, *state)
 	if err := mergeLatestSetupState(paths, state); err != nil {
 		rollbackErr := errors.Join(
-			restoreRelayAuthToken(previousToken, hadPreviousToken, tokenChanged),
+			restoreRelayAuthTokenForSetupPersistence(previousToken, hadPreviousToken, tokenChanged),
 			restoreOptionalFile(paths.ConfigFile, configSnapshot, hadConfigSnapshot),
 			restoreOptionalFile(paths.StateFile, stateSnapshot, hadStateSnapshot),
 		)
@@ -130,7 +145,7 @@ func persistInteractiveSetupStateUnlocked(paths runtimePaths, cfg runtimeConfig,
 	}
 	if err := saveStateForSetupPersistence(paths, *state); err != nil {
 		rollbackErr := errors.Join(
-			restoreRelayAuthToken(previousToken, hadPreviousToken, tokenChanged),
+			restoreRelayAuthTokenForSetupPersistence(previousToken, hadPreviousToken, tokenChanged),
 			restoreOptionalFile(paths.ConfigFile, configSnapshot, hadConfigSnapshot),
 			restoreOptionalFile(paths.StateFile, stateSnapshot, hadStateSnapshot),
 		)

--- a/cli/setup_persistence_relay_token_policy_test.go
+++ b/cli/setup_persistence_relay_token_policy_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestInteractiveSetupRollbackUsesTokenDiscoveredDuringPersistence(
+	t *testing.T,
+) {
+	originalSnapshot := snapshotRelayAuthTokenForSetupPersistence
+	originalWrite := writeRelayAuthTokenForSetupPersistence
+	originalRestore := restoreRelayAuthTokenForSetupPersistence
+	originalSaveConfig := saveConfigForSetupPersistence
+	snapshotRelayAuthTokenForSetupPersistence = func(
+		string,
+		bool,
+	) (string, bool, error) {
+		return "foreign-previous-token", true, nil
+	}
+	writeRelayAuthTokenForSetupPersistence = func(string) error {
+		return nil
+	}
+	var restoredToken string
+	var restoredExists, restoredChanged bool
+	restoreRelayAuthTokenForSetupPersistence = func(
+		token string,
+		exists, changed bool,
+	) error {
+		restoredToken = token
+		restoredExists = exists
+		restoredChanged = changed
+		return nil
+	}
+	saveConfigForSetupPersistence = func(
+		runtimePaths,
+		runtimeConfig,
+	) error {
+		return errors.New("test config failure")
+	}
+	t.Cleanup(func() {
+		snapshotRelayAuthTokenForSetupPersistence = originalSnapshot
+		writeRelayAuthTokenForSetupPersistence = originalWrite
+		restoreRelayAuthTokenForSetupPersistence = originalRestore
+		saveConfigForSetupPersistence = originalSaveConfig
+	})
+
+	err := persistInteractiveSetupStateUnlocked(
+		runtimePaths{
+			ConfigDir:  t.TempDir(),
+			ConfigFile: t.TempDir() + "/config.json",
+			StateFile:  t.TempDir() + "/state.json",
+		},
+		runtimeConfig{},
+		&installState{},
+		"",
+		false,
+		"new-token",
+	)
+	if err == nil ||
+		restoredToken != "foreign-previous-token" ||
+		!restoredExists ||
+		!restoredChanged {
+		t.Fatalf(
+			"rollback err=%v token=%q exists=%v changed=%v",
+			err,
+			restoredToken,
+			restoredExists,
+			restoredChanged,
+		)
+	}
+}

--- a/docs/work/2026-07-28-macos-doctor-no-keychain-prompt-spec.md
+++ b/docs/work/2026-07-28-macos-doctor-no-keychain-prompt-spec.md
@@ -1,0 +1,47 @@
+# macOS Doctor Without Keychain Prompts
+
+## Problem
+
+In a macOS build that does not meet the hardened Cloud secure-storage
+boundary, device-credential and legacy relay-token reads fall back to
+`go-keyring`. Its `/usr/bin/security` subprocess may open a Keychain password
+dialog even when the caller selected `SecretStoreForbidUI`. Background Doctor
+and session-start checks can therefore queue repeated password dialogs.
+
+## Contract
+
+- Every macOS Keychain operation reached by Doctor with
+  `SecretStoreForbidUI` disables Keychain interaction before access.
+- If access would require a password or approval, return a classified error
+  immediately; never show UI.
+- In development/ad-hoc builds, restore the prior process Keychain interaction
+  setting after the bounded in-process operation.
+- Serialize the temporary process-wide interaction-policy change.
+- Use the same native Keychain caller for newly written secrets and later
+  non-interactive reads.
+- Never broaden an existing item's ACL. If another executable identity owns a
+  legacy or test item, Doctor fails without UI; recovery is an explicit
+  interactive setup/re-pair with the installed signed HA NOVA build. Promotion
+  recreates the current device item under that identity instead of preserving
+  the foreign ACL.
+- Permit Keychain UI only for operations that explicitly use
+  `SecretStoreAllowUI`, such as interactive setup. Background commands never
+  retry a denied operation interactively, including relay-token writes,
+  rollbacks, and cleanup.
+- Continue decoding legacy `go-keyring` hex/base64 envelopes.
+
+## Verification
+
+- Regression tests prove Cloud-disabled macOS reads and Doctor-reachable
+  mutations use the native path and do not call `go-keyring`.
+- macOS package tests install the in-memory `go-keyring` provider during
+  package initialization, before `TestMain` or any helper subprocess can run.
+- Tests cover success, missing items, interaction-required errors, restoration,
+  serialized access, context cancellation, mutation uncertainty, relay-token
+  access, matching read/write identity, and restoration-error preservation for
+  the in-process path.
+- Native macOS CI runs the no-UI and interactive-pairing regressions while
+  sandbox policy denies `/usr/bin/security`.
+- Run targeted Darwin tests, the full Go suite, and onboarding contracts in an
+  environment that cannot invoke the user's globally installed HA NOVA; local
+  macOS verification also denies execution of `/usr/bin/security`.

--- a/tests/onboarding/macos-keyring-contract.test.ts
+++ b/tests/onboarding/macos-keyring-contract.test.ts
@@ -8,34 +8,47 @@ describe("macOS keyring contract", () => {
     "cli/cloud_oauth_secret_darwin_api.go",
     "utf8",
   );
+  const interaction = readFileSync(
+    "cli/keyring_darwin_interaction.go",
+    "utf8",
+  );
   const cloudBackend = readFileSync("cli/cloud_oauth_secret_darwin.go", "utf8");
   const cloudWorker = readFileSync("cli/native_secret_worker.go", "utf8");
   const cloudWorkerDarwin = readFileSync(
     "cli/native_secret_worker_darwin.go",
     "utf8",
   );
+  const darwinTestBackend = readFileSync(
+    "cli/keyring_darwin_test_backend_test.go",
+    "utf8",
+  );
   const ciWorkflow = readFileSync(".github/workflows/ci.yml", "utf8");
 
-  it("writes the relay token without exposing it in process argv", () => {
-    // The write path must NOT pass the secret as a `security ... -w <token>`
-    // command-line argument (visible via ps). It uses go-keyring, whose macOS
-    // backend pipes the command through `security -i` (stdin) instead.
-    expect(content).toContain("keyring.Set(service, u.Username, token)");
+  it("writes the relay token through the same native Keychain identity", () => {
+    // The token never enters subprocess argv, and matching native read/write
+    // identity keeps later non-interactive reads inside the stored item ACL.
+    expect(content).toContain("setDarwinSecretInProcess(");
+    expect(content).toContain("nativeSecretSet");
+    expect(content).toContain("SecretStoreAllowUI");
     expect(content).not.toContain('"-w", token');
     expect(content).not.toContain('"add-generic-password"');
-    // No ACL-trust flag (which would prompt); same service; default keychain.
+    expect(content).not.toContain("keyring.Set(service, u.Username, token)");
     expect(content).not.toContain('"-T", "/usr/bin/security"');
     expect(content).toContain("relayAuthTokenServiceName()");
     expect(content).not.toContain("login.keychain-db");
   });
 
-  it("reads the relay token through go-keyring so the base64 envelope is decoded", () => {
-    // go-keyring's Set base64-wraps the stored value (go-keyring-base64:...); the
-    // read path MUST use keyring.Get to decode it. A raw `security
-    // find-generic-password -w` read returns the encoded value and would
-    // authenticate every relay call with the wrong bearer token.
-    expect(content).toContain("keyring.Get(service, u.Username)");
+  it("forbids Keychain UI for background reads and decodes legacy values", () => {
+    expect(content).toContain("readDarwinSecretInProcess(");
+    expect(content).toContain("SecretStoreForbidUI");
+    expect(content).toContain("decodeDarwinGoKeyringValue(token)");
+    expect(content).toContain("go-keyring-base64:");
+    expect(interaction).toContain("setDarwinKeychainInteraction(ui)");
+    expect(interaction).toContain("darwinKeychainInteractionSemaphore");
+    expect(interaction).toContain("darwinOAuthErrorCode(status, ui)");
     expect(content).toContain("keyring.ErrNotFound");
+    expect(content).not.toContain("keyring.Get(service, u.Username)");
+    expect(content).not.toContain("exec.Command");
     expect(content).not.toContain('"find-generic-password"');
   });
 
@@ -70,9 +83,19 @@ describe("macOS keyring contract", () => {
     expect(ciWorkflow).toContain(
       "TestDarwinNativeSecretWorkerVerifiesSameExecutableParent",
     );
+    expect(ciWorkflow).toContain("Verify macOS Keychain no-UI policy");
+    expect(ciWorkflow).toContain("DoctorResume");
+    expect(ciWorkflow).toContain(
+      'deny process-exec (literal "/usr/bin/security")',
+    );
     expect(ciWorkflow).toContain("windows-native-secret-boundary:");
     expect(ciWorkflow).toContain(
       "TestWindowsOAuthNativeOperationsHonorHardDeadline",
     );
+  });
+
+  it("mocks go-keyring before any macOS package test can access Keychain", () => {
+    expect(darwinTestBackend).toContain("func init()");
+    expect(darwinTestBackend).toContain("keyring.MockInit()");
   });
 });


### PR DESCRIPTION
## Summary
- route macOS device credentials and relay tokens through the native Security.framework path with explicit UI policy
- forbid Keychain UI for Doctor, normal Relay access, background setup, rollback, and cleanup
- allow bounded UI only for interactive setup/pairing, recreating foreign-ACL items under the HA NOVA identity
- preserve interrupted pairing and relay-token rollback semantics, including headless `--credential-store=file` recovery
- add sandboxed macOS CI coverage that denies `/usr/bin/security`

## Verification
- `/usr/bin/sandbox-exec ... go test -count=1 ./...` (green, 135.827s)
- sandboxed focused `go test -race` (green)
- sandboxed `go vet ./...` (green)
- `vitest run tests/onboarding/macos-keyring-contract.test.ts` (6/6)
- `npm run test:safe` (136 files, 1461 tests)
- `npm run typecheck`

No release, tag, RC, README claim, or Cloud activation is included.