### PR TITLE
fix: stream Cloud candidate workflow history

### DIFF
--- a/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
+++ b/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
@@ -24,6 +24,8 @@ cannot produce the first candidate needed to collect the evidence.
   workflow and event, expected App, pull request, current base/head, and merge
   target; reject all same-name commit statuses and revalidate the complete
   check state before returning.
+- Keep paginated GitHub API payloads out of process arguments so normal check
+  history cannot exceed the operating system's argument-size limit.
 - Require a real clean Codex bot result bound to the current pull-request head;
   an advisory workflow timeout is insufficient. Reject requested changes,
   unresolved threads, and later Codex findings.

--- a/scripts/release/resolve-cloud-candidate-source.sh
+++ b/scripts/release/resolve-cloud-candidate-source.sh
@@ -104,7 +104,7 @@ source_app_id="$(
 github_actions_app_id=15368
 
 verify_checks() {
-  local check_pages status_pages workflow_pages checks statuses workflows
+  local check_pages status_pages workflow_pages checks statuses
   local check_name expected_workflow expected_event
   workflow_pages="$(
     gh api --paginate --slurp \
@@ -120,7 +120,6 @@ verify_checks() {
   )"
   checks="$(jq -c '[.[].check_runs[]]' <<<"${check_pages}")"
   statuses="$(jq -c '[.[].statuses[]]' <<<"${status_pages}")"
-  workflows="$(jq -c '[.[].workflow_runs[]]' <<<"${workflow_pages}")"
 
   while IFS= read -r check_name; do
     [[ -n "${check_name}" ]] || continue
@@ -141,9 +140,11 @@ verify_checks() {
       --argjson pr "${PR_NUMBER}" \
       --arg base "${base_sha}" \
       --arg head "${head_sha}" \
-      --argjson workflows "${workflows}" '
+      --slurpfile workflows <(
+        jq -c '[.[].workflow_runs[]]' <<<"${workflow_pages}"
+      ) '
         (
-          [ $workflows[]
+          [ $workflows[0][]
             | select(
                 .path == $workflow
                 and .event == $event

--- a/scripts/release/verify-cloud-candidate-workflow.mjs
+++ b/scripts/release/verify-cloud-candidate-workflow.mjs
@@ -248,6 +248,7 @@ for (const marker of [
   ".app.id == $app_id",
   'repos/${REPO}/commits/${head_sha}/status?per_page=100',
   'repos/${REPO}/actions/runs?head_sha=${head_sha}&per_page=100',
+  "--slurpfile workflows",
   '.github/workflows/codeql.yml',
   '.github/workflows/ci.yml',
   '.github/workflows/dependency-review.yml',

--- a/tests/onboarding/cloud-candidate-workflow-behavior.ts
+++ b/tests/onboarding/cloud-candidate-workflow-behavior.ts
@@ -26,6 +26,7 @@ type FixtureChange =
   | "wrong-check-event"
   | "wrong-workflow-pr"
   | "later-pending-workflow"
+  | "large-workflow-history"
   | "stale-check-base"
   | "wrong-cloud-target"
   | "later-pending-check"
@@ -242,6 +243,15 @@ function runResolver(
       : []),
   ];
   const workflowRuns = [
+    ...(change === "large-workflow-history"
+      ? [
+          {
+            id: 0,
+            path: ".github/workflows/history.yml",
+            padding: "x".repeat(3 * 1024 * 1024),
+          },
+        ]
+      : []),
     {
       id: 1,
       path: ".github/workflows/ci.yml",
@@ -565,6 +575,11 @@ describe("Cloud candidate source resolver", () => {
 
   it("accepts GitHub's passing check conclusions", () => {
     const result = runResolver("passing-conclusions");
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
+  it("accepts workflow history larger than the process argument limit", () => {
+    const result = runResolver("large-workflow-history");
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

- keep paginated workflow-run history out of the jq process argument list
- preserve the exact workflow/run selection through jq slurpfile input
- cover a 3 MiB workflow history payload that exceeds Linux and macOS argument limits

## Root cause

Cloud Candidate Bundle run 30468920990 failed before build or signing because the resolver passed the complete Actions workflow history through --argjson. Linux rejected the jq process with Argument list too long.

## Verification

- release-gates-behavior.test.ts: 202/202
- 3 MiB ARG_MAX regression
- bash -n and ShellCheck
- trusted workflow static verifier
- git diff --check
- three adversarial reviews CLEAN on 038c939926b9c8fe28c62ed7c9b8a8c1c5650a12

No candidate rerun was dispatched.
