### PR TITLE
fix: select macOS signing identity by name

### DIFF
--- a/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
+++ b/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
@@ -37,6 +37,8 @@ cannot produce the first candidate needed to collect the evidence.
   3.2.
 - Build official-tag Linux, Windows, and signed macOS binaries, then sign
   exact-tree install-bundle provenance with protected production secrets.
+- Sign with the exactly validated Developer ID common name so current macOS
+  runners do not depend on legacy SHA-1 identity lookup.
 - Smoke the exact raw binaries natively on Linux, macOS, and Windows before
   provenance signing; raw binaries must reject missing Cloud provenance.
 - After all native smokes, revalidate the complete reviewed state, build the

--- a/scripts/release/build-sign-darwin-binaries.sh
+++ b/scripts/release/build-sign-darwin-binaries.sh
@@ -68,9 +68,6 @@ identity_lines="$(
 identity_count="$(grep -c . <<<"${identity_lines}" || true)"
 [[ "${identity_count}" == "1" ]] \
   || fail "expected exactly one ${EXPECTED_IDENTITY} identity"
-identity_hash="$(awk '{print $2}' <<<"${identity_lines}")"
-[[ "${identity_hash}" =~ ^[0-9A-Fa-f]{40}$ ]] \
-  || fail "could not resolve the Developer ID identity hash"
 
 mkdir -p "${DIST_DIR}"
 for arch in amd64 arm64; do
@@ -86,7 +83,7 @@ for arch in amd64 arm64; do
   )
   /usr/bin/codesign \
     --force \
-    --sign "${identity_hash}" \
+    --sign "${EXPECTED_IDENTITY}" \
     --keychain "${keychain_path}" \
     --timestamp \
     --options runtime,hard,kill,library \

--- a/tests/onboarding/cloud-release-gate-contract.ts
+++ b/tests/onboarding/cloud-release-gate-contract.ts
@@ -409,6 +409,8 @@ export function registerCloudReleaseGateContractTests(): void {
       ),
     ).toBeLessThan(darwinBuilder.indexOf("go build -trimpath"));
     expect(darwinBuilder).toContain("-T /usr/bin/codesign");
+    expect(darwinBuilder).toContain('--sign "${EXPECTED_IDENTITY}"');
+    expect(darwinBuilder).not.toContain("identity_hash");
     expect(darwinBuilder).toContain("umask 077");
     expect(darwinBuilder).not.toContain("\n  -A \\\n");
     expect(darwinBuilder).toContain(


### PR DESCRIPTION
## Summary
- keep the exact Developer ID identity validation
- let `codesign` select that identity by its exact common name
- avoid SHA-1 identity lookup rejected by the current macOS 26 runner

## Verification
- release contract: 31/31
- `bash -n scripts/release/build-sign-darwin-binaries.sh`
- `shellcheck scripts/release/build-sign-darwin-binaries.sh`

Root cause of candidate run 30474542156. The identity imported and validated successfully; signing by its legacy SHA-1 fingerprint returned `no identity found`. No artifact was uploaded.