### PR TITLE
docs: link the official website (hanova.app) from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey" alt="macOS | Windows | Linux">
 </p>
 
+<p align="center">
+  <b><a href="https://hanova.app/">hanova.app</a></b> · the 5-minute tour
+</p>
+
 <h2 align="center">One code to connect. Every change checked.</h2>
 
 <p align="center">


### PR DESCRIPTION
Adds one centered line under the badge row pointing to the now-live project website (https://hanova.app/, GitHub Pages, repo markusleben/ha-nova-site). Uses the README's existing `·` separator style. No other README statement changes; the site follows the README, not the other way around.

Checked for further natural link spots: the anchor navigation and the issues call-out are deliberately repo-internal, so this stays one line.

`readme-stable:approved` applies: the line describes the current stable project surface (the website exists today), no version numbers, no feature claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RepkoLkfZwvvb2R6WGMJ4b