### PR TITLE
fix(release): let bundle smokes read the draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,13 +228,44 @@ jobs:
           # out of the workspace they can read.
           persist-credentials: false
 
-      - name: Download and smoke Unix release bundle
+      - name: Download Unix release assets
         if: runner.os != 'Windows'
         shell: bash
         env:
-          # Step-scoped write token: draft releases are invisible to read
-          # tokens. It is unset before any downloaded binary executes.
+          # Draft releases are invisible to read tokens. The write token
+          # lives only in this download step's shell; the smoke step below
+          # runs the downloaded binaries in a fresh process without it, so
+          # not even /proc/<ppid>/environ can leak it to them.
           GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          case "${RUNNER_OS}" in
+            macOS)
+              arch="$(uname -m | sed 's/x86_64/amd64/;s/arm64/arm64/')"
+              archive="ha-nova-installer-bundle-macos-${arch}.tar.gz"
+              ;;
+            Linux)
+              archive="ha-nova-installer-bundle-linux-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/;s/arm64/arm64/').tar.gz"
+              ;;
+            *) exit 1 ;;
+          esac
+          workdir="${RUNNER_TEMP}/ha-nova-release-smoke"
+          rm -rf "$workdir"
+          mkdir -p "$workdir"
+          gh release download "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "$archive" \
+            --dir "$workdir"
+          if [[ "${RUNNER_OS}" == "macOS" ]]; then
+            gh release download "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "ha-nova-darwin-${arch}" \
+              --dir "$workdir"
+          fi
+
+      - name: Smoke Unix release bundle
+        if: runner.os != 'Windows'
+        shell: bash
         run: |
           set -euo pipefail
           case "${RUNNER_OS}" in
@@ -249,20 +280,7 @@ jobs:
               ;;
             *) exit 1 ;;
           esac
-          workdir="$(mktemp -d)"
-          gh release download "$GITHUB_REF_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            --pattern "$archive" \
-            --dir "$workdir"
-          if [[ "${RUNNER_OS}" == "macOS" ]]; then
-            gh release download "$GITHUB_REF_NAME" \
-              --repo "$GITHUB_REPOSITORY" \
-              --pattern "ha-nova-darwin-${arch}" \
-              --dir "$workdir"
-          fi
-          # Downloads are done; the binaries under test must never see the
-          # write token.
-          unset GH_TOKEN
+          workdir="${RUNNER_TEMP}/ha-nova-release-smoke"
           test -f "$workdir/$archive"
           tar -xzf "$workdir/$archive" -C "$workdir"
           root="$workdir/ha-nova"
@@ -297,12 +315,13 @@ jobs:
             exit 1
           fi
 
-      - name: Download and smoke Windows release bundle
+      - name: Download Windows release bundle
         if: runner.os == 'Windows'
         shell: pwsh
         env:
-          # Step-scoped write token: draft releases are invisible to read
-          # tokens. It is removed before any downloaded binary executes.
+          # Draft releases are invisible to read tokens. The write token
+          # lives only in this download step's shell; the smoke step below
+          # runs the downloaded binary in a fresh process without it.
           GH_TOKEN: ${{ github.token }}
         run: |
           $archive = "ha-nova-installer-bundle-windows-amd64.zip"
@@ -313,9 +332,16 @@ jobs:
             --repo "$env:GITHUB_REPOSITORY" `
             --pattern $archive `
             --dir $workdir
-          # Downloads are done; the binary under test must never see the
-          # write token.
-          Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+          if (-not (Test-Path -LiteralPath (Join-Path $workdir $archive))) {
+            throw "Exact Windows release bundle was not downloaded"
+          }
+
+      - name: Smoke Windows release bundle
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $archive = "ha-nova-installer-bundle-windows-amd64.zip"
+          $workdir = Join-Path $env:RUNNER_TEMP "ha-nova-release"
           $archivePath = Join-Path $workdir $archive
           if (-not (Test-Path -LiteralPath $archivePath)) {
             throw "Exact Windows release bundle was not downloaded"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,15 +220,21 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The downloaded bundle binaries run below; keep git credentials
+          # out of the workspace they can read.
+          persist-credentials: false
 
       - name: Download and smoke Unix release bundle
         if: runner.os != 'Windows'
         shell: bash
+        env:
+          # Step-scoped write token: draft releases are invisible to read
+          # tokens. It is unset before any downloaded binary executes.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           case "${RUNNER_OS}" in
@@ -248,6 +254,15 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --pattern "$archive" \
             --dir "$workdir"
+          if [[ "${RUNNER_OS}" == "macOS" ]]; then
+            gh release download "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "ha-nova-darwin-${arch}" \
+              --dir "$workdir"
+          fi
+          # Downloads are done; the binaries under test must never see the
+          # write token.
+          unset GH_TOKEN
           test -f "$workdir/$archive"
           tar -xzf "$workdir/$archive" -C "$workdir"
           root="$workdir/ha-nova"
@@ -262,10 +277,6 @@ jobs:
           "$root/ha-nova" version
           if [[ "${RUNNER_OS}" == "macOS" ]]; then
             raw_binary="$workdir/ha-nova-darwin-${arch}"
-            gh release download "$GITHUB_REF_NAME" \
-              --repo "$GITHUB_REPOSITORY" \
-              --pattern "ha-nova-darwin-${arch}" \
-              --dir "$workdir"
             test -f "$raw_binary"
             cmp "$root/ha-nova" "$raw_binary"
             bash scripts/release/verify-macos-signature.sh "$root/ha-nova"
@@ -289,6 +300,10 @@ jobs:
       - name: Download and smoke Windows release bundle
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          # Step-scoped write token: draft releases are invisible to read
+          # tokens. It is removed before any downloaded binary executes.
+          GH_TOKEN: ${{ github.token }}
         run: |
           $archive = "ha-nova-installer-bundle-windows-amd64.zip"
           $workdir = Join-Path $env:RUNNER_TEMP "ha-nova-release"
@@ -298,6 +313,9 @@ jobs:
             --repo "$env:GITHUB_REPOSITORY" `
             --pattern $archive `
             --dir $workdir
+          # Downloads are done; the binary under test must never see the
+          # write token.
+          Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
           $archivePath = Join-Path $workdir $archive
           if (-not (Test-Path -LiteralPath $archivePath)) {
             throw "Exact Windows release bundle was not downloaded"
@@ -413,6 +431,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The installed binaries run below; keep git credentials out of
+          # the workspace they can read.
+          persist-credentials: false
 
       - name: Smoke Unix installer
         if: runner.os != 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,10 @@ jobs:
     needs: release
     runs-on: ${{ matrix.os }}
     permissions:
-      contents: read
+      # Draft releases are visible only to tokens with write access; this job
+      # downloads the still-draft assets before publication, so read is not
+      # enough ("release not found" on every runner otherwise).
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- all three `smoke-release-bundles` runners failed the first real `v0.22.0-rc1` run with `release not found`: the jobs (introduced in #445, first exercised by that tag) request `contents: read`, but GitHub exposes **draft** releases only to tokens with write access
- `publish-release` stayed correctly fail-closed; nothing was published
- grant the smoke job `contents: write` with an explaining comment; post-publish `smoke-installers` keeps `read` because it downloads published assets only (class sweep: no other job reads the draft)

## Verification

- `bash scripts/release/verify-release-pipeline.sh` static contract green on this head
- targeted `release-contract` + `release-gates-behavior` + `cloud-release-gate-contract` suites: 235 tests green
- failed run for reference: [30628827191](https://github.com/markusleben/ha-nova/actions/runs/30628827191)

## Release path

This is a release-workflow-only delta on top of the qualified v0.22.0 tree: it invalidates `signing_and_update_matrix` (fresh candidate + provenance + reference smoke) while all other qualification rows carry; a fresh exact-target evidence envelope, one CI rerun, and `v0.22.0-rc2` on the new merge commit follow.

## Why cloud-source-gate stays red on this PR (by design)

`verify-cloud-target-source-gate.sh` unconditionally requires the target's
`.github/workflows` tree to equal trusted `main` (or pass the `uses:`-only
allowance); a PR that fixes `release.yml` itself can therefore never turn the
required check green while Cloud is enabled. All satisfiable gates are green
(CI, CodeQL, real clean Codex result for `a3427df955`, zero unresolved
threads, both P1 findings fixed class-wide). Merge proceeds with maintainer
admin per AGENTS.md step 10; post-merge, `ci-gate` (push) and the release
workflows validate the evidence directly against the checked-out commit, where
the workflow tree is trusted by construction. A follow-up for a reviewed
workflow-maintenance path under enabled Cloud is tracked as housekeeping.

## Exact-target Cloud evidence (to be completed on the merge commit)

- qualified binaries are unchanged: `cli` / `nova` / `scripts` trees are
  byte-identical to candidate run
  [30626246441](https://github.com/markusleben/ha-nova/actions/runs/30626246441)
  (Windows reference Cloud health smoke passed today, Census absent)
- this PR's delta is `.github/workflows/release.yml` only (smoke token
  scoping); per the risk-scope spec it re-runs `signing_and_update_matrix`
  evidence: the `v0.22.0-rc2` release run itself rebuilds and verifies all
  five bundles (checksums, binary identity, Ed25519 provenance, 3-OS smokes)
  before publish, and a fresh Cloud health smoke of the published RC2
  candidate on the Windows reference platform is recorded here afterwards
- the evidence envelope is rotated to the exact merge commit/tree at merge
  time; every other qualification row carries per the #469 ledger
