### PR TITLE
docs: scope Cloud release evidence by risk

### DIFF
--- a/docs/reference/safety.md
+++ b/docs/reference/safety.md
@@ -6,8 +6,8 @@ Last verified: 2026-07-11 — `npm run verify`, `go test ./...`, and the live en
 
 The Home Assistant Cloud remote transport on current `main` is a Beta and is
 not covered by that earlier live proof. It remains release-gated on the
-real-device matrix in
-`docs/work/2026-07-25-home-assistant-cloud-remote-spec.md`.
+exact-target checks and risk-scoped real-device qualifications in
+`docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md`.
 
 ## Writes
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -185,7 +185,8 @@ OSes, the installed Relay App, and the reference Cloud health smoke always run:
 - `automatic` routing chooses Cloud only for a pure local network failure and
   never after authentication, pin, identity, protocol, or dispatch failure;
 - one 10,000-command Ingress-session stress run with bounded memory after a
-  Cloud or Relay transport change, not once per operating system;
+  Cloud or Relay transport change or stress-harness change, not once per
+  operating system;
 - real native-storage happy-path and fail-closed no-UI behavior on every
   advertised desktop OS for first support; shared orchestration changes repeat
   one reference OS and adapter changes repeat only the affected OS;

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -87,8 +87,13 @@ interface. Normal development and release binaries deliberately ignore it.
 Host-safe tests prove parsing, lifecycle, redirect rejection, no-UI policy, and
 transport selection with injected stores and servers. They do not prove a
 native keyring, a Nabu Casa OAuth flow, or a real Supervisor Ingress session.
-The Cloud Beta therefore requires a separate real-device proof on the exact
-candidate commit.
+The Cloud Beta therefore requires an exact-candidate evidence envelope plus
+every real-device qualification invalidated by the candidate diff.
+
+Every candidate still uses its downloaded binary with `HA_NOVA_NO_CENSUS=1`
+to run one reference-platform `relay health --via cloud` against the exact
+installed Relay App. This smoke is separate from full route parity and never
+carries forward.
 
 Use an isolated CLI as described above, but do not set a file-backed device
 credential or test-keyring override for a release proof. Cloud OAuth refresh
@@ -155,29 +160,43 @@ remote-first case:
 "${cloud_test_binary}" cloud remove --server <test-profile>
 ```
 
-Required evidence:
+Required evidence is exact-target plus risk-scoped qualification. Repeat a
+real-device row only for first support or after a relevant implementation
+or evidence-harness change; exact-target CI, signed provenance on all enabled
+OSes, the installed Relay App, and the reference Cloud health smoke always run:
 
 - `/health`, `/ws`, `/core`, `/files`, and `/backups` parity through a real
-  Home Assistant Cloud route;
-- default and custom Cloud domains, MFA, inactive subscription, disabled remote
-  access, authorization abort, and recovery after each durable-state boundary;
-- Owner, admin, standard, and read-only Home Assistant users, including proof
-  that functional calls are bound to the authenticated user and Relay instance;
-- App restart, update, and reinstall; device revoke; concurrent reconnect; and
-  Relay-instance mismatch;
+  Home Assistant Cloud route on one reference platform after a transport
+  change;
+- one real canonical Nabu Casa OAuth flow and one real standard
+  non-administrator binding; Home Assistant owns the MFA challenge before
+  returning the same OAuth callback, while deterministic tests cover custom
+  origins, inactive subscription, disabled remote access, and authorization
+  abort;
+- one isolated Cloud-authorized profile first proves Relay App restart and
+  reinstall recovery, then HA NOVA CLI standard uninstall/reinstall with
+  retained authorization, then full purge last; the purge revokes and verifies
+  the active remote authorization and device before local cleanup;
+  deterministic tests cover durable-state recovery and concurrent reconnect,
+  while update and instance mismatch run for relevant changes;
 - redirect rejection and absence of credentials from config, argv, logs,
   diagnostics, and AI-visible output at every network hop;
 - `automatic` routing chooses Cloud only for a pure local network failure and
   never after authentication, pin, identity, protocol, or dispatch failure;
-- a 10,000-command Ingress-session stress run with bounded memory;
-- real native-storage lock, unlock, cancellation, timeout, and no-UI behavior
-  on every advertised macOS, Windows, and Linux desktop context.
+- one 10,000-command Ingress-session stress run with bounded memory after a
+  Cloud or Relay transport change, not once per operating system;
+- real native-storage happy-path and fail-closed no-UI behavior on every
+  advertised desktop OS for first support; shared orchestration changes repeat
+  one reference OS and adapter changes repeat only the affected OS;
+  deterministic platform tests cover cancellation and timeout.
 
 Standard uninstall must keep the test profile, device pairing, and Cloud
 authorization. Full purge must revoke and verify the Cloud authorization before
 removing local config or secrets. If any security, full-parity, or native-store
-gate fails, the Beta is not eligible for release. The complete matrix lives in
-`docs/work/2026-07-25-home-assistant-cloud-remote-spec.md`.
+gate fails, the Beta is not eligible for release. The complete contract lives
+in `docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md`.
+The activation or release pull request carries the non-secret qualification
+ledger required there; no private Cloud URL belongs in it.
 
 ## Headless and cross-platform
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -92,8 +92,9 @@ every real-device qualification invalidated by the candidate diff.
 
 Every candidate still uses its downloaded binary with `HA_NOVA_NO_CENSUS=1`
 to run one reference-platform `relay health --via cloud` against the exact
-installed Relay App. This smoke is separate from full route parity and never
-carries forward.
+installed Relay App. The proof parses the JSON and requires the expected App
+version plus `ha_ws_connected: true`; command success alone is insufficient.
+This smoke is separate from full route parity and never carries forward.
 
 Use an isolated CLI as described above, but do not set a file-backed device
 credential or test-keyring override for a release proof. Cloud OAuth refresh

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -302,7 +302,8 @@ Missing or uncertain ledger data means rerun.
 Every target still runs CI, candidate signature/provenance checks on all
 enabled platforms, the exact installed Relay App, and one real Cloud health
 smoke on a reference platform. The smoke uses the downloaded candidate binary,
-`--via cloud`, the exact installed App, and `HA_NOVA_NO_CENSUS=1`.
+`--via cloud`, the exact installed App, and `HA_NOVA_NO_CENSUS=1`; its JSON must
+report the expected App version and `ha_ws_connected: true`.
 
 - `parity`: `/health`, `/ws`, `/core`, `/files`, and `/backups` through real
   Home Assistant Cloud on one reference platform after a transport change;
@@ -431,6 +432,7 @@ VERSION_TAG=v0.22.0-rc1 # replace
 CANDIDATE_OS=macos
 CANDIDATE_ARCH=arm64
 SERVER_NAME=default
+EXPECTED_RELAY_APP_VERSION=0.7.1 # replace from exact-target nova/config.yaml
 CANDIDATE_DIR="$(mktemp -d)"
 tar -xzf "cloud-candidate-install-bundles/ha-nova-installer-bundle-${CANDIDATE_OS}-${CANDIDATE_ARCH}.tar.gz" \
   -C "${CANDIDATE_DIR}"
@@ -453,6 +455,7 @@ executable explicitly:
 $ExpectedTree = "0123456789abcdef0123456789abcdef01234567" # replace
 $Version = "0.22.0-rc1" # replace
 $ServerName = "default"
+$ExpectedRelayAppVersion = "0.7.1" # replace from exact-target nova/config.yaml
 $CandidateDir = Join-Path $env:TEMP ("ha-nova-cloud-candidate-" + [guid]::NewGuid())
 Expand-Archive `
   -LiteralPath "cloud-candidate-install-bundles\ha-nova-installer-bundle-windows-amd64.zip" `
@@ -476,14 +479,38 @@ Choose exactly one reference platform for the exact-target Cloud health smoke.
 Use the same explicit downloaded candidate binary and exact installed App:
 
 ```bash
-HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" relay health \
-  --server "${SERVER_NAME}" --via cloud
+HEALTH_JSON="$(
+  HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" relay health \
+    --server "${SERVER_NAME}" --via cloud
+)"
+node -e '
+  const fs = require("node:fs");
+  const payload = JSON.parse(fs.readFileSync(0, "utf8"));
+  if (
+    payload.ok !== true ||
+    payload.data?.status !== "ok" ||
+    payload.data?.ha_ws_connected !== true ||
+    payload.data?.version !== process.argv[1]
+  ) {
+    throw new Error("candidate Cloud health payload is not release-ready");
+  }
+' "${EXPECTED_RELAY_APP_VERSION}" <<<"${HEALTH_JSON}"
 ```
 
 ```powershell
 $env:HA_NOVA_NO_CENSUS = "1"
-& $CandidateBin relay health --server $ServerName --via cloud
+$HealthJson = (& $CandidateBin relay health --server $ServerName --via cloud |
+  Out-String)
 if ($LASTEXITCODE -ne 0) { throw "candidate Cloud health smoke failed" }
+$Health = $HealthJson | ConvertFrom-Json
+if (
+  $Health.ok -ne $true -or
+  $Health.data.status -ne "ok" -or
+  $Health.data.ha_ws_connected -ne $true -or
+  $Health.data.version -ne $ExpectedRelayAppVersion
+) {
+  throw "candidate Cloud health payload is not release-ready"
+}
 ```
 
 Only after a Cloud or Relay transport change, run one stress proof on that

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -308,7 +308,8 @@ report the expected App version and `ha_ws_connected: true`.
 - `parity`: `/health`, `/ws`, `/core`, `/files`, and `/backups` through real
   Home Assistant Cloud on one reference platform after a transport change;
 - `stress_10000`: one bounded Ingress-session stress run with 10,000 commands
-  after a Cloud or Relay transport change, not once per operating system;
+  after a Cloud or Relay transport change or stress-harness change, not once
+  per operating system;
 - `keyrings`: real happy-path and fail-closed no-UI behavior on each enabled
   platform for first support; shared orchestration changes repeat one reference
   OS and adapter changes repeat only their affected OS; deterministic tests
@@ -513,8 +514,9 @@ if (
 }
 ```
 
-Only after a Cloud or Relay transport change, run one stress proof on that
-reference platform and profile:
+Only after a Cloud or Relay transport change or a change to
+`internal-cloud-stress` or its evidence collection/validation harness, run one
+stress proof on that reference platform and profile:
 
 ```bash
 HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" internal-cloud-stress \

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -292,26 +292,61 @@ The JSON is commit-specific and has this exact schema:
 ```
 
 The `keyrings` keys must exactly match `cloud_remote_platforms`. Each `true`
-value attests the complete real-device matrix rather than a unit-test proxy:
+value attests the exact-target checks plus every still-applicable risk-scoped
+qualification. Before carrying a qualification forward, inspect the complete
+qualification-to-target diff. In the activation or release pull request,
+record each carried check and keyring OS with its qualified commit/tree,
+non-secret evidence reference, inspected target, and change-class decision.
+Missing or uncertain ledger data means rerun.
+
+Every target still runs CI, candidate signature/provenance checks on all
+enabled platforms, the exact installed Relay App, and one real Cloud health
+smoke on a reference platform. The smoke uses the downloaded candidate binary,
+`--via cloud`, the exact installed App, and `HA_NOVA_NO_CENSUS=1`.
 
 - `parity`: `/health`, `/ws`, `/core`, `/files`, and `/backups` through real
-  Home Assistant Cloud;
-- `stress_10000`: one bounded Ingress-session stress run with 10,000 commands;
-- `keyrings`: real lock, unlock, cancellation, timeout, and no-UI behavior on
-  each enabled platform;
-- `roles`: Owner, admin, standard, and read-only user binding;
-- `domains_mfa`: default/custom domains, MFA, inactive subscription, disabled
-  remote access, and authorization abort;
-- `lifecycle`: durable-boundary recovery, reconnect, revoke, restart, update,
-  reinstall, instance mismatch, standard uninstall, and full purge;
+  Home Assistant Cloud on one reference platform after a transport change;
+- `stress_10000`: one bounded Ingress-session stress run with 10,000 commands
+  after a Cloud or Relay transport change, not once per operating system;
+- `keyrings`: real happy-path and fail-closed no-UI behavior on each enabled
+  platform for first support; shared orchestration changes repeat one reference
+  OS and adapter changes repeat only their affected OS; deterministic tests
+  cover cancellation and timeout branches;
+- `roles`: one real standard non-administrator binding plus exact-target user
+  and Relay identity-binding tests; Owner and administrator add no separate
+  transport path;
+- `domains_mfa`: one real canonical Nabu Casa OAuth flow plus deterministic
+  custom-origin, inactive-subscription, disabled-remote, and
+  authorization-abort branches; Home Assistant owns its MFA challenge before
+  returning the same OAuth callback;
+- `lifecycle`: one isolated Cloud-authorized profile first proves Relay App
+  restart and reinstall recovery, then HA NOVA CLI standard
+  uninstall/reinstall with retained authorization, then full purge last; the
+  purge revokes and verifies the active remote authorization and device before
+  local cleanup; deterministic durable-boundary and concurrency recovery
+  covers the other branches, with real update or instance-mismatch runs after
+  those paths change;
 - `redirects_non_disclosure`: redirect rejection plus credential absence from
-  config, argv, logs, diagnostics, and AI-visible output;
+  config, argv, logs, diagnostics, and AI-visible output, with one retained
+  real artifact scan after a relevant transport, config, argv, log,
+  diagnostics, or AI-output change;
 - `installed_relay_app`: the App installed for the real-device proof was built
   by Supervisor from the exact reviewed source commit, reports the exact
   `nova/config.yaml` version, and contains the reviewed Cloud endpoints;
-- `routing`: automatic fallback only before functional dispatch; and
-- `signing_and_update_matrix`: stable signing identity plus the complete
-  stable/RC/reinstall Keychain authorization matrix.
+- `routing`: one real automatic fallback after a routing change plus
+  exact-target fail-closed selection tests; and
+- `signing_and_update_matrix`: exact candidate signature and provenance on all
+  enabled platforms, with real install/update repetition only after installer,
+  updater, signing-identity, or native-authorization changes.
+
+No mock replaces a required real positive path. Exact-target CI, candidate
+provenance, `installed_relay_app`, and the Cloud health smoke are never carried
+forward. See
+`docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md`.
+Carry-forward applies only to the qualification behind a check boolean: create
+a new exact-target JSON envelope and never copy an older commit/tree identity.
+The complete bounded change-class map is in that spec. A test or harness change
+invalidates every qualification that relies on it as substitute evidence.
 
 For the first evidence on an activation pull request, dispatch the
 non-publishing candidate builder exactly once from current `main`.
@@ -385,10 +420,10 @@ the artifact promptly. If the run fails, inspect its logs and fix the cause in
 a reviewed pull request; workflow reruns are rejected, so use one new explicit
 dispatch only after the fix is reviewed.
 
-Run the stress proof from the exact enabled candidate bundle on each selected
-server profile. Never call a `ha-nova` found through `PATH`: extract the
-matching platform archive, verify its bundle identity against the run summary,
-and invoke that contained binary by its explicit path. For macOS or Linux:
+Never call a `ha-nova` found through `PATH`: extract each matching platform
+archive, verify its bundle identity against the run summary, and invoke that
+contained binary by its explicit path. On every enabled platform run the
+provenance check. For macOS or Linux:
 
 ```bash
 EXPECTED_TREE=0123456789abcdef0123456789abcdef01234567 # replace
@@ -409,8 +444,6 @@ if (bundle.version !== version || bundle.cloud_release?.source_tree_sha !== tree
 }
 NODE
 HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" internal-cloud-release-check
-HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" internal-cloud-stress \
-  --server "${SERVER_NAME}"
 ```
 
 On the Windows Proxmox test machine, use PowerShell and the contained
@@ -437,6 +470,31 @@ $CandidateBin = Join-Path $CandidateRoot "ha-nova.exe"
 $env:HA_NOVA_NO_CENSUS = "1"
 & $CandidateBin internal-cloud-release-check
 if ($LASTEXITCODE -ne 0) { throw "candidate provenance check failed" }
+```
+
+Choose exactly one reference platform for the exact-target Cloud health smoke.
+Use the same explicit downloaded candidate binary and exact installed App:
+
+```bash
+HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" relay health \
+  --server "${SERVER_NAME}" --via cloud
+```
+
+```powershell
+$env:HA_NOVA_NO_CENSUS = "1"
+& $CandidateBin relay health --server $ServerName --via cloud
+if ($LASTEXITCODE -ne 0) { throw "candidate Cloud health smoke failed" }
+```
+
+Only after a Cloud or Relay transport change, run one stress proof on that
+reference platform and profile:
+
+```bash
+HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" internal-cloud-stress \
+  --server "${SERVER_NAME}"
+```
+
+```powershell
 & $CandidateBin internal-cloud-stress --server $ServerName
 if ($LASTEXITCODE -ne 0) { throw "candidate Cloud stress proof failed" }
 ```
@@ -459,13 +517,15 @@ and directly controls its Cloud runtime, so evidence from the disabled source
 cannot attest the enabled runtime. The activation PR must reach a stable head,
 but in `pull_request` CI that checked-out head is GitHub's synthetic
 `refs/pull/<number>/merge` commit, not the PR branch head. Product, release
-metadata, or sensitive workflow changes require the enabled real-device matrix
-on that exact merge commit, followed by a repository-secret update and a CI
-rerun without changing the PR or its base. If the merge commit changes, repeat
-the proof. A target containing only the narrowly verified existing
-non-sensitive `uses:` version changes may reuse evidence from its exact
-ancestor instead. If a merge queue is used, `merge_group` creates another
-synthetic checkout commit and follows the same rule.
+metadata, or sensitive workflow changes require a new exact-target evidence
+envelope and every qualification row invalidated by that delta, followed by a
+repository-secret update and a CI rerun without changing the PR or its base.
+If the merge commit changes, rebuild the exact-target envelope; repeat only
+the qualification rows invalidated by the new delta. A target containing only
+the narrowly verified existing non-sensitive `uses:` version changes may
+reuse evidence from its exact ancestor instead. If a merge queue is used,
+`merge_group` creates another synthetic checkout commit and follows the same
+rule.
 
 After squash merge, the resulting `main` commit has a different SHA but may
 reuse the reviewed PR evidence only while its complete Git tree is identical

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -348,7 +348,8 @@ forward. See
 Carry-forward applies only to the qualification behind a check boolean: create
 a new exact-target JSON envelope and never copy an older commit/tree identity.
 The complete bounded change-class map is in that spec. A test or harness change
-invalidates every qualification that relies on it as substitute evidence.
+invalidates every qualification that relies on it as deterministic or real
+evidence.
 
 For the first evidence on an activation pull request, dispatch the
 non-publishing candidate builder exactly once from current `main`.

--- a/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
+++ b/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
@@ -665,13 +665,13 @@ Cloud setup/resume remain blocked.
 ## Release gates
 
 - Full route parity on one real reference platform and bounded Ingress memory
-  under one 10,000-command stress run after a Cloud or Relay transport change.
-  The hidden `internal-cloud-stress` command resolves one explicit Cloud
-  transport, then performs exactly 10,000 read-only authenticated `/health`
-  requests through that one process-local Ingress session. It has fixed
-  per-request and overall deadlines, stops on the first redirect, transport,
-  status, size, encoding, or Relay-identity failure, and never runs Census or
-  update checks.
+  under one 10,000-command stress run after a Cloud or Relay transport change
+  or stress-harness change. The hidden `internal-cloud-stress` command resolves
+  one explicit Cloud transport, then performs exactly 10,000 read-only
+  authenticated `/health` requests through that one process-local Ingress
+  session. It has fixed per-request and overall deadlines, stops on the first
+  redirect, transport, status, size, encoding, or Relay-identity failure, and
+  never runs Census or update checks.
 - Real keyring happy-path and fail-closed no-UI behavior on every advertised
   OS for first support. Shared orchestration changes repeat one reference OS;
   adapter changes repeat only the affected OS. Deterministic platform tests

--- a/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
+++ b/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
@@ -696,7 +696,9 @@ non-secret qualification ledger in the activation or release pull request.
 Changes to a deterministic substitute test invalidate its qualification.
 Exact-target CI, candidate provenance on all enabled OSes, the installed Relay
 App, and one downloaded-candidate `relay health --via cloud` smoke with Census
-suppressed never carry forward. See
+suppressed never carry forward. The smoke must parse the JSON and require the
+expected App version and `ha_ws_connected: true`; a zero exit code alone is not
+evidence. See
 `2026-07-30-cloud-release-evidence-risk-scope-spec.md`.
 
 The feature stays unavailable if any security or full-parity gate fails. The

--- a/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
+++ b/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
@@ -693,7 +693,8 @@ Cloud setup/resume remain blocked.
 Real-device qualifications remain applicable across unrelated changes only
 after reviewing the complete qualification-to-target diff and recording the
 non-secret qualification ledger in the activation or release pull request.
-Changes to a deterministic substitute test invalidate its qualification.
+Changes to a deterministic substitute or real evidence harness invalidate its
+qualification.
 Exact-target CI, candidate provenance on all enabled OSes, the installed Relay
 App, and one downloaded-candidate `relay health --via cloud` smoke with Census
 suppressed never carry forward. The smoke must parse the JSON and require the

--- a/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
+++ b/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
@@ -664,19 +664,40 @@ Cloud setup/resume remain blocked.
 
 ## Release gates
 
-- Full route parity and bounded Ingress memory under a 10,000-command stress
-  run. The hidden `internal-cloud-stress` command resolves one explicit Cloud
+- Full route parity on one real reference platform and bounded Ingress memory
+  under one 10,000-command stress run after a Cloud or Relay transport change.
+  The hidden `internal-cloud-stress` command resolves one explicit Cloud
   transport, then performs exactly 10,000 read-only authenticated `/health`
   requests through that one process-local Ingress session. It has fixed
   per-request and overall deadlines, stops on the first redirect, transport,
   status, size, encoding, or Relay-identity failure, and never runs Census or
   update checks.
-- Real keyrings on every advertised OS and all Home Assistant user roles.
-- Default/custom domains, MFA, recovery/concurrency, App lifecycle, inactive
-  subscriptions, and disabled remote access.
+- Real keyring happy-path and fail-closed no-UI behavior on every advertised
+  OS for first support. Shared orchestration changes repeat one reference OS;
+  adapter changes repeat only the affected OS. Deterministic platform tests
+  cover prompt cancellation and timeout.
+- One real standard non-administrator role binding and one canonical Nabu Casa
+  OAuth flow. Home Assistant owns its MFA challenge before returning the same
+  OAuth callback. Deterministic authorization tests cover custom origins,
+  inactive subscriptions, disabled remote access, and authorization abort.
+- One isolated Cloud-authorized lifecycle profile first covers Relay App
+  restart and reinstall recovery, then HA NOVA CLI standard uninstall/reinstall
+  with retained authorization, then full purge last. The purge revokes and
+  verifies the active remote authorization and device before local cleanup.
+  Deterministic tests cover durable recovery and concurrency; update and
+  instance mismatch receive real runs when those paths change.
 - Redirect rejection and credential non-disclosure tests at every network hop.
 - Crash-point tests for every durable-state transition and credential rotation.
 - Proof that local automatic fallback occurs only before functional dispatch.
+
+Real-device qualifications remain applicable across unrelated changes only
+after reviewing the complete qualification-to-target diff and recording the
+non-secret qualification ledger in the activation or release pull request.
+Changes to a deterministic substitute test invalidate its qualification.
+Exact-target CI, candidate provenance on all enabled OSes, the installed Relay
+App, and one downloaded-candidate `relay health --via cloud` smoke with Census
+suppressed never carry forward. See
+`2026-07-30-cloud-release-evidence-risk-scope-spec.md`.
 
 The feature stays unavailable if any security or full-parity gate fails. The
 GitHub `production` environment accepts only branch `main` and tags matching

--- a/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
+++ b/docs/work/2026-07-29-cloud-candidate-bootstrap-spec.md
@@ -57,7 +57,7 @@ cannot produce the first candidate needed to collect the evidence.
 - Expose no Cloud-runnable bundle before smoke tests and final revalidation.
 - Never execute candidate code in an artifact-producing or secret-bearing job;
   the first positive signed-runtime check uses the downloaded final artifact
-  in the real-device matrix.
+  in the required real-device qualification.
 - Fail closed on a moved pull request, stale base, missing merge ref, source
   mismatch, failed check, invalid version, or missing signing secret.
 - Preserve evidence across the required squash merge only when the resulting

--- a/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
+++ b/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
@@ -42,7 +42,8 @@ qualification ledger before the boolean is set to `true`.
 ## Invalidation map
 
 Use the narrowest matching row. A change that matches multiple rows invalidates
-their union.
+their union. A qualification trigger includes changes to every deterministic
+substitute and real evidence collection/validation harness it relies on.
 
 | Changed surface | Qualification to repeat | Real platform scope |
 |---|---|---|
@@ -54,7 +55,7 @@ their union.
 | Relay App startup, identity, device registry, or installation | `installed_relay_app`; relevant lifecycle and redirect paths | One reference platform |
 | CLI setup, install, update, uninstall, signing identity, or authorization retention | `signing_and_update_matrix`; relevant lifecycle path | Affected OS only; exact provenance still runs on all enabled OSes |
 | Config, argv, logs, diagnostics, or AI-visible output | `redirects_non_disclosure` | Affected surface; one retained real artifact scan |
-| A deterministic test or harness used in place of a real branch | Its owning qualification | Same scope as that qualification |
+| A deterministic substitute or real evidence collection/validation harness | Its owning qualification | Same scope as that qualification |
 | Release workflow or provenance machinery only | `signing_and_update_matrix` | Exact provenance on all enabled OSes |
 | Unrelated docs, tests, process, or product code | None | Exact-target layer only |
 

--- a/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
+++ b/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
@@ -49,6 +49,7 @@ their union.
 | Cloud or Relay transport, Ingress session, endpoint, or route selection | `parity`, `stress_10000`, `routing`, relevant lifecycle and non-disclosure paths | One reference platform |
 | Shared native-secret orchestration | `keyrings` | One reference platform, plus any OS with different behavior |
 | macOS, Windows, or Linux native-store adapter | `keyrings`; relevant lifecycle path | Affected OS only |
+| `internal-cloud-stress` or its evidence collection/validation harness | `stress_10000` | One reference platform |
 | OAuth, Home Assistant user binding, or App discovery | `roles`, `domains_mfa`; relevant authorization lifecycle | One reference platform |
 | Relay App startup, identity, device registry, or installation | `installed_relay_app`; relevant lifecycle and redirect paths | One reference platform |
 | CLI setup, install, update, uninstall, signing identity, or authorization retention | `signing_and_update_matrix`; relevant lifecycle path | Affected OS only; exact provenance still runs on all enabled OSes |
@@ -61,8 +62,8 @@ their union.
 
 - `parity`: real `/health`, `/ws`, `/core`, `/files`, and `/backups` parity on
   one reference platform for every Cloud or Relay transport change.
-- `stress_10000`: one real bounded run per Cloud or Relay transport change,
-  not once per operating system.
+- `stress_10000`: one real bounded run per Cloud or Relay transport change or
+  stress-harness change, not once per operating system.
 - `keyrings`: real happy-path and fail-closed no-UI behavior on every enabled
   OS for first support. A shared orchestration change repeats one reference OS;
   an adapter change repeats only its affected OS. Deterministic platform tests

--- a/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
+++ b/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
@@ -1,0 +1,120 @@
+# Cloud Release Evidence Risk Scope
+
+Status: proposed.
+
+## Problem
+
+The Cloud release contract currently requires every positive path, rare
+account state, operating system, and lifecycle failure to be repeated as one
+real-device matrix for every evidence commit. Some states need external
+accounts or subscriptions that a maintainer cannot safely manufacture. The
+Cartesian matrix spends time without adding commit-specific confidence.
+
+## Decision
+
+Keep the existing evidence schema and fail-closed verifier. Split evidence
+into two layers:
+
+1. Exact-target checks always run: CI, security and recovery contracts,
+   candidate provenance on every enabled platform, the exact installed Relay
+   App, and one real reference-platform Cloud health smoke using the
+   downloaded candidate binary with Census suppressed.
+2. Risk-scoped qualification runs on first support and after a relevant
+   implementation or evidence-harness change. A passing qualification remains
+   applicable across unrelated changes.
+
+The check owner must inspect the complete qualification-to-target diff before
+attesting carried evidence. The activation or release pull request records a
+non-secret qualification ledger for every carried check and keyring OS:
+qualified commit and tree, evidence reference, inspected target, and the
+change-class decision. The privileged evidence secret remains the attestation;
+the pull-request ledger makes its inputs reviewable without expanding the
+existing JSON schema. The verifier validates the privileged attestation and
+exact target; it does not infer the maintainer's invalidation decision. Missing
+or uncertain ledger data means rerun.
+
+Carry-forward applies only to the qualification behind a check boolean. The
+JSON envelope, commit/tree identity, candidate provenance, installed App, and
+reference health smoke remain exact-target; never reuse an older JSON envelope.
+The verifier binds that new envelope to the exact target. Reviewers verify the
+qualification ledger before the boolean is set to `true`.
+
+## Invalidation map
+
+Use the narrowest matching row. A change that matches multiple rows invalidates
+their union.
+
+| Changed surface | Qualification to repeat | Real platform scope |
+|---|---|---|
+| Cloud or Relay transport, Ingress session, endpoint, or route selection | `parity`, `stress_10000`, `routing`, relevant lifecycle and non-disclosure paths | One reference platform |
+| Shared native-secret orchestration | `keyrings` | One reference platform, plus any OS with different behavior |
+| macOS, Windows, or Linux native-store adapter | `keyrings`; relevant lifecycle path | Affected OS only |
+| OAuth, Home Assistant user binding, or App discovery | `roles`, `domains_mfa`; relevant authorization lifecycle | One reference platform |
+| Relay App startup, identity, device registry, or installation | `installed_relay_app`; relevant lifecycle and redirect paths | One reference platform |
+| CLI setup, install, update, uninstall, signing identity, or authorization retention | `signing_and_update_matrix`; relevant lifecycle path | Affected OS only; exact provenance still runs on all enabled OSes |
+| Config, argv, logs, diagnostics, or AI-visible output | `redirects_non_disclosure` | Affected surface; one retained real artifact scan |
+| A deterministic test or harness used in place of a real branch | Its owning qualification | Same scope as that qualification |
+| Release workflow or provenance machinery only | `signing_and_update_matrix` | Exact provenance on all enabled OSes |
+| Unrelated docs, tests, process, or product code | None | Exact-target layer only |
+
+## Check contract
+
+- `parity`: real `/health`, `/ws`, `/core`, `/files`, and `/backups` parity on
+  one reference platform for every Cloud or Relay transport change.
+- `stress_10000`: one real bounded run per Cloud or Relay transport change,
+  not once per operating system.
+- `keyrings`: real happy-path and fail-closed no-UI behavior on every enabled
+  OS for first support. A shared orchestration change repeats one reference OS;
+  an adapter change repeats only its affected OS. Deterministic platform tests
+  cover cancellation and timeout branches.
+- `roles`: one real standard non-administrator binding on a reference
+  platform. Exact-target tests verify that the authenticated Home Assistant
+  user and Relay instance remain bound through setup and functional dispatch;
+  Owner and administrator add no separate transport path.
+- `domains_mfa`: one real canonical Nabu Casa OAuth flow. Home Assistant owns
+  the MFA challenge before returning the same OAuth callback, so HA NOVA does
+  not manufacture account-specific MFA proof. Deterministic tests cover
+  custom-origin canonicalization, inactive subscription, disabled remote
+  access, and authorization abort.
+- `lifecycle`: one isolated Cloud-authorized profile first covers Relay App
+  restart and reinstall recovery, then HA NOVA CLI standard uninstall/reinstall
+  with retained authorization. Full purge is last; it revokes and verifies the
+  active remote authorization and device before local cleanup. Deterministic
+  crash/concurrency tests cover every durable boundary; update and
+  instance-mismatch paths get a real run when those paths change.
+- `redirects_non_disclosure`: exact-target redirect, argv, config, log,
+  diagnostic, and AI-output tests plus one retained real artifact scan after
+  a relevant transport, config, argv, log, diagnostics, or AI-output change.
+- `installed_relay_app`: always exact-target. Supervisor builds the reviewed
+  source, the App reports the expected version, and the reviewed Cloud routes
+  exist.
+- `routing`: one real automatic local-to-Cloud fallback after a routing
+  change; exact-target tests cover every fail-closed non-fallback outcome.
+- `signing_and_update_matrix`: always verify exact candidate signatures and
+  provenance on all enabled platforms. Repeat real install/update behavior
+  only after installer, updater, signing identity, or native authorization
+  changes. Existing release rules still decide when an RC rehearsal is
+  mandatory.
+
+No mock may replace the required real positive path. No carried
+qualification may cross a relevant implementation change.
+
+The exact-target Cloud health smoke is not `parity`. On every target, the
+official downloaded candidate binary must run with `HA_NOVA_NO_CENSUS=1`
+against the exact installed Relay App:
+
+```bash
+HA_NOVA_NO_CENSUS=1 <candidate-binary> relay health \
+  --server <profile> --via cloud
+```
+
+The result must identify the expected App version and a healthy Home Assistant
+WebSocket. Do not retain the private Cloud URL.
+
+## Acceptance
+
+- The JSON schema and verifier remain unchanged.
+- `docs/releasing.md`, `docs/reference/testing.md`, and the Cloud remote spec
+  describe the same risk-scoped contract.
+- Repository documentation checks pass.
+- No product, workflow, version metadata, README, tag, or release changes.


### PR DESCRIPTION
## Summary
- separate exact-target checks from risk-scoped real-device qualifications
- replace the Cartesian account/OS/lifecycle matrix with bounded invalidation rules
- require a reviewable qualification ledger while keeping the existing fail-closed evidence schema

## Verification
- npm run verify:docs
- git diff --check
- three adversarial pre-PR reviews, all clean after one batch fix

## Boundaries
- documentation only
- README.md and version.json unchanged
- no workflow, product, tag, RC, release, or publication change