### PR TITLE
fix: expose temporary macOS signing keychain

### DIFF
--- a/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
+++ b/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
@@ -37,8 +37,9 @@ cannot produce the first candidate needed to collect the evidence.
   3.2.
 - Build official-tag Linux, Windows, and signed macOS binaries, then sign
   exact-tree install-bundle provenance with protected production secrets.
-- Sign with the exactly validated Developer ID common name so current macOS
-  runners do not depend on legacy SHA-1 identity lookup.
+- Sign with the exactly validated Developer ID common name, temporarily make
+  only its keychain user-searchable, and restore the prior keychain search
+  list during cleanup.
 - Smoke the exact raw binaries natively on Linux, macOS, and Windows before
   provenance signing; raw binaries must reject missing Cloud provenance.
 - After all native smokes, revalidate the complete reviewed state, build the

--- a/scripts/release/build-sign-darwin-binaries.sh
+++ b/scripts/release/build-sign-darwin-binaries.sh
@@ -28,8 +28,13 @@ temporary_base="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
 signing_dir="$(mktemp -d "${temporary_base%/}/ha-nova-signing.XXXXXX")"
 certificate_path="${signing_dir}/developer-id.p12"
 keychain_path="${signing_dir}/ha-nova-signing.keychain-db"
+original_keychains=()
+keychain_search_list_changed=false
 
 cleanup() {
+  if [[ "${keychain_search_list_changed}" == true ]]; then
+    /usr/bin/security list-keychains -d user -s "${original_keychains[@]}" >/dev/null 2>&1 || true
+  fi
   /usr/bin/security delete-keychain "${keychain_path}" >/dev/null 2>&1 || true
   /bin/chmod -R u+rwX "${signing_dir}" >/dev/null 2>&1 || true
   /bin/rm -rf "${signing_dir}"
@@ -43,6 +48,14 @@ printf '%s' "${HA_NOVA_MACOS_CERTIFICATE_P12_BASE64}" \
   || fail "could not decode Developer ID certificate"
 unset HA_NOVA_MACOS_CERTIFICATE_P12_BASE64
 unset HA_NOVA_MACOS_CERTIFICATE_PASSWORD
+
+original_keychain_lines="$(
+  /usr/bin/security list-keychains -d user \
+    | /usr/bin/sed -E 's/^[[:space:]]*"//; s/"$//'
+)" || fail "could not read the user keychain search list"
+while IFS= read -r original_keychain; do
+  [[ -z "${original_keychain}" ]] || original_keychains+=("${original_keychain}")
+done <<< "${original_keychain_lines}"
 
 /usr/bin/security create-keychain -p "${keychain_password}" "${keychain_path}"
 /usr/bin/security set-keychain-settings -lut 21600 "${keychain_path}"
@@ -58,6 +71,8 @@ unset HA_NOVA_MACOS_CERTIFICATE_PASSWORD
   -s \
   -k "${keychain_password}" \
   "${keychain_path}" >/dev/null
+/usr/bin/security list-keychains -d user -s "${keychain_path}"
+keychain_search_list_changed=true
 unset certificate_password
 unset keychain_password
 

--- a/scripts/release/build-sign-darwin-binaries.sh
+++ b/scripts/release/build-sign-darwin-binaries.sh
@@ -33,7 +33,11 @@ keychain_search_list_changed=false
 
 cleanup() {
   if [[ "${keychain_search_list_changed}" == true ]]; then
-    /usr/bin/security list-keychains -d user -s "${original_keychains[@]}" >/dev/null 2>&1 || true
+    if (( ${#original_keychains[@]} > 0 )); then
+      /usr/bin/security list-keychains -d user -s "${original_keychains[@]}" >/dev/null 2>&1 || true
+    else
+      /usr/bin/security list-keychains -d user -s >/dev/null 2>&1 || true
+    fi
   fi
   /usr/bin/security delete-keychain "${keychain_path}" >/dev/null 2>&1 || true
   /bin/chmod -R u+rwX "${signing_dir}" >/dev/null 2>&1 || true

--- a/scripts/release/provision-macos-signing-secrets.sh
+++ b/scripts/release/provision-macos-signing-secrets.sh
@@ -41,6 +41,14 @@ if [[ "${openssl_version}" == "OpenSSL 3."* ]]; then
   openssl_pkcs12_args=(-legacy)
 fi
 
+run_openssl_pkcs12() {
+  if (( ${#openssl_pkcs12_args[@]} > 0 )); then
+    openssl pkcs12 "${openssl_pkcs12_args[@]}" "$@"
+  else
+    openssl pkcs12 "$@"
+  fi
+}
+
 gh auth status --hostname github.com >/dev/null \
   || fail "GitHub CLI authentication is unavailable"
 active_user="$(gh api user --jq .login)" \
@@ -61,8 +69,7 @@ printf '\n' >&2
 [[ -n "${certificate_password}" ]] \
   || fail "certificate password must not be empty"
 
-if ! openssl pkcs12 \
-    "${openssl_pkcs12_args[@]}" \
+if ! run_openssl_pkcs12 \
     -in "${certificate_path}" \
     -passin fd:3 \
     -nocerts \
@@ -74,8 +81,7 @@ if ! openssl pkcs12 \
 fi
 
 certificate_subject="$(
-  openssl pkcs12 \
-      "${openssl_pkcs12_args[@]}" \
+  run_openssl_pkcs12 \
       -in "${certificate_path}" \
       -passin fd:3 \
       -clcerts \

--- a/tests/onboarding/cloud-release-gate-contract.ts
+++ b/tests/onboarding/cloud-release-gate-contract.ts
@@ -411,6 +411,12 @@ export function registerCloudReleaseGateContractTests(): void {
     expect(darwinBuilder).toContain("-T /usr/bin/codesign");
     expect(darwinBuilder).toContain('--sign "${EXPECTED_IDENTITY}"');
     expect(darwinBuilder).not.toContain("identity_hash");
+    expect(darwinBuilder).toContain(
+      'security list-keychains -d user -s "${keychain_path}"',
+    );
+    expect(darwinBuilder.indexOf(
+      'security list-keychains -d user -s "${original_keychains[@]}"',
+    )).toBeLessThan(darwinBuilder.indexOf("security delete-keychain"));
     expect(darwinBuilder).toContain("umask 077");
     expect(darwinBuilder).not.toContain("\n  -A \\\n");
     expect(darwinBuilder).toContain(

--- a/tests/onboarding/cloud-release-gate-contract.ts
+++ b/tests/onboarding/cloud-release-gate-contract.ts
@@ -414,6 +414,9 @@ export function registerCloudReleaseGateContractTests(): void {
     expect(darwinBuilder).toContain(
       'security list-keychains -d user -s "${keychain_path}"',
     );
+    expect(darwinBuilder).toContain(
+      "if (( ${#original_keychains[@]} > 0 )); then",
+    );
     expect(darwinBuilder.indexOf(
       'security list-keychains -d user -s "${original_keychains[@]}"',
     )).toBeLessThan(darwinBuilder.indexOf("security delete-keychain"));

--- a/tests/onboarding/macos-signing-provision-behavior.test.ts
+++ b/tests/onboarding/macos-signing-provision-behavior.test.ts
@@ -12,6 +12,7 @@ import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 const script = "scripts/release/provision-macos-signing-secrets.sh";
+const scriptContent = readFileSync(script, "utf8");
 const temporaryRoots: string[] = [];
 
 function executable(path: string, body: string): void {
@@ -102,7 +103,7 @@ esac
 `,
   );
 
-  const result = spawnSync("bash", [script, p12], {
+  const result = spawnSync("/bin/bash", [script, p12], {
     encoding: "utf8",
     env: {
       ...process.env,
@@ -135,6 +136,12 @@ afterEach(() => {
 });
 
 describe("macOS signing secret provisioning", () => {
+  it("guards empty OpenSSL arguments for macOS Bash 3.2", () => {
+    expect(scriptContent).toContain(
+      "if (( ${#openssl_pkcs12_args[@]} > 0 )); then",
+    );
+  });
+
   it("requests one hidden password and uploads only the two protected secrets", () => {
     const result = runProvision({});
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);


### PR DESCRIPTION
## Summary
- add the temporary signing keychain to the user search list required by GitHub macOS runners
- preserve and restore the prior user keychain search list during cleanup
- keep the validated exact Developer ID identity and isolated keychain

## Verification
- release contract: 31/31
- `bash -n scripts/release/build-sign-darwin-binaries.sh`
- `shellcheck scripts/release/build-sign-darwin-binaries.sh`

Root cause confirmed by candidate runs 30474542156 and 30476183853: `security find-identity` saw the imported identity but `codesign` on macos-26-arm64 could not discover it because the temporary keychain was absent from the user search list. No candidate artifact was uploaded.