### PR TITLE
docs: make the Cloud smoke runbook reproducible and scope it by delta

### DIFF
--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -164,7 +164,8 @@ remote-first case:
 Required evidence is exact-target plus risk-scoped qualification. Repeat a
 real-device row only for first support or after a relevant implementation
 or evidence-harness change; exact-target CI, signed provenance on all enabled
-OSes, the installed Relay App, and the reference Cloud health smoke always run:
+OSes, and the installed Relay App always run, and the reference Cloud health
+smoke runs for deltas with real-platform scope:
 
 - `/health`, `/ws`, `/core`, `/files`, and `/backups` parity through a real
   Home Assistant Cloud route on one reference platform after a transport

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -90,11 +90,13 @@ native keyring, a Nabu Casa OAuth flow, or a real Supervisor Ingress session.
 The Cloud Beta therefore requires an exact-candidate evidence envelope plus
 every real-device qualification invalidated by the candidate diff.
 
-Every candidate still uses its downloaded binary with `HA_NOVA_NO_CENSUS=1`
-to run one reference-platform `relay health --via cloud` against the exact
-installed Relay App. The proof parses the JSON and requires the expected App
-version plus `ha_ws_connected: true`; command success alone is insufficient.
-This smoke is separate from full route parity and never carries forward.
+A candidate whose delta matches an invalidation-map row with real-platform
+scope uses its downloaded binary with `HA_NOVA_NO_CENSUS=1` to run one
+reference-platform `relay health --via cloud` against the exact installed
+Relay App. The proof parses the JSON and requires the expected App version
+plus `ha_ws_connected: true`; command success alone is insufficient. This
+smoke is separate from full route parity; maintenance deltas refresh the
+envelope and provenance without it.
 
 Use an isolated CLI as described above, but do not set a file-backed device
 credential or test-keyring override for a release proof. Cloud OAuth refresh

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -98,13 +98,20 @@ plus `ha_ws_connected: true`; command success alone is insufficient. This
 smoke is separate from full route parity; maintenance deltas refresh the
 envelope and provenance without it.
 
-Use an isolated CLI as described above, but do not set a file-backed device
-credential or test-keyring override for a release proof. Cloud OAuth refresh
-tokens have no production file backend or environment-variable override. Keep
-the real login `HOME`: macOS Keychain and Linux Secret Service resolve the
-interactive user's native store from that desktop identity. Relocate HA NOVA's
-non-secret config and checkpoints with `HA_NOVA_CONFIG_DIR`, and additionally
-set a cryptographically unique relay-token service before the first command:
+This isolation procedure serves the real-device qualification runs below. The
+exact-candidate provenance check and health smoke follow a different layout:
+the `SMOKE_HOME` procedure in `docs/releasing.md`, because Unix provenance
+resolves the installed bundle from `$HOME/.local/share/ha-nova` and the smoke
+profile isolates its own authorization there.
+
+For qualification runs, use an isolated CLI as described above, but do not set
+a file-backed device credential or test-keyring override for a release proof.
+Cloud OAuth refresh tokens have no production file backend or
+environment-variable override. Keep the real login `HOME`: macOS Keychain and
+Linux Secret Service resolve the interactive user's native store from that
+desktop identity. Relocate HA NOVA's non-secret config and checkpoints with
+`HA_NOVA_CONFIG_DIR`, and additionally set a cryptographically unique
+relay-token service before the first command:
 
 ```bash
 cloud_test_root="$(mktemp -d)"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -345,8 +345,9 @@ and `ha_ws_connected: true`.
 No mock replaces a required real positive path. Exact-target CI, candidate
 provenance, and `installed_relay_app` are never carried forward. The Cloud
 health smoke repeats only when the delta matches an invalidation-map row with
-real-platform scope; maintenance deltas (docs, tests, process, release
-machinery) refresh the envelope and provenance without it. See
+real-platform scope; deltas matching only the map's `None` and
+release-machinery rows refresh the envelope and provenance without it. The
+map, not any summary, decides. See
 `docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md`.
 Carry-forward applies only to the qualification behind a check boolean: create
 a new exact-target JSON envelope and never copy an older commit/tree identity.
@@ -494,21 +495,23 @@ if ($LASTEXITCODE -ne 0) { throw "candidate provenance check failed" }
 
 Choose exactly one reference platform for the exact-target Cloud health smoke.
 The smoke is required only when the delta matches an invalidation-map row with
-real-platform scope (Cloud or Relay transport, product, or qualification
-harness — see the evidence risk-scope spec); maintenance deltas (docs, tests,
-process, release machinery) refresh the envelope and provenance without it.
+real-platform scope; deltas matching only the map's `None` and
+release-machinery rows refresh the envelope and provenance without it. Consult
+the map in the evidence risk-scope spec rather than any shorthand.
 
 The smoke needs its own Cloud authorization inside the smoke HOME. NEVER copy
 the production `~/.config/ha-nova` there: the copied profile keeps the
 production ProfileID, which is the keychain account under the fixed
 `ha-nova.oauth.home-assistant-cloud.*` services — `cloud add` on top of it
 rotates the PRODUCTION Cloud authorization. A fresh profile in an empty smoke
-HOME gets a new ProfileID and is collision-free by design. Set it up once per
-smoke (browser OAuth opens interactively) and remove it afterwards:
+HOME gets a new ProfileID and is collision-free by design. `<cloud-host>` is
+the Nabu Casa remote origin (or a custom domain on it), not the LAN host. Set
+it up once per smoke (browser OAuth opens interactively) and remove it
+afterwards:
 
 ```bash
 HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" cloud add \
-  --server "${SERVER_NAME}" --url "https://<ha-host>"
+  --server "${SERVER_NAME}" --url "https://<cloud-host>"
 ```
 
 Run the health smoke below, plus the `internal-cloud-stress` proof when a
@@ -522,7 +525,7 @@ carries no production profile) and remove it after the last Cloud command:
 
 ```powershell
 $env:HA_NOVA_NO_CENSUS = "1"
-& $CandidateBin cloud add --server $ServerName --url "https://<ha-host>"
+& $CandidateBin cloud add --server $ServerName --url "https://<cloud-host>"
 ```
 
 Use the same explicit downloaded candidate binary and exact installed App:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -501,9 +501,23 @@ smoke (browser OAuth opens interactively) and remove it afterwards:
 ```bash
 HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" cloud add \
   --server "${SERVER_NAME}" --url "https://<ha-host>"
-# ... run the health smoke below ...
+# ... run the health smoke below — and, when a transport or stress-harness
+# delta requires it, the internal-cloud-stress proof too. Remove the profile
+# only after the LAST Cloud command:
 HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" cloud remove \
   --server "${SERVER_NAME}"
+```
+
+On Windows the install root resolves from the executable directory
+(be0c5e2), so no HOME override exists or is needed; create the same isolated
+authorization with the extracted binary on the dedicated test machine (which
+carries no production profile) and remove it after the last Cloud command:
+
+```powershell
+$env:HA_NOVA_NO_CENSUS = "1"
+& $CandidateBin cloud add --server $ServerName --url "https://<ha-host>"
+# ... health smoke / stress proof ...
+& $CandidateBin cloud remove --server $ServerName
 ```
 
 Use the same explicit downloaded candidate binary and exact installed App:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -567,7 +567,7 @@ Only after a Cloud or Relay transport change or a change to
 stress proof on that reference platform and profile:
 
 ```bash
-HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" internal-cloud-stress \
+HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" internal-cloud-stress \
   --server "${SERVER_NAME}"
 ```
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -434,7 +434,10 @@ EXPECTED_TREE=0123456789abcdef0123456789abcdef01234567 # replace
 VERSION_TAG=v0.22.0-rc1 # replace
 CANDIDATE_OS=macos
 CANDIDATE_ARCH=arm64
-SERVER_NAME=default
+# A unique name also isolates the OS-keyring device-credential slot, which is
+# keyed by server name; "default" would reuse (and `cloud remove` would
+# revoke) the production device credential.
+SERVER_NAME="smoke-$(uuidgen | tr 'A-F' 'a-f' | cut -c1-8)"
 EXPECTED_RELAY_APP_VERSION=0.7.1 # replace from exact-target nova/config.yaml
 # Unix builds resolve their install root from HOME, so the provenance check
 # passes only from an installed layout (see be0c5e2); calling the extracted
@@ -463,7 +466,9 @@ executable explicitly:
 ```powershell
 $ExpectedTree = "0123456789abcdef0123456789abcdef01234567" # replace
 $Version = "0.22.0-rc1" # replace
-$ServerName = "default"
+# Unique name: the device-credential slot is keyed by server name; "default"
+# would reuse or revoke the production device credential.
+$ServerName = "smoke-" + [guid]::NewGuid().ToString("N").Substring(0, 8)
 $ExpectedRelayAppVersion = "0.7.1" # replace from exact-target nova/config.yaml
 $CandidateDir = Join-Path $env:TEMP ("ha-nova-cloud-candidate-" + [guid]::NewGuid())
 Expand-Archive `

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -438,8 +438,9 @@ CANDIDATE_OS=macos
 CANDIDATE_ARCH=arm64
 # A unique name also isolates the OS-keyring device-credential slot, which is
 # keyed by server name; "default" would reuse (and `cloud remove` would
-# revoke) the production device credential.
-SERVER_NAME="smoke-$(uuidgen | tr 'A-F' 'a-f' | cut -c1-8)"
+# revoke) the production device credential. Node is required anyway and fails
+# loudly, unlike optional generators whose absence a pipeline would swallow.
+SERVER_NAME="smoke-$(node -e 'console.log(require("node:crypto").randomBytes(4).toString("hex"))')"
 EXPECTED_RELAY_APP_VERSION=0.7.1 # replace from exact-target nova/config.yaml
 # Unix builds resolve their install root from HOME, so the provenance check
 # passes only from an installed layout (see be0c5e2); calling the extracted
@@ -508,12 +509,11 @@ smoke (browser OAuth opens interactively) and remove it afterwards:
 ```bash
 HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" cloud add \
   --server "${SERVER_NAME}" --url "https://<ha-host>"
-# ... run the health smoke below — and, when a transport or stress-harness
-# delta requires it, the internal-cloud-stress proof too. Remove the profile
-# only after the LAST Cloud command:
-HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" cloud remove \
-  --server "${SERVER_NAME}"
 ```
+
+Run the health smoke below, plus the `internal-cloud-stress` proof when a
+transport or stress-harness delta requires it. The profile removal command is
+in the cleanup step at the end of this section, after the last Cloud command.
 
 On Windows the install root resolves from the executable directory
 (be0c5e2), so no HOME override exists or is needed; create the same isolated
@@ -523,8 +523,6 @@ carries no production profile) and remove it after the last Cloud command:
 ```powershell
 $env:HA_NOVA_NO_CENSUS = "1"
 & $CandidateBin cloud add --server $ServerName --url "https://<ha-host>"
-# ... health smoke / stress proof ...
-& $CandidateBin cloud remove --server $ServerName
 ```
 
 Use the same explicit downloaded candidate binary and exact installed App:
@@ -576,6 +574,18 @@ HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" internal-cloud-stres
 ```powershell
 & $CandidateBin internal-cloud-stress --server $ServerName
 if ($LASTEXITCODE -ne 0) { throw "candidate Cloud stress proof failed" }
+```
+
+Cleanup: after the last Cloud command, remove the smoke profile — this revokes
+its device authorization and deletes its keyring entries:
+
+```bash
+HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" cloud remove \
+  --server "${SERVER_NAME}"
+```
+
+```powershell
+& $CandidateBin cloud remove --server $ServerName
 ```
 
 `internal-cloud-stress` resolves Cloud once and sends exactly 10,000 read-only

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -299,10 +299,12 @@ non-secret evidence reference, inspected target, and change-class decision.
 Missing or uncertain ledger data means rerun.
 
 Every target still runs CI, candidate signature/provenance checks on all
-enabled platforms, the exact installed Relay App, and one real Cloud health
-smoke on a reference platform. The smoke uses the downloaded candidate binary,
-`--via cloud`, the exact installed App, and `HA_NOVA_NO_CENSUS=1`; its JSON must
-report the expected App version and `ha_ws_connected: true`.
+enabled platforms, and the exact installed Relay App. A target whose delta
+matches an invalidation-map row with real-platform scope also runs one real
+Cloud health smoke on a reference platform; maintenance deltas skip it. The
+smoke uses the downloaded candidate binary, `--via cloud`, the exact installed
+App, and `HA_NOVA_NO_CENSUS=1`; its JSON must report the expected App version
+and `ha_ws_connected: true`.
 
 - `parity`: `/health`, `/ws`, `/core`, `/files`, and `/backups` through real
   Home Assistant Cloud on one reference platform after a transport change;

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -576,16 +576,20 @@ HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" internal-cloud-stres
 if ($LASTEXITCODE -ne 0) { throw "candidate Cloud stress proof failed" }
 ```
 
-Cleanup: after the last Cloud command, remove the smoke profile — this revokes
-its device authorization and deletes its keyring entries:
+Cleanup: after the last Cloud command — including after a failed smoke —
+remove the smoke profile with `--yes` (without it the command asks for
+confirmation, defaults to No, and exits before revoking anything when no TTY
+is attached). This revokes the device authorization and deletes the keyring
+entries:
 
 ```bash
 HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" cloud remove \
-  --server "${SERVER_NAME}"
+  --server "${SERVER_NAME}" --yes
 ```
 
 ```powershell
-& $CandidateBin cloud remove --server $ServerName
+& $CandidateBin cloud remove --server $ServerName --yes
+if ($LASTEXITCODE -ne 0) { throw "smoke profile cleanup failed" }
 ```
 
 `internal-cloud-stress` resolves Cloud once and sends exactly 10,000 read-only

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -341,8 +341,10 @@ report the expected App version and `ha_ws_connected: true`.
   updater, signing-identity, or native-authorization changes.
 
 No mock replaces a required real positive path. Exact-target CI, candidate
-provenance, `installed_relay_app`, and the Cloud health smoke are never carried
-forward. See
+provenance, and `installed_relay_app` are never carried forward. The Cloud
+health smoke repeats only when the delta matches an invalidation-map row with
+real-platform scope; maintenance deltas (docs, tests, process, release
+machinery) refresh the envelope and provenance without it. See
 `docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md`.
 Carry-forward applies only to the qualification behind a check boolean: create
 a new exact-target JSON envelope and never copy an older commit/tree identity.
@@ -434,11 +436,17 @@ CANDIDATE_OS=macos
 CANDIDATE_ARCH=arm64
 SERVER_NAME=default
 EXPECTED_RELAY_APP_VERSION=0.7.1 # replace from exact-target nova/config.yaml
+# Unix builds resolve their install root from HOME, so the provenance check
+# passes only from an installed layout (see be0c5e2); calling the extracted
+# binary in place fails with "official Cloud release provenance is not
+# enabled".
 CANDIDATE_DIR="$(mktemp -d)"
+SMOKE_HOME="${CANDIDATE_DIR}/home"
+mkdir -p "${SMOKE_HOME}/.local/share"
 tar -xzf "cloud-candidate-install-bundles/ha-nova-installer-bundle-${CANDIDATE_OS}-${CANDIDATE_ARCH}.tar.gz" \
-  -C "${CANDIDATE_DIR}"
-CANDIDATE_BIN="${CANDIDATE_DIR}/ha-nova/ha-nova"
-node - "${CANDIDATE_DIR}/ha-nova/bundle.json" "${VERSION_TAG#v}" "${EXPECTED_TREE}" <<'NODE'
+  -C "${SMOKE_HOME}/.local/share"
+CANDIDATE_BIN="${SMOKE_HOME}/.local/share/ha-nova/ha-nova"
+node - "${SMOKE_HOME}/.local/share/ha-nova/bundle.json" "${VERSION_TAG#v}" "${EXPECTED_TREE}" <<'NODE'
 const fs = require("node:fs");
 const [path, version, tree] = process.argv.slice(2);
 const bundle = JSON.parse(fs.readFileSync(path, "utf8"));
@@ -446,7 +454,7 @@ if (bundle.version !== version || bundle.cloud_release?.source_tree_sha !== tree
   throw new Error("candidate bundle identity does not match the recorded run");
 }
 NODE
-HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" internal-cloud-release-check
+HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" internal-cloud-release-check
 ```
 
 On the Windows Proxmox test machine, use PowerShell and the contained
@@ -477,11 +485,32 @@ if ($LASTEXITCODE -ne 0) { throw "candidate provenance check failed" }
 ```
 
 Choose exactly one reference platform for the exact-target Cloud health smoke.
+The smoke is required only when the delta matches an invalidation-map row with
+real-platform scope (Cloud or Relay transport, product, or qualification
+harness — see the evidence risk-scope spec); maintenance deltas (docs, tests,
+process, release machinery) refresh the envelope and provenance without it.
+
+The smoke needs its own Cloud authorization inside the smoke HOME. NEVER copy
+the production `~/.config/ha-nova` there: the copied profile keeps the
+production ProfileID, which is the keychain account under the fixed
+`ha-nova.oauth.home-assistant-cloud.*` services — `cloud add` on top of it
+rotates the PRODUCTION Cloud authorization. A fresh profile in an empty smoke
+HOME gets a new ProfileID and is collision-free by design. Set it up once per
+smoke (browser OAuth opens interactively) and remove it afterwards:
+
+```bash
+HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" cloud add \
+  --server "${SERVER_NAME}" --url "https://<ha-host>"
+# ... run the health smoke below ...
+HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" cloud remove \
+  --server "${SERVER_NAME}"
+```
+
 Use the same explicit downloaded candidate binary and exact installed App:
 
 ```bash
 HEALTH_JSON="$(
-  HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" relay health \
+  HOME="${SMOKE_HOME}" HA_NOVA_NO_CENSUS=1 "${CANDIDATE_BIN}" relay health \
     --server "${SERVER_NAME}" --via cloud
 )"
 node -e '

--- a/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
+++ b/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
@@ -786,11 +786,13 @@ after reviewing the complete qualification-to-target diff and recording the
 non-secret qualification ledger in the activation or release pull request.
 Changes to a deterministic substitute or real evidence harness invalidate its
 qualification.
-Exact-target CI, candidate provenance on all enabled OSes, the installed Relay
-App, and one downloaded-candidate `relay health --via cloud` smoke with Census
-suppressed never carry forward. The smoke must parse the JSON and require the
-expected App version and `ha_ws_connected: true`; a zero exit code alone is not
-evidence. See
+Exact-target CI, candidate provenance on all enabled OSes, and the installed
+Relay App never carry forward. One downloaded-candidate
+`relay health --via cloud` smoke with Census suppressed repeats for deltas
+that match an invalidation-map row with real-platform scope; maintenance
+deltas refresh the envelope and provenance without it. The smoke must parse
+the JSON and require the expected App version and `ha_ws_connected: true`; a
+zero exit code alone is not evidence. See
 `2026-07-30-cloud-release-evidence-risk-scope-spec.md`.
 
 The feature stays unavailable if any security or full-parity gate fails. The

--- a/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
+++ b/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
@@ -112,8 +112,8 @@ against the exact installed Relay App (from an isolated smoke profile — see
 `docs/releasing.md` for the collision-safe setup):
 
 ```bash
-HA_NOVA_NO_CENSUS=1 <candidate-binary> relay health \
-  --server <profile> --via cloud
+HOME=<smoke-home> HA_NOVA_NO_CENSUS=1 <candidate-binary> relay health \
+  --server <smoke-profile> --via cloud
 ```
 
 The result must identify the expected App version and a healthy Home Assistant

--- a/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
+++ b/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
@@ -101,9 +101,13 @@ substitute and real evidence collection/validation harness it relies on.
 No mock may replace the required real positive path. No carried
 qualification may cross a relevant implementation change.
 
-The exact-target Cloud health smoke is not `parity`. On every target, the
-official downloaded candidate binary must run with `HA_NOVA_NO_CENSUS=1`
-against the exact installed Relay App:
+The exact-target Cloud health smoke is not `parity`. It repeats only for a
+target whose delta matches an invalidation-map row with real-platform scope;
+a maintenance delta (the `None` and release-machinery rows) refreshes the
+envelope and provenance without a new smoke. When due, the official
+downloaded candidate binary must run with `HA_NOVA_NO_CENSUS=1`
+against the exact installed Relay App (from an isolated smoke profile — see
+`docs/releasing.md` for the collision-safe setup):
 
 ```bash
 HA_NOVA_NO_CENSUS=1 <candidate-binary> relay health \

--- a/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
+++ b/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
@@ -16,9 +16,10 @@ Keep the existing evidence schema and fail-closed verifier. Split evidence
 into two layers:
 
 1. Exact-target checks always run: CI, security and recovery contracts,
-   candidate provenance on every enabled platform, the exact installed Relay
-   App, and one real reference-platform Cloud health smoke using the
-   downloaded candidate binary with Census suppressed.
+   candidate provenance on every enabled platform, and the exact installed
+   Relay App. For deltas that match an invalidation-map row with
+   real-platform scope, one real reference-platform Cloud health smoke also
+   runs, using the downloaded candidate binary with Census suppressed.
 2. Risk-scoped qualification runs on first support and after a relevant
    implementation or evidence-harness change. A passing qualification remains
    applicable across unrelated changes.
@@ -34,8 +35,9 @@ exact target; it does not infer the maintainer's invalidation decision. Missing
 or uncertain ledger data means rerun.
 
 Carry-forward applies only to the qualification behind a check boolean. The
-JSON envelope, commit/tree identity, candidate provenance, installed App, and
-reference health smoke remain exact-target; never reuse an older JSON envelope.
+JSON envelope, commit/tree identity, candidate provenance, and installed App
+remain exact-target; the reference health smoke is exact-target for deltas
+with real-platform scope. Never reuse an older JSON envelope.
 The verifier binds that new envelope to the exact target. Reviewers verify the
 qualification ledger before the boolean is set to `true`.
 


### PR DESCRIPTION
Hard-won corrections from today's PR #490 evidence cycle — so the next cycle takes minutes, not hours:

- **Provenance check**: documented in-place invocation fails with "official Cloud release provenance is not enabled"; the runbook now uses the installed layout (HOME + `.local/share/ha-nova`, per be0c5e2). Verified live today on macos-arm64.
- **Health smoke setup**: new collision-safe isolated-profile section with the real `cloud add|remove` commands (fresh ProfileID = own keychain account under the fixed `ha-nova.oauth.home-assistant-cloud.*` services). Explicit warning: copying the production config into the smoke HOME rotates the PRODUCTION Cloud authorization. Profile flow derived from CLI usage + secret-store code; to be exercised on the next real Cloud delta.
- **Smoke scope**: aligned `docs/releasing.md` and the evidence risk-scope spec — the smoke repeats only for deltas with real-platform scope; maintenance deltas (docs/tests/process/release machinery) refresh envelope + provenance without it (maintainer decision 2026-08-02).

Docs-only; `npm run verify:docs` green (20/20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RepkoLkfZwvvb2R6WGMJ4b