### PR TITLE
docs(work): archive shipped backlog-sequencing doc, repoint roadmap at the audit issue set

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -16,7 +16,7 @@ Active doc ownership lives in `docs/reference/documentation-governance.md`.
 
 ## Current Phase
 
-**Post-masterplan-2026 program** — backlog sequencing 2026-08 shipped in full as v0.23.0 (archived); the active roadmap is the 2026-08 skill-audit issue set #513–#522, sequenced in `docs/work/2026-08-09-skill-audit.md`.
+**Post-masterplan-2026 program** — backlog sequencing 2026-08 shipped in full as v0.23.0 (archived); the active roadmap is the 2026-08 skill-audit issue set #513–#522, sequenced in `docs/work/2026-08-09-skill-audit.md` (landing via PR #523 — merge that report PR before this pointer goes live).
 
 Shipped and current:
 1. Relay: `GET /health`, `POST /ws`, `POST /core`, `POST /files` (opt-in, default off); App + standalone container from one codebase

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -16,7 +16,7 @@ Active doc ownership lives in `docs/reference/documentation-governance.md`.
 
 ## Current Phase
 
-**Post-masterplan-2026 program** — the active roadmap is `docs/work/2026-08-03-backlog-sequencing.md` (masterplan-2026-h2 completed in full, archived).
+**Post-masterplan-2026 program** — backlog sequencing 2026-08 shipped in full as v0.23.0 (archived); the active roadmap is the 2026-08 skill-audit issue set #513–#522, sequenced in `docs/work/2026-08-09-skill-audit.md`.
 
 Shipped and current:
 1. Relay: `GET /health`, `POST /ws`, `POST /core`, `POST /files` (opt-in, default off); App + standalone container from one codebase

--- a/docs/archive/work/2026-08-03-backlog-sequencing.md
+++ b/docs/archive/work/2026-08-03-backlog-sequencing.md
@@ -1,6 +1,6 @@
 # Backlog Sequencing 2026-08
 
-Status: active
+Status: merged (all three phases shipped and tagged as v0.23.0 via #495–#507; archived 2026-08-09)
 Scope: successor to [masterplan-2026-h2.md](../archive/work/masterplan-2026-h2.md) as the SSOT for sequencing and decisions. Orders the open issues (13 as of 2026-08-03) into three phases following the proven "harden what exists before widening surface" logic.
 
 ## Maintainer decisions (2026-08-03)

--- a/docs/archive/work/2026-08-03-backlog-sequencing.md
+++ b/docs/archive/work/2026-08-03-backlog-sequencing.md
@@ -1,7 +1,7 @@
 # Backlog Sequencing 2026-08
 
 Status: merged (all three phases shipped and tagged as v0.23.0 via #495–#507; archived 2026-08-09)
-Scope: successor to [masterplan-2026-h2.md](../archive/work/masterplan-2026-h2.md) as the SSOT for sequencing and decisions. Orders the open issues (13 as of 2026-08-03) into three phases following the proven "harden what exists before widening surface" logic.
+Scope: successor to [masterplan-2026-h2.md](masterplan-2026-h2.md) as the SSOT for sequencing and decisions. Orders the open issues (13 as of 2026-08-03) into three phases following the proven "harden what exists before widening surface" logic.
 
 ## Maintainer decisions (2026-08-03)
 

--- a/docs/archive/work/masterplan-2026-h2.md
+++ b/docs/archive/work/masterplan-2026-h2.md
@@ -1,6 +1,6 @@
 # HA NOVA Masterplan 2026-H2
 
-Status: superseded — completed in full; successor: [2026-08-03-backlog-sequencing.md](../../work/2026-08-03-backlog-sequencing.md)
+Status: superseded — completed in full; successor: [2026-08-03-backlog-sequencing.md](2026-08-03-backlog-sequencing.md)
 Progress: committed Waves 0–7 shipped (v0.18.0 through v0.22.0); the ranked backlog remains uncommitted and carries over to the successor
 Scope: program-level plan following the completed [masterplan-2026.md](../archive/work/masterplan-2026.md) (shipped as v0.14.0, since grown to v0.18.0). Each wave breaks down into its own short spec + PRs before implementation; this doc is the SSOT for sequencing and decisions until superseded.
 
@@ -169,7 +169,7 @@ From the ideation pass; each needs its own decision before entering a wave:
 
 ## Release sequencing
 
-All committed waves landed on `main` before release, following the release-worthiness rule. Relay 0.5.0 published the `/backups` foundation; Relay 0.6.0 then shipped Wave 5 diagnosability with Pairing Code + Home Base in v0.18.0. The committed waves are complete; sequencing and decision SSOT moved to [2026-08-03-backlog-sequencing.md](../../work/2026-08-03-backlog-sequencing.md), which also carries the ranked backlog forward.
+All committed waves landed on `main` before release, following the release-worthiness rule. Relay 0.5.0 published the `/backups` foundation; Relay 0.6.0 then shipped Wave 5 diagnosability with Pairing Code + Home Base in v0.18.0. The committed waves are complete; sequencing and decision SSOT moved to [2026-08-03-backlog-sequencing.md](2026-08-03-backlog-sequencing.md), which also carries the ranked backlog forward.
 
 | Wave | Theme | Relay release | Status |
 |------|-------|---------------|--------|

--- a/docs/work/2026-08-04-hacs-lifecycle-spec.md
+++ b/docs/work/2026-08-04-hacs-lifecycle-spec.md
@@ -5,7 +5,7 @@ Scope: first-class, safe HACS lifecycle management. Supersedes the archived
 masterplan's "Deliberately NOT: HACS management parity" entry — revised by the
 maintainer in #478 with the solaredgeoptimizers migration as the reference
 case. Sequencing: Phase 3 item 1 in
-[2026-08-03-backlog-sequencing.md](2026-08-03-backlog-sequencing.md).
+[2026-08-03-backlog-sequencing.md](../archive/work/2026-08-03-backlog-sequencing.md).
 
 ## Architecture decision: skill-first, no Relay delta
 

--- a/tests/onboarding/project-docs-contract.test.ts
+++ b/tests/onboarding/project-docs-contract.test.ts
@@ -23,7 +23,8 @@ describe("project docs contract", () => {
   });
 
   it("tracks the active architecture surfaces and current skill inventory", () => {
-    expect(project).toContain("docs/work/2026-08-03-backlog-sequencing.md");
+    expect(project).toContain("docs/work/2026-08-09-skill-audit.md");
+    expect(project).toContain("#513–#522");
     expect(project).toContain("the dispatch table in `skills/ha-nova/SKILL.md` is the authoritative inventory");
     expect(project).toContain("`POST /files` (opt-in, default off)");
     expect(project).toContain("documentation-governance.md");


### PR DESCRIPTION
## Summary

Quick-win PR C from the 2026-08 skill audit (PR #523) — housekeeping only:

- `docs/work/2026-08-03-backlog-sequencing.md` → `docs/archive/work/` with `Status: merged`: every item in all three phases shipped and tagged as v0.23.0 (#495–#507); the docs/work lifecycle says archive-on-ship, and the audit flagged it as stale-but-active (seed 14).
- `PROJECT.md` roadmap pointer follows: the active roadmap is now the audit issue set #513–#522, sequenced in `docs/work/2026-08-09-skill-audit.md` (lands via #523 — merge that first so the referenced path exists on main).

Public-claim diff (PROJECT.md, 1 line): roadmap pointer only — no feature or version claims. Local `docs/breadcrumbs.md` / `docs/choices.md` received dated entries; both are gitignored by design and not part of this PR.

## Verification

- `bash scripts/check-docs.sh` green (work-doc lifecycle check no longer sees the archived doc)
- `npm run typecheck` green right before push (fast-path; docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K333rh8GtsnFVAGL8Py3Ac