### PR TITLE
fix: resolve candidate version metadata path

### DIFF
--- a/.github/workflows/cloud-candidate-bundle.yml
+++ b/.github/workflows/cloud-candidate-bundle.yml
@@ -390,7 +390,7 @@ jobs:
             node -e '
               const version = require(process.argv[1]);
               process.stdout.write(version.cloud_remote_platforms.join(","));
-            ' target/version.json
+            ' ./target/version.json
           )"
           verify_evidence() {
             local bundle_json="$1" binary="$2" os="$3" arch="$4" binary_name="$5"

--- a/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
+++ b/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
@@ -47,8 +47,8 @@ cannot produce the first candidate needed to collect the evidence.
   workflow step ends.
 - After all native smokes, revalidate the complete reviewed state, build the
   final hash-bound signed bundles, verify every archive's binary identity and
-  signed platform/architecture provenance, then revalidate again immediately
-  before upload.
+  signed platform/architecture provenance using paths resolvable from the
+  trusted workspace, then revalidate again immediately before upload.
 - Serialize duplicate dispatches for one pull request.
 - Retain Cloud-ineligible raw transport artifacts for one day and final
   candidate bundles for seven days.

--- a/scripts/release/verify-cloud-candidate-workflow.mjs
+++ b/scripts/release/verify-cloud-candidate-workflow.mjs
@@ -134,6 +134,11 @@ requireText(
   "candidate bundle version does not match workflow input",
   "Unix bundle-version assertion",
 );
+requireText(
+  workflow,
+  "' ./target/version.json",
+  "resolvable candidate version path",
+);
 const windowsSmoke = jobBody(
   workflow,
   "smoke-windows-binary",

--- a/scripts/release/verify-cloud-candidate-workflow.mjs
+++ b/scripts/release/verify-cloud-candidate-workflow.mjs
@@ -129,16 +129,22 @@ requireText(
   "verify-cloud-release-evidence.mjs",
   "public-key verification for every signed archive",
 );
-requireText(
-  workflow,
-  "candidate bundle version does not match workflow input",
-  "Unix bundle-version assertion",
+const candidateVerificationRuns = runBodies(
+  jobBody(workflow, "finalize-candidate"),
+).filter((body) =>
+  body.includes("candidate bundle version does not match workflow input")
 );
+if (candidateVerificationRuns.length !== 1) {
+  fail("candidate bundle verification run must occur exactly once");
+}
 requireText(
-  workflow,
+  candidateVerificationRuns[0],
   "' ./target/version.json",
   "resolvable candidate version path",
 );
+if (candidateVerificationRuns[0].includes("' target/version.json")) {
+  fail("candidate version path must not use a package-style lookup");
+}
 const windowsSmoke = jobBody(
   workflow,
   "smoke-windows-binary",


### PR DESCRIPTION
## Summary
- resolve candidate version metadata through an explicit relative path
- keep the workflow contract from regressing to a package-style lookup
- document the trusted-workspace path requirement

## Verification
- `node scripts/release/verify-cloud-candidate-workflow.mjs .github/workflows/cloud-candidate-bundle.yml scripts/release/resolve-cloud-candidate-source.sh`
- negative mutation: `target/version.json` rejected
- `bash scripts/release/verify-cloud-workflow-gate.sh`
- `npm test -- --run tests/onboarding/release-contract.test.ts` (32/32)
- `git diff --check`

Canary run 30482441173 reached final signed-bundle verification after all native smokes passed, then failed because Node treated `target/version.json` as a package name. No retry was dispatched.