### PR TITLE
fix(skills): capability-map contradiction, stale cross-refs, and boundary one-liners

### DIFF
--- a/skills/admin/SKILL.md
+++ b/skills/admin/SKILL.md
@@ -55,7 +55,7 @@ If this fails: `ha-nova setup`
 ## Error Handling
 
 Full relay/upstream error taxonomy: `skills/ha-nova/relay-api.md` -> Error Handling. Admin specifics:
-- `config/auth/*` requires an owner-level token: a permission error here means the LLAT belongs to a non-admin account, not that the command is wrong.
+- `config/auth/*` requires owner/admin rights upstream: a permission error here means the Relay's upstream credential lacks HA admin (App: Supervisor credential; container: the host-side `HA_LLAT`), not that the command is wrong.
 - Deleting a zone that automations reference succeeds — Home Assistant does not stop you. The damage shows up later, which is exactly why the impact advisory runs before the write.
 
 ## Output Format

--- a/skills/energy/energy-reference.md
+++ b/skills/energy/energy-reference.md
@@ -46,7 +46,7 @@ Detection: `flow_from`/`flow_to` present = legacy; flat keys = new. Emit the gen
 {"type":"gas","stat_energy_from":"sensor.gas","stat_cost":null,"entity_energy_price":null,"number_energy_price":null}
 ```
 
-`water` mirrors `gas`. Optional newer fields — preserve verbatim, add only on explicit request: `stat_rate`/`power_config` (live power, 2025.12–2026.2+), `stat_soc` (battery %, 2026.6+), `name` (2026.6+).
+`water` mirrors `gas`. Optional newer fields — preserve verbatim, add only on explicit request: `stat_rate`/`power_config` (live power, 2025.12–2026.2+), `stat_soc` (battery %, 2026.6+), `name` (2026.6+), `capacity` (battery usable kWh, weights the combined charge display, 2026.8+).
 
 ### Device consumption
 

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -81,13 +81,12 @@ For every Relay-Ready call in this skill:
 | Statistics repair / Purge / Entity registry remove | Covered | maintenance |
 | Device config-entry detach | Relay-Ready | this skill |
 | Integration onboarding (add / re-auth an integration via config flow) | Covered | integration-setup |
-| Firing custom events / triggering webhooks | Relay-Ready | this skill |
 | Custom-integration configuration APIs (Alarmo, Scheduler, Adaptive Lighting, Frigate, ...) | Relay-Ready | this skill |
 | Event Subscriptions | Roadmap Phase 1c | -- |
 | Backups (status, create, inspect, delete) | Covered | backup |
 | Config snapshots (targeted capture/restore of automations, scripts, scenes, dashboards, helpers, energy prefs, metadata, YAML files) | Covered | the owning family skill (see `skills/ha-nova/config-snapshots.md`) |
 | Updates (pending, release notes, install, skip) | Covered | updates |
-| Apps / Supervisor | External | -- |
+| Apps / Supervisor | External | -- (App updates: `updates`) |
 | HACS (registration, download, version switching, uninstall, migration) | Covered | hacs |
 | Zigbee / Z-Wave Config | External | -- (MQTT-level inspection of a Zigbee2MQTT setup: `mqtt`) |
 | Alarm / lock code management (lock user codes, alarm PINs) | External | -- (Home Assistant UI; codes never enter chat) |
@@ -198,7 +197,7 @@ Remove a config entry from a device (entity-registry removal is owned by `ha-nov
 ha-nova relay ws --data-file <payload-file>
 ```
 
-**Risks:** Device detach depends on integration support (`supports_remove_device`) and can sever the current device/config-entry relationship. Preview impact first.
+**Risks:** Device detach depends on integration support (`supports_remove_device`). HA 2026.8+ (single-config-entry model): detaching the owning entry REMOVES the device; older instances sever one of several relationships. Preview impact first and name which behavior applies.
 
 ### Custom-Integration Configuration APIs -- RELAY-READY
 

--- a/skills/ha-nova/best-practices.md
+++ b/skills/ha-nova/best-practices.md
@@ -125,7 +125,7 @@ triggers:
     id: button_toggle
 ```
 
-Find `device_ieee` and `command` values: Developer Tools → Events → subscribe to `zha_event` → press button.
+Find `device_ieee` and `command` values: Tools → Events (named Developer Tools before HA 2026.8) → subscribe to `zha_event` → press button.
 
 ### Zigbee2MQTT (Z2M)
 

--- a/skills/ha-nova/output-rules.md
+++ b/skills/ha-nova/output-rules.md
@@ -198,7 +198,7 @@ Accept numbers (e.g. "1 and 2"), or "skip".
 ## Findings
 
 - Use only three visible severity markers: 🔴 high/critical, 🟠 medium, 🟡 low/info.
-- Do not add text severity labels when the emoji is enough.
+- Do not add redundant text severity labels; pairing the emoji with one short status word for accessibility (as the health report mandates) is fine.
 - Give each finding one short descriptive title that explains the issue in plain language.
 - Never show internal check codes such as `R-01`, `S-01`, `H-01`, `M-01`, `P-01`, or `F-01` in user-facing messages.
 - Keep check codes internal in all modes: findings, summaries, clean states, pre-write verdicts, debugging help, brainstorming, and casual Q&A.

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -97,7 +97,7 @@ Use `--jq-file` for non-trivial filters. Avoid complex inline jq, especially reg
 
 System Health event payloads are mixed-shape. For events from `.data.events[]`:
 - read the event kind from `.type`
-- before reading `.data.info` or any nested field, require `(.data | type) == "object"`
+- before reading `.data.<domain>.info` (initial events nest per integration domain) or any nested field, require `(.data | type) == "object"`
 - failure can be signaled on the event itself (`success:false` or `error`) or inside object-shaped `.data` (`.data.success == false` or `.data.error`)
 - scalar `.data` values such as strings, numbers, booleans, or null are informational only; do not count them as failed checks and do not let them break jq filters
 - failed update detection must consider only `update` events whose event-level fields or object-shaped `.data` explicitly indicate failure

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -154,7 +154,8 @@ If 0 results: try synonyms or shorter stems. Never dump entire domains.
    ```text
    ha-nova relay ws --data-file <payload-file>
    ```
-5. Verify absence from `{type}/list`.
+6. Verify absence from `{type}/list`.
+7. Run storage-family post-write review (see below).
 
 ### Family 2: Config-entry helpers
 

--- a/skills/history/SKILL.md
+++ b/skills/history/SKILL.md
@@ -107,6 +107,6 @@ These slots render the Report shape (output-rules.md). Keep default output compa
 ## Guardrails
 
 - Never run an unbounded history/logbook/statistics query.
-- Cap default investigative windows at 24 hours unless the user asked for more.
+- Cap default history/logbook windows at 24 hours unless the user asked for more; statistics/trend questions keep the Flow's 30-day default.
 - If the user asks for a very large export, narrow the request first.
 - Prefer a short summary over dumping a long raw timeline.

--- a/skills/media/SKILL.md
+++ b/skills/media/SKILL.md
@@ -15,7 +15,7 @@ Media player control and discovery:
 - speaker grouping (join / unjoin)
 - TTS announcements to a player
 
-Not in scope: creating automations that use media players (`ha-nova:write`), camera streams (`ha-nova:camera` once shipped), generic service calls to other domains (`ha-nova:service-call`).
+Not in scope: creating automations that use media players (`ha-nova:write`), camera streams (`ha-nova:camera`), generic service calls to other domains (`ha-nova:service-call`).
 
 ## Bootstrap (once per session)
 

--- a/skills/organize/SKILL.md
+++ b/skills/organize/SKILL.md
@@ -21,9 +21,9 @@ Organization and registry metadata only:
 
 Not in scope:
 - entity removal (`ha-nova:maintenance` — dead registry entries only)
-- removing config entries from devices
+- removing config entries from devices (`ha-nova:fallback`)
 - device category assignment
-- zones, persons, tags
+- zones, persons, tags (`ha-nova:admin`)
 - energy management (`ha-nova:energy`) or calendar management (`ha-nova:calendar`)
 
 Hand off to the skill named per line; surfaces without one go to `ha-nova:fallback`.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -386,7 +386,7 @@ Exception: if a maintainer-provided release-validation or machine-check prompt e
 
 ### Standard mode
 
-For resolved targets `== 1`, keep this 8-section output in the same order every time:
+For resolved automation/script/helper targets `== 1`, keep this 8-section output in the same order every time (scene/dashboard targets omit skipped sections per Target Resolution):
 
 **Section 1 — Review target:**
 - domain (automation / script / helper) and target entity_id


### PR DESCRIPTION
## Summary

Quick-win PR B from the 2026-08 skill audit (`docs/work/2026-08-09-skill-audit.md`, PR #523) — 11 skill files, all mechanical corrections of contradictions and stale text; no new gates, no contract growth (word-budget ratchet enforced: fallback and organize additions were trimmed to fit).

- **fallback**: duplicate "Firing custom events / webhooks — this skill" capability row deleted (the map already assigns it to service-call — seed 2); Apps row gains the "(App updates: `updates`)" carve-out (C3-14); device-detach Risks now state the HA 2026.8 single-config-entry reality — detaching the owning entry REMOVES the device (C2-01, live-verified on 2026.8.0).
- **media**: "camera streams (`ha-nova:camera` once shipped)" — camera ships (seed 3).
- **best-practices**: "Developer Tools" → "Tools" (2026.8 rename, C2-03).
- **health**: system-health example path fixed to the real event shape `.data.<domain>.info` (C2-06, reproduced live).
- **energy-reference**: 2026.8 `capacity` battery field added to the preserve-verbatim list (C2-05).
- **organize**: zones/persons/tags → `ha-nova:admin`; config-entry detach → `ha-nova:fallback` (C3-13).
- **admin**: LLAT-era error explanation replaced with the relay-upstream-credential wording (C3-12, matches hacs).
- **history**: 24h cap scoped to history/logbook — resolves the direct contradiction with the Flow's 30-day statistics default (C6-03).
- **review**: 8-section rule qualified for automation/script/helper targets (C6-11).
- **helper**: storage-delete duplicate "5." numbering fixed; the skill's own MANDATORY post-write review step added to the delete flow (C6-05).
- **output-rules**: severity-label rule reconciled with health's accessibility pairing (C6-10).

Deferred as non-mechanical: fallback Safety-Core self-reference (C6-09) — the block is byte-identical-pinned by `skill-template-contract` → #518. Refuted on re-read: the camera:25 section pointer is correct (the version-floor paragraph lives in relay-api → Bounded Event Collection).

Refs #516 #518.

## Verification

- `npx vitest run tests/skills` — 415/415 green (word-budget ratchet initially caught fallback +29 and organize +3 words; both trimmed)
- `bash scripts/check-docs.sh` green
- `npm run typecheck` green right before push (fast-path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K333rh8GtsnFVAGL8Py3Ac