### PR TITLE
ci: add reviewed Cloud candidate builder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 # They must always receive maintainer review; the later exact matches restore
 # ownership without disabling the uses:-only Dependabot lane for other workflows.
 /.github/workflows/cloud-source-gate.yml @markusleben
+/.github/workflows/cloud-candidate-bundle.yml @markusleben
 /.github/workflows/ci.yml @markusleben
 /.github/workflows/release.yml @markusleben
 /.github/workflows/release-candidate.yml @markusleben

--- a/.github/policy/repo-policy.json
+++ b/.github/policy/repo-policy.json
@@ -86,6 +86,7 @@
     "reporter_app_slug": "ha-nova-cloud-source-gate",
     "reporter_app_id": 4400145,
     "sensitive_workflows": [
+      ".github/workflows/cloud-candidate-bundle.yml",
       ".github/workflows/cloud-source-gate.yml",
       ".github/workflows/ci.yml",
       ".github/workflows/release.yml",

--- a/.github/workflows/cloud-candidate-bundle.yml
+++ b/.github/workflows/cloud-candidate-bundle.yml
@@ -1,0 +1,452 @@
+name: Cloud Candidate Bundle
+run-name: Cloud candidate PR #${{ inputs.pull_request }} ${{ inputs.version_tag }} (${{ inputs.request_id }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: "Ready pull request whose exact merge commit will be built"
+        required: true
+        type: string
+      version_tag:
+        description: "Exact prerelease version, for example v0.22.0-rc1"
+        required: true
+        type: string
+      request_id:
+        description: "Unique operator request ID used to recover this one dispatch"
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  deployments: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: cloud-candidate-bundle-${{ inputs.pull_request }}
+  cancel-in-progress: true
+
+jobs:
+  resolve-source:
+    name: Resolve exact reviewed candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      commit_sha: ${{ steps.source.outputs.commit_sha }}
+      tree_sha: ${{ steps.source.outputs.tree_sha }}
+      base_sha: ${{ steps.source.outputs.base_sha }}
+      head_sha: ${{ steps.source.outputs.head_sha }}
+    steps:
+      - name: Checkout trusted main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve exact pull request source
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pull_request }}
+        run: |
+          scripts/release/resolve-cloud-candidate-source.sh \
+            "${PR_NUMBER}"
+
+      - name: Checkout exact candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.source.outputs.commit_sha }}
+          path: target
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify exact candidate checkout
+        env:
+          EXPECTED_COMMIT: ${{ steps.source.outputs.commit_sha }}
+          EXPECTED_TREE: ${{ steps.source.outputs.tree_sha }}
+        run: |
+          test "$(git -C target rev-parse HEAD)" = "${EXPECTED_COMMIT}"
+          test "$(git -C target rev-parse HEAD^{tree})" = "${EXPECTED_TREE}"
+
+      - name: Verify candidate release metadata
+        env:
+          HA_NOVA_SOURCE_ROOT: ${{ github.workspace }}/target
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: |
+          bash scripts/release/verify-release-metadata.sh \
+            "${VERSION_TAG}"
+
+      - name: Verify candidate Cloud platforms
+        run: |
+          node - "${GITHUB_WORKSPACE}/target" <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const root = process.argv[2];
+          const version = JSON.parse(fs.readFileSync(path.join(root, "version.json")));
+          const app = JSON.parse(fs.readFileSync(path.join(root, "nova/version.json")));
+          const allowed = new Set(["darwin", "linux", "windows"]);
+          const platforms = version.cloud_remote_platforms;
+          if (
+            version.cloud_remote_enabled !== true ||
+            !Array.isArray(platforms) ||
+            platforms.length === 0 ||
+            new Set(platforms).size !== platforms.length ||
+            platforms.some((platform) => !allowed.has(platform)) ||
+            app.cloud_remote_enabled !== true ||
+            JSON.stringify(app.cloud_remote_platforms) !== JSON.stringify(platforms)
+          ) {
+            throw new Error("candidate must enable matching supported Cloud platforms");
+          }
+          NODE
+
+  build-signed-darwin:
+    name: Build signed Darwin candidate binaries
+    needs: resolve-source
+    runs-on: macos-latest
+    timeout-minutes: 25
+    environment:
+      name: production
+      deployment: false
+    steps:
+      - name: Checkout trusted main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          path: trusted
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout exact candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve-source.outputs.commit_sha }}
+          path: target
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.5"
+          cache-dependency-path: target/cli/go.sum
+
+      - name: Verify production environment policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash trusted/scripts/release/verify-github-production-environment.sh
+
+      - name: Verify live main protection
+        env:
+          HA_NOVA_SOURCE_ROOT: ${{ github.workspace }}/target
+          HA_NOVA_CLOUD_SOURCE_CHECK_APP_ID: ${{ secrets.HA_NOVA_CLOUD_SOURCE_CHECK_APP_ID }}
+          HA_NOVA_CLOUD_SOURCE_CHECK_APP_PRIVATE_KEY: ${{ secrets.HA_NOVA_CLOUD_SOURCE_CHECK_APP_PRIVATE_KEY }}
+        run: bash trusted/scripts/release/verify-cloud-publication-main-protection.sh
+
+      - name: Revalidate reviewed state before Darwin signing
+        working-directory: trusted
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pull_request }}
+          HA_NOVA_CLOUD_CANDIDATE_EXPECTED_COMMIT: ${{ needs.resolve-source.outputs.commit_sha }}
+          HA_NOVA_CLOUD_CANDIDATE_EXPECTED_TREE: ${{ needs.resolve-source.outputs.tree_sha }}
+          HA_NOVA_CLOUD_CANDIDATE_EXPECTED_BASE: ${{ needs.resolve-source.outputs.base_sha }}
+          HA_NOVA_CLOUD_CANDIDATE_EXPECTED_HEAD: ${{ needs.resolve-source.outputs.head_sha }}
+        run: scripts/release/resolve-cloud-candidate-source.sh "${PR_NUMBER}"
+
+      - name: Build and sign exact Darwin candidate binaries
+        env:
+          HA_NOVA_SOURCE_ROOT: ${{ github.workspace }}/target
+          DIST_DIR: ${{ github.workspace }}/dist
+          EXPECTED_COMMIT: ${{ needs.resolve-source.outputs.commit_sha }}
+          HA_NOVA_MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.HA_NOVA_MACOS_CERTIFICATE_P12_BASE64 }}
+          HA_NOVA_MACOS_CERTIFICATE_PASSWORD: ${{ secrets.HA_NOVA_MACOS_CERTIFICATE_PASSWORD }}
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: |
+          test "$(git -C target rev-parse HEAD)" = "${EXPECTED_COMMIT}"
+          bash trusted/scripts/release/build-sign-darwin-binaries.sh \
+            "${VERSION_TAG}"
+
+      - name: Upload signed Darwin candidate binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cloud-candidate-signed-darwin-binaries
+          path: dist/ha-nova-darwin-*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-raw-binaries:
+    name: Build raw candidate binaries
+    needs:
+      - resolve-source
+      - build-signed-darwin
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout trusted main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          path: trusted
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout exact candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve-source.outputs.commit_sha }}
+          path: target
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.5"
+          cache-dependency-path: target/cli/go.sum
+
+      - name: Build exact candidate binaries
+        env:
+          HA_NOVA_SOURCE_ROOT: ${{ github.workspace }}/target
+          DIST_DIR: ${{ github.workspace }}/dist
+          EXPECTED_COMMIT: ${{ needs.resolve-source.outputs.commit_sha }}
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: |
+          test "$(git -C target rev-parse HEAD)" = "${EXPECTED_COMMIT}"
+          bash trusted/scripts/release/build-rc-binaries.sh \
+            "${VERSION_TAG}"
+
+      - name: Download signed Darwin candidate binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cloud-candidate-signed-darwin-binaries
+          path: dist
+
+      - name: Upload raw candidate binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cloud-candidate-raw-binaries
+          path: |
+            dist/ha-nova-darwin-*
+            dist/ha-nova-linux-*
+            dist/ha-nova-windows-*.exe
+          if-no-files-found: error
+          retention-days: 1
+
+  smoke-darwin-binary:
+    name: Smoke Darwin candidate binary
+    needs: build-raw-binaries
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download raw candidate binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cloud-candidate-raw-binaries
+          path: dist
+
+      - name: Smoke raw Darwin candidate binary
+        run: |
+          arch="$(uname -m | sed 's/x86_64/amd64/;s/arm64/arm64/')"
+          binary="dist/ha-nova-darwin-${arch}"
+          chmod 755 "$binary"
+          "$binary" version
+          if "$binary" internal-cloud-release-check; then
+            echo "::error::Raw Darwin binary accepted missing Cloud provenance."
+            exit 1
+          fi
+
+  smoke-linux-binary:
+    name: Smoke Linux candidate binary
+    needs: build-raw-binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download raw candidate binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cloud-candidate-raw-binaries
+          path: dist
+
+      - name: Smoke raw Linux candidate binary
+        run: |
+          binary="dist/ha-nova-linux-amd64"
+          chmod 755 "$binary"
+          "$binary" version
+          if "$binary" internal-cloud-release-check; then
+            echo "::error::Raw Linux binary accepted missing Cloud provenance."
+            exit 1
+          fi
+
+  smoke-windows-binary:
+    name: Smoke Windows candidate binary
+    needs: build-raw-binaries
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download raw candidate binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cloud-candidate-raw-binaries
+          path: dist
+
+      - name: Smoke raw Windows candidate binary
+        shell: pwsh
+        run: |
+          $binary = "dist/ha-nova-windows-amd64.exe"
+          & $binary version
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows candidate binary version check failed"
+          }
+          & $binary internal-cloud-release-check
+          if ($LASTEXITCODE -eq 0) {
+            throw "Raw Windows binary accepted missing Cloud provenance"
+          }
+
+  finalize-candidate:
+    name: Finalize current reviewed candidate
+    needs:
+      - resolve-source
+      - build-raw-binaries
+      - smoke-darwin-binary
+      - smoke-linux-binary
+      - smoke-windows-binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: production
+      deployment: false
+    steps:
+      - name: Checkout trusted main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+
+      - name: Verify production environment policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/release/verify-github-production-environment.sh
+
+      - name: Checkout exact candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve-source.outputs.commit_sha }}
+          path: target
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify live main protection
+        env:
+          HA_NOVA_SOURCE_ROOT: ${{ github.workspace }}/target
+          HA_NOVA_CLOUD_SOURCE_CHECK_APP_ID: ${{ secrets.HA_NOVA_CLOUD_SOURCE_CHECK_APP_ID }}
+          HA_NOVA_CLOUD_SOURCE_CHECK_APP_PRIVATE_KEY: ${{ secrets.HA_NOVA_CLOUD_SOURCE_CHECK_APP_PRIVATE_KEY }}
+        run: bash scripts/release/verify-cloud-publication-main-protection.sh
+
+      - name: Download smoke-bound raw candidate binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cloud-candidate-raw-binaries
+          path: dist
+
+      - name: Revalidate reviewed state before signing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pull_request }}
+          HA_NOVA_CLOUD_CANDIDATE_EXPECTED_COMMIT: ${{ needs.resolve-source.outputs.commit_sha }}
+          HA_NOVA_CLOUD_CANDIDATE_EXPECTED_TREE: ${{ needs.resolve-source.outputs.tree_sha }}
+          HA_NOVA_CLOUD_CANDIDATE_EXPECTED_BASE: ${{ needs.resolve-source.outputs.base_sha }}
+          HA_NOVA_CLOUD_CANDIDATE_EXPECTED_HEAD: ${{ needs.resolve-source.outputs.head_sha }}
+        run: scripts/release/resolve-cloud-candidate-source.sh "${PR_NUMBER}"
+
+      - name: Build exact signed candidate bundles
+        env:
+          HA_NOVA_SOURCE_ROOT: ${{ github.workspace }}/target
+          DIST_DIR: ${{ github.workspace }}/dist
+          HA_NOVA_CLOUD_RELEASE_SIGNING_KEY_PEM: ${{ secrets.HA_NOVA_CLOUD_RELEASE_SIGNING_KEY_PEM }}
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: |
+          bash scripts/release/build-install-bundle.sh "${VERSION_TAG#v}"
+
+      - name: Verify exact signed candidate bundles
+        env:
+          EXPECTED_TREE: ${{ needs.resolve-source.outputs.tree_sha }}
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: |
+          test "$(git -C target rev-parse HEAD^{tree})" = "${EXPECTED_TREE}"
+          platforms="$(
+            node -e '
+              const version = require(process.argv[1]);
+              process.stdout.write(version.cloud_remote_platforms.join(","));
+            ' target/version.json
+          )"
+          verify_evidence() {
+            local bundle_json="$1" binary="$2" os="$3" arch="$4" binary_name="$5"
+            node "${GITHUB_WORKSPACE}/scripts/release/verify-cloud-release-evidence.mjs" \
+              "$bundle_json" "$binary" "${VERSION_TAG#v}" "$os" "$arch" \
+              "$binary_name" "${EXPECTED_TREE}" "$platforms"
+          }
+          cd dist/install-bundles
+          for checksum in *.sha256; do sha256sum --check "$checksum"; done
+          verify_tar_binary() {
+            local bundle="$1" raw="$2" os="$3" arch="$4" workdir
+            workdir="$(mktemp -d)"
+            tar -xzf "$bundle" -C "$workdir"
+            cmp "$workdir/ha-nova/ha-nova" "../$raw"
+            verify_evidence \
+              "$workdir/ha-nova/bundle.json" "../$raw" "$os" "$arch" ha-nova
+          }
+          verify_tar_binary ha-nova-installer-bundle-linux-amd64.tar.gz ha-nova-linux-amd64 linux amd64
+          verify_tar_binary ha-nova-installer-bundle-linux-arm64.tar.gz ha-nova-linux-arm64 linux arm64
+          verify_tar_binary ha-nova-installer-bundle-macos-amd64.tar.gz ha-nova-darwin-amd64 macos amd64
+          verify_tar_binary ha-nova-installer-bundle-macos-arm64.tar.gz ha-nova-darwin-arm64 macos arm64
+          windows_dir="$(mktemp -d)"
+          unzip -q ha-nova-installer-bundle-windows-amd64.zip -d "$windows_dir"
+          cmp "$windows_dir/ha-nova/ha-nova.exe" ../ha-nova-windows-amd64.exe
+          verify_evidence \
+            "$windows_dir/ha-nova/bundle.json" ../ha-nova-windows-amd64.exe \
+            windows amd64 ha-nova.exe
+          workdir="$(mktemp -d)"
+          tar -xzf ha-nova-installer-bundle-linux-amd64.tar.gz -C "$workdir"
+          node -e '
+            const bundle = require(process.argv[1]);
+            if (bundle.version !== process.argv[2].replace(/^v/, "")) {
+              throw new Error("candidate bundle version does not match workflow input");
+            }
+          ' "$workdir/ha-nova/bundle.json" "${VERSION_TAG}"
+
+      - name: Revalidate complete reviewed state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pull_request }}
+          HA_NOVA_CLOUD_CANDIDATE_EXPECTED_COMMIT: ${{ needs.resolve-source.outputs.commit_sha }}
+          HA_NOVA_CLOUD_CANDIDATE_EXPECTED_TREE: ${{ needs.resolve-source.outputs.tree_sha }}
+          HA_NOVA_CLOUD_CANDIDATE_EXPECTED_BASE: ${{ needs.resolve-source.outputs.base_sha }}
+          HA_NOVA_CLOUD_CANDIDATE_EXPECTED_HEAD: ${{ needs.resolve-source.outputs.head_sha }}
+        run: scripts/release/resolve-cloud-candidate-source.sh "${PR_NUMBER}"
+
+      - name: Upload final candidate bundles
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cloud-candidate-install-bundles
+          path: dist/install-bundles/*
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Record exact candidate identity
+        env:
+          COMMIT_SHA: ${{ needs.resolve-source.outputs.commit_sha }}
+          TREE_SHA: ${{ needs.resolve-source.outputs.tree_sha }}
+        run: |
+          {
+            echo "Candidate commit: \`${COMMIT_SHA}\`"
+            echo "Candidate tree: \`${TREE_SHA}\`"
+            echo "Artifact: \`cloud-candidate-install-bundles\`"
+          } >>"${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -84,7 +84,8 @@ jobs:
         env:
           HA_NOVA_MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.HA_NOVA_MACOS_CERTIFICATE_P12_BASE64 }}
           HA_NOVA_MACOS_CERTIFICATE_PASSWORD: ${{ secrets.HA_NOVA_MACOS_CERTIFICATE_PASSWORD }}
-        run: bash scripts/release/build-sign-darwin-binaries.sh "${{ inputs.version_tag }}"
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: bash scripts/release/build-sign-darwin-binaries.sh "${VERSION_TAG}"
 
       - name: Upload signed Darwin RC binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -127,7 +128,9 @@ jobs:
         run: npm run verify
 
       - name: Build exact RC binaries
-        run: bash scripts/release/build-rc-binaries.sh "${{ inputs.version_tag }}"
+        env:
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: bash scripts/release/build-rc-binaries.sh "${VERSION_TAG}"
 
       - name: Download signed Darwin RC binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -173,6 +176,8 @@ jobs:
       - name: Smoke Unix bundles
         if: runner.os != 'Windows'
         shell: bash
+        env:
+          VERSION_TAG: ${{ inputs.version_tag }}
         run: |
           case "${RUNNER_OS}" in
             macOS) bundle="dist/install-bundles/ha-nova-installer-bundle-macos-$(uname -m | sed 's/x86_64/amd64/;s/arm64/arm64/').tar.gz" ;;
@@ -188,7 +193,7 @@ jobs:
             if (bundle.version !== process.argv[2].replace(/^v/, "")) {
               throw new Error("RC bundle version does not match workflow input");
             }
-          ' "$workdir/ha-nova/bundle.json" "${{ inputs.version_tag }}"
+          ' "$workdir/ha-nova/bundle.json" "${VERSION_TAG}"
           "$workdir/ha-nova/ha-nova" version
           case "${RUNNER_OS}" in
             macOS) platform="darwin" ;;
@@ -217,6 +222,8 @@ jobs:
       - name: Smoke Windows bundle
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          VERSION_TAG: ${{ inputs.version_tag }}
         run: |
           $workdir = Join-Path $env:RUNNER_TEMP "ha-nova-rc"
           Remove-Item -LiteralPath $workdir -Recurse -Force -ErrorAction SilentlyContinue
@@ -226,7 +233,7 @@ jobs:
             throw "bundle.json missing from Windows RC bundle"
           }
           $bundle = Get-Content -LiteralPath $bundlePath -Raw | ConvertFrom-Json
-          $expectedVersion = "${{ inputs.version_tag }}".Substring(1)
+          $expectedVersion = $env:VERSION_TAG.Substring(1)
           if ($bundle.version -ne $expectedVersion) {
             throw "Windows RC bundle version does not match workflow input"
           }

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -221,9 +221,11 @@ trusted check completions re-evaluate normally.
 
 While the target enables Cloud, the evidence
 always binds its own exact evidence commit and full source tree. It may cover a
-newer target only when that evidence commit is an ancestor and the complete
-evidence-to-target tree delta consists exclusively of the permitted existing
-non-sensitive `uses:` version changes. Such a change must retain the action
+different commit only when the complete Git tree is byte-identical, as with the
+reviewed activation PR's squash commit. Otherwise, it may cover a newer target
+only when that evidence commit is an ancestor and the complete evidence-to-target
+tree delta consists exclusively of the permitted existing non-sensitive
+`uses:` version changes. Such a change must retain the action
 identity, move forward within the same major release, use full commit SHAs, and
 have both SHAs resolve to their stated canonical `vX.Y.Z` release tags through
 the GitHub API. Workflow additions,
@@ -447,9 +449,11 @@ not run Census or update checks. A pass from a developer build, a different
 commit, or a command restarted after failure is not release evidence.
 
 The checked-out `HEAD` must equal `GITHUB_SHA`; `commit_sha` and `tree_sha` must
-exactly identify the evidence commit and its full Git tree. They may differ
-from the target only through the ancestor-bound safe `uses:` normalization
-described above. Every other earlier evidence is rejected, including for an
+exactly identify the evidence commit and its full Git tree. The evidence commit
+is fetched by exact SHA when it is no longer in the local clone. Evidence may
+differ from the target commit only when the full target tree is identical or
+through the ancestor-bound safe `uses:` normalization described above. Every
+other earlier evidence is rejected, including for an
 apparently metadata-only activation: `nova/version.json` is copied into the App
 and directly controls its Cloud runtime, so evidence from the disabled source
 cannot attest the enabled runtime. The activation PR must reach a stable head,
@@ -463,14 +467,12 @@ non-sensitive `uses:` version changes may reuse evidence from its exact
 ancestor instead. If a merge queue is used, `merge_group` creates another
 synthetic checkout commit and follows the same rule.
 
-After squash merge, the resulting `main` commit has a different SHA. For any
-product or metadata delta, its first push CI run fails closed with the PR
-evidence: run the matrix again on that exact `main` commit, update both the
-repository and production environment secrets, and rerun CI before release
-preparation continues. A squash or merge containing only the verified safe
-`uses:`-version delta may reuse exact ancestor evidence. Every other later
-enabled commit requires fresh evidence. This also closes direct-to-main
-App-source and unknown-path bypasses.
+After squash merge, the resulting `main` commit has a different SHA but may
+reuse the reviewed PR evidence only while its complete Git tree is identical
+to the tested synthetic merge tree. This exact-tree bridge is the sole
+commit-only rewrite exception. Every tree delta still requires fresh evidence,
+except for the narrowly verified ancestor-bound safe `uses:` version changes.
+This also closes direct-to-main App-source and unknown-path bypasses.
 
 `relay_app.source_commit` and `relay_app.source_tree_sha` must repeat the
 top-level identity, and the evidence App version must equal its

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -311,12 +311,132 @@ value attests the complete real-device matrix rather than a unit-test proxy:
 - `signing_and_update_matrix`: stable signing identity plus the complete
   stable/RC/reinstall Keychain authorization matrix.
 
-Run the stress proof from the exact enabled candidate bundle on each selected
-server profile:
+For the first evidence on an activation pull request, dispatch the
+non-publishing candidate builder exactly once from current `main`.
+
+The pull request must be ready, same-repository, current with `main`, and green
+on every protected/advisory check except the expected failing
+`cloud-source-gate`. It must also have a real clean Codex bot result for the
+current head; an advisory gate timeout does not qualify. The workflow resolves
+GitHub's exact synthetic merge commit, uses only trusted build/signing scripts
+from `main`, smokes the exact raw binaries natively on all three platforms,
+then revalidates and creates the hash-bound signed bundles. It verifies the
+binary identity and signed platform/architecture provenance in all five
+archives with the public release key. Raw transport artifacts lack Cloud
+provenance, fail closed, and expire after one day. The final
+`cloud-candidate-install-bundles` artifact is retained for seven days.
+The workflow never creates a deployment, tag, or release. The normal RC and
+release workflows remain evidence-first. In this solo-maintainer repository,
+dispatch by the exact maintainer account is the candidate approval when GitHub
+reports `REVIEW_REQUIRED`; requested changes and unresolved threads still
+block the run.
+
+Dispatch, capture, and monitor that single run:
 
 ```bash
-ha-nova internal-cloud-release-check
-ha-nova internal-cloud-stress --server <name>
+PR_NUMBER=469 # replace
+VERSION_TAG=v0.22.0-rc1 # replace
+REQUEST_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+RUN_NAME="Cloud candidate PR #${PR_NUMBER} ${VERSION_TAG} (${REQUEST_ID})"
+RUN_URL="$(
+  gh workflow run cloud-candidate-bundle.yml --ref main \
+    -f pull_request="${PR_NUMBER}" -f version_tag="${VERSION_TAG}" \
+    -f request_id="${REQUEST_ID}" | tail -n 1
+)"
+RUN_ID="${RUN_URL##*/}"
+if [[ ! "${RUN_ID}" =~ ^[0-9]+$ ]]; then
+  for _ in 1 2 3 4 5 6; do
+    RUN_IDS="$(
+      gh run list --workflow cloud-candidate-bundle.yml --event workflow_dispatch \
+        --branch main --limit 20 --json databaseId,displayTitle \
+        --jq '.[] | [.databaseId, .displayTitle] | @tsv' \
+        | awk -F '\t' -v name="${RUN_NAME}" '$2 == name { print $1 }'
+    )
+    RUN_COUNT="$(awk 'NF { count += 1 } END { print count + 0 }' <<<"${RUN_IDS}")"
+    [[ "${RUN_COUNT}" -gt 1 ]] && {
+      echo "More than one matching run exists; stop." >&2
+      exit 1
+    }
+    [[ "${RUN_COUNT}" -eq 1 ]] && RUN_ID="${RUN_IDS}" && break
+    sleep 5
+  done
+fi
+[[ "${RUN_ID}" =~ ^[0-9]+$ ]] || {
+  echo "Dispatched run not found; do not dispatch again." >&2
+  exit 1
+}
+if ! gh run watch "${RUN_ID}" --exit-status; then
+  gh run view "${RUN_ID}" --log
+  exit 1
+fi
+gh run view "${RUN_ID}" --json url,headSha,status,conclusion
+gh run download "${RUN_ID}" -n cloud-candidate-install-bundles \
+  -D cloud-candidate-install-bundles
+(
+  cd cloud-candidate-install-bundles
+  for checksum in *.sha256; do shasum -a 256 -c "${checksum}"; done
+)
+```
+
+Record the run URL, candidate commit, and tree from the run summary. Download
+the artifact promptly. If the run fails, inspect its logs and fix the cause in
+a reviewed pull request; workflow reruns are rejected, so use one new explicit
+dispatch only after the fix is reviewed.
+
+Run the stress proof from the exact enabled candidate bundle on each selected
+server profile. Never call a `ha-nova` found through `PATH`: extract the
+matching platform archive, verify its bundle identity against the run summary,
+and invoke that contained binary by its explicit path. For macOS or Linux:
+
+```bash
+EXPECTED_TREE=0123456789abcdef0123456789abcdef01234567 # replace
+VERSION_TAG=v0.22.0-rc1 # replace
+CANDIDATE_OS=macos
+CANDIDATE_ARCH=arm64
+SERVER_NAME=default
+CANDIDATE_DIR="$(mktemp -d)"
+tar -xzf "cloud-candidate-install-bundles/ha-nova-installer-bundle-${CANDIDATE_OS}-${CANDIDATE_ARCH}.tar.gz" \
+  -C "${CANDIDATE_DIR}"
+CANDIDATE_BIN="${CANDIDATE_DIR}/ha-nova/ha-nova"
+node - "${CANDIDATE_DIR}/ha-nova/bundle.json" "${VERSION_TAG#v}" "${EXPECTED_TREE}" <<'NODE'
+const fs = require("node:fs");
+const [path, version, tree] = process.argv.slice(2);
+const bundle = JSON.parse(fs.readFileSync(path, "utf8"));
+if (bundle.version !== version || bundle.cloud_release?.source_tree_sha !== tree) {
+  throw new Error("candidate bundle identity does not match the recorded run");
+}
+NODE
+HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" internal-cloud-release-check
+HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" internal-cloud-stress \
+  --server "${SERVER_NAME}"
+```
+
+On the Windows Proxmox test machine, use PowerShell and the contained
+executable explicitly:
+
+```powershell
+$ExpectedTree = "0123456789abcdef0123456789abcdef01234567" # replace
+$Version = "0.22.0-rc1" # replace
+$ServerName = "default"
+$CandidateDir = Join-Path $env:TEMP ("ha-nova-cloud-candidate-" + [guid]::NewGuid())
+Expand-Archive `
+  -LiteralPath "cloud-candidate-install-bundles\ha-nova-installer-bundle-windows-amd64.zip" `
+  -DestinationPath $CandidateDir
+$CandidateRoot = Join-Path $CandidateDir "ha-nova"
+$Bundle = Get-Content (Join-Path $CandidateRoot "bundle.json") -Raw |
+  ConvertFrom-Json
+if (
+  $Bundle.version -ne $Version -or
+  $Bundle.cloud_release.source_tree_sha -ne $ExpectedTree
+) {
+  throw "candidate bundle identity does not match the recorded run"
+}
+$CandidateBin = Join-Path $CandidateRoot "ha-nova.exe"
+$env:HA_NOVA_NO_CENSUS = "1"
+& $CandidateBin internal-cloud-release-check
+if ($LASTEXITCODE -ne 0) { throw "candidate provenance check failed" }
+& $CandidateBin internal-cloud-stress --server $ServerName
+if ($LASTEXITCODE -ne 0) { throw "candidate Cloud stress proof failed" }
 ```
 
 `internal-cloud-stress` resolves Cloud once and sends exactly 10,000 read-only

--- a/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
+++ b/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
@@ -1,0 +1,64 @@
+# Cloud Candidate Bootstrap
+
+Status: implemented; awaiting GitHub review.
+
+## Problem
+
+Cloud activation requires real-device evidence from an official bundle bound
+to the exact pull-request merge commit. The existing Release Candidate
+workflow verifies that evidence before it builds official bundles, so it
+cannot produce the first candidate needed to collect the evidence.
+
+## Required behavior
+
+- Add one manually dispatched workflow that builds but never publishes.
+- Run the workflow only from the current `main` branch.
+- Accept one open same-repository pull request targeting the current `main`.
+- Resolve and bind GitHub's exact synthetic pull-request merge commit, tree,
+  base parent, and head parent.
+- Require every current protected check except `cloud-source-gate` to pass.
+  That one check is expected to fail until this candidate produces evidence.
+- Require a real clean Codex bot result bound to the current pull-request head;
+  an advisory workflow timeout is insufficient. Reject requested changes,
+  unresolved threads, and later Codex findings.
+- Re-run the trusted source policy without external evidence and accept only
+  the expected evidence-pending state.
+- Use trusted build and signing scripts from `main`; treat the candidate
+  checkout only as source and bundle data.
+- Build official-tag Linux, Windows, and signed macOS binaries, then sign
+  exact-tree install-bundle provenance with protected production secrets.
+- Smoke the exact raw binaries natively on Linux, macOS, and Windows before
+  provenance signing; raw binaries must reject missing Cloud provenance.
+- After all native smokes, revalidate the complete reviewed state, build the
+  final hash-bound signed bundles, verify every archive's binary identity and
+  signed platform/architecture provenance, then revalidate again immediately
+  before upload.
+- Serialize duplicate dispatches for one pull request.
+- Retain Cloud-ineligible raw transport artifacts for one day and final
+  candidate bundles for seven days.
+- Never create or move a tag, release, draft release, deployment, or public
+  asset.
+- Expose no Cloud-runnable bundle before smoke tests and final revalidation.
+- Never execute candidate code in an artifact-producing or secret-bearing job;
+  the first positive signed-runtime check uses the downloaded final artifact
+  in the real-device matrix.
+- Fail closed on a moved pull request, stale base, missing merge ref, source
+  mismatch, failed check, invalid version, or missing signing secret.
+
+## KISS boundary
+
+Reuse the existing RC binary, Darwin signing, bundle, provenance, and smoke
+contracts. Add no service, persistent state, retry loop, release mode, or
+automatic dispatch. One explicit run creates one immutable candidate.
+
+## Acceptance
+
+- Static contracts reject publication commands and untrusted script execution.
+- Resolver tests cover valid source selection plus repository, branch, base,
+  merge-ref, parent, and check failures.
+- Existing release workflows retain their evidence-first publication gate.
+- The explicit dispatch by the exact maintainer account is the solo-project
+  approval when GitHub reports `REVIEW_REQUIRED`; requested changes and
+  unresolved threads still fail closed.
+- The complete local release-contract suite passes before one reviewed
+  bootstrap workflow run is allowed.

--- a/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
+++ b/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
@@ -44,6 +44,8 @@ cannot produce the first candidate needed to collect the evidence.
   in the real-device matrix.
 - Fail closed on a moved pull request, stale base, missing merge ref, source
   mismatch, failed check, invalid version, or missing signing secret.
+- Preserve evidence across the required squash merge only when the resulting
+  full Git tree is identical to the tested synthetic merge tree.
 
 ## KISS boundary
 

--- a/scripts/release/build-install-bundle.sh
+++ b/scripts/release/build-install-bundle.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TRUSTED_ROOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT_DIR="$(cd -- "${HA_NOVA_SOURCE_ROOT:-${TRUSTED_ROOT}}" && pwd)"
 DIST_DIR="${DIST_DIR:-${ROOT_DIR}/dist}"
 OUTPUT_DIR="${DIST_DIR}/install-bundles"
 VERSION="${1:-$(sed -n 's/.*"skill_version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${ROOT_DIR}/version.json" | head -1)}"
@@ -93,7 +94,7 @@ write_bundle_metadata() {
   local evidence_json="null"
   if [[ "${CLOUD_REMOTE_ENABLED}" == "true" ]]; then
     evidence_json="$(
-      node "${ROOT_DIR}/scripts/release/sign-cloud-release-evidence.mjs" \
+      node "${TRUSTED_ROOT}/scripts/release/sign-cloud-release-evidence.mjs" \
         "${VERSION}" "${os_name}" "${arch_name}" "${binary_name}" \
         "${bundle_root}/${binary_name}" "${SOURCE_TREE_SHA}" \
         "${CLOUD_REMOTE_PLATFORMS}"

--- a/scripts/release/build-rc-binaries.sh
+++ b/scripts/release/build-rc-binaries.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TRUSTED_ROOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT_DIR="$(cd -- "${HA_NOVA_SOURCE_ROOT:-${TRUSTED_ROOT}}" && pwd)"
 DIST_DIR="${DIST_DIR:-${ROOT_DIR}/dist}"
 RAW_TAG="${1:-}"
 

--- a/scripts/release/build-sign-darwin-binaries.sh
+++ b/scripts/release/build-sign-darwin-binaries.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 umask 077
 
-ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TRUSTED_ROOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT_DIR="$(cd -- "${HA_NOVA_SOURCE_ROOT:-${TRUSTED_ROOT}}" && pwd)"
 DIST_DIR="${DIST_DIR:-${ROOT_DIR}/dist}"
 RAW_TAG="${1:-}"
 EXPECTED_IDENTITY="Developer ID Application: Markus Leben (CTF9J94274)"
@@ -91,7 +92,7 @@ for arch in amd64 arm64; do
     --options runtime,hard,kill,library \
     --identifier "${SIGNING_IDENTIFIER}" \
     "${output}"
-  bash "${ROOT_DIR}/scripts/release/verify-macos-signature.sh" "${output}"
+  bash "${TRUSTED_ROOT}/scripts/release/verify-macos-signature.sh" "${output}"
 done
 
 echo "[build-sign-darwin-binaries] Signed Darwin binaries ready for v${version}"

--- a/scripts/release/resolve-cloud-candidate-source.sh
+++ b/scripts/release/resolve-cloud-candidate-source.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-}"
+PR_NUMBER="${1:-}"
+POLICY_FILE="${2:-.github/policy/repo-policy.json}"
+
+fail() {
+  echo "[resolve-cloud-candidate-source] ERROR: $*" >&2
+  exit 1
+}
+
+require_sha() {
+  [[ "$1" =~ ^[0-9a-f]{40}$ ]] || fail "$2 must be a full lowercase SHA-1"
+}
+
+resolve_remote_sha() {
+  local ref="$1" label="$2" remote_line remote_sha remote_name extra
+  remote_line="$(git ls-remote --refs origin "${ref}")"
+  [[ -n "${remote_line}" && "${remote_line}" != *$'\n'* ]] \
+    || fail "${label} must resolve exactly once"
+  read -r remote_sha remote_name extra <<<"${remote_line}"
+  require_sha "${remote_sha:-}" "${label} SHA"
+  [[ "${remote_name:-}" == "${ref}" && -z "${extra:-}" ]] \
+    || fail "${label} response is invalid"
+  printf '%s\n' "${remote_sha}"
+}
+
+[[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]] \
+  || fail "candidate builds require workflow_dispatch"
+[[ "${GITHUB_REF:-}" == "refs/heads/main" ]] \
+  || fail "candidate builds must run from main"
+[[ "${REPO}" == "markusleben/ha-nova" ]] \
+  || fail "candidate builds are pinned to markusleben/ha-nova"
+[[ "${GITHUB_ACTOR:-}" == "markusleben" \
+  && "${GITHUB_ACTOR_ID:-}" == "6522814" ]] \
+  || fail "candidate dispatch requires the exact maintainer identity"
+[[ "${GITHUB_TRIGGERING_ACTOR:-}" == "markusleben" \
+  && "${GITHUB_RUN_ATTEMPT:-}" == "1" ]] \
+  || fail "candidate builds cannot be rerun or triggered by another account"
+require_sha "${GITHUB_SHA:-}" "GITHUB_SHA"
+trusted_head="$(git rev-parse --verify HEAD)"
+require_sha "${trusted_head}" "trusted checkout HEAD"
+[[ "${trusted_head}" == "${GITHUB_SHA}" ]] \
+  || fail "trusted checkout must equal the main workflow SHA"
+[[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]] \
+  || fail "pull request number must be a positive integer"
+[[ -f "${POLICY_FILE}" ]] || fail "repository policy is missing"
+[[ -n "${GITHUB_OUTPUT:-}" ]] || fail "GITHUB_OUTPUT is required"
+command -v gh >/dev/null 2>&1 || fail "gh is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+pr="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
+jq -e '
+  type == "object"
+  and .state == "open"
+  and .draft == false
+  and .base.ref == "main"
+  and .base.repo.full_name == "markusleben/ha-nova"
+  and .head.repo.full_name == "markusleben/ha-nova"
+' >/dev/null <<<"${pr}" \
+  || fail "pull request must be open, ready, same-repository, and target main"
+
+base_sha="$(jq -r '.base.sha' <<<"${pr}")"
+head_sha="$(jq -r '.head.sha' <<<"${pr}")"
+merge_sha="$(jq -r '.merge_commit_sha // empty' <<<"${pr}")"
+require_sha "${base_sha}" "pull request base SHA"
+require_sha "${head_sha}" "pull request head SHA"
+require_sha "${merge_sha}" "pull request merge commit SHA"
+[[ "${base_sha}" == "${GITHUB_SHA}" ]] \
+  || fail "pull request base must equal the current main workflow SHA"
+
+source_ref="refs/pull/${PR_NUMBER}/merge"
+remote_main_sha="$(resolve_remote_sha refs/heads/main "remote main")"
+[[ "${remote_main_sha}" == "${GITHUB_SHA}" ]] \
+  || fail "workflow SHA is no longer current main"
+
+remote_sha="$(resolve_remote_sha "${source_ref}" "pull request merge ref")"
+[[ "${remote_sha}" == "${merge_sha}" ]] \
+  || fail "pull request API and merge ref disagree"
+
+commit="$(gh api "repos/${REPO}/git/commits/${merge_sha}")"
+tree_sha="$(jq -r '.tree.sha' <<<"${commit}")"
+require_sha "${tree_sha}" "pull request merge tree SHA"
+jq -e \
+  --arg merge "${merge_sha}" \
+  --arg base "${base_sha}" \
+  --arg head "${head_sha}" '
+    .sha == $merge
+    and (.parents | type == "array" and length == 2)
+    and .parents[0].sha == $base
+    and .parents[1].sha == $head
+  ' >/dev/null <<<"${commit}" \
+  || fail "pull request merge commit does not bind the current base and head"
+
+check_pages="$(
+  gh api --paginate --slurp \
+    "repos/${REPO}/commits/${merge_sha}/check-runs?filter=latest&per_page=100"
+)"
+checks="$(jq -c '[.[].check_runs[]]' <<<"${check_pages}")"
+
+while IFS= read -r check_name; do
+  [[ -n "${check_name}" ]] || continue
+  jq -e --arg name "${check_name}" '
+    [ .[] | select(.name == $name) ] as $matches
+    | ($matches | length) > 0
+      and all($matches[]; .status == "completed" and .conclusion == "success")
+  ' >/dev/null <<<"${checks}" \
+    || fail "required pre-evidence check ${check_name} is not successful"
+done < <(
+  jq -r '
+    .main_branch_protection
+    | ((.required_status_checks - ["cloud-source-gate"]) + .advisory_checks)
+    | unique[]
+  ' "${POLICY_FILE}"
+)
+
+issue_comment_pages="$(
+  gh api --paginate --slurp \
+    "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100"
+)"
+review_pages="$(
+  gh api --paginate --slurp \
+    "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100"
+)"
+inline_comment_pages="$(
+  gh api --paginate --slurp \
+    "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100"
+)"
+reaction_pages="$(
+  gh api --paginate --slurp \
+    "repos/${REPO}/issues/${PR_NUMBER}/reactions?per_page=100"
+)"
+thread_pages="$(
+  gh api graphql --paginate --slurp \
+    -f owner=markusleben \
+    -f repo=ha-nova \
+    -F number="${PR_NUMBER}" \
+    -f query='
+      query($owner: String!, $repo: String!, $number: Int!, $endCursor: String) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviewDecision
+            reviewThreads(first: 100, after: $endCursor) {
+              nodes { isResolved }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }
+      }
+    '
+)"
+head_prefix="${head_sha:0:10}"
+clean_at="$(
+  jq -r --arg prefix "${head_prefix}" '
+    [ .[][]
+      | select(
+          .user.login == "chatgpt-codex-connector[bot]"
+          and .user.id == 199175422
+          and .user.type == "Bot"
+          and (.body | contains("Codex Review: Didn\u0027t find any major issues"))
+          and (.body | contains("**Reviewed commit:** `" + $prefix + "`"))
+        )
+      | .created_at
+    ]
+    | sort
+    | last // empty
+  ' <<<"${issue_comment_pages}"
+)"
+[[ "${clean_at}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]] \
+  || fail "current pull request head lacks a real clean Codex bot result"
+jq -e '
+  length > 0
+  and all(.[];
+    .data.repository.pullRequest != null
+    and (
+      .data.repository.pullRequest.reviewDecision == "APPROVED"
+      or .data.repository.pullRequest.reviewDecision == "REVIEW_REQUIRED"
+      or .data.repository.pullRequest.reviewDecision == null
+    )
+    and all(
+      .data.repository.pullRequest.reviewThreads.nodes[];
+      .isResolved == true
+    )
+  )
+' >/dev/null <<<"${thread_pages}" \
+  || fail "pull request has requested changes or unresolved review threads"
+jq -e --arg clean_at "${clean_at}" --arg head "${head_sha}" '
+  all(
+    [ .[][]
+      | select(
+          .user.login == "chatgpt-codex-connector[bot]"
+          and .user.id == 199175422
+          and .user.type == "Bot"
+        )
+    ][];
+    (.commit_id != $head) or (.submitted_at <= $clean_at)
+  )
+' >/dev/null <<<"${review_pages}" \
+  || fail "a later Codex review supersedes the clean result"
+jq -e --arg clean_at "${clean_at}" --arg head "${head_sha}" '
+  all(
+    [ .[][]
+      | select(
+          .user.login == "chatgpt-codex-connector[bot]"
+          and .user.id == 199175422
+          and .user.type == "Bot"
+        )
+    ][];
+    (.commit_id != $head) or (.created_at <= $clean_at)
+  )
+' >/dev/null <<<"${inline_comment_pages}" \
+  || fail "a later Codex inline finding supersedes the clean result"
+jq -e --arg clean_at "${clean_at}" --arg prefix "${head_prefix}" '
+  all(
+    [ .[][]
+      | select(
+          .user.login == "chatgpt-codex-connector[bot]"
+          and .user.id == 199175422
+          and .user.type == "Bot"
+        )
+    ][];
+    (.created_at <= $clean_at)
+    or (
+      (.body | contains("Codex Review: Didn\u0027t find any major issues"))
+      and (.body | contains("**Reviewed commit:** `" + $prefix + "`"))
+    )
+  )
+' >/dev/null <<<"${issue_comment_pages}" \
+  || fail "a later Codex issue result supersedes the clean result"
+jq -e --arg clean_at "${clean_at}" '
+  all(
+    [ .[][]
+      | select(
+          .user.login == "chatgpt-codex-connector[bot]"
+          and .user.id == 199175422
+          and .user.type == "User"
+        )
+    ][];
+    (.created_at <= $clean_at) or .content == "+1"
+  )
+' >/dev/null <<<"${reaction_pages}" \
+  || fail "a later Codex reaction supersedes the clean result"
+
+source_app_id="$(
+  jq -r '.main_branch_protection.required_status_check_apps["cloud-source-gate"]' \
+    "${POLICY_FILE}"
+)"
+[[ "${source_app_id}" =~ ^[1-9][0-9]*$ ]] \
+  || fail "cloud-source-gate App ID is not provisioned"
+jq -e --argjson app_id "${source_app_id}" '
+  [ .[]
+    | select(.name == "cloud-source-gate" and .app.id == $app_id)
+  ] as $matches
+  | ($matches | length) > 0
+    and all($matches[]; .status == "completed" and .conclusion == "failure")
+' >/dev/null <<<"${checks}" \
+  || fail "cloud-source-gate must be the sole expected failed evidence check"
+
+HA_NOVA_CLOUD_GATE_SOURCE_REF="${source_ref}" \
+HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT="${merge_sha}" \
+HA_NOVA_CLOUD_GATE_EXPECTED_HEAD_COMMIT="${head_sha}" \
+HA_NOVA_CLOUD_GATE_EXPECTED_BASE_COMMIT="${base_sha}" \
+  bash scripts/release/verify-cloud-target-source-gate.sh candidate
+
+latest_pr="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
+jq -e \
+  --arg base "${base_sha}" \
+  --arg head "${head_sha}" \
+  --arg merge "${merge_sha}" '
+    .state == "open"
+    and .draft == false
+    and .base.sha == $base
+    and .head.sha == $head
+    and .merge_commit_sha == $merge
+  ' >/dev/null <<<"${latest_pr}" \
+  || fail "pull request changed while candidate source was resolved"
+[[ "$(resolve_remote_sha refs/heads/main "final remote main")" == "${base_sha}" ]] \
+  || fail "main changed while candidate source was resolved"
+[[ "$(resolve_remote_sha "${source_ref}" "final pull request merge ref")" == "${merge_sha}" ]] \
+  || fail "pull request merge ref changed while candidate source was resolved"
+
+expected_commit="${HA_NOVA_CLOUD_CANDIDATE_EXPECTED_COMMIT:-}"
+expected_tree="${HA_NOVA_CLOUD_CANDIDATE_EXPECTED_TREE:-}"
+expected_base="${HA_NOVA_CLOUD_CANDIDATE_EXPECTED_BASE:-}"
+expected_head="${HA_NOVA_CLOUD_CANDIDATE_EXPECTED_HEAD:-}"
+if [[ -n "${expected_commit}${expected_tree}${expected_base}${expected_head}" ]]; then
+  [[ -n "${expected_commit}" && -n "${expected_tree}" \
+    && -n "${expected_base}" && -n "${expected_head}" ]] \
+    || fail "expected candidate identity must be provided completely"
+  require_sha "${expected_commit}" "expected candidate commit"
+  require_sha "${expected_tree}" "expected candidate tree"
+  require_sha "${expected_base}" "expected candidate base"
+  require_sha "${expected_head}" "expected candidate head"
+  [[ "${merge_sha}" == "${expected_commit}" \
+    && "${tree_sha}" == "${expected_tree}" \
+    && "${base_sha}" == "${expected_base}" \
+    && "${head_sha}" == "${expected_head}" ]] \
+    || fail "candidate identity changed since the initial resolution"
+fi
+
+{
+  printf 'commit_sha=%s\n' "${merge_sha}"
+  printf 'tree_sha=%s\n' "${tree_sha}"
+  printf 'base_sha=%s\n' "${base_sha}"
+  printf 'head_sha=%s\n' "${head_sha}"
+} >>"${GITHUB_OUTPUT}"
+
+echo "[resolve-cloud-candidate-source] OK: PR #${PR_NUMBER} -> ${merge_sha}"

--- a/scripts/release/resolve-cloud-candidate-source.sh
+++ b/scripts/release/resolve-cloud-candidate-source.sh
@@ -234,7 +234,7 @@ jq -e --arg clean_at "${clean_at}" '
       | select(
           .user.login == "chatgpt-codex-connector[bot]"
           and .user.id == 199175422
-          and .user.type == "User"
+          and (.user.type == "User" or .user.type == "Bot")
         )
     ][];
     (.created_at <= $clean_at) or .content == "+1"

--- a/scripts/release/verify-cloud-action-pins.mjs
+++ b/scripts/release/verify-cloud-action-pins.mjs
@@ -45,6 +45,7 @@ function sensitiveJobIDs(workflowPath, jobs) {
       return new Set(["disposable-ha"]);
     case "release.yml":
     case "release-candidate.yml":
+    case "cloud-candidate-bundle.yml":
       return new Set(jobs.map((job) => job.id));
     default:
       fail(workflowPath, "is not a recognized Cloud-sensitive workflow");

--- a/scripts/release/verify-cloud-candidate-workflow.mjs
+++ b/scripts/release/verify-cloud-candidate-workflow.mjs
@@ -241,7 +241,7 @@ for (const marker of [
   '.user.login == "chatgpt-codex-connector[bot]"',
   ".user.id == 199175422",
   '.user.type == "Bot"',
-  '.user.type == "User"',
+  '(.user.type == "User" or .user.type == "Bot")',
   "pull request has requested changes or unresolved review threads",
   "a later Codex inline finding supersedes the clean result",
   '**Reviewed commit:** `" + $prefix + "`',

--- a/scripts/release/verify-cloud-candidate-workflow.mjs
+++ b/scripts/release/verify-cloud-candidate-workflow.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { workflowSyntaxProblem } from "./verify-cloud-workflow-syntax.mjs";
+
+const [workflowPath, resolverPath] = process.argv.slice(2);
+
+function fail(message) {
+  console.error(`[verify-cloud-candidate-workflow] ERROR: ${message}`);
+  process.exit(1);
+}
+
+function read(path) {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    fail(`${basename(path ?? "")} must exist and be readable`);
+  }
+}
+
+function requireText(source, text, label) {
+  if (!source.includes(text)) {
+    fail(`${label} is missing`);
+  }
+}
+
+function requireCount(source, text, expected, label) {
+  const actual = source.split(text).length - 1;
+  if (actual !== expected) {
+    fail(`${label} must occur exactly ${expected} time(s), found ${actual}`);
+  }
+}
+
+function jobBody(source, name, nextName) {
+  const start = source.indexOf(`  ${name}:`);
+  const end = nextName === undefined
+    ? source.length
+    : source.indexOf(`  ${nextName}:`, start + 1);
+  if (start < 0 || end < 0) {
+    fail(`workflow job ${name} is missing`);
+  }
+  return source.slice(start, end);
+}
+
+function runBodies(source) {
+  const lines = source.split(/\r?\n/);
+  const bodies = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = /^(\s*)run:\s*(.*)$/.exec(lines[index]);
+    if (match === null) continue;
+    const indent = match[1].length;
+    const body = [match[2]];
+    while (index + 1 < lines.length) {
+      const next = lines[index + 1];
+      if (next.trim() !== "" && next.length - next.trimStart().length <= indent) {
+        break;
+      }
+      body.push(next);
+      index += 1;
+    }
+    bodies.push(body.join("\n"));
+  }
+  return bodies;
+}
+
+if (!workflowPath || !resolverPath) {
+  fail("workflow and resolver paths are required");
+}
+const workflow = read(workflowPath);
+const resolver = read(resolverPath);
+const syntaxProblem = workflowSyntaxProblem(workflow.split(/\r?\n/));
+if (syntaxProblem !== null) {
+  fail(`${basename(workflowPath)} ${syntaxProblem}`);
+}
+
+requireText(workflow, "name: Cloud Candidate Bundle", "workflow name");
+requireText(
+  workflow,
+  "on:\n  workflow_dispatch:\n    inputs:",
+  "manual-only trigger",
+);
+requireText(workflow, "pull_request:", "pull request input");
+requireText(workflow, "version_tag:", "version input");
+requireText(workflow, "request_id:", "dispatch recovery input");
+requireText(
+  workflow,
+  "run-name: Cloud candidate PR #${{ inputs.pull_request }} ${{ inputs.version_tag }} (${{ inputs.request_id }})",
+  "unique recoverable run name",
+);
+requireText(
+  workflow,
+  "group: cloud-candidate-bundle-${{ inputs.pull_request }}",
+  "per-pull-request concurrency",
+);
+requireText(workflow, "cancel-in-progress: true", "duplicate-run cancellation");
+requireText(
+  workflow,
+  "ref: ${{ steps.source.outputs.commit_sha }}",
+  "exact resolved candidate checkout",
+);
+requireText(
+  workflow,
+  "ref: ${{ needs.resolve-source.outputs.commit_sha }}",
+  "downstream exact candidate checkout",
+);
+requireText(
+  workflow,
+  "bash trusted/scripts/release/build-rc-binaries.sh",
+  "trusted Linux and Windows builder",
+);
+requireText(
+  workflow,
+  "bash trusted/scripts/release/build-sign-darwin-binaries.sh",
+  "trusted Darwin builder",
+);
+requireText(
+  workflow,
+  "bash scripts/release/build-install-bundle.sh",
+  "trusted bundle builder",
+);
+requireText(
+  workflow,
+  "internal-cloud-release-check",
+  "official provenance smoke",
+);
+requireText(
+  workflow,
+  "verify-cloud-release-evidence.mjs",
+  "public-key verification for every signed archive",
+);
+requireText(
+  workflow,
+  "candidate bundle version does not match workflow input",
+  "Unix bundle-version assertion",
+);
+requireText(
+  workflow,
+  "Raw Windows binary accepted missing Cloud provenance",
+  "Windows raw-binary provenance rejection",
+);
+requireCount(
+  workflow,
+  'chmod 755 "$binary"',
+  2,
+  "restored Unix executable mode after artifact transport",
+);
+requireCount(
+  workflow,
+  "scripts/release/resolve-cloud-candidate-source.sh",
+  4,
+  "final complete-state revalidation",
+);
+requireText(
+  workflow,
+  "name: cloud-candidate-raw-binaries",
+  "raw-binary transport artifact",
+);
+requireText(
+  workflow,
+  "name: cloud-candidate-install-bundles",
+  "final smoke-tested artifact",
+);
+requireCount(
+  workflow,
+  "environment:\n      name: production\n      deployment: false",
+  2,
+  "non-deploying production environment binding",
+);
+requireCount(
+  workflow,
+  "secrets.HA_NOVA_MACOS_CERTIFICATE_P12_BASE64",
+  1,
+  "macOS certificate binding",
+);
+requireCount(
+  workflow,
+  "secrets.HA_NOVA_MACOS_CERTIFICATE_PASSWORD",
+  1,
+  "macOS certificate password binding",
+);
+requireCount(
+  workflow,
+  "secrets.HA_NOVA_CLOUD_RELEASE_SIGNING_KEY_PEM",
+  1,
+  "Cloud provenance signing-key binding",
+);
+requireCount(workflow, "retention-days: 1", 2, "one-day raw artifact retention");
+requireCount(workflow, "retention-days: 7", 1, "seven-day final artifact retention");
+if (workflow.includes("cloud-candidate-install-bundles-staging")) {
+  fail("signed candidate bundles must not be uploaded before final validation");
+}
+for (const [name, nextName] of [
+  ["build-signed-darwin", "build-raw-binaries"],
+  ["build-raw-binaries", "smoke-darwin-binary"],
+  ["finalize-candidate", undefined],
+]) {
+  if (jobBody(workflow, name, nextName).includes("internal-cloud-release-check")) {
+    fail(`artifact producer ${name} must not execute candidate binaries`);
+  }
+}
+
+if (runBodies(workflow).some((body) => body.includes("${{ inputs."))) {
+  fail("workflow_dispatch inputs must reach run scripts only through env");
+}
+
+for (const forbidden of [
+  /\bgh\s+release\b/i,
+  /\bgit\s+tag\b/i,
+  /\brelease\.yml\b/,
+  /HA_NOVA_CLOUD_GATE_EVIDENCE_JSON/,
+  /(?:bash|node|\.)\s+["']?(?:\$GITHUB_WORKSPACE\/)?target\//,
+]) {
+  if (forbidden.test(workflow)) {
+    fail(
+      `workflow contains forbidden publication or target-script path: ${forbidden}`,
+    );
+  }
+}
+
+for (const marker of [
+  '[[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]',
+  '[[ "${GITHUB_REF:-}" == "refs/heads/main" ]]',
+  '[[ "${REPO}" == "markusleben/ha-nova" ]]',
+  '[[ "${GITHUB_ACTOR:-}" == "markusleben"',
+  '"${GITHUB_ACTOR_ID:-}" == "6522814"',
+  '[[ "${GITHUB_TRIGGERING_ACTOR:-}" == "markusleben"',
+  '"${GITHUB_RUN_ATTEMPT:-}" == "1"',
+  '[[ "${trusted_head}" == "${GITHUB_SHA}" ]]',
+  ".draft == false",
+  '.base.ref == "main"',
+  '.head.repo.full_name == "markusleben/ha-nova"',
+  '[[ "${base_sha}" == "${GITHUB_SHA}" ]]',
+  '[[ "${remote_main_sha}" == "${GITHUB_SHA}" ]]',
+  'source_ref="refs/pull/${PR_NUMBER}/merge"',
+  '[[ "${remote_sha}" == "${merge_sha}" ]]',
+  ".parents[0].sha == $base",
+  ".parents[1].sha == $head",
+  '.required_status_checks - ["cloud-source-gate"]',
+  "current pull request head lacks a real clean Codex bot result",
+  '.user.login == "chatgpt-codex-connector[bot]"',
+  ".user.id == 199175422",
+  '.user.type == "Bot"',
+  '.user.type == "User"',
+  "pull request has requested changes or unresolved review threads",
+  "a later Codex inline finding supersedes the clean result",
+  '**Reviewed commit:** `" + $prefix + "`',
+  '.name == "cloud-source-gate" and .app.id == $app_id',
+  '.conclusion == "failure"',
+  "bash scripts/release/verify-cloud-target-source-gate.sh candidate",
+  "pull request changed while candidate source was resolved",
+  "final pull request merge ref",
+]) {
+  requireText(resolver, marker, `resolver guard ${marker}`);
+}
+
+console.log(
+  "[verify-cloud-candidate-workflow] OK: exact reviewed source -> native raw-binary smoke -> final signed bundles -> complete-state check; no publication",
+);

--- a/scripts/release/verify-cloud-publication-main-protection.sh
+++ b/scripts/release/verify-cloud-publication-main-protection.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TRUSTED_ROOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_ROOT="$(cd -- "${HA_NOVA_SOURCE_ROOT:-${TRUSTED_ROOT}}" && pwd)"
 TOKEN_OUTPUT=""
 
 fail() {
@@ -23,7 +24,7 @@ cloud_enabled="$(
     ).cloud_remote_enabled;
     if (typeof value !== "boolean") process.exit(2);
     process.stdout.write(String(value));
-  ' "${ROOT_DIR}/version.json"
+  ' "${SOURCE_ROOT}/version.json"
 )" || fail "version.json cloud_remote_enabled must be a boolean"
 
 if [[ "${cloud_enabled}" == "false" ]]; then
@@ -47,7 +48,7 @@ expected_app_id="$(
     ).cloud_source_gate?.reporter_app_id;
     if (!Number.isSafeInteger(value) || value <= 0) process.exit(2);
     process.stdout.write(String(value));
-  ' "${ROOT_DIR}/.github/policy/repo-policy.json"
+  ' "${TRUSTED_ROOT}/.github/policy/repo-policy.json"
 )" || fail "enabled Cloud publication requires a provisioned source-check App policy"
 [[ "${HA_NOVA_CLOUD_SOURCE_CHECK_APP_ID}" == "${expected_app_id}" ]] \
   || fail "source-check App secret does not match the exact policy App ID"
@@ -55,12 +56,12 @@ expected_app_id="$(
 TOKEN_OUTPUT="$(mktemp)"
 GITHUB_OUTPUT="${TOKEN_OUTPUT}" \
 HA_NOVA_CLOUD_SOURCE_CHECK_TOKEN_MODE="administration-read" \
-  node "${ROOT_DIR}/scripts/release/create-cloud-source-check-token.mjs"
+  node "${TRUSTED_ROOT}/scripts/release/create-cloud-source-check-token.mjs"
 
 token="$(sed -n 's/^token=//p' "${TOKEN_OUTPUT}")"
 [[ "${token}" != *$'\n'* && "${#token}" -ge 20 ]] \
   || fail "dedicated administration-read installation token is invalid"
 
 GH_TOKEN="${token}" \
-  bash "${ROOT_DIR}/scripts/release/verify-github-main-protection.sh" \
+  bash "${TRUSTED_ROOT}/scripts/release/verify-github-main-protection.sh" \
     "${GITHUB_REPOSITORY}" main

--- a/scripts/release/verify-cloud-release-evidence.mjs
+++ b/scripts/release/verify-cloud-release-evidence.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import {
+  createHash,
+  createPublicKey,
+  verify,
+} from "node:crypto";
+import { readFileSync } from "node:fs";
+
+const [
+  bundlePath,
+  binaryPath,
+  version,
+  os,
+  arch,
+  binaryName,
+  sourceTreeSHA,
+  platformList,
+] = process.argv.slice(2);
+
+function fail(message) {
+  console.error(`[verify-cloud-release-evidence] ERROR: ${message}`);
+  process.exit(1);
+}
+
+let bundle;
+try {
+  bundle = JSON.parse(readFileSync(bundlePath, "utf8"));
+} catch {
+  fail("bundle metadata must be readable JSON");
+}
+const platforms = (platformList ?? "").split(",").filter(Boolean);
+const evidence = bundle?.cloud_release;
+if (
+  bundle?.bundle_format_version !== 1 ||
+  bundle.version !== version ||
+  bundle.os !== os ||
+  bundle.arch !== arch ||
+  bundle.binary_name !== binaryName ||
+  evidence?.schema !== 1 ||
+  evidence.source_tree_sha !== sourceTreeSHA ||
+  platforms.length === 0
+) {
+  fail("bundle identity or Cloud release evidence does not match");
+}
+
+const binarySHA256 = createHash("sha256")
+  .update(readFileSync(binaryPath))
+  .digest("hex");
+if (evidence.binary_sha256 !== binarySHA256) {
+  fail("bundle evidence does not match the candidate binary");
+}
+
+let signature;
+try {
+  signature = Buffer.from(evidence.signature, "base64");
+} catch {
+  fail("bundle evidence signature is not valid base64");
+}
+if (
+  signature.length !== 64 ||
+  signature.toString("base64") !== evidence.signature
+) {
+  fail("bundle evidence signature is not canonical Ed25519");
+}
+
+const payload = {
+  schema: evidence.schema,
+  version,
+  os,
+  arch,
+  binary_name: binaryName,
+  binary_sha256: binarySHA256,
+  source_tree_sha: sourceTreeSHA,
+  platforms,
+};
+const publicKey = createPublicKey({
+  key: {
+    kty: "OKP",
+    crv: "Ed25519",
+    x: "hzgQeiYLwpJdgL52IfcsIzTfCstcfqbRuoyWmmPkwrQ",
+  },
+  format: "jwk",
+});
+if (
+  !verify(
+    null,
+    Buffer.from(JSON.stringify(payload)),
+    publicKey,
+    signature,
+  )
+) {
+  fail("bundle evidence signature is invalid");
+}
+
+console.log(
+  `[verify-cloud-release-evidence] OK: ${os}/${arch} ${binarySHA256}`,
+);

--- a/scripts/release/verify-cloud-release-gate.sh
+++ b/scripts/release/verify-cloud-release-gate.sh
@@ -190,6 +190,36 @@ function validateEvidenceIdentity(evidence, target) {
         stdio: ["ignore", "pipe", "ignore"],
       },
     ).trim();
+  } catch {
+    try {
+      execFileSync(
+        "git",
+        [
+          "fetch",
+          "--no-tags",
+          "--depth=1",
+          "origin",
+          evidence.commit_sha,
+        ],
+        {
+          cwd: trustedRepoRoot,
+          stdio: ["ignore", "ignore", "ignore"],
+        },
+      );
+      evidenceCommitTree = execFileSync(
+        "git",
+        ["rev-parse", "--verify", `${evidence.commit_sha}^{tree}`],
+        {
+          cwd: trustedRepoRoot,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        },
+      ).trim();
+    } catch {
+      fail("Home Assistant Cloud evidence commit must exist in the repository");
+    }
+  }
+  try {
     targetCommitTree = execFileSync(
       "git",
       ["rev-parse", "--verify", `${target.commit}^{tree}`],
@@ -200,7 +230,7 @@ function validateEvidenceIdentity(evidence, target) {
       },
     ).trim();
   } catch {
-    fail("Home Assistant Cloud evidence and target commits must exist locally");
+    fail("Home Assistant Cloud target commit must exist locally");
   }
   if (evidenceCommitTree !== evidence.tree_sha) {
     fail(
@@ -210,10 +240,7 @@ function validateEvidenceIdentity(evidence, target) {
   if (targetCommitTree !== target.tree) {
     fail("Home Assistant Cloud gate target tree must match its target commit");
   }
-  if (
-    evidence.tree_sha === target.tree &&
-    evidence.commit_sha === target.commit
-  ) {
+  if (evidence.tree_sha === target.tree) {
     return;
   }
   try {

--- a/scripts/release/verify-cloud-release-gate.sh
+++ b/scripts/release/verify-cloud-release-gate.sh
@@ -7,13 +7,15 @@ if [[ "$#" -gt 0 ]]; then
 fi
 ROOT_DIR="${1:-$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 TRUSTED_REPO_ROOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EVIDENCE_MODE="${2:-require-evidence}"
 
-node - "${ROOT_DIR}" "${TARGET_ROOT_MODE}" "${TRUSTED_REPO_ROOT}" <<'NODE'
+node - "${ROOT_DIR}" "${TARGET_ROOT_MODE}" "${TRUSTED_REPO_ROOT}" "${EVIDENCE_MODE}" <<'NODE'
 const fs = require("node:fs");
 const path = require("node:path");
 const { execFileSync } = require("node:child_process");
 
-const [rootDir, targetRootMode, trustedRepoRoot] = process.argv.slice(2);
+const [rootDir, targetRootMode, trustedRepoRoot, evidenceMode] =
+  process.argv.slice(2);
 const allowedPlatforms = new Set(["darwin", "linux", "windows"]);
 const requiredChecks = [
   "domains_mfa",
@@ -27,6 +29,10 @@ const requiredChecks = [
   "stress_10000",
 ];
 const maxEvidenceBytes = 32 * 1024;
+
+if (!["require-evidence", "metadata-only"].includes(evidenceMode)) {
+  fail("evidence mode must be require-evidence or metadata-only");
+}
 
 function fail(message) {
   console.error(`[verify-cloud-release-gate] ERROR: ${message}`);
@@ -296,6 +302,19 @@ if (
   fail(
     "Cloud remote requires a Relay App version newer than the pre-Cloud 0.7.1 release",
   );
+}
+
+if (evidenceMode === "metadata-only") {
+  if (
+    targetRootMode !== "1" ||
+    process.env.HA_NOVA_CLOUD_GATE_TRUSTED_PR_MODE !== "1"
+  ) {
+    fail("metadata-only verification is reserved for trusted candidate source checks");
+  }
+  console.log(
+    `[verify-cloud-release-gate] OK: enabled Cloud metadata verified for ${platforms.length} platform(s); external evidence intentionally pending`,
+  );
+  process.exit(0);
 }
 
 const rawEvidence =

--- a/scripts/release/verify-cloud-target-source-gate.sh
+++ b/scripts/release/verify-cloud-target-source-gate.sh
@@ -6,6 +6,7 @@ SOURCE_REF="${HA_NOVA_CLOUD_GATE_SOURCE_REF:-}"
 EXPECTED_TARGET="${HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT:-}"
 EXPECTED_HEAD="${HA_NOVA_CLOUD_GATE_EXPECTED_HEAD_COMMIT:-}"
 EXPECTED_BASE="${HA_NOVA_CLOUD_GATE_EXPECTED_BASE_COMMIT:-}"
+MODE="${1:-release}"
 
 fail() {
   echo "[verify-cloud-target-source-gate] ERROR: $*" >&2
@@ -15,6 +16,8 @@ fail() {
 [[ "${SOURCE_REF}" == refs/pull/*/merge \
   || "${SOURCE_REF}" == refs/heads/gh-readonly-queue/main/* ]] \
   || fail "source ref must identify a pull request merge or main merge queue"
+[[ "${MODE}" == "release" || "${MODE}" == "candidate" ]] \
+  || fail "mode must be release or candidate"
 [[ -z "${EXPECTED_TARGET}" || "${EXPECTED_TARGET}" =~ ^[0-9a-f]{40}$ ]] \
   || fail "expected target commit must be a full lowercase SHA-1"
 [[ -z "${EXPECTED_HEAD}" || "${EXPECTED_HEAD}" =~ ^[0-9a-f]{40}$ ]] \
@@ -55,18 +58,19 @@ for relative_path in version.json nova/version.json nova/config.yaml; do
     || fail "target commit is missing ${relative_path}"
 done
 
-HA_NOVA_CLOUD_GATE_TARGET_COMMIT="${target_commit}" \
-HA_NOVA_CLOUD_GATE_TARGET_TREE="${target_tree}" \
-HA_NOVA_CLOUD_GATE_TRUSTED_PR_MODE=1 \
-  bash "${ROOT_DIR}/scripts/release/verify-cloud-release-gate.sh" \
-    "${target_root}"
-
 cloud_enabled="$(
   node -e \
     'process.stdout.write(String(JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")).cloud_remote_enabled))' \
     "${target_root}/version.json"
 )"
 if [[ "${cloud_enabled}" == "false" ]]; then
+  [[ "${MODE}" == "release" ]] \
+    || fail "candidate source must enable Home Assistant Cloud"
+  HA_NOVA_CLOUD_GATE_TARGET_COMMIT="${target_commit}" \
+  HA_NOVA_CLOUD_GATE_TARGET_TREE="${target_tree}" \
+  HA_NOVA_CLOUD_GATE_TRUSTED_PR_MODE=1 \
+    bash "${ROOT_DIR}/scripts/release/verify-cloud-release-gate.sh" \
+      "${target_root}"
   exit 0
 fi
 [[ "${cloud_enabled}" == "true" ]] \
@@ -122,3 +126,18 @@ target_workflows_tree="$(
   || node "${ROOT_DIR}/scripts/release/verify-cloud-workflow-uses-only.mjs" \
     "${ROOT_DIR}" "$(git -C "${ROOT_DIR}" rev-parse HEAD)" "${target_commit}" \
     workflow-tree-only
+
+if [[ "${MODE}" == "candidate" ]]; then
+  HA_NOVA_CLOUD_GATE_TARGET_COMMIT="${target_commit}" \
+  HA_NOVA_CLOUD_GATE_TARGET_TREE="${target_tree}" \
+  HA_NOVA_CLOUD_GATE_TRUSTED_PR_MODE=1 \
+    bash "${ROOT_DIR}/scripts/release/verify-cloud-release-gate.sh" \
+      "${target_root}" metadata-only
+  exit 0
+fi
+
+HA_NOVA_CLOUD_GATE_TARGET_COMMIT="${target_commit}" \
+HA_NOVA_CLOUD_GATE_TARGET_TREE="${target_tree}" \
+HA_NOVA_CLOUD_GATE_TRUSTED_PR_MODE=1 \
+  bash "${ROOT_DIR}/scripts/release/verify-cloud-release-gate.sh" \
+    "${target_root}"

--- a/scripts/release/verify-cloud-workflow-gate.mjs
+++ b/scripts/release/verify-cloud-workflow-gate.mjs
@@ -338,6 +338,28 @@ function assertArtifactStepStatus(workflowPath, lines, job, artifactLine) {
     );
   }
 }
+function assertNoRawDispatchInputInRun(workflowPath, lines) {
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = /^(\s*)run:\s*(.*)$/.exec(lines[index]);
+    if (match === null) continue;
+    const indent = match[1].length;
+    const body = [match[2]];
+    while (index + 1 < lines.length) {
+      const next = lines[index + 1];
+      if (next.trim() !== "" && next.length - next.trimStart().length <= indent) {
+        break;
+      }
+      body.push(next);
+      index += 1;
+    }
+    if (body.some((line) => line.includes("${{ inputs."))) {
+      fail(
+        workflowPath,
+        "workflow_dispatch inputs must reach run scripts only through env",
+      );
+    }
+  }
+}
 function verifyWorkflow(workflowPath) {
   let lines;
   try {
@@ -349,6 +371,7 @@ function verifyWorkflow(workflowPath) {
   if (syntaxProblem !== null) {
     fail(workflowPath, syntaxProblem);
   }
+  assertNoRawDispatchInputInRun(workflowPath, lines);
   const metadata = assertRequiredStep(workflowPath, lines, metadataStepName);
   const mainProtection = assertRequiredStep(
     workflowPath,

--- a/scripts/release/verify-cloud-workflow-gate.sh
+++ b/scripts/release/verify-cloud-workflow-gate.sh
@@ -7,6 +7,7 @@ if [[ "$#" -eq 0 ]]; then
   set -- \
     "${ROOT_DIR}/.github/workflows/release.yml" \
     "${ROOT_DIR}/.github/workflows/release-candidate.yml" \
+    "${ROOT_DIR}/.github/workflows/cloud-candidate-bundle.yml" \
     "${ROOT_DIR}/.github/workflows/cloud-source-gate.yml" \
     "${ROOT_DIR}/.github/workflows/ci.yml" \
     "${ROOT_DIR}/.github/workflows/e2e-disposable-ha.yml"
@@ -26,5 +27,8 @@ done
   echo "[verify-cloud-workflow-gate] ERROR: release workflows are required" >&2
   exit 1
 }
+node "${ROOT_DIR}/scripts/release/verify-cloud-candidate-workflow.mjs" \
+  "${ROOT_DIR}/.github/workflows/cloud-candidate-bundle.yml" \
+  "${ROOT_DIR}/scripts/release/resolve-cloud-candidate-source.sh"
 exec node "${ROOT_DIR}/scripts/release/verify-cloud-workflow-gate.mjs" \
   "${release_workflows[@]}"

--- a/scripts/release/verify-cloud-workflow-syntax.mjs
+++ b/scripts/release/verify-cloud-workflow-syntax.mjs
@@ -1,4 +1,11 @@
-const allowedRootKeys = new Set(["name", "on", "permissions", "jobs"]);
+const allowedRootKeys = new Set([
+  "name",
+  "run-name",
+  "on",
+  "permissions",
+  "concurrency",
+  "jobs",
+]);
 const nonCanonicalNestedKey =
   /^(?: {4}| {8})(?:["']|[?:]\s|<<\s*:|[!&*]|[^#\s][^:]*[ \t]+:)/;
 

--- a/scripts/release/verify-release-metadata.sh
+++ b/scripts/release/verify-release-metadata.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TRUSTED_ROOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT_DIR="$(cd -- "${HA_NOVA_SOURCE_ROOT:-${TRUSTED_ROOT}}" && pwd)"
 TAG_NAME="${1:-}"
 
 node - "${ROOT_DIR}" "${TAG_NAME}" <<'NODE'

--- a/tests/onboarding/cloud-candidate-workflow-behavior.ts
+++ b/tests/onboarding/cloud-candidate-workflow-behavior.ts
@@ -1,0 +1,473 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+type FixtureChange =
+  | "draft"
+  | "wrong-actor"
+  | "wrong-trigger"
+  | "rerun"
+  | "stale-base"
+  | "wrong-head-repo"
+  | "wrong-parent"
+  | "failed-check"
+  | "stale-codex"
+  | "spoofed-codex"
+  | "later-codex-finding"
+  | "later-codex-reaction"
+  | "unresolved-thread"
+  | "changes-requested"
+  | "moved-late"
+  | "source-rejected"
+  | "identity-mismatch"
+  | "cloud-success";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function writeExecutable(path: string, body: string): void {
+  writeFileSync(path, body, "utf8");
+  chmodSync(path, 0o755);
+}
+
+function runResolver(
+  change?: FixtureChange,
+  pullRequest = "42",
+): ReturnType<typeof spawnSync> {
+  const root = mkdtempSync(join(tmpdir(), "ha-nova-cloud-candidate-"));
+  const remote = mkdtempSync(join(tmpdir(), "ha-nova-cloud-candidate-remote-"));
+  const fakeBin = join(root, "fake-bin");
+  mkdirSync(fakeBin);
+  mkdirSync(join(root, "scripts", "release"), { recursive: true });
+
+  git(root, ["init", "-q", "-b", "main"]);
+  git(root, ["config", "user.name", "Candidate Test"]);
+  git(root, ["config", "user.email", "candidate@example.invalid"]);
+  writeFileSync(join(root, "source.txt"), "base\n");
+  git(root, ["add", "source.txt"]);
+  git(root, ["commit", "-qm", "base"]);
+  const base = git(root, ["rev-parse", "HEAD"]);
+  git(root, ["switch", "-qc", "candidate"]);
+  writeFileSync(join(root, "source.txt"), "candidate\n");
+  git(root, ["commit", "-qam", "candidate"]);
+  const head = git(root, ["rev-parse", "HEAD"]);
+  git(root, ["switch", "-q", "main"]);
+  git(root, ["switch", "-qc", "merge-source"]);
+  git(root, ["merge", "--no-ff", "-qm", "merge", "candidate"]);
+  const merge = git(root, ["rev-parse", "HEAD"]);
+  const tree = git(root, ["rev-parse", "HEAD^{tree}"]);
+  git(root, ["switch", "-q", "main"]);
+  git(remote, ["init", "--bare", "-q"]);
+  git(root, ["remote", "add", "origin", remote]);
+  git(root, ["push", "-q", "origin", `${base}:refs/heads/main`]);
+  git(root, ["push", "-q", "origin", `${merge}:refs/pull/42/merge`]);
+
+  const policy = {
+    main_branch_protection: {
+      required_status_checks: ["analyze", "ci-gate", "cloud-source-gate"],
+      required_status_check_apps: { "cloud-source-gate": 4400145 },
+      advisory_checks: ["codex-review-gate"],
+    },
+  };
+  const policyPath = join(root, "repo-policy.json");
+  writeFileSync(policyPath, JSON.stringify(policy));
+
+  const pr = {
+    number: 42,
+    state: "open",
+    draft: change === "draft",
+    base: {
+      ref: "main",
+      sha: base,
+      repo: { full_name: "markusleben/ha-nova" },
+    },
+    head: {
+      sha: head,
+      repo: {
+        full_name:
+          change === "wrong-head-repo" ? "someone/fork" : "markusleben/ha-nova",
+      },
+    },
+    merge_commit_sha: merge,
+  };
+  const commit = {
+    sha: merge,
+    tree: { sha: tree },
+    parents: [{ sha: change === "wrong-parent" ? head : base }, { sha: head }],
+  };
+  const checks = [
+    {
+      name: "analyze",
+      status: "completed",
+      conclusion: "success",
+      app: { id: 1 },
+    },
+    {
+      name: "ci-gate",
+      status: "completed",
+      conclusion: change === "failed-check" ? "failure" : "success",
+      app: { id: 1 },
+    },
+    {
+      name: "codex-review-gate",
+      status: "completed",
+      conclusion: "success",
+      app: { id: 1 },
+    },
+    {
+      name: "cloud-source-gate",
+      status: "completed",
+      conclusion: change === "cloud-success" ? "success" : "failure",
+      app: { id: 4400145 },
+    },
+  ];
+  const prPath = join(root, "pr.json");
+  const commitPath = join(root, "commit.json");
+  const checksPath = join(root, "checks.json");
+  const commentsPath = join(root, "comments.json");
+  const reviewsPath = join(root, "reviews.json");
+  const inlineCommentsPath = join(root, "inline-comments.json");
+  const reactionsPath = join(root, "reactions.json");
+  const threadsPath = join(root, "threads.json");
+  const prCallsPath = join(root, "pr-calls");
+  writeFileSync(prPath, JSON.stringify(pr));
+  writeFileSync(commitPath, JSON.stringify(commit));
+  writeFileSync(checksPath, JSON.stringify([{ check_runs: checks }]));
+  writeFileSync(
+    commentsPath,
+    JSON.stringify([
+      [
+        {
+          user: {
+            login:
+              change === "spoofed-codex"
+                ? "chatgpt-codex-connector-review"
+                : "chatgpt-codex-connector[bot]",
+            id: change === "spoofed-codex" ? 999 : 199175422,
+            type: change === "spoofed-codex" ? "User" : "Bot",
+          },
+          created_at: "2026-07-29T10:00:00Z",
+          body:
+            "Codex Review: Didn't find any major issues. Keep it up!\n\n" +
+            `**Reviewed commit:** \`${change === "stale-codex" ? "0000000000" : head.slice(0, 10)}\``,
+        },
+      ],
+    ]),
+  );
+  writeFileSync(reviewsPath, JSON.stringify([[]]));
+  writeFileSync(
+    inlineCommentsPath,
+    JSON.stringify([
+      change === "later-codex-finding"
+        ? [
+            {
+              user: {
+                login: "chatgpt-codex-connector[bot]",
+                id: 199175422,
+                type: "Bot",
+              },
+              commit_id: head,
+              created_at: "2026-07-29T10:01:00Z",
+              body: "A later finding",
+            },
+          ]
+        : [],
+    ]),
+  );
+  writeFileSync(
+    reactionsPath,
+    JSON.stringify([
+      change === "later-codex-reaction"
+        ? [
+            {
+              user: {
+                login: "chatgpt-codex-connector[bot]",
+                id: 199175422,
+                type: "User",
+              },
+              created_at: "2026-07-29T10:01:00Z",
+              content: "eyes",
+            },
+          ]
+        : [],
+    ]),
+  );
+  writeFileSync(
+    threadsPath,
+    JSON.stringify([
+      {
+        data: {
+          repository: {
+            pullRequest: {
+              reviewDecision:
+                change === "changes-requested"
+                  ? "CHANGES_REQUESTED"
+                  : "REVIEW_REQUIRED",
+              reviewThreads: {
+                nodes: [
+                  { isResolved: change !== "unresolved-thread" },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        },
+      },
+    ]),
+  );
+  writeFileSync(prCallsPath, "0\n");
+  writeExecutable(
+    join(root, "scripts", "release", "verify-cloud-target-source-gate.sh"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+[[ "$*" == "candidate" ]]
+[[ "$HA_NOVA_CLOUD_GATE_SOURCE_REF" == "refs/pull/42/merge" ]]
+[[ "$HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT" == "$FAKE_MERGE" ]]
+[[ "$HA_NOVA_CLOUD_GATE_EXPECTED_HEAD_COMMIT" == "$FAKE_HEAD" ]]
+[[ "$HA_NOVA_CLOUD_GATE_EXPECTED_BASE_COMMIT" == "$FAKE_BASE" ]]
+[[ "$FAKE_CHANGE" != "source-rejected" ]]
+`,
+  );
+  writeExecutable(
+    join(fakeBin, "gh"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "api repos/markusleben/ha-nova/pulls/42")
+    calls="$(( $(<"$FAKE_PR_CALLS") + 1 ))"
+    printf '%s\n' "$calls" >"$FAKE_PR_CALLS"
+    if [[ "$FAKE_CHANGE" == "moved-late" && "$calls" -gt 1 ]]; then
+      sed 's/"state":"open"/"state":"closed"/' "$FAKE_PR"
+    else
+      cat "$FAKE_PR"
+    fi
+    ;;
+  "api repos/markusleben/ha-nova/git/commits/$FAKE_MERGE") cat "$FAKE_COMMIT" ;;
+  "api --paginate --slurp repos/markusleben/ha-nova/commits/$FAKE_MERGE/check-runs?filter=latest&per_page=100") cat "$FAKE_CHECKS" ;;
+  "api --paginate --slurp repos/markusleben/ha-nova/issues/42/comments?per_page=100") cat "$FAKE_COMMENTS" ;;
+  "api --paginate --slurp repos/markusleben/ha-nova/pulls/42/reviews?per_page=100") cat "$FAKE_REVIEWS" ;;
+  "api --paginate --slurp repos/markusleben/ha-nova/pulls/42/comments?per_page=100") cat "$FAKE_INLINE_COMMENTS" ;;
+  "api --paginate --slurp repos/markusleben/ha-nova/issues/42/reactions?per_page=100") cat "$FAKE_REACTIONS" ;;
+  api\\ graphql*) cat "$FAKE_THREADS" ;;
+  *) exit 2 ;;
+esac
+`,
+  );
+  const output = join(root, "github-output");
+  writeFileSync(output, "");
+  return spawnSync(
+    "bash",
+    [
+      resolve("scripts/release/resolve-cloud-candidate-source.sh"),
+      pullRequest,
+      policyPath,
+    ],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        FAKE_PR: prPath,
+        FAKE_COMMIT: commitPath,
+        FAKE_CHECKS: checksPath,
+        FAKE_COMMENTS: commentsPath,
+        FAKE_REVIEWS: reviewsPath,
+        FAKE_INLINE_COMMENTS: inlineCommentsPath,
+        FAKE_REACTIONS: reactionsPath,
+        FAKE_THREADS: threadsPath,
+        FAKE_PR_CALLS: prCallsPath,
+        FAKE_CHANGE: change ?? "valid",
+        FAKE_BASE: base,
+        FAKE_HEAD: head,
+        FAKE_MERGE: merge,
+        GITHUB_EVENT_NAME: "workflow_dispatch",
+        GITHUB_REF: "refs/heads/main",
+        GITHUB_REPOSITORY: "markusleben/ha-nova",
+        GITHUB_ACTOR: change === "wrong-actor" ? "other-user" : "markusleben",
+        GITHUB_ACTOR_ID: change === "wrong-actor" ? "999" : "6522814",
+        GITHUB_TRIGGERING_ACTOR:
+          change === "wrong-trigger" ? "other-user" : "markusleben",
+        GITHUB_RUN_ATTEMPT: change === "rerun" ? "2" : "1",
+        GITHUB_SHA: change === "stale-base" ? head : base,
+        GITHUB_OUTPUT: output,
+        ...(change === "identity-mismatch"
+          ? {
+              HA_NOVA_CLOUD_CANDIDATE_EXPECTED_COMMIT:
+                "0".repeat(40),
+              HA_NOVA_CLOUD_CANDIDATE_EXPECTED_TREE: tree,
+              HA_NOVA_CLOUD_CANDIDATE_EXPECTED_BASE: base,
+              HA_NOVA_CLOUD_CANDIDATE_EXPECTED_HEAD: head,
+            }
+          : {}),
+      },
+    },
+  );
+}
+
+describe("Cloud candidate source resolver", () => {
+  it("accepts one current reviewed merge source with only the evidence gate failed", () => {
+    const result = runResolver();
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("OK: PR #42");
+  });
+
+  it.each([
+    ["a draft", "draft"],
+    ["a non-maintainer dispatcher", "wrong-actor"],
+    ["a non-maintainer rerun trigger", "wrong-trigger"],
+    ["a rerun attempt", "rerun"],
+    ["a stale base", "stale-base"],
+    ["a fork", "wrong-head-repo"],
+    ["wrong merge parents", "wrong-parent"],
+    ["another failed check", "failed-check"],
+    ["a stale Codex result", "stale-codex"],
+    ["a prefixed Codex impersonator", "spoofed-codex"],
+    ["a later Codex finding", "later-codex-finding"],
+    ["a later Codex reaction", "later-codex-reaction"],
+    ["an unresolved review thread", "unresolved-thread"],
+    ["requested changes", "changes-requested"],
+    ["a pull request that moves during resolution", "moved-late"],
+    ["a source rejected by the trusted bootstrap verifier", "source-rejected"],
+    ["a changed expected identity", "identity-mismatch"],
+    ["an already-successful evidence gate", "cloud-success"],
+  ] as const)("rejects %s", (_label, change) => {
+    const result = runResolver(change);
+    expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+  });
+
+  it("rejects a shell payload passed as the pull request input", () => {
+    const result = runResolver(
+      undefined,
+      '42"; printf "commit_sha=0000000000000000000000000000000000000000\\n" >>"$GITHUB_OUTPUT"; #',
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).not.toContain("OK: PR #42");
+  });
+});
+
+describe("Cloud candidate workflow contract", () => {
+  const workflowPath = ".github/workflows/cloud-candidate-bundle.yml";
+  const resolverPath = "scripts/release/resolve-cloud-candidate-source.sh";
+  const verifierPath = "scripts/release/verify-cloud-candidate-workflow.mjs";
+  const workflow = readFileSync(workflowPath, "utf8");
+
+  it("passes the trusted non-publishing workflow verifier", () => {
+    const result = spawnSync(
+      "node",
+      [verifierPath, workflowPath, resolverPath],
+      { encoding: "utf8" },
+    );
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
+  it("rejects publication commands", () => {
+    const root = mkdtempSync(
+      join(tmpdir(), "ha-nova-cloud-candidate-contract-"),
+    );
+    const unsafeWorkflow = join(root, "cloud-candidate-bundle.yml");
+    writeFileSync(unsafeWorkflow, `${workflow}\n# gh release create\n`);
+    const result = spawnSync(
+      "node",
+      [verifierPath, unsafeWorkflow, resolverPath],
+      { encoding: "utf8" },
+    );
+    expect(result.status).not.toBe(0);
+  });
+
+  it("rejects raw dispatch-input interpolation in a run block", () => {
+    const root = mkdtempSync(
+      join(tmpdir(), "ha-nova-cloud-candidate-contract-"),
+    );
+    const unsafeWorkflow = join(root, "cloud-candidate-bundle.yml");
+    writeFileSync(
+      unsafeWorkflow,
+      workflow.replace(
+        '"${PR_NUMBER}"',
+        '"${{ inputs.pull_request }}; echo injected"',
+      ),
+    );
+    const result = spawnSync(
+      "node",
+      [verifierPath, unsafeWorkflow, resolverPath],
+      { encoding: "utf8" },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "workflow_dispatch inputs must reach run scripts only through env",
+    );
+  });
+
+  it("uses trusted scripts with an explicit immutable source root", () => {
+    for (const path of [
+      "scripts/release/build-rc-binaries.sh",
+      "scripts/release/build-sign-darwin-binaries.sh",
+      "scripts/release/build-install-bundle.sh",
+      "scripts/release/verify-release-metadata.sh",
+    ]) {
+      expect(readFileSync(path, "utf8"), path).toContain(
+        "HA_NOVA_SOURCE_ROOT:-${TRUSTED_ROOT}",
+      );
+    }
+    expect(workflow).not.toMatch(/\b(?:bash|node)\s+target\//);
+    expect(workflow).not.toContain("HA_NOVA_CLOUD_GATE_EVIDENCE_JSON");
+    expect(workflow).not.toMatch(/\bgh\s+release\b|\bgit\s+tag\b/);
+    expect(readFileSync("docs/releasing.md", "utf8")).toContain(
+      "gh workflow run cloud-candidate-bundle.yml --ref main",
+    );
+    expect(readFileSync(".github/CODEOWNERS", "utf8")).toContain(
+      "/.github/workflows/cloud-candidate-bundle.yml @markusleben",
+    );
+  });
+
+  it("rejects Cloud evidence that lacks a valid release signature", () => {
+    const root = mkdtempSync(join(tmpdir(), "ha-nova-cloud-evidence-"));
+    const binary = join(root, "ha-nova");
+    const bundle = join(root, "bundle.json");
+    writeFileSync(binary, "candidate");
+    writeFileSync(
+      bundle,
+      JSON.stringify({
+        bundle_format_version: 1,
+        version: "0.22.0-rc1",
+        os: "linux",
+        arch: "amd64",
+        binary_name: "ha-nova",
+        cloud_release: {
+          schema: 1,
+          source_tree_sha: "1".repeat(40),
+          binary_sha256:
+            "dda18a0e21ae47c53b4309434cbc02ae8bf764fa83a6defbb719431242722aa7",
+          signature: Buffer.alloc(64).toString("base64"),
+        },
+      }),
+    );
+    const result = spawnSync(
+      "node",
+      [
+        "scripts/release/verify-cloud-release-evidence.mjs",
+        bundle,
+        binary,
+        "0.22.0-rc1",
+        "linux",
+        "amd64",
+        "ha-nova",
+        "1".repeat(40),
+        "darwin,linux,windows",
+      ],
+      { encoding: "utf8" },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("signature is invalid");
+  });
+});

--- a/tests/onboarding/cloud-candidate-workflow-behavior.ts
+++ b/tests/onboarding/cloud-candidate-workflow-behavior.ts
@@ -24,6 +24,7 @@ type FixtureChange =
   | "spoofed-codex"
   | "later-codex-finding"
   | "later-codex-reaction"
+  | "later-codex-bot-reaction"
   | "unresolved-thread"
   | "changes-requested"
   | "moved-late"
@@ -187,13 +188,15 @@ function runResolver(
   writeFileSync(
     reactionsPath,
     JSON.stringify([
-      change === "later-codex-reaction"
+      change === "later-codex-reaction" ||
+      change === "later-codex-bot-reaction"
         ? [
             {
               user: {
                 login: "chatgpt-codex-connector[bot]",
                 id: 199175422,
-                type: "User",
+                type:
+                  change === "later-codex-bot-reaction" ? "Bot" : "User",
               },
               created_at: "2026-07-29T10:01:00Z",
               content: "eyes",
@@ -335,6 +338,7 @@ describe("Cloud candidate source resolver", () => {
     ["a prefixed Codex impersonator", "spoofed-codex"],
     ["a later Codex finding", "later-codex-finding"],
     ["a later Codex reaction", "later-codex-reaction"],
+    ["a later Codex bot reaction", "later-codex-bot-reaction"],
     ["an unresolved review thread", "unresolved-thread"],
     ["requested changes", "changes-requested"],
     ["a pull request that moves during resolution", "moved-late"],

--- a/tests/onboarding/cloud-release-commit-gate-behavior.ts
+++ b/tests/onboarding/cloud-release-commit-gate-behavior.ts
@@ -390,7 +390,7 @@ export function registerCloudReleaseCommitGateBehaviorTests(): void {
       },
     );
 
-    it("rejects an identical tree after a commit-only rewrite", () => {
+    it("accepts an identical tree after a squash-style commit rewrite", () => {
       const enabled = {
         min_relay_version: "0.8.0",
         cloud_remote_enabled: true,
@@ -407,10 +407,7 @@ export function registerCloudReleaseCommitGateBehaviorTests(): void {
       expect(head).not.toBe(fixture.sha);
 
       const result = runCloudGate(fixture, validCloudEvidence(fixture, ["linux"]), head);
-      expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
-      expect(`${result.stdout}\n${result.stderr}`).toContain(
-        "stale Home Assistant Cloud evidence may cover only",
-      );
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     });
 
     it("rejects disabled-source evidence for a later enabled runtime", () => {

--- a/tests/onboarding/cloud-release-commit-gate-behavior.ts
+++ b/tests/onboarding/cloud-release-commit-gate-behavior.ts
@@ -126,6 +126,7 @@ esac
   return {
     fixture,
     prGate,
+    targetGate,
     trustedHead,
     workflowDir,
     env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}` },
@@ -159,6 +160,40 @@ function runPRGate(
 
 export function registerCloudReleaseCommitGateBehaviorTests(): void {
   describe("Home Assistant Cloud full-tree evidence behavior", () => {
+    it("permits only trusted candidate metadata to remain evidence-pending", () => {
+      const { fixture, targetGate, trustedHead } =
+        preparePRGateFixture(true);
+      execFileSync(
+        "git",
+        ["update-ref", "refs/pull/1/merge", trustedHead],
+        { cwd: fixture.root },
+      );
+      const env = {
+        ...process.env,
+        HA_NOVA_CLOUD_GATE_SOURCE_REF: "refs/pull/1/merge",
+        HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT: trustedHead,
+      };
+      const candidate = spawnSync("bash", [targetGate, "candidate"], {
+        cwd: fixture.root,
+        encoding: "utf8",
+        env,
+      });
+      expect(
+        candidate.status,
+        `${candidate.stdout}\n${candidate.stderr}`,
+      ).toBe(0);
+
+      const release = spawnSync("bash", [targetGate], {
+        cwd: fixture.root,
+        encoding: "utf8",
+        env,
+      });
+      expect(release.status).not.toBe(0);
+      expect(`${release.stdout}\n${release.stderr}`).toContain(
+        "HA_NOVA_CLOUD_GATE_EVIDENCE_JSON is required",
+      );
+    });
+
     it("binds a pull request merge commit to the expected base and head", () => {
       const { fixture, prGate, trustedHead } = preparePRGateFixture();
       execFileSync("git", ["checkout", "-qb", "feature"], {

--- a/tests/onboarding/cloud-release-gate-behavior.ts
+++ b/tests/onboarding/cloud-release-gate-behavior.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import {
   CLOUD_CHECK_NAMES,
@@ -107,6 +108,32 @@ export function registerCloudReleaseGateBehaviorTests(): void {
       const result = runCloudGate(fixture, `{"${marker}":`);
       expect(result.status).not.toBe(0);
       expect(`${result.stdout}\n${result.stderr}`).not.toContain(marker);
+    });
+    it("allows evidence-pending metadata only in trusted candidate mode", () => {
+      const fixture = cloudGateFixture({
+        cloud_remote_enabled: true,
+        cloud_remote_platforms: ["linux"],
+      });
+      const trusted = spawnSync(
+        "bash",
+        [fixture.script, fixture.root, "metadata-only"],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            HA_NOVA_CLOUD_GATE_TRUSTED_PR_MODE: "1",
+          },
+        },
+      );
+      expect(trusted.status, `${trusted.stdout}\n${trusted.stderr}`).toBe(0);
+      expect(trusted.stdout).toContain("external evidence intentionally pending");
+
+      const untrusted = spawnSync(
+        "bash",
+        [fixture.script, fixture.root, "metadata-only"],
+        { encoding: "utf8", env: process.env },
+      );
+      expect(untrusted.status).not.toBe(0);
     });
     it("accepts complete evidence bound to the exact checked-out commit", () => {
       const platforms: CloudPlatform[] = ["linux", "windows"];

--- a/tests/onboarding/cloud-release-gate-contract.ts
+++ b/tests/onboarding/cloud-release-gate-contract.ts
@@ -48,6 +48,10 @@ export function registerCloudReleaseGateContractTests(): void {
     ciWorkflow.indexOf("  go-build:"),
   );
   const releasing = readFileSync("docs/releasing.md", "utf8");
+  const releaseEvidenceVerifier = readFileSync(
+    "scripts/release/verify-cloud-release-evidence.mjs",
+    "utf8",
+  );
 
   it("keeps Cloud publication disabled until commit-bound real-device evidence exists", () => {
     const version = JSON.parse(readFileSync("version.json", "utf8")) as {
@@ -315,6 +319,7 @@ export function registerCloudReleaseGateContractTests(): void {
     const codeowners = readFileSync(".github/CODEOWNERS", "utf8");
     for (const workflow of [
       "cloud-source-gate.yml",
+      "cloud-candidate-bundle.yml",
       "ci.yml",
       "release.yml",
       "release-candidate.yml",
@@ -345,8 +350,19 @@ export function registerCloudReleaseGateContractTests(): void {
     expect(provenance).toContain("BinarySHA256");
     expect(provenance).toContain("SourceTreeSHA");
     expect(provenance).toContain("cloudReleaseEvidencePublicKey");
+    const publicKey = Buffer.from(
+      [...provenance.matchAll(/0x([0-9a-f]{2})/g)].map((match) =>
+        Number.parseInt(match[1]!, 16),
+      ),
+    ).toString("base64url");
+    expect(publicKey).toHaveLength(43);
+    expect(releaseEvidenceVerifier).toContain(`x: "${publicKey}"`);
+    expect(releaseEvidenceVerifier).toContain("verify(");
     expect(rcWorkflow).toContain(
-      'bash scripts/release/build-rc-binaries.sh "${{ inputs.version_tag }}"',
+      "VERSION_TAG: ${{ inputs.version_tag }}",
+    );
+    expect(rcWorkflow).toContain(
+      'bash scripts/release/build-rc-binaries.sh "${VERSION_TAG}"',
     );
     for (const workflow of [releaseWorkflow, rcWorkflow]) {
       expect(workflow).toContain(

--- a/tests/onboarding/cloud-workflow-gate-behavior.ts
+++ b/tests/onboarding/cloud-workflow-gate-behavior.ts
@@ -66,6 +66,7 @@ function workflowGateFixture(mutateRelease?: (workflow: string) => string): {
   script: string;
   releaseWorkflow: string;
   rcWorkflow: string;
+  candidateWorkflow: string;
   sourceWorkflow: string;
   ciWorkflow: string;
 } {
@@ -78,13 +79,30 @@ function workflowGateFixture(mutateRelease?: (workflow: string) => string): {
   const script = join(releaseDir, "verify-cloud-workflow-gate.sh");
   const module = join(releaseDir, "verify-cloud-workflow-gate.mjs");
   const actionPins = join(releaseDir, "verify-cloud-action-pins.mjs");
+  const candidateVerifier = join(
+    releaseDir,
+    "verify-cloud-candidate-workflow.mjs",
+  );
+  const candidateResolver = join(
+    releaseDir,
+    "resolve-cloud-candidate-source.sh",
+  );
   const releaseWorkflow = join(workflowDir, "release.yml");
   const rcWorkflow = join(workflowDir, "release-candidate.yml");
+  const candidateWorkflow = join(workflowDir, "cloud-candidate-bundle.yml");
   const sourceWorkflow = join(workflowDir, "cloud-source-gate.yml");
   const ciWorkflow = join(workflowDir, "ci.yml");
   copyFileSync("scripts/release/verify-cloud-workflow-gate.sh", script);
   copyFileSync("scripts/release/verify-cloud-workflow-gate.mjs", module);
   copyFileSync("scripts/release/verify-cloud-action-pins.mjs", actionPins);
+  copyFileSync(
+    "scripts/release/verify-cloud-candidate-workflow.mjs",
+    candidateVerifier,
+  );
+  copyFileSync(
+    "scripts/release/resolve-cloud-candidate-source.sh",
+    candidateResolver,
+  );
   copyFileSync(
     "scripts/release/verify-cloud-workflow-syntax.mjs",
     join(releaseDir, "verify-cloud-workflow-syntax.mjs"),
@@ -97,6 +115,10 @@ function workflowGateFixture(mutateRelease?: (workflow: string) => string): {
     "utf8",
   );
   copyFileSync(".github/workflows/release-candidate.yml", rcWorkflow);
+  copyFileSync(
+    ".github/workflows/cloud-candidate-bundle.yml",
+    candidateWorkflow,
+  );
   copyFileSync(".github/workflows/cloud-source-gate.yml", sourceWorkflow);
   copyFileSync(".github/workflows/ci.yml", ciWorkflow);
   return {
@@ -104,6 +126,7 @@ function workflowGateFixture(mutateRelease?: (workflow: string) => string): {
     script,
     releaseWorkflow,
     rcWorkflow,
+    candidateWorkflow,
     sourceWorkflow,
     ciWorkflow,
   };
@@ -118,6 +141,7 @@ function runWorkflowGate(
       fixture.script,
       fixture.releaseWorkflow,
       fixture.rcWorkflow,
+      fixture.candidateWorkflow,
       fixture.sourceWorkflow,
       fixture.ciWorkflow,
     ],
@@ -148,7 +172,9 @@ export function registerCloudWorkflowGateBehaviorTests(): void {
         ),
         "utf8",
       );
-      expect(() => parse(readFileSync(fixture.ciWorkflow, "utf8"))).not.toThrow();
+      expect(() =>
+        parse(readFileSync(fixture.ciWorkflow, "utf8")),
+      ).not.toThrow();
       const result = runWorkflowGate(fixture);
       expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
       expect(result.stderr).toContain("uses non-canonical step syntax");
@@ -216,9 +242,28 @@ export function registerCloudWorkflowGateBehaviorTests(): void {
       );
     });
 
+    it("rejects dispatch inputs interpolated directly into shell source", () => {
+      const fixture = workflowGateFixture();
+      const workflow = readFileSync(fixture.rcWorkflow, "utf8");
+      writeFileSync(
+        fixture.rcWorkflow,
+        workflow.replace(
+          'run: bash scripts/release/build-rc-binaries.sh "${VERSION_TAG}"',
+          'run: bash scripts/release/build-rc-binaries.sh "${{ inputs.version_tag }}"',
+        ),
+        "utf8",
+      );
+      const result = runWorkflowGate(fixture);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        "workflow_dispatch inputs must reach run scripts only through env",
+      );
+    });
+
     it.each([
       ["release", "releaseWorkflow"],
       ["release candidate", "rcWorkflow"],
+      ["Cloud candidate", "candidateWorkflow"],
       ["source gate", "sourceWorkflow"],
       ["direct-main CI gate", "ciWorkflow"],
     ] as const)(

--- a/tests/onboarding/dependabot-automation-contract.test.ts
+++ b/tests/onboarding/dependabot-automation-contract.test.ts
@@ -365,6 +365,7 @@ describe("dependabot automation contract", () => {
       protection_rule_types: ["branch_policy"],
     });
     expect(policy.cloud_source_gate.sensitive_workflows).toEqual([
+      ".github/workflows/cloud-candidate-bundle.yml",
       ".github/workflows/cloud-source-gate.yml",
       ".github/workflows/ci.yml",
       ".github/workflows/release.yml",

--- a/tests/onboarding/main-protection-gate.test.ts
+++ b/tests/onboarding/main-protection-gate.test.ts
@@ -87,12 +87,14 @@ function runPublicationProtectionGate(
   enabled: boolean,
   provisioned: boolean,
   appId = "42",
+  sourceEnabled?: boolean,
 ) {
   const root = mkdtempSync(join(tmpdir(), "ha-nova-publication-protection-"));
   const releaseDirectory = join(root, "scripts", "release");
   const policyDirectory = join(root, ".github", "policy");
   mkdirSync(releaseDirectory, { recursive: true });
   mkdirSync(policyDirectory, { recursive: true });
+  const sourceRoot = join(root, "candidate");
   copyFileSync(
     "scripts/release/verify-cloud-publication-main-protection.sh",
     join(releaseDirectory, "verify-cloud-publication-main-protection.sh"),
@@ -105,10 +107,23 @@ function runPublicationProtectionGate(
     }),
     "utf8",
   );
+  if (sourceEnabled !== undefined) {
+    mkdirSync(sourceRoot);
+    writeFileSync(
+      join(sourceRoot, "version.json"),
+      JSON.stringify({
+        cloud_remote_enabled: sourceEnabled,
+        cloud_remote_platforms: sourceEnabled ? ["linux"] : [],
+      }),
+      "utf8",
+    );
+  }
   writeFileSync(
     join(policyDirectory, "repo-policy.json"),
     JSON.stringify({
-      cloud_source_gate: { reporter_app_id: enabled ? 42 : 0 },
+      cloud_source_gate: {
+        reporter_app_id: enabled || sourceEnabled === true ? 42 : 0,
+      },
     }),
     "utf8",
   );
@@ -142,6 +157,9 @@ set -euo pipefail
       env: {
         ...process.env,
         GITHUB_REPOSITORY: "owner/repo",
+        ...(sourceEnabled === undefined
+          ? {}
+          : { HA_NOVA_SOURCE_ROOT: sourceRoot }),
         HA_NOVA_CLOUD_SOURCE_CHECK_APP_ID: provisioned ? appId : "",
         HA_NOVA_CLOUD_SOURCE_CHECK_APP_PRIVATE_KEY: provisioned
           ? "-----BEGIN PRIVATE KEY-----"
@@ -161,6 +179,12 @@ describe("Cloud publication main protection gate", () => {
   it("mints an administration-read token before enabled publication", () => {
     const result = runPublicationProtectionGate(true, true);
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
+  it("checks protection for an enabled candidate while trusted main is disabled", () => {
+    const result = runPublicationProtectionGate(false, true, "42", true);
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).not.toContain("Cloud Remote disabled");
   });
 
   it("fails enabled publication when the read App is unprovisioned", () => {

--- a/tests/onboarding/release-gates-behavior.test.ts
+++ b/tests/onboarding/release-gates-behavior.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from "vitest";
 
 import { registerCloudReleaseGateBehaviorTests } from "./cloud-release-gate-behavior.js";
 import { registerCloudWorkflowGateBehaviorTests } from "./cloud-workflow-gate-behavior.js";
+import "./cloud-candidate-workflow-behavior.js";
 import "./cloud-evidence-normalization-behavior.js";
 
 const ACCOUNT_ID = "58e387e1204bdfe78781caca64f2cd15";


### PR DESCRIPTION
## Summary
- add one manual, non-publishing Cloud candidate bundle workflow
- bind it to the exact reviewed synthetic PR merge source and current main
- build immutable raw binaries, smoke them in secret-free native jobs, then create publicly verified signed bundles
- reject reruns, duplicate/changed identity, stale reviews, and incomplete GitHub policy

## Verification
- `npm run verify`
- pre-push: 1,491 tests, build, typecheck, docs
- three adversarial pre-PR reviews: clean
- `git diff --check`

## Boundaries
- no dispatch performed
- no tag, release, deployment, publication, or README claim
- first positive signed-runtime check remains in the real-device matrix using the downloaded final artifact