### PR TITLE
docs: describe pairing positively instead of by absent tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,7 @@ Use below list to store and recall user notes when asked to do so.
 - For graphics/diagrams, labels must stay consistent across all views (top view, side view, etc.).
 - Relay stays dumb, Skills stay smart. No business logic in the server.
 - Preferred terminology (2026+): use "App" instead of "Add-on", except where technical API paths force legacy terms (for example `/addons/*`).
+- Pairing/onboarding copy rule (2026-08-02): describe pairing by what happens (one-time six-digit code, per-device connection, revocable anytime) — never define the product by the absence of tokens or legacy flows ("no token to copy" confuses users who never saw the old flow). Technical token documentation (standalone container LLAT, relay auth token, OAuth storage) is exempt.
 - Priority: deliver a working MVP first, but keep the architecture modular from day one for later extension.
 - Skills remain pure `*.md` files; no hidden business logic outside this model.
 - Relay implementation must remain lean, clean, and efficient (KISS + DRY, clear responsibilities).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <h2 align="center">One code to connect. Every change checked.</h2>
 
 <p align="center">
-  On HA OS or Supervised, pair your AI with one six-digit code — no token to create or copy.<br>
+  On HA OS or Supervised, pair your AI with one six-digit code from the NOVA page.<br>
   Every change is previewed and approved first, then verified by reading it back.
 </p>
 
@@ -31,7 +31,7 @@
   <img src="assets/pairing-flow.png" alt="Pairing flow: run the installer, click Connect a device on the NOVA page, type the six-digit code">
 </p>
 
-*On HA OS or Supervised, there is no token to create or copy — the code is one-time and expires in minutes. Each device gets its own connection you can revoke anytime from NOVA.*
+*The code is one-time and expires in minutes. Each device gets its own connection you can revoke anytime from NOVA.*
 
 <p align="center">
   <b><a href="#-what-you-can-do">What it does</a></b> · <b><a href="#%EF%B8%8F-safe-by-design">Is it safe?</a></b> · <b><a href="#-get-started">Get started</a></b> · <b><a href="#optional-remote-access-with-home-assistant-cloud-beta">Cloud</a></b> · <b><a href="#%EF%B8%8F-how-it-works">How it works</a></b>

--- a/docs/reference/comparison.md
+++ b/docs/reference/comparison.md
@@ -53,7 +53,7 @@ Being honest about this is the point of the page:
 
 ## Where HA NOVA is ahead (as of 2026-07-20)
 
-- **Per-device pairing you can see and revoke.** One six-digit code per device, a console that lists every paired machine, one-click revocation — and no Home Assistant token to create anywhere in the App flow.
+- **Per-device pairing you can see and revoke.** One six-digit code per device, a console that lists every paired machine, one-click revocation.
 - **Media, notifications, MQTT, and voice** have dedicated skills with real domain rules — feature-bit gating before a media call, the iOS/Android payload split for notifications, retained-vs-live distinction when listening to MQTT, utterance testing that says plainly it executes what it understands.
 - **Root-cause diagnosis** as a workflow (traces → logs → bounded history → template probe), not just raw log access.
 - **The safety model above**, enforced structurally rather than configured per tool.

--- a/nova/DOCS.md
+++ b/nova/DOCS.md
@@ -137,7 +137,7 @@ from the NOVA page, then pairs securely: the device receives its own credential
 (kept in the client's OS credential store — or in a private file for
 `--service` installs, explicit `ha-nova pair --credential-store=file` opt-ins,
 and headless systems without a keyring) and talks to the Relay over pinned TLS.
-Nothing to copy or paste. Existing saved tokens, `--relay-token`, service token
+Existing saved tokens, `--relay-token`, service token
 files, and standalone Container/Core setups keep their explicit-token paths.
 
 Cloud OAuth refresh tokens are separate from Relay/device credentials and live

--- a/nova/src/http/handlers/nova-page.ts
+++ b/nova/src/http/handlers/nova-page.ts
@@ -232,7 +232,7 @@ function renderPage(m: PageModel): string {
          <p class="code">${escapeHtml(formatCode(m.pairing.code))}</p>
          <p class="muted waiting">Waiting for the device… this page updates on its own once it connects.</p>
          ${formOpen}${csrfField("cancel_code")}<button class="secondary" type="submit">Cancel</button></form>`
-      : `<p class="muted">Generate a one-time code, then enter it on your computer when NOVA asks. Each device gets its own secure connection — no tokens to copy.</p>
+      : `<p class="muted">Generate a one-time code, then enter it on your computer when NOVA asks. Each device gets its own secure connection.</p>
          ${formOpen}${csrfField("generate_code")}<button type="submit">Connect a device</button></form>${
           m.pairing.phase === "consumed" ? `<p class="ok">✓ A device was just connected.</p>` : ""
         }`;
@@ -324,7 +324,7 @@ function renderPage(m: PageModel): string {
 </style></head><body>
 <main>
 <h1>${star}NOVA</h1>
-<p class="intro">Let your AI assistant work with Home Assistant — safely. Connect each computer once with a one-time code; there are no tokens to copy or paste.</p>
+<p class="intro">Let your AI assistant work with Home Assistant — safely. Connect each computer once with a one-time code; every device gets its own connection.</p>
 ${errorSection}<section><h2>Home Assistant</h2><p>${m.connection.haConnected ? "Connected." : `<span class="muted">Not connected — check the App logs.</span>`}</p></section>
 ${recoverySection}<section><h2>Update</h2><p>${updateLine}</p></section>
 <section><h2>Pairing</h2>${pairingSection}</section>


### PR DESCRIPTION
## Summary

- new users never saw the legacy long-lived-token flow, so "no token to create or copy" reads as noise next to the six-digit code they DO type
- every self-referential absence claim now states the positive facts instead (one-time code, per-device connection, revocable anytime): README hero + pairing caption, NOVA Home Base intro + pairing text, `nova/DOCS.md` wizard paragraph, comparison bullet
- factual token documentation stays untouched: standalone container LLAT, explicit `--relay-token`/service-token paths, competitor mechanism descriptions, archive/history
- adds the durable wording rule to AGENTS.md user notes; the landing-page repo got the matching edit separately
- README changes are stable-truth corrections (no feature/version claims) → `readme-stable:approved` path

## Verification

- full `npm run verify` green on this head (all suites incl. nova build; no test pins any of the removed sentences — verified by phrase grep before editing)
- residual grep across README/nova/docs/skills/cli/installers shows only technical token references

## Cloud evidence ledger (exact-target, UI-text-only delta)

Delta is README/docs text plus two display strings in `nova-page.ts` — no Cloud, transport, auth, or lifecycle code. Per the risk-scope invalidation map ("unrelated docs/tests/process/product code → none") every qualification row carries; the evidence envelope is bound to this PR's synthetic merge commit before merge and rotated to the squash commit right after.