### PR TITLE
fix: bind Cloud candidate checks to PR head

### DIFF
--- a/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
+++ b/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
@@ -16,8 +16,14 @@ cannot produce the first candidate needed to collect the evidence.
 - Accept one open same-repository pull request targeting the current `main`.
 - Resolve and bind GitHub's exact synthetic pull-request merge commit, tree,
   base parent, and head parent.
-- Require every current protected check except `cloud-source-gate` to pass.
-  That one check is expected to fail until this candidate produces evidence.
+- Require the current `main` commit to be an ancestor of the pull-request head,
+  so the head-bound checks cover the exact candidate tree.
+- Require the latest run of every current protected check on the pull-request
+  head except `cloud-source-gate` to pass. That one check is expected to fail
+  until this candidate produces evidence. Bind check runs to the exact
+  workflow and event, expected App, pull request, current base/head, and merge
+  target; reject all same-name commit statuses and revalidate the complete
+  check state before returning.
 - Require a real clean Codex bot result bound to the current pull-request head;
   an advisory workflow timeout is insufficient. Reject requested changes,
   unresolved threads, and later Codex findings.

--- a/scripts/release/resolve-cloud-candidate-source.sh
+++ b/scripts/release/resolve-cloud-candidate-source.sh
@@ -92,28 +92,151 @@ jq -e \
     and .parents[1].sha == $head
   ' >/dev/null <<<"${commit}" \
   || fail "pull request merge commit does not bind the current base and head"
+git merge-base --is-ancestor "${base_sha}" "${head_sha}" \
+  || fail "pull request head must contain current main"
 
-check_pages="$(
-  gh api --paginate --slurp \
-    "repos/${REPO}/commits/${merge_sha}/check-runs?filter=latest&per_page=100"
+source_app_id="$(
+  jq -r '.main_branch_protection.required_status_check_apps["cloud-source-gate"]' \
+    "${POLICY_FILE}"
 )"
-checks="$(jq -c '[.[].check_runs[]]' <<<"${check_pages}")"
+[[ "${source_app_id}" =~ ^[1-9][0-9]*$ ]] \
+  || fail "cloud-source-gate App ID is not provisioned"
+github_actions_app_id=15368
 
-while IFS= read -r check_name; do
-  [[ -n "${check_name}" ]] || continue
-  jq -e --arg name "${check_name}" '
-    [ .[] | select(.name == $name) ] as $matches
-    | ($matches | length) > 0
-      and all($matches[]; .status == "completed" and .conclusion == "success")
-  ' >/dev/null <<<"${checks}" \
-    || fail "required pre-evidence check ${check_name} is not successful"
-done < <(
-  jq -r '
-    .main_branch_protection
-    | ((.required_status_checks - ["cloud-source-gate"]) + .advisory_checks)
-    | unique[]
-  ' "${POLICY_FILE}"
-)
+verify_checks() {
+  local check_pages status_pages workflow_pages checks statuses workflows
+  local check_name expected_workflow expected_event
+  workflow_pages="$(
+    gh api --paginate --slurp \
+      "repos/${REPO}/actions/runs?head_sha=${head_sha}&per_page=100"
+  )"
+  status_pages="$(
+    gh api --paginate --slurp \
+      "repos/${REPO}/commits/${head_sha}/status?per_page=100"
+  )"
+  check_pages="$(
+    gh api --paginate --slurp \
+      "repos/${REPO}/commits/${head_sha}/check-runs?filter=latest&per_page=100"
+  )"
+  checks="$(jq -c '[.[].check_runs[]]' <<<"${check_pages}")"
+  statuses="$(jq -c '[.[].statuses[]]' <<<"${status_pages}")"
+  workflows="$(jq -c '[.[].workflow_runs[]]' <<<"${workflow_pages}")"
+
+  while IFS= read -r check_name; do
+    [[ -n "${check_name}" ]] || continue
+    case "${check_name}" in
+      analyze) expected_workflow=".github/workflows/codeql.yml"; expected_event="pull_request" ;;
+      ci-gate) expected_workflow=".github/workflows/ci.yml"; expected_event="pull_request" ;;
+      dependency-review) expected_workflow=".github/workflows/dependency-review.yml"; expected_event="pull_request" ;;
+      manifest-review-gate) expected_workflow=".github/workflows/manifest-review-gate.yml"; expected_event="pull_request_target" ;;
+      readme-release-gate) expected_workflow=".github/workflows/readme-release-gate.yml"; expected_event="pull_request_target" ;;
+      codex-review-gate) expected_workflow=".github/workflows/codex-review-gate.yml"; expected_event="pull_request" ;;
+      *) fail "required pre-evidence check ${check_name} has no trusted workflow binding" ;;
+    esac
+    jq -e \
+      --arg name "${check_name}" \
+      --arg workflow "${expected_workflow}" \
+      --arg event "${expected_event}" \
+      --argjson app_id "${github_actions_app_id}" \
+      --argjson pr "${PR_NUMBER}" \
+      --arg base "${base_sha}" \
+      --arg head "${head_sha}" \
+      --argjson workflows "${workflows}" '
+        (
+          [ $workflows[]
+            | select(
+                .path == $workflow
+                and .event == $event
+                and .head_sha == $head
+                and any(
+                  .pull_requests[];
+                  .number == $pr
+                  and .base.sha == $base
+                  and .head.sha == $head
+                )
+              )
+          ] | max_by(.id)
+        ) as $latest_workflow
+        | (
+          [ .[]
+            | select(
+                .name == $name
+                and .app.id == $app_id
+                and .head_sha == $head
+                and any(
+                  .pull_requests[];
+                  .number == $pr
+                  and .base.sha == $base
+                  and .head.sha == $head
+                )
+              )
+          ] | max_by(.id)
+        ) as $latest
+        | (
+            $latest.details_url
+            | capture(
+                "^https://github\\.com/markusleben/ha-nova/actions/runs/(?<run>[0-9]+)/job/[0-9]+$"
+              ).run
+          ) as $run
+        | $latest != null
+          and $latest_workflow != null
+          and $latest.status == "completed"
+          and (
+            $latest.conclusion == "success"
+            or $latest.conclusion == "skipped"
+            or $latest.conclusion == "neutral"
+          )
+          and ($latest_workflow.id | tostring) == $run
+          and $latest_workflow.status == "completed"
+          and $latest_workflow.conclusion == "success"
+      ' >/dev/null <<<"${checks}" \
+      || fail "required pre-evidence check ${check_name} is not successful"
+    jq -e --arg name "${check_name}" '
+      [ .[] | select(.context == $name) ] | length == 0
+    ' >/dev/null <<<"${statuses}" \
+      || fail "required pre-evidence check ${check_name} must not be shadowed by a commit status"
+  done < <(
+    jq -r '
+      .main_branch_protection
+      | ((.required_status_checks - ["cloud-source-gate"]) + .advisory_checks)
+      | unique[]
+    ' "${POLICY_FILE}"
+  )
+
+  jq -e \
+    --argjson app_id "${source_app_id}" \
+    --argjson pr "${PR_NUMBER}" \
+    --arg base "${base_sha}" \
+    --arg head "${head_sha}" \
+    --arg target "workflow-run:" \
+    --arg suffix ":target:${merge_sha}" '
+      [ .[]
+        | select(
+            .name == "cloud-source-gate"
+            and .app.id == $app_id
+            and .head_sha == $head
+            and (.external_id | type == "string")
+            and (.external_id | startswith($target) and endswith($suffix))
+            and any(
+              .pull_requests[];
+              .number == $pr
+              and .base.sha == $base
+              and .head.sha == $head
+            )
+          )
+      ] | max_by(.id) as $latest
+      | $latest != null
+        and $latest.status == "completed"
+        and $latest.conclusion == "failure"
+    ' >/dev/null <<<"${checks}" \
+    || fail "cloud-source-gate must be the sole expected failed evidence check"
+  jq -e '
+    [ .[] | select(.context == "cloud-source-gate") ] | length == 0
+  ' >/dev/null <<<"${statuses}" \
+    || fail "cloud-source-gate must not be shadowed by a commit status"
+}
+
+verify_checks
 
 issue_comment_pages="$(
   gh api --paginate --slurp \
@@ -242,43 +365,11 @@ jq -e --arg clean_at "${clean_at}" '
 ' >/dev/null <<<"${reaction_pages}" \
   || fail "a later Codex reaction supersedes the clean result"
 
-source_app_id="$(
-  jq -r '.main_branch_protection.required_status_check_apps["cloud-source-gate"]' \
-    "${POLICY_FILE}"
-)"
-[[ "${source_app_id}" =~ ^[1-9][0-9]*$ ]] \
-  || fail "cloud-source-gate App ID is not provisioned"
-jq -e --argjson app_id "${source_app_id}" '
-  [ .[]
-    | select(.name == "cloud-source-gate" and .app.id == $app_id)
-  ] as $matches
-  | ($matches | length) > 0
-    and all($matches[]; .status == "completed" and .conclusion == "failure")
-' >/dev/null <<<"${checks}" \
-  || fail "cloud-source-gate must be the sole expected failed evidence check"
-
 HA_NOVA_CLOUD_GATE_SOURCE_REF="${source_ref}" \
 HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT="${merge_sha}" \
 HA_NOVA_CLOUD_GATE_EXPECTED_HEAD_COMMIT="${head_sha}" \
 HA_NOVA_CLOUD_GATE_EXPECTED_BASE_COMMIT="${base_sha}" \
   bash scripts/release/verify-cloud-target-source-gate.sh candidate
-
-latest_pr="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
-jq -e \
-  --arg base "${base_sha}" \
-  --arg head "${head_sha}" \
-  --arg merge "${merge_sha}" '
-    .state == "open"
-    and .draft == false
-    and .base.sha == $base
-    and .head.sha == $head
-    and .merge_commit_sha == $merge
-  ' >/dev/null <<<"${latest_pr}" \
-  || fail "pull request changed while candidate source was resolved"
-[[ "$(resolve_remote_sha refs/heads/main "final remote main")" == "${base_sha}" ]] \
-  || fail "main changed while candidate source was resolved"
-[[ "$(resolve_remote_sha "${source_ref}" "final pull request merge ref")" == "${merge_sha}" ]] \
-  || fail "pull request merge ref changed while candidate source was resolved"
 
 expected_commit="${HA_NOVA_CLOUD_CANDIDATE_EXPECTED_COMMIT:-}"
 expected_tree="${HA_NOVA_CLOUD_CANDIDATE_EXPECTED_TREE:-}"
@@ -298,6 +389,25 @@ if [[ -n "${expected_commit}${expected_tree}${expected_base}${expected_head}" ]]
     && "${head_sha}" == "${expected_head}" ]] \
     || fail "candidate identity changed since the initial resolution"
 fi
+
+verify_checks
+
+latest_pr="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
+jq -e \
+  --arg base "${base_sha}" \
+  --arg head "${head_sha}" \
+  --arg merge "${merge_sha}" '
+    .state == "open"
+    and .draft == false
+    and .base.sha == $base
+    and .head.sha == $head
+    and .merge_commit_sha == $merge
+  ' >/dev/null <<<"${latest_pr}" \
+  || fail "pull request changed while candidate source was resolved"
+[[ "$(resolve_remote_sha refs/heads/main "final remote main")" == "${base_sha}" ]] \
+  || fail "main changed while candidate source was resolved"
+[[ "$(resolve_remote_sha "${source_ref}" "final pull request merge ref")" == "${merge_sha}" ]] \
+  || fail "pull request merge ref changed while candidate source was resolved"
 
 {
   printf 'commit_sha=%s\n' "${merge_sha}"

--- a/scripts/release/verify-cloud-candidate-workflow.mjs
+++ b/scripts/release/verify-cloud-candidate-workflow.mjs
@@ -245,14 +245,29 @@ for (const marker of [
   "pull request has requested changes or unresolved review threads",
   "a later Codex inline finding supersedes the clean result",
   '**Reviewed commit:** `" + $prefix + "`',
-  '.name == "cloud-source-gate" and .app.id == $app_id',
+  ".app.id == $app_id",
+  'repos/${REPO}/commits/${head_sha}/status?per_page=100',
+  'repos/${REPO}/actions/runs?head_sha=${head_sha}&per_page=100',
+  '.github/workflows/codeql.yml',
+  '.github/workflows/ci.yml',
+  '.github/workflows/dependency-review.yml',
+  '.github/workflows/manifest-review-gate.yml',
+  '.github/workflows/readme-release-gate.yml',
+  '.github/workflows/codex-review-gate.yml',
+  ".event == $event",
+  "$latest_workflow.id",
+  "must not be shadowed by a commit status",
+  '.name == "cloud-source-gate"',
+  ":target:${merge_sha}",
   '.conclusion == "failure"',
+  "pull request head must contain current main",
   "bash scripts/release/verify-cloud-target-source-gate.sh candidate",
   "pull request changed while candidate source was resolved",
   "final pull request merge ref",
 ]) {
   requireText(resolver, marker, `resolver guard ${marker}`);
 }
+requireCount(resolver, "verify_checks", 3, "initial plus final check validation");
 
 console.log(
   "[verify-cloud-candidate-workflow] OK: exact reviewed source -> native raw-binary smoke -> final signed bundles -> complete-state check; no publication",

--- a/tests/onboarding/cloud-candidate-workflow-behavior.ts
+++ b/tests/onboarding/cloud-candidate-workflow-behavior.ts
@@ -20,6 +20,18 @@ type FixtureChange =
   | "wrong-head-repo"
   | "wrong-parent"
   | "failed-check"
+  | "older-failed-check"
+  | "spoofed-check"
+  | "same-app-spoofed-check"
+  | "wrong-check-event"
+  | "wrong-workflow-pr"
+  | "later-pending-workflow"
+  | "stale-check-base"
+  | "wrong-cloud-target"
+  | "later-pending-check"
+  | "failed-commit-status"
+  | "successful-commit-status"
+  | "passing-conclusions"
   | "stale-codex"
   | "spoofed-codex"
   | "later-codex-finding"
@@ -28,6 +40,7 @@ type FixtureChange =
   | "unresolved-thread"
   | "changes-requested"
   | "moved-late"
+  | "moved-during-final-checks"
   | "source-rejected"
   | "identity-mismatch"
   | "cloud-success";
@@ -106,44 +119,248 @@ function runResolver(
     tree: { sha: tree },
     parents: [{ sha: change === "wrong-parent" ? head : base }, { sha: head }],
   };
+  const checkBinding = {
+    head_sha: head,
+    pull_requests: [
+      {
+        number: 42,
+        base: {
+          sha: change === "stale-check-base" ? "f".repeat(40) : base,
+        },
+        head: { sha: head },
+      },
+    ],
+  };
+  const workflowBinding = {
+    ...checkBinding,
+    pull_requests: checkBinding.pull_requests.map((pullRequest) => ({
+      ...pullRequest,
+      number: change === "wrong-workflow-pr" ? 43 : pullRequest.number,
+    })),
+  };
   const checks = [
+    ...(change === "older-failed-check"
+      ? [
+          {
+            id: 0,
+            name: "cloud-source-gate",
+            status: "completed",
+            conclusion: "success",
+            app: { id: 4400145 },
+            details_url:
+              "https://github.com/markusleben/ha-nova/actions/runs/0/job/0",
+            external_id: `workflow-run:1:attempt:1:target:${merge}`,
+            ...checkBinding,
+          },
+          {
+            id: 1,
+            name: "ci-gate",
+            status: "completed",
+            conclusion: "failure",
+            app: { id: 15368 },
+            details_url:
+              "https://github.com/markusleben/ha-nova/actions/runs/1/job/1",
+            ...checkBinding,
+          },
+        ]
+      : []),
     {
+      id: 2,
       name: "analyze",
       status: "completed",
-      conclusion: "success",
-      app: { id: 1 },
+      conclusion: change === "passing-conclusions" ? "neutral" : "success",
+      app: { id: 15368 },
+      details_url:
+        "https://github.com/markusleben/ha-nova/actions/runs/2/job/2",
+      ...checkBinding,
     },
     {
+      id: 3,
       name: "ci-gate",
       status: "completed",
-      conclusion: change === "failed-check" ? "failure" : "success",
-      app: { id: 1 },
+      conclusion:
+        change === "failed-check" || change === "spoofed-check"
+          ? "failure"
+          : change === "passing-conclusions"
+            ? "skipped"
+            : "success",
+      app: { id: 15368 },
+      details_url:
+        "https://github.com/markusleben/ha-nova/actions/runs/3/job/3",
+      ...checkBinding,
     },
     {
+      id: 4,
       name: "codex-review-gate",
       status: "completed",
       conclusion: "success",
-      app: { id: 1 },
+      app: { id: 15368 },
+      details_url:
+        "https://github.com/markusleben/ha-nova/actions/runs/4/job/4",
+      ...checkBinding,
     },
     {
+      id: 5,
       name: "cloud-source-gate",
       status: "completed",
       conclusion: change === "cloud-success" ? "success" : "failure",
       app: { id: 4400145 },
+      details_url:
+        "https://github.com/markusleben/ha-nova/actions/runs/5/job/5",
+      external_id: `workflow-run:1:attempt:1:target:${
+        change === "wrong-cloud-target" ? "e".repeat(40) : merge
+      }`,
+      ...checkBinding,
     },
+    ...(change === "spoofed-check"
+      ? [
+          {
+            id: 99,
+            name: "ci-gate",
+            status: "completed",
+            conclusion: "success",
+            app: { id: 999 },
+            details_url:
+              "https://github.com/markusleben/ha-nova/actions/runs/99/job/99",
+            ...checkBinding,
+          },
+        ]
+      : []),
+    ...(change === "same-app-spoofed-check"
+      ? [
+          {
+            id: 99,
+            name: "ci-gate",
+            status: "completed",
+            conclusion: "success",
+            app: { id: 15368 },
+            details_url:
+              "https://github.com/markusleben/ha-nova/actions/runs/99/job/99",
+            ...checkBinding,
+          },
+        ]
+      : []),
+  ];
+  const workflowRuns = [
+    {
+      id: 1,
+      path: ".github/workflows/ci.yml",
+      event: "pull_request",
+      status: "completed",
+      conclusion: "failure",
+      ...workflowBinding,
+    },
+    {
+      id: 2,
+      path: ".github/workflows/codeql.yml",
+      event: "pull_request",
+      status: "completed",
+      conclusion: "success",
+      ...workflowBinding,
+    },
+    {
+      id: 3,
+      path: ".github/workflows/ci.yml",
+      event: change === "wrong-check-event" ? "push" : "pull_request",
+      status: "completed",
+      conclusion: "success",
+      ...workflowBinding,
+    },
+    {
+      id: 4,
+      path: ".github/workflows/codex-review-gate.yml",
+      event: "pull_request",
+      status: "completed",
+      conclusion: "success",
+      ...workflowBinding,
+    },
+    ...(change === "same-app-spoofed-check"
+      ? [
+          {
+            id: 99,
+            path: ".github/workflows/spoof.yml",
+            event: "pull_request",
+            status: "completed",
+            conclusion: "success",
+            ...workflowBinding,
+          },
+        ]
+      : []),
+    ...(change === "later-pending-workflow"
+      ? [
+          {
+            id: 100,
+            path: ".github/workflows/ci.yml",
+            event: "pull_request",
+            status: "in_progress",
+            conclusion: null,
+            ...workflowBinding,
+          },
+        ]
+      : []),
   ];
   const prPath = join(root, "pr.json");
   const commitPath = join(root, "commit.json");
   const checksPath = join(root, "checks.json");
+  const laterChecksPath = join(root, "later-checks.json");
+  const statusesPath = join(root, "statuses.json");
+  const workflowRunsPath = join(root, "workflow-runs.json");
   const commentsPath = join(root, "comments.json");
   const reviewsPath = join(root, "reviews.json");
   const inlineCommentsPath = join(root, "inline-comments.json");
   const reactionsPath = join(root, "reactions.json");
   const threadsPath = join(root, "threads.json");
   const prCallsPath = join(root, "pr-calls");
+  const checkCallsPath = join(root, "check-calls");
   writeFileSync(prPath, JSON.stringify(pr));
   writeFileSync(commitPath, JSON.stringify(commit));
   writeFileSync(checksPath, JSON.stringify([{ check_runs: checks }]));
+  writeFileSync(
+    laterChecksPath,
+    JSON.stringify([
+      {
+        check_runs:
+          change === "later-pending-check"
+            ? [
+                ...checks,
+                {
+                  id: 100,
+                  name: "ci-gate",
+                  status: "in_progress",
+                  conclusion: null,
+                  app: { id: 15368 },
+                  ...checkBinding,
+                },
+              ]
+            : checks,
+      },
+    ]),
+  );
+  writeFileSync(
+    statusesPath,
+    JSON.stringify([
+      {
+        statuses:
+          change === "failed-commit-status" ||
+          change === "successful-commit-status"
+            ? [
+                {
+                  id: 1,
+                  context: "ci-gate",
+                  state:
+                    change === "successful-commit-status"
+                      ? "success"
+                      : "failure",
+                },
+              ]
+            : [],
+      },
+    ]),
+  );
+  writeFileSync(
+    workflowRunsPath,
+    JSON.stringify([{ workflow_runs: workflowRuns }]),
+  );
   writeFileSync(
     commentsPath,
     JSON.stringify([
@@ -229,6 +446,7 @@ function runResolver(
     ]),
   );
   writeFileSync(prCallsPath, "0\n");
+  writeFileSync(checkCallsPath, "0\n");
   writeExecutable(
     join(root, "scripts", "release", "verify-cloud-target-source-gate.sh"),
     `#!/usr/bin/env bash
@@ -249,14 +467,25 @@ case "$*" in
   "api repos/markusleben/ha-nova/pulls/42")
     calls="$(( $(<"$FAKE_PR_CALLS") + 1 ))"
     printf '%s\n' "$calls" >"$FAKE_PR_CALLS"
-    if [[ "$FAKE_CHANGE" == "moved-late" && "$calls" -gt 1 ]]; then
+    if [[ "$FAKE_CHANGE" == "moved-late" && "$calls" -gt 1 ]] || \
+       [[ "$FAKE_CHANGE" == "moved-during-final-checks" && $(<"$FAKE_CHECK_CALLS") -gt 1 ]]; then
       sed 's/"state":"open"/"state":"closed"/' "$FAKE_PR"
     else
       cat "$FAKE_PR"
     fi
     ;;
   "api repos/markusleben/ha-nova/git/commits/$FAKE_MERGE") cat "$FAKE_COMMIT" ;;
-  "api --paginate --slurp repos/markusleben/ha-nova/commits/$FAKE_MERGE/check-runs?filter=latest&per_page=100") cat "$FAKE_CHECKS" ;;
+  "api --paginate --slurp repos/markusleben/ha-nova/commits/$FAKE_HEAD/check-runs?filter=latest&per_page=100")
+    calls="$(( $(<"$FAKE_CHECK_CALLS") + 1 ))"
+    printf '%s\n' "$calls" >"$FAKE_CHECK_CALLS"
+    if [[ "$FAKE_CHANGE" == "later-pending-check" && "$calls" -gt 1 ]]; then
+      cat "$FAKE_LATER_CHECKS"
+    else
+      cat "$FAKE_CHECKS"
+    fi
+    ;;
+  "api --paginate --slurp repos/markusleben/ha-nova/commits/$FAKE_HEAD/status?per_page=100") cat "$FAKE_STATUSES" ;;
+  "api --paginate --slurp repos/markusleben/ha-nova/actions/runs?head_sha=$FAKE_HEAD&per_page=100") cat "$FAKE_WORKFLOW_RUNS" ;;
   "api --paginate --slurp repos/markusleben/ha-nova/issues/42/comments?per_page=100") cat "$FAKE_COMMENTS" ;;
   "api --paginate --slurp repos/markusleben/ha-nova/pulls/42/reviews?per_page=100") cat "$FAKE_REVIEWS" ;;
   "api --paginate --slurp repos/markusleben/ha-nova/pulls/42/comments?per_page=100") cat "$FAKE_INLINE_COMMENTS" ;;
@@ -284,12 +513,16 @@ esac
         FAKE_PR: prPath,
         FAKE_COMMIT: commitPath,
         FAKE_CHECKS: checksPath,
+        FAKE_LATER_CHECKS: laterChecksPath,
+        FAKE_STATUSES: statusesPath,
+        FAKE_WORKFLOW_RUNS: workflowRunsPath,
         FAKE_COMMENTS: commentsPath,
         FAKE_REVIEWS: reviewsPath,
         FAKE_INLINE_COMMENTS: inlineCommentsPath,
         FAKE_REACTIONS: reactionsPath,
         FAKE_THREADS: threadsPath,
         FAKE_PR_CALLS: prCallsPath,
+        FAKE_CHECK_CALLS: checkCallsPath,
         FAKE_CHANGE: change ?? "valid",
         FAKE_BASE: base,
         FAKE_HEAD: head,
@@ -325,6 +558,16 @@ describe("Cloud candidate source resolver", () => {
     expect(result.stdout).toContain("OK: PR #42");
   });
 
+  it("uses the latest protected and evidence check runs", () => {
+    const result = runResolver("older-failed-check");
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
+  it("accepts GitHub's passing check conclusions", () => {
+    const result = runResolver("passing-conclusions");
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
   it.each([
     ["a draft", "draft"],
     ["a non-maintainer dispatcher", "wrong-actor"],
@@ -334,6 +577,16 @@ describe("Cloud candidate source resolver", () => {
     ["a fork", "wrong-head-repo"],
     ["wrong merge parents", "wrong-parent"],
     ["another failed check", "failed-check"],
+    ["a same-name check from another App", "spoofed-check"],
+    ["a same-name check from another workflow", "same-app-spoofed-check"],
+    ["a check backed by the wrong workflow event", "wrong-check-event"],
+    ["a check backed by another pull request", "wrong-workflow-pr"],
+    ["an older check behind a newer pending workflow", "later-pending-workflow"],
+    ["checks from a stale pull-request base", "stale-check-base"],
+    ["a Cloud check for another merge target", "wrong-cloud-target"],
+    ["a later pending check", "later-pending-check"],
+    ["a failed same-name commit status", "failed-commit-status"],
+    ["a successful same-name commit status", "successful-commit-status"],
     ["a stale Codex result", "stale-codex"],
     ["a prefixed Codex impersonator", "spoofed-codex"],
     ["a later Codex finding", "later-codex-finding"],
@@ -342,6 +595,7 @@ describe("Cloud candidate source resolver", () => {
     ["an unresolved review thread", "unresolved-thread"],
     ["requested changes", "changes-requested"],
     ["a pull request that moves during resolution", "moved-late"],
+    ["a pull request that moves during final check validation", "moved-during-final-checks"],
     ["a source rejected by the trusted bootstrap verifier", "source-rejected"],
     ["a changed expected identity", "identity-mismatch"],
     ["an already-successful evidence gate", "cloud-success"],


### PR DESCRIPTION
## Summary

- validate protected checks on the pull-request head used by GitHub
- bind each check to the exact Actions workflow, event, PR, base, head, App, and latest run
- reject same-name commit statuses and revalidate mutable state before output

## Root cause

Cloud Candidate Bundle run 30462637236 queried the synthetic merge SHA for checks. GitHub attached the PR checks to head SHA a0d498df999fa89315e00675fd4618561f1e0c57, so source resolution failed before any build, signing, or secret-bearing job.

## Verification

- release-gates-behavior.test.ts: 201/201
- resolver focused suite: 34/34
- bash -n and ShellCheck
- trusted workflow static verifier
- git diff --check
- three adversarial reviews CLEAN on 9566566bdc131d76758f596a287f77e332c7a58b

No canary rerun was dispatched.
