### PR TITLE
feat(cli): self-describing update-revert checkpoints (#483)

### DIFF
--- a/cli/snapshot.go
+++ b/cli/snapshot.go
@@ -10,51 +10,6 @@ import (
 	"strings"
 )
 
-// undoSnapshot is one client-side record of a revertible write. It stores the
-// pre-write config (to restore) and the post-write verified read-back (to
-// detect external drift before restoring).
-//
-// The store performs NO Home Assistant calls. The skill orchestrates the
-// actual restore through `ha-nova relay` and the apply-agent, so the single
-// write path and the dumb-relay contract stay intact — this command only reads
-// and writes a local JSON file.
-type undoSnapshot struct {
-	SchemaVersion int             `json:"schema_version"`
-	Op            string          `json:"op"`
-	Domain        string          `json:"domain"`
-	TargetID      string          `json:"target_id"`
-	BeforeConfig  json.RawMessage `json:"before_config"`
-	ExpectedAfter json.RawMessage `json:"expected_after"`
-}
-
-const undoSnapshotSchemaVersion = 1
-
-// undoSnapshotStack keeps the most recent revertible updates, newest first —
-// one entry per domain+target (a re-update of the same target replaces its
-// entry; reverting an update always restores that target's LAST before-state).
-// Bounded so a multi-target logical change stays fully revertible without the
-// store growing forever (issue #282; previously a single slot).
-type undoSnapshotStack struct {
-	SchemaVersion int            `json:"schema_version"`
-	Snapshots     []undoSnapshot `json:"snapshots"`
-}
-
-const undoSnapshotStackSchemaVersion = 2
-const undoSnapshotStackLimit = 5
-
-// Exit codes for `snapshot verify`: 0 = live matches the post-write state,
-// snapshotExitDrift = live drifted (external edit), 1 = operational error.
-const snapshotExitDrift = 2
-
-// undoSnapshotPath is the legacy single-slot store; still read for migration.
-func undoSnapshotPath(paths runtimePaths) string {
-	return filepath.Join(paths.ConfigDir, "undo-snapshot.json")
-}
-
-func undoSnapshotStackPath(paths runtimePaths) string {
-	return filepath.Join(paths.ConfigDir, "undo-snapshots.json")
-}
-
 func runSnapshotCommand(paths runtimePaths, args []string) int {
 	if len(args) == 0 {
 		printErr("Usage: ha-nova snapshot <save|show|verify> ...")
@@ -126,10 +81,19 @@ func runSnapshotSave(paths runtimePaths, args []string) int {
 			return 1
 		}
 	}
-	if err := saveUndoSnapshotBytes(paths, data); err != nil {
+	receipt, err := saveUndoSnapshotBytes(paths, data)
+	if err != nil {
 		printErr("%s", err)
 		return 1
 	}
+	// Structured receipt on stdout (#483): the skill repeats it in the result
+	// so a silent save — or a silent same-target replacement — cannot happen.
+	out, err := json.MarshalIndent(receipt, "", "  ")
+	if err != nil {
+		printErr("cannot render snapshot receipt: %s", err)
+		return 1
+	}
+	fmt.Fprintln(os.Stdout, string(out))
 	return 0
 }
 
@@ -183,14 +147,9 @@ func runSnapshotShow(paths runtimePaths, args []string) int {
 			printErr("%s", err)
 			return 1
 		}
-		type entry struct {
-			Op       string `json:"op"`
-			Domain   string `json:"domain"`
-			TargetID string `json:"target_id"`
-		}
-		entries := make([]entry, 0, len(stack.Snapshots))
+		entries := make([]snapshotListingEntry, 0, len(stack.Snapshots))
 		for _, s := range stack.Snapshots {
-			entries = append(entries, entry{Op: s.Op, Domain: s.Domain, TargetID: s.TargetID})
+			entries = append(entries, snapshotListing(s))
 		}
 		out, err := json.MarshalIndent(entries, "", "  ")
 		if err != nil {
@@ -286,192 +245,3 @@ func runSnapshotVerify(paths runtimePaths, args []string) int {
 // assumes single-flight writes: the skill's single write path (apply-agent)
 // serialises operations. The write itself is atomic (temp file + rename), so a
 // reader never sees a torn file even if that assumption is violated.
-func saveUndoSnapshotBytes(paths runtimePaths, data []byte) error {
-	var snap undoSnapshot
-	if err := unmarshalStrictJSON(data, "snapshot payload", &snap); err != nil {
-		return err
-	}
-	if err := validateUndoSnapshot(snap); err != nil {
-		return err
-	}
-	snap.SchemaVersion = undoSnapshotSchemaVersion
-	stack, err := loadUndoSnapshotStack(paths)
-	if err != nil {
-		return err
-	}
-	kept := make([]undoSnapshot, 0, len(stack.Snapshots)+1)
-	kept = append(kept, snap)
-	for _, existing := range stack.Snapshots {
-		if existing.Domain == snap.Domain && existing.TargetID == snap.TargetID {
-			continue
-		}
-		kept = append(kept, existing)
-	}
-	if len(kept) > undoSnapshotStackLimit {
-		kept = kept[:undoSnapshotStackLimit]
-	}
-	stack = undoSnapshotStack{SchemaVersion: undoSnapshotStackSchemaVersion, Snapshots: kept}
-	if err := writeJSONFile(undoSnapshotStackPath(paths), stack, 0o600); err != nil {
-		return fmt.Errorf("cannot write snapshot: %s", err)
-	}
-	// The legacy single-slot file is folded into the stack above; drop it so
-	// the two stores can never disagree. Best effort — a leftover legacy file
-	// only re-migrates as the oldest entry.
-	if err := os.Remove(undoSnapshotPath(paths)); err != nil && !isNotExist(err) {
-		printHumanWarn("legacy undo-snapshot cleanup skipped: %s", err)
-	}
-	return nil
-}
-
-// loadUndoSnapshotStack reads the stack store; a pre-stack single-slot file
-// migrates as a one-element stack so an update written by an older CLI stays
-// revertible after upgrading.
-func loadUndoSnapshotStack(paths runtimePaths) (undoSnapshotStack, error) {
-	data, err := os.ReadFile(undoSnapshotStackPath(paths))
-	if err == nil {
-		var stack undoSnapshotStack
-		if err := unmarshalStrictJSON(data, "undo snapshot store", &stack); err != nil {
-			return undoSnapshotStack{}, fmt.Errorf("undo snapshot store is corrupt: %s", err)
-		}
-		return stack, nil
-	}
-	if !isNotExist(err) {
-		return undoSnapshotStack{}, err
-	}
-	legacy, err := os.ReadFile(undoSnapshotPath(paths))
-	if err != nil {
-		if isNotExist(err) {
-			return undoSnapshotStack{SchemaVersion: undoSnapshotStackSchemaVersion}, nil
-		}
-		return undoSnapshotStack{}, err
-	}
-	var snap undoSnapshot
-	if err := unmarshalStrictJSON(legacy, "legacy undo snapshot", &snap); err != nil {
-		return undoSnapshotStack{}, fmt.Errorf("undo snapshot is corrupt: %s", err)
-	}
-	return undoSnapshotStack{
-		SchemaVersion: undoSnapshotStackSchemaVersion,
-		Snapshots:     []undoSnapshot{snap},
-	}, nil
-}
-
-// selectUndoSnapshot picks the newest snapshot, or the one for an explicit
-// target (optionally narrowed by domain).
-func selectUndoSnapshot(paths runtimePaths, target, domain string) (undoSnapshot, error) {
-	stack, err := loadUndoSnapshotStack(paths)
-	if err != nil {
-		return undoSnapshot{}, err
-	}
-	if len(stack.Snapshots) == 0 {
-		return undoSnapshot{}, fmt.Errorf("no undo snapshot available")
-	}
-	target = strings.TrimSpace(target)
-	domain = strings.TrimSpace(domain)
-	if target == "" {
-		if domain != "" {
-			return undoSnapshot{}, fmt.Errorf("--domain requires --target")
-		}
-		return stack.Snapshots[0], nil
-	}
-	var matches []undoSnapshot
-	for _, snap := range stack.Snapshots {
-		if snap.TargetID != target {
-			continue
-		}
-		if domain != "" && snap.Domain != domain {
-			continue
-		}
-		matches = append(matches, snap)
-	}
-	switch len(matches) {
-	case 0:
-		return undoSnapshot{}, fmt.Errorf("no undo snapshot for target %s", target)
-	case 1:
-		return matches[0], nil
-	default:
-		// Same target_id in more than one domain (save keys on domain+target,
-		// so this is legal): never guess which config to restore.
-		return undoSnapshot{}, fmt.Errorf("target %s is ambiguous across domains; pass --domain", target)
-	}
-}
-
-func validateUndoSnapshot(snap undoSnapshot) error {
-	if strings.TrimSpace(snap.Op) == "" {
-		return fmt.Errorf("snapshot is missing op")
-	}
-	if strings.TrimSpace(snap.Domain) == "" {
-		return fmt.Errorf("snapshot is missing domain")
-	}
-	if strings.TrimSpace(snap.TargetID) == "" {
-		return fmt.Errorf("snapshot is missing target_id")
-	}
-	if !hasJSONContent(snap.BeforeConfig) {
-		return fmt.Errorf("snapshot is missing before_config")
-	}
-	if !hasJSONContent(snap.ExpectedAfter) {
-		return fmt.Errorf("snapshot is missing expected_after")
-	}
-	// Reject at save time what verify can never evaluate: both bodies must be
-	// JSON objects. An array/scalar would pass the content check but make
-	// `snapshot verify` error out (exit 1) instead of returning match/drift.
-	if _, err := configObjectFromBytes(snap.BeforeConfig); err != nil {
-		return fmt.Errorf("snapshot before_config is not a JSON object: %s", err)
-	}
-	if _, err := configObjectFromBytes(snap.ExpectedAfter); err != nil {
-		return fmt.Errorf("snapshot expected_after is not a JSON object: %s", err)
-	}
-	return nil
-}
-
-func hasJSONContent(raw json.RawMessage) bool {
-	trimmed := strings.TrimSpace(string(raw))
-	return trimmed != "" && trimmed != "null"
-}
-
-// loadUndoSnapshot returns the newest stored snapshot (legacy call sites and
-// tests; selection lives in selectUndoSnapshot).
-func loadUndoSnapshot(paths runtimePaths) (undoSnapshot, error) {
-	return selectUndoSnapshot(paths, "", "")
-}
-
-// snapshotMatchesLive reports whether the live config still matches the stored
-// post-write read-back. It compares at the CONTENT level — using the same
-// normalisation as `ha-nova diff` — so volatile HA bookkeeping (created_at,
-// last_triggered, …) and singular/plural alias differences are never mistaken for
-// drift. Object key order is irrelevant; array order stays significant.
-//
-// Identity is the exception: a storage helper's `id` is the `{type}_id` the revert
-// rebuilds its update from, so if the target was deleted/recreated with the same
-// visible fields but a new internal id, the content compares equal yet a blind
-// restore would apply to a stale id and fail. When `id`/`unique_id` are present on
-// BOTH sides and differ, treat it as drift. A key the stored snapshot omitted
-// (older/filtered read-back) can't be compared, so it is never treated as drift.
-func snapshotMatchesLive(snap undoSnapshot, liveRaw []byte) (bool, error) {
-	expected, err := configObjectFromBytes(snap.ExpectedAfter)
-	if err != nil {
-		return false, fmt.Errorf("stored snapshot is corrupt: %s", err)
-	}
-	live, err := configObjectFromBytes(liveRaw)
-	if err != nil {
-		return false, fmt.Errorf("live config is not valid JSON: %s", err)
-	}
-	if len(renderConfigChanges(expected, live)) != 0 {
-		return false, nil
-	}
-	return identityKeysMatch(expected, live), nil
-}
-
-// identityKeysMatch reports whether the identity keys agree. Only a value present
-// on both sides that differs counts as a mismatch — a key the snapshot omitted is
-// uncomparable, not drift (preserves the HA-managed-id behaviour where a filtered
-// snapshot has no id but the live config carries one).
-func identityKeysMatch(expected, live map[string]interface{}) bool {
-	for _, k := range []string{"id", "unique_id"} {
-		ev, eok := expected[k]
-		lv, lok := live[k]
-		if eok && lok && !valuesEqual(ev, lv) {
-			return false
-		}
-	}
-	return true
-}

--- a/cli/snapshot_command_test.go
+++ b/cli/snapshot_command_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // These exercise the actual subcommands (not just the pure helpers), because the
@@ -18,7 +22,7 @@ func seedTestSnapshot(t *testing.T, paths runtimePaths, expectedAfter string) {
 		t.Fatalf("mkdir config dir: %v", err)
 	}
 	payload := `{"op":"update","domain":"automation","target_id":"1","before_config":{"alias":"X"},"expected_after":` + expectedAfter + `}`
-	if err := saveUndoSnapshotBytes(paths, []byte(payload)); err != nil {
+	if _, err := saveUndoSnapshotBytes(paths, []byte(payload)); err != nil {
 		t.Fatalf("seed snapshot: %v", err)
 	}
 }
@@ -183,5 +187,158 @@ func TestRunDiffCommandContract(t *testing.T) {
 	}
 	if got, want := string(data), "| Mode | single | restart |\n"; got != want {
 		t.Fatalf("diff file = %q, want %q", got, want)
+	}
+}
+
+func TestSnapshotSaveReceiptContract(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths: %v", err)
+	}
+	if err := os.MkdirAll(paths.ConfigDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	restore := snapshotNow
+	snapshotNow = func() time.Time { return time.Date(2026, 8, 4, 6, 0, 0, 0, time.UTC) }
+	defer func() { snapshotNow = restore }()
+
+	record := func(target, name string) []byte {
+		return []byte(`{"op":"update","domain":"automation","target_id":"` + target + `","name":"` + name + `","before_config":{"alias":"X"},"expected_after":{"alias":"Y"}}`)
+	}
+
+	// First save creates, stamps the CLI clock, and carries the alias.
+	receipt, err := saveUndoSnapshotBytes(paths, record("t1", "Morning routine"))
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if receipt.Action != "created" || receipt.Name != "Morning routine" ||
+		receipt.SavedAt != "2026-08-04T06:00:00Z" || receipt.Coverage == "" || len(receipt.Evicted) != 0 {
+		t.Fatalf("unexpected create receipt: %+v", receipt)
+	}
+
+	// Same-target save replaces — and says so.
+	receipt, err = saveUndoSnapshotBytes(paths, record("t1", "Morning routine"))
+	if err != nil {
+		t.Fatalf("re-save: %v", err)
+	}
+	if receipt.Action != "replaced" {
+		t.Fatalf("expected replaced, got %+v", receipt)
+	}
+
+	// Filling past the cap evicts the oldest and names it in the receipt.
+	for i := 2; i <= undoSnapshotStackLimit; i++ {
+		if _, err := saveUndoSnapshotBytes(paths, record(fmt.Sprintf("t%d", i), "")); err != nil {
+			t.Fatalf("fill %d: %v", i, err)
+		}
+	}
+	receipt, err = saveUndoSnapshotBytes(paths, record("t6", "Overflow"))
+	if err != nil {
+		t.Fatalf("overflow save: %v", err)
+	}
+	if len(receipt.Evicted) != 1 || receipt.Evicted[0].TargetID != "t1" || receipt.Evicted[0].Name != "Morning routine" {
+		t.Fatalf("expected t1 evicted with alias, got %+v", receipt.Evicted)
+	}
+
+	// The listing carries name, saved time, and the one-step coverage.
+	stack, err := loadUndoSnapshotStack(paths)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	listing := snapshotListing(stack.Snapshots[0])
+	if listing.Name != "Overflow" || listing.SavedAt == "" || listing.Coverage != snapshotCoverage {
+		t.Fatalf("unexpected listing: %+v", listing)
+	}
+}
+
+func TestSnapshotSavePreFieldRecordStillLoads(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths: %v", err)
+	}
+	if err := os.MkdirAll(paths.ConfigDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Records written by older CLIs have neither name nor saved_at.
+	receipt, err := saveUndoSnapshotBytes(paths, []byte(`{"op":"update","domain":"automation","target_id":"legacy","before_config":{"a":1},"expected_after":{"a":2}}`))
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if receipt.Name != "" || receipt.Action != "created" || receipt.SavedAt == "" {
+		t.Fatalf("unexpected receipt: %+v", receipt)
+	}
+}
+
+func TestRunSnapshotSavePrintsReceiptJSON(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths: %v", err)
+	}
+	if err := os.MkdirAll(paths.ConfigDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	record := filepath.Join(t.TempDir(), "record.json")
+	if err := os.WriteFile(record, []byte(`{"op":"update","domain":"automation","target_id":"cmd1","name":"Cmd Alias","before_config":{"a":1},"expected_after":{"a":2}}`), 0o600); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+
+	// Capture the command's stdout — the receipt is its ONLY output contract.
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	code := runSnapshotSave(paths, []string{"--data-file", record})
+	w.Close()
+	os.Stdout = orig
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code %d, output %s", code, out)
+	}
+	var receipt snapshotSaveReceipt
+	if err := json.Unmarshal(out, &receipt); err != nil {
+		t.Fatalf("stdout is not the receipt JSON: %v\n%s", err, out)
+	}
+	if receipt.Action != "created" || receipt.TargetID != "cmd1" ||
+		receipt.Name != "Cmd Alias" || receipt.SavedAt == "" || receipt.Coverage != snapshotCoverage {
+		t.Fatalf("unexpected receipt: %+v", receipt)
+	}
+}
+
+func TestSnapshotStackPreFieldStoreLoadsAndLists(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths: %v", err)
+	}
+	if err := os.MkdirAll(paths.ConfigDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A stack written by a pre-#483 CLI: no name, no saved_at anywhere.
+	preField := `{"schema_version":2,"snapshots":[{"schema_version":1,"op":"update","domain":"automation","target_id":"old1","before_config":{"a":1},"expected_after":{"a":2}}]}`
+	if err := os.WriteFile(undoSnapshotStackPath(paths), []byte(preField), 0o600); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	stack, err := loadUndoSnapshotStack(paths)
+	if err != nil {
+		t.Fatalf("pre-field store must load: %v", err)
+	}
+	listing := snapshotListing(stack.Snapshots[0])
+	if listing.TargetID != "old1" || listing.Name != "" || listing.SavedAt != "" || listing.Coverage != snapshotCoverage {
+		t.Fatalf("unexpected legacy listing: %+v", listing)
+	}
+	// Saving on top still works and reports a receipt.
+	receipt, err := saveUndoSnapshotBytes(paths, []byte(`{"op":"update","domain":"automation","target_id":"old1","before_config":{"a":2},"expected_after":{"a":3}}`))
+	if err != nil {
+		t.Fatalf("save over legacy: %v", err)
+	}
+	if receipt.Action != "replaced" {
+		t.Fatalf("expected replaced over legacy entry, got %+v", receipt)
 	}
 }

--- a/cli/snapshot_store.go
+++ b/cli/snapshot_store.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// undoSnapshot is one client-side record of a revertible write. It stores the
+// pre-write config (to restore) and the post-write verified read-back (to
+// detect external drift before restoring).
+//
+// The store performs NO Home Assistant calls. The skill orchestrates the
+// actual restore through `ha-nova relay` and the apply-agent, so the single
+// write path and the dumb-relay contract stay intact — this command only reads
+// and writes a local JSON file.
+type undoSnapshot struct {
+	SchemaVersion int    `json:"schema_version"`
+	Op            string `json:"op"`
+	Domain        string `json:"domain"`
+	TargetID      string `json:"target_id"`
+	// Name is the human-readable alias supplied by the skill so the owner
+	// console and `snapshot show --list` stay recognizable (#483). Optional:
+	// records written by older CLIs simply have none.
+	Name string `json:"name,omitempty"`
+	// SavedAt is stamped by the CLI at save time (RFC3339, UTC).
+	SavedAt       string          `json:"saved_at,omitempty"`
+	BeforeConfig  json.RawMessage `json:"before_config"`
+	ExpectedAfter json.RawMessage `json:"expected_after"`
+}
+
+// snapshotSaveReceipt makes every checkpoint operation self-describing (#483):
+// what was saved, when, and whether it created a new checkpoint, replaced the
+// same target's previous one, or evicted the oldest entries past the stack cap.
+type snapshotSaveReceipt struct {
+	Action   string                 `json:"action"` // "created" or "replaced"
+	Op       string                 `json:"op"`
+	Domain   string                 `json:"domain"`
+	TargetID string                 `json:"target_id"`
+	Name     string                 `json:"name,omitempty"`
+	SavedAt  string                 `json:"saved_at"`
+	Coverage string                 `json:"coverage"`
+	Evicted  []snapshotListingEntry `json:"evicted,omitempty"`
+}
+
+// snapshotListingEntry is one row of `snapshot show --list` and of a receipt's
+// evicted list.
+type snapshotListingEntry struct {
+	Op       string `json:"op"`
+	Domain   string `json:"domain"`
+	TargetID string `json:"target_id"`
+	Name     string `json:"name,omitempty"`
+	SavedAt  string `json:"saved_at,omitempty"`
+	Coverage string `json:"coverage"`
+}
+
+// snapshotCoverage states the one-step honesty limit everywhere a checkpoint
+// is surfaced: only the target's LAST verified update is revertible.
+const snapshotCoverage = "one step back: this target's last update only"
+
+const undoSnapshotSchemaVersion = 1
+
+// undoSnapshotStack keeps the most recent revertible updates, newest first —
+// one entry per domain+target (a re-update of the same target replaces its
+// entry; reverting an update always restores that target's LAST before-state).
+// Bounded so a multi-target logical change stays fully revertible without the
+// store growing forever (issue #282; previously a single slot).
+type undoSnapshotStack struct {
+	SchemaVersion int            `json:"schema_version"`
+	Snapshots     []undoSnapshot `json:"snapshots"`
+}
+
+const undoSnapshotStackSchemaVersion = 2
+const undoSnapshotStackLimit = 5
+
+// Exit codes for `snapshot verify`: 0 = live matches the post-write state,
+// snapshotExitDrift = live drifted (external edit), 1 = operational error.
+const snapshotExitDrift = 2
+
+// undoSnapshotPath is the legacy single-slot store; still read for migration.
+func undoSnapshotPath(paths runtimePaths) string {
+	return filepath.Join(paths.ConfigDir, "undo-snapshot.json")
+}
+
+func undoSnapshotStackPath(paths runtimePaths) string {
+	return filepath.Join(paths.ConfigDir, "undo-snapshots.json")
+}
+
+func saveUndoSnapshotBytes(paths runtimePaths, data []byte) (snapshotSaveReceipt, error) {
+	var snap undoSnapshot
+	if err := unmarshalStrictJSON(data, "snapshot payload", &snap); err != nil {
+		return snapshotSaveReceipt{}, err
+	}
+	if err := validateUndoSnapshot(snap); err != nil {
+		return snapshotSaveReceipt{}, err
+	}
+	snap.SchemaVersion = undoSnapshotSchemaVersion
+	// The CLI clock is the single source of the stamp; a caller-supplied
+	// saved_at is overwritten, never trusted.
+	snap.SavedAt = snapshotNow().UTC().Format(time.RFC3339)
+	stack, err := loadUndoSnapshotStack(paths)
+	if err != nil {
+		return snapshotSaveReceipt{}, err
+	}
+	action := "created"
+	kept := make([]undoSnapshot, 0, len(stack.Snapshots)+1)
+	kept = append(kept, snap)
+	for _, existing := range stack.Snapshots {
+		if existing.Domain == snap.Domain && existing.TargetID == snap.TargetID {
+			// Same-target update: the previous checkpoint is replaced — only
+			// the newest state stays revertible, and the receipt says so.
+			action = "replaced"
+			continue
+		}
+		kept = append(kept, existing)
+	}
+	var evicted []snapshotListingEntry
+	if len(kept) > undoSnapshotStackLimit {
+		for _, dropped := range kept[undoSnapshotStackLimit:] {
+			evicted = append(evicted, snapshotListing(dropped))
+		}
+		kept = kept[:undoSnapshotStackLimit]
+	}
+	stack = undoSnapshotStack{SchemaVersion: undoSnapshotStackSchemaVersion, Snapshots: kept}
+	if err := writeJSONFile(undoSnapshotStackPath(paths), stack, 0o600); err != nil {
+		return snapshotSaveReceipt{}, fmt.Errorf("cannot write snapshot: %s", err)
+	}
+	// The legacy single-slot file is folded into the stack above; drop it so
+	// the two stores can never disagree. Best effort — a leftover legacy file
+	// only re-migrates as the oldest entry.
+	if err := os.Remove(undoSnapshotPath(paths)); err != nil && !isNotExist(err) {
+		printHumanWarn("legacy undo-snapshot cleanup skipped: %s", err)
+	}
+	return snapshotSaveReceipt{
+		Action:   action,
+		Op:       snap.Op,
+		Domain:   snap.Domain,
+		TargetID: snap.TargetID,
+		Name:     snap.Name,
+		SavedAt:  snap.SavedAt,
+		Coverage: snapshotCoverage,
+		Evicted:  evicted,
+	}, nil
+}
+
+func snapshotListing(snap undoSnapshot) snapshotListingEntry {
+	return snapshotListingEntry{
+		Op:       snap.Op,
+		Domain:   snap.Domain,
+		TargetID: snap.TargetID,
+		Name:     snap.Name,
+		SavedAt:  snap.SavedAt,
+		Coverage: snapshotCoverage,
+	}
+}
+
+// snapshotNow is swappable for tests.
+var snapshotNow = time.Now
+
+// loadUndoSnapshotStack reads the stack store; a pre-stack single-slot file
+// migrates as a one-element stack so an update written by an older CLI stays
+// revertible after upgrading.
+func loadUndoSnapshotStack(paths runtimePaths) (undoSnapshotStack, error) {
+	data, err := os.ReadFile(undoSnapshotStackPath(paths))
+	if err == nil {
+		var stack undoSnapshotStack
+		if err := unmarshalStrictJSON(data, "undo snapshot store", &stack); err != nil {
+			return undoSnapshotStack{}, fmt.Errorf("undo snapshot store is corrupt: %s", err)
+		}
+		return stack, nil
+	}
+	if !isNotExist(err) {
+		return undoSnapshotStack{}, err
+	}
+	legacy, err := os.ReadFile(undoSnapshotPath(paths))
+	if err != nil {
+		if isNotExist(err) {
+			return undoSnapshotStack{SchemaVersion: undoSnapshotStackSchemaVersion}, nil
+		}
+		return undoSnapshotStack{}, err
+	}
+	var snap undoSnapshot
+	if err := unmarshalStrictJSON(legacy, "legacy undo snapshot", &snap); err != nil {
+		return undoSnapshotStack{}, fmt.Errorf("undo snapshot is corrupt: %s", err)
+	}
+	return undoSnapshotStack{
+		SchemaVersion: undoSnapshotStackSchemaVersion,
+		Snapshots:     []undoSnapshot{snap},
+	}, nil
+}
+
+// selectUndoSnapshot picks the newest snapshot, or the one for an explicit
+// target (optionally narrowed by domain).
+func selectUndoSnapshot(paths runtimePaths, target, domain string) (undoSnapshot, error) {
+	stack, err := loadUndoSnapshotStack(paths)
+	if err != nil {
+		return undoSnapshot{}, err
+	}
+	if len(stack.Snapshots) == 0 {
+		return undoSnapshot{}, fmt.Errorf("no undo snapshot available")
+	}
+	target = strings.TrimSpace(target)
+	domain = strings.TrimSpace(domain)
+	if target == "" {
+		if domain != "" {
+			return undoSnapshot{}, fmt.Errorf("--domain requires --target")
+		}
+		return stack.Snapshots[0], nil
+	}
+	var matches []undoSnapshot
+	for _, snap := range stack.Snapshots {
+		if snap.TargetID != target {
+			continue
+		}
+		if domain != "" && snap.Domain != domain {
+			continue
+		}
+		matches = append(matches, snap)
+	}
+	switch len(matches) {
+	case 0:
+		return undoSnapshot{}, fmt.Errorf("no undo snapshot for target %s", target)
+	case 1:
+		return matches[0], nil
+	default:
+		// Same target_id in more than one domain (save keys on domain+target,
+		// so this is legal): never guess which config to restore.
+		return undoSnapshot{}, fmt.Errorf("target %s is ambiguous across domains; pass --domain", target)
+	}
+}
+
+func validateUndoSnapshot(snap undoSnapshot) error {
+	if strings.TrimSpace(snap.Op) == "" {
+		return fmt.Errorf("snapshot is missing op")
+	}
+	if strings.TrimSpace(snap.Domain) == "" {
+		return fmt.Errorf("snapshot is missing domain")
+	}
+	if strings.TrimSpace(snap.TargetID) == "" {
+		return fmt.Errorf("snapshot is missing target_id")
+	}
+	if !hasJSONContent(snap.BeforeConfig) {
+		return fmt.Errorf("snapshot is missing before_config")
+	}
+	if !hasJSONContent(snap.ExpectedAfter) {
+		return fmt.Errorf("snapshot is missing expected_after")
+	}
+	// Reject at save time what verify can never evaluate: both bodies must be
+	// JSON objects. An array/scalar would pass the content check but make
+	// `snapshot verify` error out (exit 1) instead of returning match/drift.
+	if _, err := configObjectFromBytes(snap.BeforeConfig); err != nil {
+		return fmt.Errorf("snapshot before_config is not a JSON object: %s", err)
+	}
+	if _, err := configObjectFromBytes(snap.ExpectedAfter); err != nil {
+		return fmt.Errorf("snapshot expected_after is not a JSON object: %s", err)
+	}
+	return nil
+}
+
+func hasJSONContent(raw json.RawMessage) bool {
+	trimmed := strings.TrimSpace(string(raw))
+	return trimmed != "" && trimmed != "null"
+}
+
+// loadUndoSnapshot returns the newest stored snapshot (legacy call sites and
+// tests; selection lives in selectUndoSnapshot).
+func loadUndoSnapshot(paths runtimePaths) (undoSnapshot, error) {
+	return selectUndoSnapshot(paths, "", "")
+}
+
+// snapshotMatchesLive reports whether the live config still matches the stored
+// post-write read-back. It compares at the CONTENT level — using the same
+// normalisation as `ha-nova diff` — so volatile HA bookkeeping (created_at,
+// last_triggered, …) and singular/plural alias differences are never mistaken for
+// drift. Object key order is irrelevant; array order stays significant.
+//
+// Identity is the exception: a storage helper's `id` is the `{type}_id` the revert
+// rebuilds its update from, so if the target was deleted/recreated with the same
+// visible fields but a new internal id, the content compares equal yet a blind
+// restore would apply to a stale id and fail. When `id`/`unique_id` are present on
+// BOTH sides and differ, treat it as drift. A key the stored snapshot omitted
+// (older/filtered read-back) can't be compared, so it is never treated as drift.
+func snapshotMatchesLive(snap undoSnapshot, liveRaw []byte) (bool, error) {
+	expected, err := configObjectFromBytes(snap.ExpectedAfter)
+	if err != nil {
+		return false, fmt.Errorf("stored snapshot is corrupt: %s", err)
+	}
+	live, err := configObjectFromBytes(liveRaw)
+	if err != nil {
+		return false, fmt.Errorf("live config is not valid JSON: %s", err)
+	}
+	if len(renderConfigChanges(expected, live)) != 0 {
+		return false, nil
+	}
+	return identityKeysMatch(expected, live), nil
+}
+
+// identityKeysMatch reports whether the identity keys agree. Only a value present
+// on both sides that differs counts as a mismatch — a key the snapshot omitted is
+// uncomparable, not drift (preserves the HA-managed-id behaviour where a filtered
+// snapshot has no id but the live config carries one).
+func identityKeysMatch(expected, live map[string]interface{}) bool {
+	for _, k := range []string{"id", "unique_id"} {
+		ev, eok := expected[k]
+		lv, lok := live[k]
+		if eok && lok && !valuesEqual(ev, lv) {
+			return false
+		}
+	}
+	return true
+}

--- a/cli/snapshot_test.go
+++ b/cli/snapshot_test.go
@@ -25,7 +25,7 @@ func validSnapshotJSON() []byte {
 func TestSnapshotSaveShowRoundTrip(t *testing.T) {
 	paths := testSnapshotPaths(t)
 
-	if err := saveUndoSnapshotBytes(paths, validSnapshotJSON()); err != nil {
+	if _, err := saveUndoSnapshotBytes(paths, validSnapshotJSON()); err != nil {
 		t.Fatalf("save failed: %v", err)
 	}
 
@@ -60,7 +60,7 @@ func TestSnapshotStackKeepsMultipleTargetsAndReplacesSameTarget(t *testing.T) {
 	}
 	// Three targets, then a re-update of the second: 3 entries, second replaced + moved to top.
 	for _, r := range []string{record("t1", "b1"), record("t2", "b2"), record("t3", "b3"), record("t2", "b2-new")} {
-		if err := saveUndoSnapshotBytes(paths, []byte(r)); err != nil {
+		if _, err := saveUndoSnapshotBytes(paths, []byte(r)); err != nil {
 			t.Fatalf("save failed: %v", err)
 		}
 	}
@@ -87,7 +87,7 @@ func TestSnapshotStackKeepsMultipleTargetsAndReplacesSameTarget(t *testing.T) {
 	}
 	// Same target_id in a second domain: target-only selection must refuse
 	// to guess, and --domain must disambiguate.
-	if err := saveUndoSnapshotBytes(paths, []byte(`{"op":"update","domain":"script","target_id":"t1","before_config":{"a":1},"expected_after":{"a":2}}`)); err != nil {
+	if _, err := saveUndoSnapshotBytes(paths, []byte(`{"op":"update","domain":"script","target_id":"t1","before_config":{"a":1},"expected_after":{"a":2}}`)); err != nil {
 		t.Fatalf("save script t1: %v", err)
 	}
 	if _, err := selectUndoSnapshot(paths, "t1", ""); err == nil || !strings.Contains(err.Error(), "ambiguous") {
@@ -105,7 +105,7 @@ func TestSnapshotStackEvictsOldestBeyondLimit(t *testing.T) {
 	paths := testSnapshotPaths(t)
 	for i := 0; i < undoSnapshotStackLimit+2; i++ {
 		r := `{"op":"update","domain":"automation","target_id":"t` + string(rune('a'+i)) + `","before_config":{"a":1},"expected_after":{"a":2}}`
-		if err := saveUndoSnapshotBytes(paths, []byte(r)); err != nil {
+		if _, err := saveUndoSnapshotBytes(paths, []byte(r)); err != nil {
 			t.Fatalf("save %d failed: %v", i, err)
 		}
 	}
@@ -137,7 +137,7 @@ func TestSnapshotLegacySingleFileMigratesIntoStack(t *testing.T) {
 	}
 	// Write path: a new save folds the legacy record in and removes the file.
 	next := `{"op":"update","domain":"automation","target_id":"new","before_config":{"b":1},"expected_after":{"b":2}}`
-	if err := saveUndoSnapshotBytes(paths, []byte(next)); err != nil {
+	if _, err := saveUndoSnapshotBytes(paths, []byte(next)); err != nil {
 		t.Fatalf("save after legacy: %v", err)
 	}
 	stack, err := loadUndoSnapshotStack(paths)
@@ -163,7 +163,7 @@ func TestSnapshotSaveRejectsMissingFields(t *testing.T) {
 	}
 	for name, payload := range cases {
 		t.Run(name, func(t *testing.T) {
-			if err := saveUndoSnapshotBytes(paths, []byte(payload)); err == nil {
+			if _, err := saveUndoSnapshotBytes(paths, []byte(payload)); err == nil {
 				t.Fatalf("expected validation error for %q", name)
 			}
 			if _, err := os.Stat(undoSnapshotPath(paths)); !os.IsNotExist(err) {
@@ -184,7 +184,7 @@ func TestSnapshotSaveRejectsNonObjectBodies(t *testing.T) {
 	}
 	for name, payload := range cases {
 		t.Run(name, func(t *testing.T) {
-			if err := saveUndoSnapshotBytes(paths, []byte(payload)); err == nil {
+			if _, err := saveUndoSnapshotBytes(paths, []byte(payload)); err == nil {
 				t.Fatalf("expected validation error for %q", name)
 			}
 			if _, err := os.Stat(undoSnapshotPath(paths)); !os.IsNotExist(err) {
@@ -212,7 +212,7 @@ func TestRunSnapshotSaveFromDataFile(t *testing.T) {
 
 func TestSnapshotSaveRejectsInvalidJSON(t *testing.T) {
 	paths := testSnapshotPaths(t)
-	if err := saveUndoSnapshotBytes(paths, []byte("{not json")); err == nil {
+	if _, err := saveUndoSnapshotBytes(paths, []byte("{not json")); err == nil {
 		t.Fatal("expected error for invalid JSON")
 	}
 }
@@ -223,10 +223,10 @@ func TestSnapshotSaveOverwritesSingleSlot(t *testing.T) {
 	first := []byte(`{"op":"update","domain":"automation","target_id":"AAA","before_config":{"v":1},"expected_after":{"v":2}}`)
 	second := []byte(`{"op":"update","domain":"script","target_id":"BBB","before_config":{"v":3},"expected_after":{"v":4}}`)
 
-	if err := saveUndoSnapshotBytes(paths, first); err != nil {
+	if _, err := saveUndoSnapshotBytes(paths, first); err != nil {
 		t.Fatalf("first save failed: %v", err)
 	}
-	if err := saveUndoSnapshotBytes(paths, second); err != nil {
+	if _, err := saveUndoSnapshotBytes(paths, second); err != nil {
 		t.Fatalf("second save failed: %v", err)
 	}
 
@@ -248,7 +248,7 @@ func TestSnapshotShowMissing(t *testing.T) {
 
 func TestSnapshotVerifyMatchIgnoresKeyOrder(t *testing.T) {
 	paths := testSnapshotPaths(t)
-	if err := saveUndoSnapshotBytes(paths, validSnapshotJSON()); err != nil {
+	if _, err := saveUndoSnapshotBytes(paths, validSnapshotJSON()); err != nil {
 		t.Fatalf("save failed: %v", err)
 	}
 	snap, err := loadUndoSnapshot(paths)
@@ -269,7 +269,7 @@ func TestSnapshotVerifyMatchIgnoresKeyOrder(t *testing.T) {
 
 func TestSnapshotVerifyDetectsDrift(t *testing.T) {
 	paths := testSnapshotPaths(t)
-	if err := saveUndoSnapshotBytes(paths, validSnapshotJSON()); err != nil {
+	if _, err := saveUndoSnapshotBytes(paths, validSnapshotJSON()); err != nil {
 		t.Fatalf("save failed: %v", err)
 	}
 	snap, err := loadUndoSnapshot(paths)

--- a/cli/strict_selector_test.go
+++ b/cli/strict_selector_test.go
@@ -164,7 +164,7 @@ func TestSnapshotRejectsEmptyOrAmbiguousSelectionBeforeNewestFallback(t *testing
 		`{"op":"update","domain":"automation","target_id":"t1","before_config":{"v":0},"expected_after":{"v":1}}`,
 		`{"op":"update","domain":"automation","target_id":"t2","before_config":{"v":1},"expected_after":{"v":2}}`,
 	} {
-		if err := saveUndoSnapshotBytes(paths, []byte(record)); err != nil {
+		if _, err := saveUndoSnapshotBytes(paths, []byte(record)); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/cli/strict_utf8_input_test.go
+++ b/cli/strict_utf8_input_test.go
@@ -360,7 +360,7 @@ func TestSnapshotDiffAndJQRejectInvalidUTF8(t *testing.T) {
 
 	paths := testSnapshotPaths(t)
 	invalidSnapshot := append(append([]byte(`{"op":"update","domain":"automation","target_id":"1","before_config":{"alias":"`), 0xDC), []byte(`"},"expected_after":{"alias":"ok"}}`)...)
-	if err := saveUndoSnapshotBytes(paths, invalidSnapshot); err == nil || !strings.Contains(err.Error(), "UTF-8") {
+	if _, err := saveUndoSnapshotBytes(paths, invalidSnapshot); err == nil || !strings.Contains(err.Error(), "UTF-8") {
 		t.Fatalf("snapshot error = %v, want UTF-8 rejection", err)
 	}
 	if _, err := os.Stat(undoSnapshotStackPath(paths)); !os.IsNotExist(err) {

--- a/skills/ha-nova/update-revert.md
+++ b/skills/ha-nova/update-revert.md
@@ -1,5 +1,17 @@
 # HA NOVA Update-Revert Execution
 
+## Three recovery layers, never conflated
+
+- **Update-revert checkpoint** (this file): client-local, per domain+target,
+  ONE step back to the last verified update; a same-target update replaces
+  it. `ha-nova snapshot show --list` shows alias, saved time, and coverage —
+  records saved by older CLI versions carry neither alias nor saved time.
+- **Config snapshot** (`skills/ha-nova/config-snapshots.md`): captured before
+  covered destructive HA NOVA operations; restores the deleted/overwritten
+  item itself.
+- **Home Assistant Backup**: full system recovery, the safety net when
+  neither targeted layer covers the case.
+
 Load this file whenever the user asks to revert, undo, or restore a verified
 update — any of those intents, not only the literal word `revert`.
 Snapshot capture and the revert offer live in `skills/ha-nova/write-safety.md`

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -232,9 +232,11 @@ Scope: **update only**. A create is undone by deleting the new item through the
 normal HA NOVA delete flow; that delete still requires a delete preview, exact
 `confirm:<token>`, and absence verification, even when the item was created earlier in the same session.
 Do not call this `revert`, and do not imply that manual deletion or a full Home Assistant Backup restore is the only cleanup path.
-A delete has no HA NOVA `revert`; rollback requires restoring a suitable existing
-Home Assistant Backup, or recreating the item. Point the user to HA Backups
-(Settings > System > Backups) for that case.
+A delete has no HA NOVA `revert`; a snapshot-covered delete restores from its
+auto config snapshot (`skills/ha-nova/config-snapshots.md`) — that is the
+first rollback path. When no config snapshot was captured, rollback requires
+restoring a suitable existing Home Assistant Backup (Settings > System >
+Backups), or recreating the item.
 
 ### 1. Capture the snapshot (after a verified update)
 
@@ -270,8 +272,17 @@ Record shape:
 
 ```json
 {"op":"update","domain":"automation","target_id":"<config id>",
+ "name":"<the item's alias/friendly name>",
  "before_config":{ ... },"expected_after":{ ... }}
 ```
+
+Include `name` so the checkpoint stays recognizable in listings. The CLI
+prints a structured receipt with the keys `action` (`created` | `replaced`),
+`op`, `domain`, `target_id`, `name`, `saved_at`, `coverage`, and `evicted[]`
+(each evicted entry carries the same listing keys) — repeat its essence in
+the result line: a `replaced` receipt means the target's PREVIOUS checkpoint
+is gone and only the newest update stays revertible; name evicted targets as
+no longer revertible.
 
 ### 2. Offer the revert
 

--- a/skills/write/SKILL.md
+++ b/skills/write/SKILL.md
@@ -118,7 +118,7 @@ Do NOT invoke `ha-nova:review` separately.
    - **Findings**: real issues only. **Collision check**: only when related items exist (list them + the verdict); a failed scan is NOT empty output — report it as "consumer check inconclusive". **Advisory**: only when non-empty. Omit any section with nothing to report — never print an empty "none" bucket.
    - If nothing is worth reporting, collapse to one scope-honest confirmation line (write-safety → Verification Honesty).
    - Never emit `Questions to consider`, `Suggestions`, or `Instant help` post-write; never repeat an item across **Findings** and **Advisory**.
-5. Update-Revert: updates only → **run `ha-nova snapshot save`** and offer `revert` (see `skills/ha-nova/write-safety.md`). Creates → cleanup via normal HA NOVA delete flow with preview, `confirm:<token>`, and absence verification. Deletes → name the captured config snapshot as the restore path (`skills/ha-nova/config-snapshots.md`); when no snapshot was captured (store missing/full), Home Assistant Backups.
+5. Update-Revert: updates only → **run `ha-nova snapshot save`** and offer `revert` (see `skills/ha-nova/write-safety.md`); reflect the save receipt in the result — a `replaced` receipt means only this newest update stays revertible, and evicted targets are no longer revertible. Creates → cleanup via normal HA NOVA delete flow with preview, `confirm:<token>`, and absence verification. Deletes → name the captured config snapshot as the restore path (`skills/ha-nova/config-snapshots.md`); when no snapshot was captured (store missing/full), Home Assistant Backups.
 
 ### Phase 5: Test Offer (create/update only)
 

--- a/tests/skills/config-snapshots-contract.test.ts
+++ b/tests/skills/config-snapshots-contract.test.ts
@@ -81,3 +81,24 @@ describe("config snapshots contract", () => {
     expect(reference).toContain("Never use batch delete to emulate prune or to widen `keep_named`");
   });
 });
+
+describe("update-revert checkpoint observability (#483)", () => {
+  const writeSafety = readFileSync("skills/ha-nova/write-safety.md", "utf8");
+  const updateRevert = readFileSync("skills/ha-nova/update-revert.md", "utf8");
+  const writeSkill = readFileSync("skills/write/SKILL.md", "utf8");
+
+  it("carries the alias in the record and reflects the CLI receipt", () => {
+    expect(writeSafety).toContain('"name":"<the item\'s alias/friendly name>"');
+    expect(writeSafety).toContain("structured receipt");
+    expect(writeSafety).toContain("`replaced` receipt means the target's PREVIOUS checkpoint");
+    expect(writeSkill).toContain("reflect the save receipt in the result");
+    expect(writeSkill).toContain("evicted targets are no longer revertible");
+  });
+
+  it("separates the three recovery layers explicitly", () => {
+    expect(updateRevert).toContain("Three recovery layers, never conflated");
+    expect(updateRevert).toContain("Update-revert checkpoint");
+    expect(updateRevert).toContain("Config snapshot");
+    expect(updateRevert).toContain("Home Assistant Backup");
+  });
+});

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -123,7 +123,8 @@ const WORD_BUDGETS: Record<string, number> = {
   // Fail-closed consumer scan: canonical filter with inline recreate
   // fallback at both search/related call sites + delete-direction
   // clarification (#489).
-  write: 2000,
+  // Self-describing update-revert checkpoint receipts (#483).
+  write: 2025,
   // Cards adoption pointer (#389).
   diagnose: 1500,
   // Report-shape declaration line (shared output shapes); repair dedup,


### PR DESCRIPTION
## Summary

Every checkpoint operation becomes self-describing (#483):

- **Structured save receipt on stdout:** `action` (`created` | `replaced`), `op`/`domain`/`target_id`, optional alias (`name` — new optional record field the skill supplies), CLI-stamped `saved_at` (UTC; caller-supplied values are overwritten, never trusted), the explicit one-step `coverage` line, and `evicted[]` when the stack cap drops the oldest targets. A silent save — or the silent same-target replacement the issue demonstrated — can no longer happen; the write skill reflects the receipt in its result.
- **Recognizable listing:** `snapshot show --list` rows now carry alias, saved time, and the coverage line. Stores written by pre-#483 CLIs load unchanged (fields simply absent — pinned by test), and older records are qualified as alias-less in the docs.
- **Terminology separated:** `update-revert.md` now states the three recovery layers explicitly (update-revert checkpoint / config snapshot / Home Assistant Backup); `write-safety.md` documents the exact receipt keys and names config-snapshot restore as the first delete-recovery path.
- **Structure:** `snapshot.go` split into command handling + `snapshot_store.go` (store/receipt logic) per the file-length guideline.

## Verification

- Go: receipt contract (create/replace/evict with injected clock), command stdout JSON shape via captured stdout, pre-field store compatibility; full `go test ./...` green (136s), `go vet` clean, gofmt applied
- Skills: new pins in `config-snapshots-contract.test.ts` (receipt keys, three-layer section, result reflection); full `tests/skills/` suite green
- Local Codex CLI diff review (pre-push workflow): 6 findings — receipt-key docs, delete-recovery consistency, legacy qualification, stdout-shape test, pre-field store test, file split — all fixed before this PR

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RjvsWLvNQNYq5AKserdQt