### PR TITLE
fix: acknowledge expected Windows candidate smoke exit

### DIFF
--- a/.github/workflows/cloud-candidate-bundle.yml
+++ b/.github/workflows/cloud-candidate-bundle.yml
@@ -304,6 +304,7 @@ jobs:
           if ($LASTEXITCODE -eq 0) {
             throw "Raw Windows binary accepted missing Cloud provenance"
           }
+          exit 0
 
   finalize-candidate:
     name: Finalize current reviewed candidate

--- a/.github/workflows/cloud-candidate-bundle.yml
+++ b/.github/workflows/cloud-candidate-bundle.yml
@@ -300,11 +300,15 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "Windows candidate binary version check failed"
           }
-          & $binary internal-cloud-release-check
-          if ($LASTEXITCODE -eq 0) {
-            throw "Raw Windows binary accepted missing Cloud provenance"
+          $provenanceOutput = (& $binary internal-cloud-release-check 2>&1 | Out-String).Trim()
+          $provenanceExitCode = $LASTEXITCODE
+          if (
+            $provenanceExitCode -ne 1 -or
+            $provenanceOutput -notmatch "official Cloud release provenance is not enabled"
+          ) {
+            throw "Raw Windows binary returned an unexpected provenance result"
           }
-          exit 0
+          $global:LASTEXITCODE = 0
 
   finalize-candidate:
     name: Finalize current reviewed candidate

--- a/.github/workflows/cloud-candidate-bundle.yml
+++ b/.github/workflows/cloud-candidate-bundle.yml
@@ -304,7 +304,7 @@ jobs:
           $provenanceExitCode = $LASTEXITCODE
           if (
             $provenanceExitCode -ne 1 -or
-            $provenanceOutput -notmatch "official Cloud release provenance is not enabled"
+            $provenanceOutput -ne "[ha-nova] ERROR: official Cloud release provenance is not enabled"
           ) {
             throw "Raw Windows binary returned an unexpected provenance result"
           }

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -258,7 +258,7 @@ jobs:
             $provenanceExitCode = $LASTEXITCODE
             if (
               $provenanceExitCode -ne 1 -or
-              $provenanceOutput -notmatch "official Cloud release provenance is not enabled"
+              $provenanceOutput -ne "[ha-nova] ERROR: official Cloud release provenance is not enabled"
             ) {
               throw "unlisted Windows runtime returned an unexpected provenance result"
             }

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -254,8 +254,13 @@ jobs:
               throw "enabled Cloud runtime provenance check failed"
             }
           } else {
-            & $binary internal-cloud-release-check
-            if ($LASTEXITCODE -eq 0) {
-              throw "unlisted Windows runtime accepted Cloud release provenance"
+            $provenanceOutput = (& $binary internal-cloud-release-check 2>&1 | Out-String).Trim()
+            $provenanceExitCode = $LASTEXITCODE
+            if (
+              $provenanceExitCode -ne 1 -or
+              $provenanceOutput -notmatch "official Cloud release provenance is not enabled"
+            ) {
+              throw "unlisted Windows runtime returned an unexpected provenance result"
             }
+            $global:LASTEXITCODE = 0
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,12 +320,21 @@ jobs:
             $metadata.cloud_remote_enabled -eq $true -and
             @($metadata.cloud_remote_platforms) -contains "windows"
           )
-          & $binary internal-cloud-release-check
-          if ($listed -and $LASTEXITCODE -ne 0) {
-            throw "enabled Windows Cloud release provenance check failed"
-          }
-          if (-not $listed -and $LASTEXITCODE -eq 0) {
-            throw "unlisted Windows runtime accepted Cloud release provenance"
+          if ($listed) {
+            & $binary internal-cloud-release-check
+            if ($LASTEXITCODE -ne 0) {
+              throw "enabled Windows Cloud release provenance check failed"
+            }
+          } else {
+            $provenanceOutput = (& $binary internal-cloud-release-check 2>&1 | Out-String).Trim()
+            $provenanceExitCode = $LASTEXITCODE
+            if (
+              $provenanceExitCode -ne 1 -or
+              $provenanceOutput -notmatch "official Cloud release provenance is not enabled"
+            ) {
+              throw "unlisted Windows runtime returned an unexpected provenance result"
+            }
+            $global:LASTEXITCODE = 0
           }
 
   publish-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,7 +330,7 @@ jobs:
             $provenanceExitCode = $LASTEXITCODE
             if (
               $provenanceExitCode -ne 1 -or
-              $provenanceOutput -notmatch "official Cloud release provenance is not enabled"
+              $provenanceOutput -ne "[ha-nova] ERROR: official Cloud release provenance is not enabled"
             ) {
               throw "unlisted Windows runtime returned an unexpected provenance result"
             }

--- a/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
+++ b/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
@@ -42,6 +42,8 @@ cannot produce the first candidate needed to collect the evidence.
   list during cleanup.
 - Smoke the exact raw binaries natively on Linux, macOS, and Windows before
   provenance signing; raw binaries must reject missing Cloud provenance.
+  The Windows negative smoke must then return success instead of leaking that
+  expected native rejection code into the workflow step.
 - After all native smokes, revalidate the complete reviewed state, build the
   final hash-bound signed bundles, verify every archive's binary identity and
   signed platform/architecture provenance, then revalidate again immediately

--- a/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
+++ b/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
@@ -42,9 +42,9 @@ cannot produce the first candidate needed to collect the evidence.
   list during cleanup.
 - Smoke the exact raw binaries natively on Linux, macOS, and Windows before
   provenance signing; raw binaries must reject missing Cloud provenance.
-  Windows negative smokes must accept only the documented exit code and
-  message, then clear that expected native rejection before the workflow step
-  ends.
+  Windows negative smokes must accept only the documented exit code and exact
+  complete message, then clear that expected native rejection before the
+  workflow step ends.
 - After all native smokes, revalidate the complete reviewed state, build the
   final hash-bound signed bundles, verify every archive's binary identity and
   signed platform/architecture provenance, then revalidate again immediately

--- a/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
+++ b/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
@@ -42,8 +42,9 @@ cannot produce the first candidate needed to collect the evidence.
   list during cleanup.
 - Smoke the exact raw binaries natively on Linux, macOS, and Windows before
   provenance signing; raw binaries must reject missing Cloud provenance.
-  The Windows negative smoke must then return success instead of leaking that
-  expected native rejection code into the workflow step.
+  Windows negative smokes must accept only the documented exit code and
+  message, then clear that expected native rejection before the workflow step
+  ends.
 - After all native smokes, revalidate the complete reviewed state, build the
   final hash-bound signed bundles, verify every archive's binary identity and
   signed platform/architecture provenance, then revalidate again immediately

--- a/scripts/release/verify-cloud-candidate-workflow.mjs
+++ b/scripts/release/verify-cloud-candidate-workflow.mjs
@@ -139,6 +139,11 @@ requireText(
   "Raw Windows binary accepted missing Cloud provenance",
   "Windows raw-binary provenance rejection",
 );
+requireText(
+  workflow,
+  'throw "Raw Windows binary accepted missing Cloud provenance"\n          }\n          exit 0',
+  "successful Windows negative-smoke completion",
+);
 requireCount(
   workflow,
   'chmod 755 "$binary"',

--- a/scripts/release/verify-cloud-candidate-workflow.mjs
+++ b/scripts/release/verify-cloud-candidate-workflow.mjs
@@ -134,14 +134,19 @@ requireText(
   "candidate bundle version does not match workflow input",
   "Unix bundle-version assertion",
 );
-requireText(
+const windowsSmoke = jobBody(
   workflow,
-  "Raw Windows binary accepted missing Cloud provenance",
-  "Windows raw-binary provenance rejection",
+  "smoke-windows-binary",
+  "finalize-candidate",
 );
 requireText(
-  workflow,
-  'throw "Raw Windows binary accepted missing Cloud provenance"\n          }\n          exit 0',
+  windowsSmoke,
+  '$provenanceExitCode -ne 1 -or\n            $provenanceOutput -notmatch "official Cloud release provenance is not enabled"',
+  "exact Windows raw-binary provenance rejection",
+);
+requireText(
+  windowsSmoke,
+  "$global:LASTEXITCODE = 0",
   "successful Windows negative-smoke completion",
 );
 requireCount(

--- a/scripts/release/verify-cloud-candidate-workflow.mjs
+++ b/scripts/release/verify-cloud-candidate-workflow.mjs
@@ -141,7 +141,7 @@ const windowsSmoke = jobBody(
 );
 requireText(
   windowsSmoke,
-  '$provenanceExitCode -ne 1 -or\n            $provenanceOutput -notmatch "official Cloud release provenance is not enabled"',
+  '$provenanceExitCode -ne 1 -or\n            $provenanceOutput -ne "[ha-nova] ERROR: official Cloud release provenance is not enabled"',
   "exact Windows raw-binary provenance rejection",
 );
 requireText(

--- a/tests/onboarding/cloud-candidate-workflow-behavior.ts
+++ b/tests/onboarding/cloud-candidate-workflow-behavior.ts
@@ -681,6 +681,26 @@ describe("Cloud candidate workflow contract", () => {
     );
   });
 
+  it("rejects a Windows negative smoke without explicit completion", () => {
+    const root = mkdtempSync(
+      join(tmpdir(), "ha-nova-cloud-candidate-contract-"),
+    );
+    const unsafeWorkflow = join(root, "cloud-candidate-bundle.yml");
+    writeFileSync(
+      unsafeWorkflow,
+      workflow.replace("          $global:LASTEXITCODE = 0\n", ""),
+    );
+    const result = spawnSync(
+      "node",
+      [verifierPath, unsafeWorkflow, resolverPath],
+      { encoding: "utf8" },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "successful Windows negative-smoke completion is missing",
+    );
+  });
+
   it("uses trusted scripts with an explicit immutable source root", () => {
     for (const path of [
       "scripts/release/build-rc-binaries.sh",

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -68,7 +68,7 @@ describe("release contract", () => {
     for (const workflow of [releaseWorkflow, rcWorkflow]) {
       expect(workflow).toContain("$provenanceExitCode -ne 1 -or");
       expect(workflow).toContain(
-        '$provenanceOutput -notmatch "official Cloud release provenance is not enabled"',
+        '$provenanceOutput -ne "[ha-nova] ERROR: official Cloud release provenance is not enabled"',
       );
       expect(workflow).toContain("$global:LASTEXITCODE = 0");
     }

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -64,6 +64,16 @@ describe("release contract", () => {
     expect(existsSync("release/winget-publication-state.json")).toBe(false);
   });
 
+  it("accepts only the exact expected Windows negative provenance result", () => {
+    for (const workflow of [releaseWorkflow, rcWorkflow]) {
+      expect(workflow).toContain("$provenanceExitCode -ne 1 -or");
+      expect(workflow).toContain(
+        '$provenanceOutput -notmatch "official Cloud release provenance is not enabled"',
+      );
+      expect(workflow).toContain("$global:LASTEXITCODE = 0");
+    }
+  });
+
   it.each(["v0.22.0-rc0", "v0.22.0-rc01", "v01.22.0-rc1"])(
     "rejects non-canonical RC tag %s across release entry points",
     (tag) => {

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -260,7 +260,7 @@ describe("release contract", () => {
       'elif "$workdir/ha-nova/ha-nova" internal-cloud-release-check; then',
     );
     expect(rcWorkflow).toContain(
-      "unlisted Windows runtime accepted Cloud release provenance",
+      "unlisted Windows runtime returned an unexpected provenance result",
     );
   });
 


### PR DESCRIPTION
## Summary
- finish the successful Windows negative provenance smoke with exit code 0
- enforce the completion contract in the candidate workflow verifier
- document the fail-closed/step-success distinction

## Verification
- `node scripts/release/verify-cloud-candidate-workflow.mjs .github/workflows/cloud-candidate-bundle.yml scripts/release/resolve-cloud-candidate-source.sh`
- `npx vitest run tests/onboarding/release-gates-behavior.test.ts -t "passes the trusted non-publishing workflow verifier"`
- full `tests/onboarding/release-gates-behavior.test.ts` (203/203)
- `git diff --check`

No tag, release, publication, or candidate dispatch.