### PR TITLE
fix: support macOS Bash in main protection check

### DIFF
--- a/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
+++ b/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
@@ -33,6 +33,8 @@ cannot produce the first candidate needed to collect the evidence.
   the expected evidence-pending state.
 - Use trusted build and signing scripts from `main`; treat the candidate
   checkout only as source and bundle data.
+- Keep shared trusted shell checks compatible with the macOS runner's Bash
+  3.2.
 - Build official-tag Linux, Windows, and signed macOS binaries, then sign
   exact-tree install-bundle provenance with protected production secrets.
 - Smoke the exact raw binaries natively on Linux, macOS, and Windows before
@@ -72,3 +74,5 @@ automatic dispatch. One explicit run creates one immutable candidate.
   unresolved threads still fail closed.
 - The complete local release-contract suite passes before one reviewed
   bootstrap workflow run is allowed.
+- The live main-protection check passes when invoked with `/bin/bash` on
+  macOS.

--- a/scripts/release/verify-github-main-protection.sh
+++ b/scripts/release/verify-github-main-protection.sh
@@ -122,12 +122,15 @@ if [[ "${strict}" != "${expected_strict}" ]]; then
   exit 1
 fi
 
-mapfile -t advisory_checks < <(jq -r '.main_branch_protection.advisory_checks[]?' "${POLICY_FILE}")
-for advisory_check in "${advisory_checks[@]}"; do
+advisory_checks="$(
+  jq -r '.main_branch_protection.advisory_checks[]?' "${POLICY_FILE}"
+)"
+while IFS= read -r advisory_check; do
+  [[ -z "${advisory_check}" ]] && continue
   if printf '%s' "${actual_contexts_json}" | grep -Fq "\"${advisory_check}\""; then
     echo "::error::${advisory_check} must remain advisory on ${REPO}:${BRANCH}."
     exit 1
   fi
-done
+done <<< "${advisory_checks}"
 
 echo "[verify-github-main-protection] OK: ${REPO}:${BRANCH}"

--- a/tests/onboarding/dependabot-automation-contract.test.ts
+++ b/tests/onboarding/dependabot-automation-contract.test.ts
@@ -349,6 +349,7 @@ describe("dependabot automation contract", () => {
     expect(protectionScript).toContain("dismiss_stale_reviews");
     expect(protectionScript).toContain("required_conversation_resolution");
     expect(protectionScript).toContain("strict_required_status_checks");
+    expect(protectionScript).not.toContain("mapfile");
   });
 
   it("pins production deployment refs and keeps only the existing safe actions lane", () => {


### PR DESCRIPTION
## Summary
- replace Bash 4-only `mapfile` in the shared main-protection verifier
- preserve fail-fast policy parsing on macOS Bash 3.2
- document and guard the candidate workflow portability contract

## Verification
- `/bin/bash scripts/release/verify-github-main-protection.sh`
- `npx vitest run` release-contract suite: 416/416
- targeted main-protection tests: 22/22
- `shellcheck -e SC2043 scripts/release/verify-github-main-protection.sh`

Root cause of candidate run 30472140895; no signing or build step ran.