### PR TITLE
feat(cli): add-another-server wizard on the completed-setup screen (#411)

### DIFF
--- a/cli/setup_add_server.go
+++ b/cli/setup_add_server.go
@@ -120,7 +120,9 @@ func runAddServerFlow(
 func printAddServerPartialGuidance(out io.Writer, name string) {
 	renderSetupParagraph(out,
 		fmt.Sprintf("The server %q was saved but is not paired yet.", name),
-		fmt.Sprintf("Finish pairing with: ha-nova pair --server %s --relay-url <relay-url>", name),
+		// The saved profile already carries the derived relay URL — pair
+		// reuses it, and a retyped value would overwrite the saved target.
+		fmt.Sprintf("Finish pairing with: ha-nova pair --server %s", name),
 		fmt.Sprintf("Or remove it with: ha-nova server remove %s", name),
 	)
 }

--- a/cli/setup_add_server.go
+++ b/cli/setup_add_server.go
@@ -169,7 +169,7 @@ func runAddServerStages(
 			return cancelKeepingPartialProfile()
 		}
 		printHumanErr("%s", err)
-		return 1
+		return failKeepingPartialProfile()
 	}
 
 	for {
@@ -316,7 +316,11 @@ func addServerHostPortKey(value string) string {
 	if trimmed == "" {
 		return ""
 	}
-	if !strings.Contains(trimmed, "://") {
+	// A bare host implies the HA default port; an explicit URL without a
+	// port means the SCHEME default (80/443) — conflating https://ha.example
+	// with ha.example:8123 would hide a genuinely different instance.
+	hadScheme := strings.Contains(trimmed, "://")
+	if !hadScheme {
 		trimmed = "http://" + trimmed
 	}
 	parsed, err := url.Parse(trimmed)
@@ -325,7 +329,14 @@ func addServerHostPortKey(value string) string {
 	}
 	port := parsed.Port()
 	if port == "" {
-		port = "8123"
+		switch {
+		case !hadScheme:
+			port = "8123"
+		case parsed.Scheme == "https":
+			port = "443"
+		default:
+			port = "80"
+		}
 	}
 	return strings.ToLower(strings.TrimSuffix(parsed.Hostname(), ".")) + ":" + port
 }

--- a/cli/setup_add_server.go
+++ b/cli/setup_add_server.go
@@ -1,0 +1,350 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+)
+
+// Test seam: the offer must not fire (and then die on EOF) when stdin is not
+// interactive — `ha-nova setup </dev/null` on a completed install has to keep
+// exiting 0 with the done banner.
+var addServerOfferStdinIsTTY = isInteractiveTTY
+
+// Add-another-server flow (#411, multi-server layer 2). Offered only on the
+// completed-setup screen — the single-server first run never sees it. It
+// reuses the existing building blocks (discovery UI, relay install
+// instructions, secure pairing flow, device verify); the one new mechanic is
+// that every result is written to a NEW named profile by flipping the
+// process-global selection seam, exactly like `ha-nova pair --server` does.
+// Named profiles are device-credential-only: the legacy token path stays
+// default-profile-only, so pairing runs with the legacy store marked
+// unavailable and fails closed on pre-v1 relays.
+
+func maybeOfferAddServerForCompletedSetup(
+	reader *bufio.Reader,
+	out io.Writer,
+	paths runtimePaths,
+	serviceMode bool,
+	lifecycleMarker ...[]byte,
+) (bool, int) {
+	if serviceMode || !writerSupportsTTYForSetup(out) || !addServerOfferStdinIsTTY() {
+		return false, 0
+	}
+	// An explicit --server/env selection on `setup` is handled by the named
+	// setup guard long before this screen; only the plain default run offers
+	// the add flow.
+	if requested, _ := requestedServerSelection(); requested != "" {
+		return false, 0
+	}
+	fmt.Fprintln(out)
+	add, err := promptWizardYesNoFromReader(
+		reader,
+		out,
+		"Add another Home Assistant server?",
+		false,
+	)
+	if errors.Is(err, errSetupExit) || errors.Is(err, errSetupBack) {
+		return false, 0
+	}
+	if err != nil {
+		printHumanErr("%s", err)
+		return true, 1
+	}
+	if !add {
+		return false, 0
+	}
+	return true, runAddServerFlow(reader, out, paths, lifecycleMarker...)
+}
+
+func runAddServerFlow(
+	reader *bufio.Reader,
+	out io.Writer,
+	paths runtimePaths,
+	lifecycleMarker ...[]byte,
+) int {
+	doc, err := loadConfigDocument(paths.ConfigFile)
+	if err != nil {
+		printHumanErr("cannot read the existing server profiles: %s", err)
+		return 1
+	}
+	name, nameErr := promptNewServerProfileName(reader, out, doc)
+	if nameErr == errSetupBack || nameErr == errSetupExit {
+		renderSetupCancelledNote(out)
+		return 0
+	}
+	if nameErr != nil {
+		printHumanErr("%s", nameErr)
+		return 1
+	}
+
+	// The seam redirects both config saves (saveTargetProfileName) and the
+	// device-credential slots to the new profile; restore it afterwards so
+	// anything after this flow (census ask, later commands in-process) works
+	// on the default profile again.
+	previousProfile := activeServerProfile()
+	setServerSelectionOverride(name)
+	setActiveServerProfile(name)
+	defer func() {
+		setServerSelectionOverride("")
+		setActiveServerProfile(previousProfile)
+	}()
+
+	return runAddServerStages(reader, out, paths, doc, name, lifecycleMarker...)
+}
+
+// Printed only once the profile exists on disk — before the first save there
+// is nothing to finish or remove.
+func printAddServerPartialGuidance(out io.Writer, name string) {
+	renderSetupParagraph(out,
+		fmt.Sprintf("The server %q was saved but is not paired yet.", name),
+		fmt.Sprintf("Finish pairing with: ha-nova pair --server %s --relay-url <relay-url>", name),
+		fmt.Sprintf("Or remove it with: ha-nova server remove %s", name),
+	)
+}
+
+func runAddServerStages(
+	reader *bufio.Reader,
+	out io.Writer,
+	paths runtimePaths,
+	doc *configDocument,
+	name string,
+	lifecycleMarker ...[]byte,
+) int {
+	// A brand-new profile mints its own ProfileID directly —
+	// ensureProfileIdentityForSetup would try to resolve the not-yet-saved
+	// profile name and fail loud on the unknown selection. The install-wide
+	// ClientInstallID must be SEEDED from the document: leaving it empty makes
+	// the pairing stage mint a fresh one, which the immutability guard in
+	// withProfileDocument rejects on every install that already paired
+	// securely (the cmd_pair precedent seeds it the same way).
+	cfg := runtimeConfig{ClientInstallID: doc.meta.ClientInstallID}
+	if err := ensureProfileID(&cfg); err != nil {
+		printHumanErr("cannot prepare the server profile identity: %s", err)
+		return 1
+	}
+
+	host, haURL, hostErr := selectAddServerHAHost(reader, out, doc)
+	if hostErr == errSetupBack || hostErr == errSetupExit {
+		renderSetupCancelledNote(out)
+		return 0
+	}
+	if hostErr != nil {
+		printHumanErr("%s", hostErr)
+		return 1
+	}
+	cfg = applySelectedSetupHost(cfg, host, haURL, "")
+	if err := saveSetupConfigWithLifecycle(paths, cfg, lifecycleMarker...); err != nil {
+		printHumanErr("cannot save the new server profile: %s", err)
+		return 1
+	}
+	// From here on the profile exists on disk: a cancel must still say how to
+	// finish or remove it.
+	cancelKeepingPartialProfile := func() int {
+		renderSetupCancelledNote(out)
+		printAddServerPartialGuidance(out, name)
+		return 0
+	}
+	failKeepingPartialProfile := func() int {
+		printAddServerPartialGuidance(out, name)
+		return 1
+	}
+
+	repositoryURL := haAddRepositoryURL(cfg.HAURL)
+	renderSetupParagraph(out,
+		"Next, install the NOVA Relay App on this Home Assistant instance.",
+	)
+	renderSetupLink(out, "Add the repository:", repositoryURL)
+	renderSetupIndentedBlock(out, "Then:", "    ",
+		"1. Go to Settings > Apps > App Store (on older Home Assistant: Settings > Add-ons)",
+		`2. Search for "NOVA Relay"`,
+		"3. Click Install and wait for it to finish",
+		"4. Click Start",
+	)
+	if _, err := promptWizardLineFromReader(reader, out, "Press Enter when the app is running", ""); err != nil {
+		if err == errSetupBack || err == errSetupExit {
+			return cancelKeepingPartialProfile()
+		}
+		printHumanErr("%s", err)
+		return 1
+	}
+
+	for {
+		// legacyTokenStoreUnavailable=true: named profiles never use the
+		// machine-wide legacy token (spec: device-credential-only, fail
+		// closed on relays without secure pairing).
+		_, pairErr := runSetupPairingFlow(reader, out, paths, &cfg, true, lifecycleMarker...)
+		if pairErr == errSetupRelayTokenStep {
+			renderSetupErrorLine(out, "Additional servers pair with the six-digit code only; the manual token path stays on the default server.")
+			continue
+		}
+		if errors.Is(pairErr, errSetupDevicePaired) {
+			break
+		}
+		if pairErr == errSetupBack || pairErr == errSetupExit {
+			return cancelKeepingPartialProfile()
+		}
+		if pairErr != nil {
+			printHumanErr("%s", pairErr)
+			return failKeepingPartialProfile()
+		}
+		// A nil return would mean a legacy token exchange, which the
+		// unavailable-store guard above rules out; treat it as a failure
+		// rather than continuing with a token the profile must not hold.
+		printHumanErr("pairing did not produce a device credential for %q", name)
+		return failKeepingPartialProfile()
+	}
+
+	if !verifyDeviceHealth(cfg) {
+		renderSetupErrorLine(out, "Paired, but the secure device endpoint did not answer yet. The App may still be starting.")
+		if _, err := promptWizardLineFromReader(reader, out, "Press Enter to retry once", ""); err != nil {
+			if err == errSetupBack || err == errSetupExit {
+				return cancelKeepingPartialProfile()
+			}
+			printHumanErr("%s", err)
+			return 1
+		}
+		if !verifyDeviceHealth(cfg) {
+			printHumanErr("the secure device endpoint for %q did not answer", name)
+			return failKeepingPartialProfile()
+		}
+	}
+	renderSetupSuccessLine(out, "Server %q is paired and verified", name)
+	renderSetupParagraph(out,
+		fmt.Sprintf("Use it per call with HA_NOVA_SERVER=%s (AI clients) or --server %s (CLI).", name, name),
+		fmt.Sprintf("The default server is unchanged; switch it with: ha-nova server default %s", name),
+	)
+	return 0
+}
+
+func promptNewServerProfileName(
+	reader *bufio.Reader,
+	out io.Writer,
+	doc *configDocument,
+) (string, error) {
+	existing := make(map[string]bool)
+	for _, profile := range doc.profileNames() {
+		existing[profile] = true
+	}
+	// "default" is always taken, even on hand-edited or pair-server-first
+	// configs whose servers map lacks a literal default entry — a wizard
+	// profile with that name would seize the un-suffixed credential slots and
+	// the legacy mirror.
+	existing[defaultServerProfileName] = true
+	for {
+		entered, err := promptWizardLineFromReader(
+			reader,
+			out,
+			"Name for the new server (a-z, 0-9, '-'; e.g. cabin)",
+			"",
+		)
+		if err != nil {
+			return "", err
+		}
+		name := strings.TrimSpace(entered)
+		if err := validateServerProfileName(name); err != nil {
+			renderSetupErrorLine(out, "%s", err)
+			continue
+		}
+		if existing[name] {
+			renderSetupErrorLine(out, "A server named %q already exists. Choose a different name.", name)
+			continue
+		}
+		return name, nil
+	}
+}
+
+// selectAddServerHAHost discovers instances and hides every already-configured
+// one — offering the user their existing server as "new" would only produce a
+// duplicate profile against the same relay.
+func selectAddServerHAHost(
+	reader *bufio.Reader,
+	out io.Writer,
+	doc *configDocument,
+) (string, string, error) {
+	result := runSetupDiscoveryWithFeedback(out, runtimeConfig{})
+	configured := configuredServerHostPortKeys(doc)
+	candidates := make([]setupDiscoveryCandidate, 0, len(result.candidates))
+	for _, candidate := range result.candidates {
+		if configured[addServerHostPortKey(candidate.HAURL)] ||
+			configured[addServerViaHostPortKey(candidate)] {
+			continue
+		}
+		candidates = append(candidates, candidate)
+	}
+	if len(candidates) == 0 {
+		if len(result.candidates) > 0 {
+			renderSetupParagraphTight(out, "Every discovered Home Assistant instance is already configured.")
+		}
+		return promptValidHAHostFromReader(reader, out, "")
+	}
+	fmt.Fprintf(out, "  Found %d Home Assistant instance(s) that are not configured yet.\n", len(candidates))
+	candidate, selected, err := promptSetupDiscoveryCandidateInteractive(reader, out, candidates)
+	if err != nil {
+		return "", "", err
+	}
+	if selected {
+		return candidate.Host, candidate.HAURL, nil
+	}
+	return promptValidHAHostFromReader(reader, out, candidate.Host)
+}
+
+// Instance identity is host:HA-port. A port difference on the same host is a
+// DIFFERENT instance (two HA containers on one Docker host), while a .local
+// name and the IPv4 it resolved to are the SAME one — mDNS candidates carry
+// the original name in Via, so both spellings are matched.
+func addServerHostPortKey(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	if !strings.Contains(trimmed, "://") {
+		trimmed = "http://" + trimmed
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Hostname() == "" {
+		return ""
+	}
+	port := parsed.Port()
+	if port == "" {
+		port = "8123"
+	}
+	return strings.ToLower(strings.TrimSuffix(parsed.Hostname(), ".")) + ":" + port
+}
+
+func addServerViaHostPortKey(candidate setupDiscoveryCandidate) string {
+	if strings.TrimSpace(candidate.Via) == "" {
+		return ""
+	}
+	port := "8123"
+	if parsed, err := url.Parse(candidate.HAURL); err == nil && parsed.Port() != "" {
+		port = parsed.Port()
+	}
+	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(candidate.Via), ".")) + ":" + port
+}
+
+func configuredServerHostPortKeys(doc *configDocument) map[string]bool {
+	keys := make(map[string]bool)
+	add := func(value string) {
+		if key := addServerHostPortKey(value); key != "" {
+			keys[key] = true
+		}
+	}
+	for _, name := range doc.profileNames() {
+		profile, ok := doc.flatProfile(name)
+		if !ok {
+			continue
+		}
+		add(profile.HAURL)
+		// Bare hosts and relay-only profiles carry no HA port; assume the
+		// default so the same box is still recognized.
+		add(profile.HAHost)
+		if profile.HAURL == "" && profile.HAHost == "" {
+			add(normalizeHostInput(profile.RelayBaseURL))
+		}
+	}
+	return keys
+}

--- a/cli/setup_add_server.go
+++ b/cli/setup_add_server.go
@@ -57,6 +57,8 @@ func maybeOfferAddServerForCompletedSetup(
 	if !add {
 		return false, 0
 	}
+	// attempted=true from here on — the flow's own closing output (success,
+	// cancel note, or partial-profile guidance) replaces the done banner.
 	return true, runAddServerFlow(reader, out, paths, lifecycleMarker...)
 }
 
@@ -290,11 +292,28 @@ func selectAddServerHAHost(
 		}
 		candidates = append(candidates, candidate)
 	}
+	// Manually entered addresses get the same already-configured check as
+	// discovery — typing the existing server would create the duplicate
+	// profile the filter exists to prevent.
+	promptUnconfiguredHost := func(defaultHost string) (string, string, error) {
+		for {
+			host, haURL, err := promptValidHAHostFromReader(reader, out, defaultHost)
+			if err != nil {
+				return "", "", err
+			}
+			if configured[addServerHostPortKey(haURL)] {
+				renderSetupErrorLine(out, "This Home Assistant is already configured as a server profile. Enter a different address.")
+				defaultHost = ""
+				continue
+			}
+			return host, haURL, nil
+		}
+	}
 	if len(candidates) == 0 {
 		if len(result.candidates) > 0 {
 			renderSetupParagraphTight(out, "Every discovered Home Assistant instance is already configured.")
 		}
-		return promptValidHAHostFromReader(reader, out, "")
+		return promptUnconfiguredHost("")
 	}
 	fmt.Fprintf(out, "  Found %d Home Assistant instance(s) that are not configured yet.\n", len(candidates))
 	candidate, selected, err := promptSetupDiscoveryCandidateInteractive(reader, out, candidates)
@@ -304,7 +323,7 @@ func selectAddServerHAHost(
 	if selected {
 		return candidate.Host, candidate.HAURL, nil
 	}
-	return promptValidHAHostFromReader(reader, out, candidate.Host)
+	return promptUnconfiguredHost(candidate.Host)
 }
 
 // Instance identity is host:HA-port. A port difference on the same host is a
@@ -342,14 +361,19 @@ func addServerHostPortKey(value string) string {
 }
 
 func addServerViaHostPortKey(candidate setupDiscoveryCandidate) string {
-	if strings.TrimSpace(candidate.Via) == "" {
+	via := strings.TrimSuffix(strings.TrimSpace(candidate.Via), ".")
+	if via == "" {
 		return ""
 	}
-	port := "8123"
-	if parsed, err := url.Parse(candidate.HAURL); err == nil && parsed.Port() != "" {
-		port = parsed.Port()
+	// The alias must carry the SAME effective port as the candidate URL —
+	// including scheme defaults — or a portless advertised URL (keyed :80 on
+	// the configured side) never matches.
+	urlKey := addServerHostPortKey(candidate.HAURL)
+	separator := strings.LastIndex(urlKey, ":")
+	if separator < 0 {
+		return ""
 	}
-	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(candidate.Via), ".")) + ":" + port
+	return strings.ToLower(via) + urlKey[separator:]
 }
 
 func configuredServerHostPortKeys(doc *configDocument) map[string]bool {
@@ -365,9 +389,12 @@ func configuredServerHostPortKeys(doc *configDocument) map[string]bool {
 			continue
 		}
 		add(profile.HAURL)
-		// Bare hosts and relay-only profiles carry no HA port; assume the
-		// default so the same box is still recognized.
-		add(profile.HAHost)
+		// The bare HAHost implies the default port ONLY when no URL pins the
+		// real one — otherwise a second instance on :8123 of the same host
+		// would be hidden by a profile that actually lives on another port.
+		if profile.HAURL == "" {
+			add(profile.HAHost)
+		}
 		if profile.HAURL == "" && profile.HAHost == "" {
 			add(normalizeHostInput(profile.RelayBaseURL))
 		}

--- a/cli/setup_add_server.go
+++ b/cli/setup_add_server.go
@@ -198,18 +198,33 @@ func runAddServerStages(
 		return failKeepingPartialProfile()
 	}
 
+	// After errSetupDevicePaired the credential and secure endpoint are
+	// already persisted — a verification failure is a reachability problem,
+	// never an unpaired profile, so the guidance must not suggest pairing
+	// again (that would replace a working credential).
+	renderPairedButUnverified := func() {
+		renderSetupParagraph(out,
+			fmt.Sprintf("The server %q is paired; only the verification could not reach it yet.", name),
+			"Make sure the NOVA Relay App is running, then check with:",
+			fmt.Sprintf("  ha-nova doctor --server %s", name),
+		)
+	}
 	if !verifyDeviceHealth(cfg) {
 		renderSetupErrorLine(out, "Paired, but the secure device endpoint did not answer yet. The App may still be starting.")
 		if _, err := promptWizardLineFromReader(reader, out, "Press Enter to retry once", ""); err != nil {
 			if err == errSetupBack || err == errSetupExit {
-				return cancelKeepingPartialProfile()
+				renderSetupCancelledNote(out)
+				renderPairedButUnverified()
+				return 0
 			}
 			printHumanErr("%s", err)
+			renderPairedButUnverified()
 			return 1
 		}
 		if !verifyDeviceHealth(cfg) {
 			printHumanErr("the secure device endpoint for %q did not answer", name)
-			return failKeepingPartialProfile()
+			renderPairedButUnverified()
+			return 1
 		}
 	}
 	renderSetupSuccessLine(out, "Server %q is paired and verified", name)

--- a/cli/setup_add_server.go
+++ b/cli/setup_add_server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"strings"
 )
@@ -284,6 +285,7 @@ func selectAddServerHAHost(
 ) (string, string, error) {
 	result := runSetupDiscoveryWithFeedback(out, runtimeConfig{})
 	configured := configuredServerHostPortKeys(doc)
+	expandConfiguredLocalAliases(configured)
 	candidates := make([]setupDiscoveryCandidate, 0, len(result.candidates))
 	for _, candidate := range result.candidates {
 		if configured[addServerHostPortKey(candidate.HAURL)] ||
@@ -374,6 +376,21 @@ func addServerViaHostPortKey(candidate setupDiscoveryCandidate) string {
 		return ""
 	}
 	return strings.ToLower(via) + urlKey[separator:]
+}
+
+// Profiles configured under a .local name additionally claim their RESOLVED
+// IPv4 (bounded lookup), so the same server rediscovered or manually entered
+// by IP is recognized even without a Via alias.
+func expandConfiguredLocalAliases(configured map[string]bool) {
+	for key := range configured {
+		host, port, splitErr := net.SplitHostPort(key)
+		if splitErr != nil || !strings.HasSuffix(host, ".local") {
+			continue
+		}
+		if ip := resolveHostToIPv4ForDiscovery(host, setupDiscoveryIPResolveTimeout); ip != "" && ip != host {
+			configured[ip+":"+port] = true
+		}
+	}
 }
 
 func configuredServerHostPortKeys(doc *configDocument) map[string]bool {

--- a/cli/setup_add_server.go
+++ b/cli/setup_add_server.go
@@ -58,6 +58,15 @@ func maybeOfferAddServerForCompletedSetup(
 	if !add {
 		return false, 0
 	}
+	// The completed re-run path deliberately drops its lifecycle markers
+	// before this screen — but the add flow's saves still need uninstall
+	// protection, so capture a fresh generation now.
+	if len(lifecycleMarker) == 0 {
+		lifecycleMarker = [][]byte{
+			captureInstallLifecycleGeneration(paths),
+			captureCensusLifecycleMarker(paths),
+		}
+	}
 	// attempted=true from here on — the flow's own closing output (success,
 	// cancel note, or partial-profile guidance) replaces the done banner.
 	return true, runAddServerFlow(reader, out, paths, lifecycleMarker...)
@@ -303,7 +312,7 @@ func selectAddServerHAHost(
 			if err != nil {
 				return "", "", err
 			}
-			if configured[addServerHostPortKey(haURL)] {
+			if manualHostIsConfigured(configured, haURL) {
 				renderSetupErrorLine(out, "This Home Assistant is already configured as a server profile. Enter a different address.")
 				defaultHost = ""
 				continue
@@ -376,6 +385,23 @@ func addServerViaHostPortKey(candidate setupDiscoveryCandidate) string {
 		return ""
 	}
 	return strings.ToLower(via) + urlKey[separator:]
+}
+
+// The manual check works in BOTH alias directions: a typed .local hostname
+// also matches a profile configured by that host's resolved IPv4.
+func manualHostIsConfigured(configured map[string]bool, haURL string) bool {
+	key := addServerHostPortKey(haURL)
+	if configured[key] {
+		return true
+	}
+	host, port, splitErr := net.SplitHostPort(key)
+	if splitErr != nil || !strings.HasSuffix(host, ".local") {
+		return false
+	}
+	if ip := resolveHostToIPv4ForDiscovery(host, setupDiscoveryIPResolveTimeout); ip != "" && ip != host {
+		return configured[ip+":"+port]
+	}
+	return false
 }
 
 // Profiles configured under a .local name additionally claim their RESOLVED

--- a/cli/setup_add_server.go
+++ b/cli/setup_add_server.go
@@ -60,11 +60,18 @@ func maybeOfferAddServerForCompletedSetup(
 	}
 	// The completed re-run path deliberately drops its lifecycle markers
 	// before this screen — but the add flow's saves still need uninstall
-	// protection, so capture a fresh generation now.
+	// protection AND the config-snapshot CAS, so capture the full
+	// three-element marker exactly like runSetup does.
 	if len(lifecycleMarker) == 0 {
+		configSnapshot, snapshotErr := readSetupConfigSnapshot(paths)
+		if snapshotErr != nil {
+			printHumanErr("cannot inspect server configuration: %s", snapshotErr)
+			return true, 1
+		}
 		lifecycleMarker = [][]byte{
 			captureInstallLifecycleGeneration(paths),
 			captureCensusLifecycleMarker(paths),
+			configSnapshot,
 		}
 	}
 	// attempted=true from here on — the flow's own closing output (success,

--- a/cli/setup_add_server_test.go
+++ b/cli/setup_add_server_test.go
@@ -116,6 +116,9 @@ func TestAddServerOfferDeclineKeepsConfig(t *testing.T) {
 	if !strings.Contains(output, "Add another Home Assistant server?") {
 		t.Fatalf("expected add-server offer on the completed screen:\n%s", output)
 	}
+	if !strings.Contains(output, "Everything is already set up!") {
+		t.Fatalf("declining the offer keeps the done banner:\n%s", output)
+	}
 	after, err := os.ReadFile(paths.ConfigFile)
 	if err != nil {
 		t.Fatalf("read config after: %v", err)
@@ -284,6 +287,11 @@ func TestAddServerDiscoveryFiltersConfiguredInstances(t *testing.T) {
 	if !strings.Contains(output, "was saved but is not paired yet") {
 		t.Fatalf("expected the partial-profile note after cancelling:\n%s", output)
 	}
+	// A ran add flow replaces the done banner — ending a cancelled add with
+	// "Everything is already set up!" would bury the partial-profile state.
+	if strings.Contains(output, "Everything is already set up!") {
+		t.Fatalf("done banner must not follow a ran add flow:\n%s", output)
+	}
 	doc, err := loadConfigDocument(paths.ConfigFile)
 	if err != nil {
 		t.Fatalf("load config document: %v", err)
@@ -305,7 +313,8 @@ func TestAddServerHostPortIdentityKeys(t *testing.T) {
 		"default_server": "default",
 		"servers": {
 			"default": {"ha_host": "homeassistant.local", "ha_url": "http://homeassistant.local:8123"},
-			"relayonly": {"relay_base_url": "http://192.168.1.9:8791"}
+			"relayonly": {"relay_base_url": "http://192.168.1.9:8791"},
+			"proxied": {"ha_host": "ha2.example", "ha_url": "https://ha2.example"}
 		}
 	}`))
 	if err != nil {
@@ -337,6 +346,25 @@ func TestAddServerHostPortIdentityKeys(t *testing.T) {
 	if got := addServerHostPortKey("ha.example"); got != "ha.example:8123" {
 		t.Fatalf("bare host key = %q", got)
 	}
+	// A profile whose URL pins a non-default port must NOT also claim the
+	// host at 8123 through its bare HAHost — that would hide a genuinely
+	// separate instance there.
+	if configured["ha2.example:8123"] {
+		t.Fatal("bare HAHost must not add a default-port key when the URL pins another port")
+	}
+	if !configured["ha2.example:443"] {
+		t.Fatal("the URL's scheme-default port key is the profile's identity")
+	}
+	// The Via alias inherits the candidate URL's EFFECTIVE port, including
+	// scheme defaults for portless URLs.
+	portlessVia := setupDiscoveryCandidate{
+		Host:  "192.168.1.6",
+		HAURL: "http://192.168.1.6",
+		Via:   "portless.local",
+	}
+	if got := addServerViaHostPortKey(portlessVia); got != "portless.local:80" {
+		t.Fatalf("portless Via key = %q", got)
+	}
 }
 
 func TestDNSSDAdvertisedLocalHostSurvivesIPv4Rewrite(t *testing.T) {
@@ -356,6 +384,15 @@ func TestDNSSDAdvertisedLocalHostSurvivesIPv4Rewrite(t *testing.T) {
 	entry.Text["internal_url"] = "https://ha.example.com"
 	if got := dnssdAdvertisedLocalHost(entry); got != "" {
 		t.Fatalf("non-.local internal_url must not produce a Via: %q", got)
+	}
+	// Without an internal_url the record's own .local Host is the advertised
+	// name the IPv4 rewrite replaced.
+	noInternal := dnssd.BrowseEntry{
+		Host: "0123456789abcdef0123456789abcdef.local.",
+		Text: map[string]string{"uuid": "0123456789abcdef0123456789abcdef"},
+	}
+	if got := dnssdAdvertisedLocalHost(noInternal); got != "0123456789abcdef0123456789abcdef.local" {
+		t.Fatalf("entry.Host .local name lost without internal_url: %q", got)
 	}
 }
 

--- a/cli/setup_add_server_test.go
+++ b/cli/setup_add_server_test.go
@@ -389,6 +389,15 @@ func TestExpandConfiguredLocalAliasesClaimsResolvedIPv4(t *testing.T) {
 	if len(configured) != 3 {
 		t.Fatalf("only the .local key may expand, got %v", configured)
 	}
+	// The reverse direction: a typed .local hostname matches a profile
+	// configured by its resolved IPv4.
+	ipOnly := map[string]bool{"192.168.1.5:8123": true}
+	if !manualHostIsConfigured(ipOnly, "http://homeassistant.local:8123") {
+		t.Fatal("a typed .local hostname must match its IPv4-configured profile")
+	}
+	if manualHostIsConfigured(ipOnly, "http://other.local:8123") {
+		t.Fatal("an unresolvable .local hostname must not match")
+	}
 }
 
 func TestDNSSDAdvertisedLocalHostSurvivesIPv4Rewrite(t *testing.T) {

--- a/cli/setup_add_server_test.go
+++ b/cli/setup_add_server_test.go
@@ -1,0 +1,326 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Fixture: a fully completed default-profile install, mirroring
+// TestInteractiveSetupAlreadyDoneUsesResumeBanner. Returns everything needed
+// to drive interactiveSetup into the already-done screen.
+func setupCompletedInstallFixture(t *testing.T) (runtimePaths, runtimeConfig, installState, [][]byte) {
+	t.Helper()
+	withClientRuntimeAvailability(t, map[string]bool{"claude": true})
+	withClientAttachmentPresence(t, map[string]bool{"claude": true})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HA_NOVA_NO_BROWSER", "1")
+	t.Setenv("HA_NOVA_ALLOW_INSECURE_TEST_KEYRING", "1")
+	t.Setenv("HA_NOVA_TEST_KEYRING_FILE", filepath.Join(home, ".config", "ha-nova", ".test-relay-auth-token"))
+	stubCensusTTY(t, true, true)
+	resetServerProfileSelection(t)
+
+	relayServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"ha_ws_connected":true}}`))
+	}))
+	t.Cleanup(relayServer.Close)
+
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	// A modern secure-paired install carries the install-wide
+	// client_install_id — the add flow must seed it, or the pairing stage
+	// mints a fresh one and the immutability guard kills the flow.
+	cfg := runtimeConfig{
+		HAHost:          "192.168.1.5",
+		HAURL:           "http://192.168.1.5:8123",
+		RelayBaseURL:    relayServer.URL,
+		ClientInstallID: "inst-0123456789abcdef0123456789abcdef",
+	}
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	if err := writeRelayAuthToken("test-relay-token"); err != nil {
+		t.Fatalf("writeRelayAuthToken() error: %v", err)
+	}
+	state := loadStateOrDefault(paths)
+	mergeStateClients(&state, []string{"claude"})
+	if err := saveState(paths, state); err != nil {
+		t.Fatalf("saveState() error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "plugins"), 0o755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	writeInstalledClaudePluginFixture(t, home)
+	writeClaudeMarketplaceRegistrationFixture(t, home, filepath.Join(paths.ConfigDir, "claude-marketplace"))
+	if err := markCensusLifecycleStopped(paths); err != nil {
+		t.Fatalf("mark census lifecycle stopped: %v", err)
+	}
+	marker := [][]byte{
+		captureInstallLifecycleGeneration(paths),
+		captureCensusLifecycleMarker(paths),
+	}
+	return paths, cfg, state, marker
+}
+
+func stubAddServerTTY(t *testing.T) {
+	t.Helper()
+	originalTTY := writerSupportsTTYForSetup
+	writerSupportsTTYForSetup = func(io.Writer) bool { return true }
+	t.Cleanup(func() { writerSupportsTTYForSetup = originalTTY })
+	originalStdin := addServerOfferStdinIsTTY
+	addServerOfferStdinIsTTY = func() bool { return true }
+	t.Cleanup(func() { addServerOfferStdinIsTTY = originalStdin })
+}
+
+// captureInteractiveSetupIO installs its own no-candidate discovery stub, so
+// per-test candidates must be injected INSIDE the capture callback.
+func withAddServerDiscovery(candidates []setupDiscoveryCandidate, fn func() int) func() int {
+	return func() int {
+		discoverReachableHAHostsForSetup = func(runtimeConfig) ([]setupDiscoveryCandidate, string) {
+			return candidates, ""
+		}
+		return fn()
+	}
+}
+
+func TestAddServerOfferDeclineKeepsConfig(t *testing.T) {
+	paths, cfg, state, marker := setupCompletedInstallFixture(t)
+	stubAddServerTTY(t)
+	before, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config before: %v", err)
+	}
+
+	// Enter declines the offer (default No); "2" answers the census ask.
+	stdout, stderr := captureInteractiveSetupIO(t, "\n2\n", func() int {
+		return interactiveSetup(paths, cfg, state, "claude", "", "", "", "", false, marker...)
+	})
+	output := stdout + stderr
+	if !strings.Contains(output, "Add another Home Assistant server?") {
+		t.Fatalf("expected add-server offer on the completed screen:\n%s", output)
+	}
+	after, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("declining the offer must not change config.json:\nbefore: %s\nafter: %s", before, after)
+	}
+}
+
+func TestAddServerFlowCreatesNamedProfileAndKeepsDefaultIntact(t *testing.T) {
+	paths, cfg, state, marker := setupCompletedInstallFixture(t)
+	stubAddServerTTY(t)
+
+	originalProbe := probePairingV1ForSetup
+	probePairingV1ForSetup = func(string) bool { return true }
+	t.Cleanup(func() { probePairingV1ForSetup = originalProbe })
+
+	originalPair := securePairForSetup
+	securePairForSetup = func(
+		_ string,
+		code string,
+		pairCfg *runtimeConfig,
+		save func(*runtimeConfig) error,
+		_ pairingClientInfo,
+	) (string, error) {
+		if code != "123456" {
+			t.Fatalf("unexpected pairing code: %q", code)
+		}
+		pairCfg.RelaySecureBaseURL = "https://192.168.1.7:8792"
+		pairCfg.RelaySpkiPin = "test-pin"
+		if err := save(pairCfg); err != nil {
+			t.Fatalf("pairing save failed: %v", err)
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { securePairForSetup = originalPair })
+
+	originalVerify := verifyDeviceHealth
+	verifyDeviceHealth = func(runtimeConfig) bool { return true }
+	t.Cleanup(func() { verifyDeviceHealth = originalVerify })
+
+	docBefore, err := loadConfigDocument(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("load config document before: %v", err)
+	}
+	defaultBefore, ok := docBefore.flatProfile(defaultServerProfileName)
+	if !ok {
+		t.Fatal("default profile missing before add-server flow")
+	}
+
+	// y (offer) → cabin (name) → 1 (discovery pick) → Enter (app running)
+	// → Enter (open NOVA) → 123456 (code) → 2 (census).
+	input := joinSetupInputs([]string{"y", "cabin", "1", "", "", "123456", "2"})
+	stdout, stderr := captureInteractiveSetupIO(t, input, withAddServerDiscovery(
+		[]setupDiscoveryCandidate{
+			{Host: "192.168.1.7", HAURL: "http://192.168.1.7:8123", Via: "mDNS", Source: "mdns"},
+		},
+		func() int {
+			return interactiveSetup(paths, cfg, state, "claude", "", "", "", "", false, marker...)
+		},
+	))
+	output := stdout + stderr
+	if !strings.Contains(output, `Server "cabin" is paired and verified`) {
+		t.Fatalf("expected add-server success line:\n%s", output)
+	}
+	if !strings.Contains(output, "HA_NOVA_SERVER=cabin") {
+		t.Fatalf("expected selection hint for the new profile:\n%s", output)
+	}
+
+	if got := activeServerProfile(); got != defaultServerProfileName {
+		t.Fatalf("selection seam not restored after add flow: %q", got)
+	}
+
+	docAfter, err := loadConfigDocument(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("load config document after: %v", err)
+	}
+	cabin, ok := docAfter.flatProfile("cabin")
+	if !ok {
+		t.Fatalf("cabin profile missing after add-server flow; profiles: %v", docAfter.profileNames())
+	}
+	if cabin.HAHost != "192.168.1.7" {
+		t.Fatalf("cabin profile host = %q, want 192.168.1.7", cabin.HAHost)
+	}
+	if cabin.RelaySecureBaseURL != "https://192.168.1.7:8792" {
+		t.Fatalf("cabin secure endpoint = %q", cabin.RelaySecureBaseURL)
+	}
+	defaultAfter, ok := docAfter.flatProfile(defaultServerProfileName)
+	if !ok {
+		t.Fatal("default profile missing after add-server flow")
+	}
+	// The install-wide ClientInstallID is seeded from the document — a fresh
+	// mint would be rejected by the immutability guard on every secure-paired
+	// install.
+	if cabin.ClientInstallID != "inst-0123456789abcdef0123456789abcdef" {
+		t.Fatalf("cabin must carry the seeded install-wide id, got %q", cabin.ClientInstallID)
+	}
+	if !reflect.DeepEqual(defaultBefore, defaultAfter) {
+		t.Fatalf("default profile changed by add-server flow:\nbefore: %+v\nafter: %+v", defaultBefore, defaultAfter)
+	}
+}
+
+func TestAddServerOfferSkippedWithoutInteractiveStdin(t *testing.T) {
+	paths, cfg, state, marker := setupCompletedInstallFixture(t)
+	stubAddServerTTY(t)
+	addServerOfferStdinIsTTY = func() bool { return false }
+
+	// Only the census answer is consumed — the offer must not read stdin.
+	stdout, stderr := captureInteractiveSetupIO(t, "2\n", func() int {
+		return interactiveSetup(paths, cfg, state, "claude", "", "", "", "", false, marker...)
+	})
+	output := stdout + stderr
+	if strings.Contains(output, "Add another Home Assistant server?") {
+		t.Fatalf("offer must not appear without interactive stdin:\n%s", output)
+	}
+	if !strings.Contains(output, "Everything is already set up!") {
+		t.Fatalf("expected the done banner:\n%s", output)
+	}
+}
+
+func TestAddServerRejectsInvalidAndDuplicateNames(t *testing.T) {
+	paths, cfg, state, marker := setupCompletedInstallFixture(t)
+	stubAddServerTTY(t)
+
+	// y → invalid name → duplicate name → exit.
+	input := joinSetupInputs([]string{"y", "Bad Name!", defaultServerProfileName, "exit"})
+	stdout, stderr := captureInteractiveSetupIO(t, input, func() int {
+		return interactiveSetup(paths, cfg, state, "claude", "", "", "", "", false, marker...)
+	})
+	output := stdout + stderr
+	if !strings.Contains(output, "already exists") {
+		t.Fatalf("expected duplicate-name rejection:\n%s", output)
+	}
+	doc, err := loadConfigDocument(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("load config document: %v", err)
+	}
+	if got := doc.profileNames(); len(got) != 1 {
+		t.Fatalf("no profile may be created on name errors; profiles: %v", got)
+	}
+}
+
+func TestAddServerDiscoveryFiltersConfiguredInstances(t *testing.T) {
+	paths, cfg, state, marker := setupCompletedInstallFixture(t)
+	stubAddServerTTY(t)
+
+	// y → cabin → 1 (only the unconfigured instance) → exit at the app prompt.
+	input := joinSetupInputs([]string{"y", "cabin", "1", "exit"})
+	stdout, stderr := captureInteractiveSetupIO(t, input, withAddServerDiscovery(
+		[]setupDiscoveryCandidate{
+			// Already configured on the default profile — must be hidden.
+			{Host: "192.168.1.5", HAURL: "http://192.168.1.5:8123", Source: "mdns"},
+			{Host: "192.168.1.7", HAURL: "http://192.168.1.7:8123", Source: "mdns"},
+			// Same HOST as the configured instance but a different HA port is
+			// a DIFFERENT instance and must survive the filter.
+			{Host: "192.168.1.5", HAURL: "http://192.168.1.5:8124", Source: "mdns"},
+		},
+		func() int {
+			return interactiveSetup(paths, cfg, state, "claude", "", "", "", "", false, marker...)
+		},
+	))
+	output := stdout + stderr
+	if !strings.Contains(output, "Found 2 Home Assistant instance(s) that are not configured yet.") {
+		t.Fatalf("expected the configured instance to be filtered from discovery:\n%s", output)
+	}
+	if !strings.Contains(output, "was saved but is not paired yet") {
+		t.Fatalf("expected the partial-profile note after cancelling:\n%s", output)
+	}
+	doc, err := loadConfigDocument(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("load config document: %v", err)
+	}
+	cabin, ok := doc.flatProfile("cabin")
+	if !ok {
+		t.Fatalf("cabin profile missing; profiles: %v", doc.profileNames())
+	}
+	if cabin.HAHost != "192.168.1.7" {
+		t.Fatalf("cabin picked the wrong instance: %q", cabin.HAHost)
+	}
+}
+
+func TestAddServerHostPortIdentityKeys(t *testing.T) {
+	// A .local-configured profile matches the same instance rediscovered as a
+	// resolved IPv4 through the candidate's Via spelling.
+	doc, err := parseConfigDocument([]byte(`{
+		"schema_version": 3,
+		"default_server": "default",
+		"servers": {
+			"default": {"ha_host": "homeassistant.local", "ha_url": "http://homeassistant.local:8123"},
+			"relayonly": {"relay_base_url": "http://192.168.1.9:8791"}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("parse fixture document: %v", err)
+	}
+	configured := configuredServerHostPortKeys(doc)
+	viaCandidate := setupDiscoveryCandidate{
+		Host:  "192.168.1.5",
+		HAURL: "http://192.168.1.5:8123",
+		Via:   "homeassistant.local",
+	}
+	if !configured[addServerViaHostPortKey(viaCandidate)] {
+		t.Fatal("resolved-IPv4 candidate with a configured .local Via must be recognized as configured")
+	}
+	if !configured[addServerHostPortKey("http://192.168.1.9:8123")] {
+		t.Fatal("relay-URL-only profiles must still claim their host at the default HA port")
+	}
+	if configured[addServerHostPortKey("http://homeassistant.local:8124")] {
+		t.Fatal("a different HA port on the same host is a different instance")
+	}
+}

--- a/cli/setup_add_server_test.go
+++ b/cli/setup_add_server_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -9,6 +10,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/brutella/dnssd"
 )
 
 // Fixture: a fully completed default-profile install, mirroring
@@ -322,5 +325,36 @@ func TestAddServerHostPortIdentityKeys(t *testing.T) {
 	}
 	if configured[addServerHostPortKey("http://homeassistant.local:8124")] {
 		t.Fatal("a different HA port on the same host is a different instance")
+	}
+	// Scheme-default ports: an explicit URL without a port means 80/443,
+	// never the HA default — only bare hosts imply 8123.
+	if got := addServerHostPortKey("https://ha.example"); got != "ha.example:443" {
+		t.Fatalf("https default port key = %q", got)
+	}
+	if got := addServerHostPortKey("http://ha.example"); got != "ha.example:80" {
+		t.Fatalf("http default port key = %q", got)
+	}
+	if got := addServerHostPortKey("ha.example"); got != "ha.example:8123" {
+		t.Fatalf("bare host key = %q", got)
+	}
+}
+
+func TestDNSSDAdvertisedLocalHostSurvivesIPv4Rewrite(t *testing.T) {
+	entry := dnssd.BrowseEntry{
+		Text: map[string]string{
+			"uuid":         "0123456789abcdef0123456789abcdef",
+			"internal_url": "http://homeassistant.local:8123",
+		},
+		IPs: []net.IP{net.ParseIP("192.168.1.5")},
+	}
+	if got := homeAssistantDNSSDURL(entry); got != "http://192.168.1.5:8123" {
+		t.Fatalf("expected the IPv4 rewrite, got %q", got)
+	}
+	if got := dnssdAdvertisedLocalHost(entry); got != "homeassistant.local" {
+		t.Fatalf("advertised .local host lost in rewrite: %q", got)
+	}
+	entry.Text["internal_url"] = "https://ha.example.com"
+	if got := dnssdAdvertisedLocalHost(entry); got != "" {
+		t.Fatalf("non-.local internal_url must not produce a Via: %q", got)
 	}
 }

--- a/cli/setup_add_server_test.go
+++ b/cli/setup_add_server_test.go
@@ -445,3 +445,42 @@ func TestCollectDiscoveryProbesKeepsAdvertisedVia(t *testing.T) {
 		t.Fatalf("advertised Via flattened away in probe collection: %+v", probes)
 	}
 }
+
+func TestAddServerCancelSuppressesCloudFallbackReadyBanner(t *testing.T) {
+	paths, cfg, state, marker := setupCompletedInstallFixture(t)
+	stubAddServerTTY(t)
+	// A secure-paired install accepting the fresh Cloud offer on this
+	// pass: the accepted offer ends Cloud-ready with the automatic route
+	// policy — exactly the state whose success banner must not bury a
+	// cancelled add flow.
+	cfg.RelaySecureBaseURL = "https://ha:18792"
+	cfg.RelaySpkiPin = "PIN"
+	if err := saveConfig(paths, cfg); err != nil {
+		t.Fatalf("saveConfig() error: %v", err)
+	}
+	coordinator := successfulCloudCoordinatorForTest()
+	installCloudSetupTestSeams(t, coordinator, true, true)
+
+	// "y" accepts the Cloud fallback offer; the next "y" accepts the add
+	// offer; "exit" cancels at the profile-name prompt; "2" answers the
+	// census ask.
+	stdout, stderr := captureInteractiveSetupIO(t, "y\ny\nexit\n2\n", func() int {
+		return interactiveSetup(paths, cfg, state, "claude", "", "", "", "", false, marker...)
+	})
+	output := stdout + stderr
+	if !strings.Contains(output, "Add Home Assistant Cloud fallback now?") {
+		t.Fatalf("expected the fresh Cloud offer:\n%s", output)
+	}
+	if !strings.Contains(output, "Add another Home Assistant server?") {
+		t.Fatalf("expected the add-server offer after the Cloud accept:\n%s", output)
+	}
+	if !strings.Contains(output, "Setup cancelled.") {
+		t.Fatalf("expected the cancelled note from the aborted add flow:\n%s", output)
+	}
+	if strings.Contains(output, "Setup complete!") {
+		t.Fatalf("cancelled add flow must suppress the Cloud fallback ready banner:\n%s", output)
+	}
+	if strings.Contains(output, "Everything is already set up!") {
+		t.Fatalf("cancelled add flow must suppress the already-done banner:\n%s", output)
+	}
+}

--- a/cli/setup_add_server_test.go
+++ b/cli/setup_add_server_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/brutella/dnssd"
 )
@@ -364,6 +365,29 @@ func TestAddServerHostPortIdentityKeys(t *testing.T) {
 	}
 	if got := addServerViaHostPortKey(portlessVia); got != "portless.local:80" {
 		t.Fatalf("portless Via key = %q", got)
+	}
+}
+
+func TestExpandConfiguredLocalAliasesClaimsResolvedIPv4(t *testing.T) {
+	originalResolve := resolveHostToIPv4ForDiscovery
+	resolveHostToIPv4ForDiscovery = func(host string, _ time.Duration) string {
+		if host == "homeassistant.local" {
+			return "192.168.1.5"
+		}
+		return ""
+	}
+	t.Cleanup(func() { resolveHostToIPv4ForDiscovery = originalResolve })
+
+	configured := map[string]bool{
+		"homeassistant.local:8123": true,
+		"192.168.1.9:8123":         true,
+	}
+	expandConfiguredLocalAliases(configured)
+	if !configured["192.168.1.5:8123"] {
+		t.Fatal("the .local profile must claim its resolved IPv4 at the same port")
+	}
+	if len(configured) != 3 {
+		t.Fatalf("only the .local key may expand, got %v", configured)
 	}
 }
 

--- a/cli/setup_add_server_test.go
+++ b/cli/setup_add_server_test.go
@@ -358,3 +358,20 @@ func TestDNSSDAdvertisedLocalHostSurvivesIPv4Rewrite(t *testing.T) {
 		t.Fatalf("non-.local internal_url must not produce a Via: %q", got)
 	}
 }
+
+func TestCollectDiscoveryProbesKeepsAdvertisedVia(t *testing.T) {
+	originalMDNS := discoverHAViaMDNSForDiscovery
+	discoverHAViaMDNSForDiscovery = func() []setupDiscoveryProbe {
+		return []setupDiscoveryProbe{{
+			Host:   "http://192.168.1.5:8123",
+			Source: "mDNS",
+			Via:    "homeassistant.local",
+		}}
+	}
+	t.Cleanup(func() { discoverHAViaMDNSForDiscovery = originalMDNS })
+
+	probes := collectDiscoveryProbes(runtimeConfig{})
+	if len(probes) != 1 || probes[0].Via != "homeassistant.local" {
+		t.Fatalf("advertised Via flattened away in probe collection: %+v", probes)
+	}
+}

--- a/cli/setup_discovery.go
+++ b/cli/setup_discovery.go
@@ -303,11 +303,17 @@ func discoverHAViaMDNS() []setupDiscoveryProbe {
 	return discovered
 }
 
-// The advertised internal_url .local hostname survives the IPv4 rewrite in
-// homeAssistantDNSSDURL only through this side channel.
+// The advertised .local hostname survives the IPv4 rewrite in
+// homeAssistantDNSSDURL only through this side channel. Without an
+// internal_url the record's own .local entry.Host is the advertised name
+// that got rewritten.
 func dnssdAdvertisedLocalHost(entry dnssd.BrowseEntry) string {
 	internalURL := strings.TrimSpace(entry.Text["internal_url"])
 	if internalURL == "" {
+		host := strings.TrimSuffix(strings.TrimSpace(entry.Host), ".")
+		if strings.HasSuffix(strings.ToLower(host), ".local") {
+			return normalizeHostInput(host)
+		}
 		return ""
 	}
 	parsed, err := url.Parse(internalURL)

--- a/cli/setup_discovery.go
+++ b/cli/setup_discovery.go
@@ -259,7 +259,7 @@ func discoverHAViaMDNS() []setupDiscoveryProbe {
 	)
 	defer cancel()
 	discovered := []setupDiscoveryProbe{}
-	seen := map[string]struct{}{}
+	seen := map[string]int{}
 	err := lookupDNSSDForDiscovery(
 		ctx,
 		"_home-assistant._tcp.local.",
@@ -269,10 +269,16 @@ func discoverHAViaMDNS() []setupDiscoveryProbe {
 				return
 			}
 			key := setupDiscoveryEndpointKey(endpoint)
-			if _, exists := seen[key]; exists {
+			if idx, exists := seen[key]; exists {
+				// A duplicate announcement may be the one carrying the
+				// .local alias — losing it would let the add-server filter
+				// miss a profile configured with that spelling.
+				if discovered[idx].Via == "" {
+					discovered[idx].Via = dnssdAdvertisedLocalHost(entry)
+				}
 				return
 			}
-			seen[key] = struct{}{}
+			seen[key] = len(discovered)
 			source := "mDNS"
 			if name := safeDNSSDName(entry.Text["location_name"]); name != "" {
 				source += ": " + name

--- a/cli/setup_discovery.go
+++ b/cli/setup_discovery.go
@@ -193,9 +193,9 @@ func resolveHostToIPv4(host string, timeout time.Duration) string {
 
 func collectDiscoveryProbes(cfg runtimeConfig) []setupDiscoveryProbe {
 	candidates := []setupDiscoveryProbe{}
-	appendUnique := func(value, source string) {
-		value = strings.TrimSpace(value)
-		key := setupDiscoveryEndpointKey(value)
+	appendUnique := func(probe setupDiscoveryProbe) {
+		probe.Host = strings.TrimSpace(probe.Host)
+		key := setupDiscoveryEndpointKey(probe.Host)
 		if key == "" || len(candidates) >= setupDiscoveryMaxCandidateCount {
 			return
 		}
@@ -204,14 +204,16 @@ func collectDiscoveryProbes(cfg runtimeConfig) []setupDiscoveryProbe {
 				return
 			}
 		}
-		candidates = append(candidates, setupDiscoveryProbe{Host: value, Source: source})
+		candidates = append(candidates, probe)
 	}
 
-	appendUnique(cfg.HAHost, "saved Home Assistant address")
-	appendUnique(cfg.HAURL, "saved Home Assistant address")
-	appendUnique(normalizeHostInput(cfg.RelayBaseURL), "saved Relay address")
+	appendUnique(setupDiscoveryProbe{Host: cfg.HAHost, Source: "saved Home Assistant address"})
+	appendUnique(setupDiscoveryProbe{Host: cfg.HAURL, Source: "saved Home Assistant address"})
+	appendUnique(setupDiscoveryProbe{Host: normalizeHostInput(cfg.RelayBaseURL), Source: "saved Relay address"})
 	for _, discovered := range discoverHAViaMDNSForDiscovery() {
-		appendUnique(discovered.Host, discovered.Source)
+		// Pass the whole probe through — flattening to (Host, Source) would
+		// drop the advertised-.local Via the add-server filter relies on.
+		appendUnique(discovered)
 	}
 
 	return candidates

--- a/cli/setup_discovery.go
+++ b/cli/setup_discovery.go
@@ -39,6 +39,10 @@ type setupDiscoveryCandidate struct {
 type setupDiscoveryProbe struct {
 	Host   string
 	Source string
+	// Via carries the advertised .local hostname when the discovery path
+	// rewrote it to an IPv4 URL — the add-server filter matches it against
+	// profiles configured with the .local spelling.
+	Via string
 }
 
 func detectDefaultHAHost(cfg runtimeConfig) string {
@@ -110,6 +114,7 @@ func discoverReachableHAHosts(cfg runtimeConfig) ([]setupDiscoveryCandidate, str
 			Host:   normalizeHostInput(resolved),
 			HAURL:  strings.TrimRight(resolved, "/"),
 			Source: probe.Source,
+			Via:    probe.Via,
 		}
 		if probeDeadline.After(deadline) {
 			probeDeadline = deadline
@@ -117,7 +122,9 @@ func discoverReachableHAHosts(cfg runtimeConfig) ([]setupDiscoveryCandidate, str
 		if host, haURL := confirmedDiscoveryIPv4(candidate.HAURL, probeDeadline); host != "" {
 			candidate.Host = host
 			candidate.HAURL = haURL
-			candidate.Via = normalizeHostInput(probe.Host)
+			if candidate.Via == "" {
+				candidate.Via = normalizeHostInput(probe.Host)
+			}
 		}
 		key := setupDiscoveryEndpointKey(candidate.HAURL)
 		if key == "" {
@@ -273,6 +280,7 @@ func discoverHAViaMDNS() []setupDiscoveryProbe {
 			discovered = append(discovered, setupDiscoveryProbe{
 				Host:   endpoint,
 				Source: source,
+				Via:    dnssdAdvertisedLocalHost(entry),
 			})
 		},
 		func(dnssd.BrowseEntry) {},
@@ -291,6 +299,24 @@ func discoverHAViaMDNS() []setupDiscoveryProbe {
 		return left < right
 	})
 	return discovered
+}
+
+// The advertised internal_url .local hostname survives the IPv4 rewrite in
+// homeAssistantDNSSDURL only through this side channel.
+func dnssdAdvertisedLocalHost(entry dnssd.BrowseEntry) string {
+	internalURL := strings.TrimSpace(entry.Text["internal_url"])
+	if internalURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(internalURL)
+	if err != nil || parsed.Hostname() == "" {
+		return ""
+	}
+	host := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
+	if !strings.HasSuffix(host, ".local") {
+		return ""
+	}
+	return normalizeHostInput(host)
 }
 
 func safeDNSSDName(value string) string {

--- a/cli/setup_discovery_test.go
+++ b/cli/setup_discovery_test.go
@@ -338,3 +338,40 @@ func TestDiscoverReachableHAHostsReservesTimeAfterStaleSavedAddress(t *testing.T
 type assertDiscoveryFailure struct{}
 
 func (assertDiscoveryFailure) Error() string { return "unreachable" }
+
+func TestDiscoverHAViaMDNSDuplicateUpgradesLocalAlias(t *testing.T) {
+	originalLookup := lookupDNSSDForDiscovery
+	t.Cleanup(func() { lookupDNSSDForDiscovery = originalLookup })
+	lookupDNSSDForDiscovery = func(
+		_ context.Context,
+		_ string,
+		add dnssd.AddFunc,
+		_ dnssd.RmvFunc,
+	) error {
+		// First announcement: plain IP internal_url, no alias.
+		add(dnssd.BrowseEntry{Text: map[string]string{
+			"uuid":          "556851affd194582ad3f150856f13a05",
+			"location_name": "Home",
+			"internal_url":  "http://192.168.1.5:8123",
+		}})
+		// Duplicate announcement of the SAME endpoint carrying the .local
+		// alias — the dedupe must preserve the alias, not discard it.
+		add(dnssd.BrowseEntry{
+			IPs: []net.IP{net.ParseIP("192.168.1.5")},
+			Text: map[string]string{
+				"uuid":          "556851affd194582ad3f150856f13a05",
+				"location_name": "Home",
+				"internal_url":  "http://homeassistant.local:8123",
+			},
+		})
+		return nil
+	}
+
+	got := discoverHAViaMDNS()
+	if len(got) != 1 || got[0].Host != "http://192.168.1.5:8123" {
+		t.Fatalf("discoverHAViaMDNS() = %+v", got)
+	}
+	if got[0].Via != "homeassistant.local" {
+		t.Fatalf("duplicate with .local alias must upgrade Via, got %+v", got[0])
+	}
+}

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -68,6 +68,11 @@ func maybeHandleInteractiveSetupCurrentState(reader *bufio.Reader, out io.Writer
 		if cloudAttempted && cfg.Cloud != nil && !cfg.Cloud.ready() {
 			return true, cloudCode
 		}
+		// Offered before completeSetupLifecycle so the add flow's config
+		// saves run under the same lifecycle marker as this setup pass.
+		if addAttempted, addCode := maybeOfferAddServerForCompletedSetup(reader, out, paths, serviceMode, lifecycleMarker...); addAttempted && addCode != 0 {
+			return true, addCode
+		}
 		if err := completeSetupLifecycle(paths, lifecycleMarker...); err != nil {
 			printHumanErr("cannot finalize setup lifecycle: %s", err)
 			return true, 1

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -70,7 +70,8 @@ func maybeHandleInteractiveSetupCurrentState(reader *bufio.Reader, out io.Writer
 		}
 		// Offered before completeSetupLifecycle so the add flow's config
 		// saves run under the same lifecycle marker as this setup pass.
-		if addAttempted, addCode := maybeOfferAddServerForCompletedSetup(reader, out, paths, serviceMode, lifecycleMarker...); addAttempted && addCode != 0 {
+		addAttempted, addCode := maybeOfferAddServerForCompletedSetup(reader, out, paths, serviceMode, lifecycleMarker...)
+		if addAttempted && addCode != 0 {
 			return true, addCode
 		}
 		if err := completeSetupLifecycle(paths, lifecycleMarker...); err != nil {
@@ -82,7 +83,12 @@ func maybeHandleInteractiveSetupCurrentState(reader *bufio.Reader, out io.Writer
 			renderSetupCloudFallbackReadyBanner(out)
 			return true, 0
 		}
-		renderSetupAlreadyDoneBanner(out, cfg.RelaySecureBaseURL == "" && cfg.RelayBaseURL != "")
+		// After a ran add flow (success or cancel) its own closing lines are
+		// the message — the already-done banner would bury a cancelled or
+		// partial add under "Everything is already set up!".
+		if !addAttempted {
+			renderSetupAlreadyDoneBanner(out, cfg.RelaySecureBaseURL == "" && cfg.RelayBaseURL != "")
+		}
 		return true, 0
 	}
 	if summary := current.SkipSummary(); summary != "" {

--- a/cli/setup_interactive.go
+++ b/cli/setup_interactive.go
@@ -78,7 +78,10 @@ func maybeHandleInteractiveSetupCurrentState(reader *bufio.Reader, out io.Writer
 			printHumanErr("cannot finalize setup lifecycle: %s", err)
 			return true, 1
 		}
-		if cloudAttempted && cfg.Cloud.ready() &&
+		// Same suppression as the done banner below: after a ran add flow
+		// its own closing lines are the message — never bury a cancelled or
+		// partial add under a success banner.
+		if !addAttempted && cloudAttempted && cfg.Cloud.ready() &&
 			cfg.RoutePolicy == routePolicyAutomatic {
 			renderSetupCloudFallbackReadyBanner(out)
 			return true, 0

--- a/docs/work/2026-07-20-multi-server-spec.md
+++ b/docs/work/2026-07-20-multi-server-spec.md
@@ -1,6 +1,6 @@
 # Multi-Server Support Spec (draft)
 
-Status: active — layer 1 shipped in v0.20.0; wizard layer 2 is tracked in #411
+Status: active — layer 1 shipped in v0.20.0; wizard layer 2 (#411) implemented (completed-screen "Add another server" offer + filtered discovery; the optional first-run discovery-assist one-liner was deliberately skipped to keep the first run untouched)
 Date: 2026-07-20
 Trigger: issue #343 — one client machine should reach more than one Home Assistant server; today `config.json` holds exactly one flat server configuration.
 

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -44,6 +44,8 @@ If missing: `ha-nova setup`
   - `ha-nova doctor`
 - pairing on a machine whose desktop keyring is never unlocked (headless VM, agent box):
   - `ha-nova setup --service <client>` — or standalone: `ha-nova pair --credential-store=file`
+- connecting a second Home Assistant server:
+  - rerun `ha-nova setup` — the completed-setup screen offers "Add another Home Assistant server" (per-call selection stays `HA_NOVA_SERVER=<name>`)
 
 ## Output Format
 


### PR DESCRIPTION
## Summary
- **Multi-server layer 2** per `docs/work/2026-07-20-multi-server-spec.md` → Wizard integration: a completed `ha-nova setup` run now offers **"Add another Home Assistant server"** (the path the onboarding skill points AI clients to). First-run stays untouched — no new first-run prompts (the scripted-stdin wizard tests are the byte-level guard), and the optional discovery-assist one-liner was deliberately skipped.
- The add flow reuses the existing stages — discovery UI, relay App install instructions, `runSetupPairingFlow`, device verify — and writes to a **new named profile** by flipping the process-global selection seam exactly like `ha-nova pair --server` (restored on every exit, deferred).
- **Named profiles stay device-credential-only** (spec: fail closed): pairing runs with the legacy store marked unavailable; the manual-token path is rejected with a pointer to the default server.
- **Discovery filters already-configured instances** by host:HA-port identity: `.local` spellings match their resolved IPv4 through the candidate's `Via`, a different HA port on the same host is a different instance, relay-URL-only profiles claim their host at the default port.
- Cancel/failure paths after the first save print how to finish (`ha-nova pair --server <name> --relay-url …`) or remove (`ha-nova server remove <name>`) the partial profile.

## Pre-PR adversarial review (2 agents, high-risk category onboarding/auth)
Both agents' findings fixed before this PR:
- **HIGH:** the install-wide `client_install_id` is now seeded from the config document — an empty one made `prepareSecurePairingClientInstallID` mint a fresh id that the immutability guard rejects, killing the flow on every secure-paired install (reproduced live by both agents; regression covered by the now-secure-install fixture).
- **MEDIUM:** the offer additionally requires interactive stdin — `ha-nova setup </dev/null` on a completed install keeps exiting 0 with the done banner.
- **MEDIUM:** endpoint-spelling filter replaced by host:port identity keys (+ `Via` match, + relay-only profiles, + port sensitivity).
- **LOW ×4:** name prompt always reserves `default`; raw pairing errors render before the guidance; partial-profile guidance only after the profile exists; per-case regression tests.

## Verification
- `go build`, `go vet`, new `TestAddServer*` suite (6 tests incl. seam-restore, default-profile byte-identity, filter identity keys), full `go test ./...` green (149s).
- `tests/skills/` suite green (onboarding skill line).

Part of the stacked pre-release train (merges before the release-prep PR #502; cloud-source-gate red until the merge train refreshes evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RjvsWLvNQNYq5AKserdQt