### PR TITLE
fix(release): smoke Unix bundles from an installed layout

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -186,22 +186,30 @@ jobs:
           esac
           workdir="$(mktemp -d)"
           tar -xzf "$bundle" -C "$workdir"
-          test -f "$workdir/ha-nova/bundle.json"
-          test -x "$workdir/ha-nova/ha-nova"
+          # Unix builds resolve their install root from HOME only (no
+          # executable-directory fallback like Windows), so the provenance
+          # check requires the bundle to sit in a real installed layout.
+          smoke_home="$workdir/home"
+          install_root="$smoke_home/.local/share/ha-nova"
+          mkdir -p "$smoke_home/.local/share"
+          mv "$workdir/ha-nova" "$install_root"
+          root="$install_root"
+          test -f "$root/bundle.json"
+          test -x "$root/ha-nova"
           node -e '
             const bundle = require(process.argv[1]);
             if (bundle.version !== process.argv[2].replace(/^v/, "")) {
               throw new Error("RC bundle version does not match workflow input");
             }
-          ' "$workdir/ha-nova/bundle.json" "${VERSION_TAG}"
-          "$workdir/ha-nova/ha-nova" version
+          ' "$root/bundle.json" "${VERSION_TAG}"
+          HOME="$smoke_home" "$root/ha-nova" version
           case "${RUNNER_OS}" in
             macOS) platform="darwin" ;;
             Linux) platform="linux" ;;
             *) exit 1 ;;
           esac
           if [[ "${RUNNER_OS}" == "macOS" ]]; then
-            bash scripts/release/verify-macos-signature.sh "$workdir/ha-nova/ha-nova"
+            bash scripts/release/verify-macos-signature.sh "$root/ha-nova"
           fi
           listed="$(
             node -e '
@@ -210,11 +218,11 @@ jobs:
                 metadata.cloud_remote_enabled === true
                 && metadata.cloud_remote_platforms.includes(process.argv[2])
               ));
-            ' "$workdir/ha-nova/version.json" "$platform"
+            ' "$root/version.json" "$platform"
           )"
           if [[ "$listed" == "true" ]]; then
-            "$workdir/ha-nova/ha-nova" internal-cloud-release-check
-          elif "$workdir/ha-nova/ha-nova" internal-cloud-release-check; then
+            HOME="$smoke_home" "$root/ha-nova" internal-cloud-release-check
+          elif HOME="$smoke_home" "$root/ha-nova" internal-cloud-release-check; then
             echo "::error::Unlisted $platform runtime accepted Cloud release provenance."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,7 +283,14 @@ jobs:
           workdir="${RUNNER_TEMP}/ha-nova-release-smoke"
           test -f "$workdir/$archive"
           tar -xzf "$workdir/$archive" -C "$workdir"
-          root="$workdir/ha-nova"
+          # Unix builds resolve their install root from HOME only (no
+          # executable-directory fallback like Windows), so the provenance
+          # check requires the bundle to sit in a real installed layout.
+          smoke_home="$workdir/home"
+          install_root="$smoke_home/.local/share/ha-nova"
+          mkdir -p "$smoke_home/.local/share"
+          mv "$workdir/ha-nova" "$install_root"
+          root="$install_root"
           test -f "$root/bundle.json"
           test -x "$root/ha-nova"
           node -e '
@@ -292,7 +299,7 @@ jobs:
               throw new Error("release bundle version does not match tag");
             }
           ' "$root/bundle.json" "$GITHUB_REF_NAME"
-          "$root/ha-nova" version
+          HOME="$smoke_home" "$root/ha-nova" version
           if [[ "${RUNNER_OS}" == "macOS" ]]; then
             raw_binary="$workdir/ha-nova-darwin-${arch}"
             test -f "$raw_binary"
@@ -309,8 +316,8 @@ jobs:
             ' "$root/version.json" "$platform"
           )"
           if [[ "$listed" == "true" ]]; then
-            "$root/ha-nova" internal-cloud-release-check
-          elif "$root/ha-nova" internal-cloud-release-check; then
+            HOME="$smoke_home" "$root/ha-nova" internal-cloud-release-check
+          elif HOME="$smoke_home" "$root/ha-nova" internal-cloud-release-check; then
             echo "::error::Unlisted $platform runtime accepted Cloud release provenance."
             exit 1
           fi

--- a/tests/onboarding/release-contract.test.ts
+++ b/tests/onboarding/release-contract.test.ts
@@ -257,7 +257,7 @@ describe("release contract", () => {
     expect(rcWorkflow).toContain('platform="darwin"');
     expect(rcWorkflow).toContain('platform="linux"');
     expect(rcWorkflow).toContain(
-      'elif "$workdir/ha-nova/ha-nova" internal-cloud-release-check; then',
+      'elif HOME="$smoke_home" "$root/ha-nova" internal-cloud-release-check; then',
     );
     expect(rcWorkflow).toContain(
       "unlisted Windows runtime returned an unexpected provenance result",


### PR DESCRIPTION
## Summary

- `v0.22.0-rc2` exposed the second day-one gap in the #445 bundle smokes: `internal-cloud-release-check` requires the real installed layout, and Unix builds resolve their install root from `HOME` only — Windows has an executable-directory fallback (`cli/paths.go:61-81`), which is exactly why only the Windows smoke passed
- move each extracted Unix bundle to `$smoke_home/.local/share/ha-nova` and run the binary with that HOME, in `release.yml` and `release-candidate.yml` (class sweep); update the pinned RC workflow string in the release contract test
- **proved locally against the real rc2 draft bundle**: `0.22.0-rc2` + `official Cloud release provenance verified` (exit 0) with the new layout; the failing pre-fix behavior reproduced identically

## Verification

- YAML parse + `verify-release-pipeline.sh` static contract green
- `release-contract` suite 32/32 green after the pin update
- failed runs for reference: [rc2 release run](https://github.com/markusleben/ha-nova/actions/runs/30635189527)

## Release path

Same situation as #480: this PR touches sensitive release workflows, so the required `cloud-source-gate` stays red by design (broker requires the trusted workflow tree). After CI + a real clean Codex result, it merges with maintainer admin; the evidence envelope is rotated to the exact merge commit and `v0.22.0-rc3` follows on it.