### PR TITLE
fix(skills): routing vocabulary, boundary owners, and the rules nobody pointed at

### DIFF
--- a/scripts/test/safe-core-files.json
+++ b/scripts/test/safe-core-files.json
@@ -96,6 +96,7 @@
   "tests/skills/output-design-contract.test.ts",
   "tests/skills/relay-unicode-contract.test.ts",
   "tests/skills/review-contract.test.ts",
+  "tests/skills/routing-contract.test.ts",
   "tests/skills/scene-contract.test.ts",
   "tests/skills/service-call-contract.test.ts",
   "tests/skills/skill-template-contract.test.ts",

--- a/skills/admin/SKILL.md
+++ b/skills/admin/SKILL.md
@@ -41,6 +41,7 @@ If this fails: `ha-nova setup`
 4. **Users**: WS `config/auth/list` shows accounts (`id`, `name`, `username`, `is_owner`, `is_active`, `system_generated`, `group_ids`).
    - listing and reviewing access is the safe, common case
    - `config/auth/create` / `config/auth/delete` exist, and are the most dangerous writes in HA NOVA
+   - create payload: `{"type":"config/auth/create","name":"<display name>","group_ids":["system-users"],"local_only":false}` — `system-admin` in `group_ids` makes the account an administrator, so name that in the preview. The password is NOT set here: Home Assistant issues the credential separately, so tell the user to finish in Settings → People rather than offering to set one
    - before any delete: WS `auth/current_user` returns the account this relay's token belongs to — that account is never deletable
 5. Verify every write by re-reading the list — never from the command response alone.
 

--- a/skills/assist/SKILL.md
+++ b/skills/assist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assist
-description: Use when working with Home Assistant's own built-in voice assistant (Assist) — testing what it understands, inspecting or editing Assist pipelines, managing which entities are exposed to voice, and listing TTS/STT/wake-word engines — through HA NOVA Relay. Not for Alexa or Google Assistant, which are configured outside Home Assistant.
+description: Use when working with Home Assistant's own built-in voice assistant (Assist) — testing what it understands, inspecting or editing Assist pipelines, managing which entities are exposed to voice, and listing TTS/STT/wake-word engines — through HA NOVA Relay. Not for Alexa or Google Assistant — those have their own Home Assistant setup paths (`ha-nova:integration-setup`, or `ha-nova:yaml-config` for a manual cloud config), not this skill.
 license: MIT
 compatibility: Requires the ha-nova CLI (run 'ha-nova setup' first) and the HA NOVA Relay in Home Assistant (App, or standalone container on Container/Core).
 ---
@@ -15,7 +15,7 @@ Home Assistant's built-in voice assistant (Assist):
 - manage which entities are exposed to voice, and their aliases
 - list available TTS, STT, conversation, and wake-word engines
 
-Not in scope: speaking through a speaker (`ha-nova:media` for TTS announcements), microphone/satellite hardware setup, or the third-party assistants (Alexa/Google) — those are configured outside Home Assistant.
+Not in scope: speaking through a speaker (`ha-nova:media` for TTS announcements), microphone/satellite hardware setup, or the third-party assistants (Alexa/Google) — those have their own Home Assistant setup paths; route them to `ha-nova:integration-setup` (or `ha-nova:yaml-config` for a manual cloud config).
 
 ## Bootstrap (once per session)
 

--- a/skills/assist/SKILL.md
+++ b/skills/assist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assist
-description: Use when working with Home Assistant's voice assistant — testing what Assist understands, inspecting or editing Assist pipelines, managing which entities are exposed to voice, and listing TTS/STT/wake-word engines — through HA NOVA Relay.
+description: Use when working with Home Assistant's own built-in voice assistant (Assist) — testing what it understands, inspecting or editing Assist pipelines, managing which entities are exposed to voice, and listing TTS/STT/wake-word engines — through HA NOVA Relay. Not for Alexa or Google Assistant, which are configured outside Home Assistant.
 license: MIT
 compatibility: Requires the ha-nova CLI (run 'ha-nova setup' first) and the HA NOVA Relay in Home Assistant (App, or standalone container on Container/Core).
 ---

--- a/skills/assist/SKILL.md
+++ b/skills/assist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assist
-description: Use when working with Home Assistant's own built-in voice assistant (Assist) — testing what it understands, inspecting or editing Assist pipelines, managing which entities are exposed to voice, and listing TTS/STT/wake-word engines — through HA NOVA Relay. Not for Alexa or Google Assistant: setting those up is `ha-nova:integration-setup` (or `ha-nova:yaml-config` for a manual cloud config), and one that STOPPED working is a concrete failure for `ha-nova:diagnose`.
+description: Use when working with Home Assistant's own built-in voice assistant (Assist) — testing what it understands, inspecting or editing Assist pipelines, managing which entities are exposed to voice, and listing TTS/STT/wake-word engines — through HA NOVA Relay. Not for Alexa or Google Assistant — setting those up is `ha-nova:integration-setup` (or `ha-nova:yaml-config` for a manual cloud config), and one that STOPPED working is a concrete failure for `ha-nova:diagnose`.
 license: MIT
 compatibility: Requires the ha-nova CLI (run 'ha-nova setup' first) and the HA NOVA Relay in Home Assistant (App, or standalone container on Container/Core).
 ---

--- a/skills/assist/SKILL.md
+++ b/skills/assist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assist
-description: Use when working with Home Assistant's own built-in voice assistant (Assist) — testing what it understands, inspecting or editing Assist pipelines, managing which entities are exposed to voice, and listing TTS/STT/wake-word engines — through HA NOVA Relay. Not for Alexa or Google Assistant — those have their own Home Assistant setup paths (`ha-nova:integration-setup`, or `ha-nova:yaml-config` for a manual cloud config), not this skill.
+description: Use when working with Home Assistant's own built-in voice assistant (Assist) — testing what it understands, inspecting or editing Assist pipelines, managing which entities are exposed to voice, and listing TTS/STT/wake-word engines — through HA NOVA Relay. Not for Alexa or Google Assistant: setting those up is `ha-nova:integration-setup` (or `ha-nova:yaml-config` for a manual cloud config), and one that STOPPED working is a concrete failure for `ha-nova:diagnose`.
 license: MIT
 compatibility: Requires the ha-nova CLI (run 'ha-nova setup' first) and the HA NOVA Relay in Home Assistant (App, or standalone container on Container/Core).
 ---
@@ -15,7 +15,7 @@ Home Assistant's built-in voice assistant (Assist):
 - manage which entities are exposed to voice, and their aliases
 - list available TTS, STT, conversation, and wake-word engines
 
-Not in scope: speaking through a speaker (`ha-nova:media` for TTS announcements), microphone/satellite hardware setup, or the third-party assistants (Alexa/Google) — those have their own Home Assistant setup paths; route them to `ha-nova:integration-setup` (or `ha-nova:yaml-config` for a manual cloud config).
+Not in scope: speaking through a speaker (`ha-nova:media` for TTS announcements), microphone/satellite hardware setup, or the third-party assistants (Alexa/Google) — setup goes to `ha-nova:integration-setup` (or `ha-nova:yaml-config` for a manual cloud config), and a failure ("Alexa stopped working") to `ha-nova:diagnose` like any other integration incident.
 
 ## Bootstrap (once per session)
 

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -64,7 +64,7 @@ Relevant WS types:
 - `lovelace/resources/delete`
 
 Critical behavior:
-- `lovelace/config/save` is a full-document overwrite
+- `lovelace/config/save` is a full-document overwrite. Payload shape: `{"type":"lovelace/config/save","url_path":"<url_path or null for the default dashboard>","config":{"views":[...]}}` — the whole document goes under `config`, and whatever is missing from it is gone
 - there is no partial update endpoint
 - omitted views/cards are lost
 - `lovelace/dashboards/list` is the source of truth for `dashboard_id`, `url_path`, and `mode`

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -64,7 +64,7 @@ Relevant WS types:
 - `lovelace/resources/delete`
 
 Critical behavior:
-- `lovelace/config/save` is a full-document overwrite. Payload shape: `{"type":"lovelace/config/save","url_path":"<url_path or null for the default dashboard>","config":{"views":[...]}}` — the whole document goes under `config`, and whatever is missing from it is gone
+- `lovelace/config/save` is a full-document overwrite. Payload shape: `{"type":"lovelace/config/save","url_path":"<url_path>","config":{"views":[...]}}` — the whole document goes under `config`, and whatever is missing from it is gone. For the DEFAULT dashboard omit `url_path` entirely; the field takes a string, so an explicit `null` is rejected and the save never lands
 - there is no partial update endpoint
 - omitted views/cards are lost
 - `lovelace/dashboards/list` is the source of truth for `dashboard_id`, `url_path`, and `mode`

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -57,7 +57,7 @@ Only where the log file exists (Container/Core installs; on HA OS/Supervised the
    ```jq
    .data.body | split("\n")[] | select(test("<entity_or_integration>|ERROR"; "i"))
    ```
-   `-r` is required for raw text output — `relay core --jq` does not support it, so the filtering happens in this second step. Substitute only an `entity_id`, domain, or integration slug into that pattern: those charsets are regex-safe. A friendly name can contain `(`, `)`, `.` or `|` and would break the filter or silently widen it.
+   `-r` is required for raw text output — `relay core --jq` does not support it, so the filtering happens in this second step. Substitute only an `entity_id`, domain, or integration slug — never a friendly name, which can contain `(`, `)` or `|` and would break the filter. Even a slug is not literal: the `.` in `sensor.kitchen` is a regex wildcard, so escape it (`sensor\\.kitchen`) or the filter also matches `sensor_kitchen` and reports unrelated lines as evidence.
 
 ## Flow
 

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -55,9 +55,11 @@ Only where the log file exists (Container/Core installs; on HA OS/Supervised the
    ```
    with `<filter-file>`:
    ```jq
-   .data.body | split("\n")[] | select(test("<entity_or_integration>|ERROR"; "i"))
+   .data.body | split("\n")[] | select(test("<entity_or_integration>"; "i"))
    ```
    `-r` is required for raw text output — `relay core --jq` does not support it, so the filtering happens in this second step. Substitute only an `entity_id`, domain, or integration slug — never a friendly name, which can contain `(`, `)` or `|` and would break the filter. Even a slug is not literal: the `.` in `sensor.kitchen` is a regex wildcard, so escape it (`sensor\\.kitchen`) or the filter also matches `sensor_kitchen` and reports unrelated lines as evidence.
+
+   The identifier is the ONLY selector — never OR a severity into it. `test("sensor\\.kitchen|ERROR")` matches every error line in the log, from every unrelated integration, and each one then looks like evidence for this incident. To narrow by severity, AND it: `select(test("sensor\\.kitchen"; "i") and test("ERROR|WARNING"; "i"))`. And a log with no matching line is a finding in itself — say the log holds nothing about this entity, rather than widening the filter until something appears.
 
 ## Flow
 

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -57,7 +57,7 @@ Only where the log file exists (Container/Core installs; on HA OS/Supervised the
    ```jq
    .data.body | split("\n")[] | select(test("<entity_or_integration>|ERROR"; "i"))
    ```
-   `-r` is required for raw text output — `relay core --jq` does not support it, so the filtering happens in this second step.
+   `-r` is required for raw text output — `relay core --jq` does not support it, so the filtering happens in this second step. Substitute only an `entity_id`, domain, or integration slug into that pattern: those charsets are regex-safe. A friendly name can contain `(`, `)`, `.` or `|` and would break the filter or silently widen it.
 
 ## Flow
 

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -100,7 +100,7 @@ For every Relay-Ready call in this skill:
 3. If "Relay-Ready":
    a. FIRST: Search web using the provided Search query — understand current payload schema before any call
    b. Show experimental relay call examples informed by search results
-   c. If the endpoint matches a row in Write Safety by Endpoint Type (below), classify it BEFORE drafting — a full-document endpoint needs a read-merge-verify payload, not a partial one. Endpoints the table does not cover (response-driven config-entry flows, `blueprint/save`, resource replacement) follow the schema the research step returned: submit exactly the fields that step named, one flow step at a time. Then preview the full payload; never guess fields
+   c. If the endpoint matches a row in Write Safety by Endpoint Type (below), classify it BEFORE drafting — a full-document endpoint needs a read-merge-verify payload, not a partial one. Endpoints the table does not cover split by where their schema comes from. A response-driven config-entry flow carries its own: submit exactly the fields the LIVE response named for that step, one step at a time, and never the fields the research step suggested — research is how you understand the flow, the response is what you answer. They diverge by domain and by Home Assistant version, and a stale field set fails the step or writes the wrong config. For the rest (`blueprint/save`, resource replacement) the research schema is the only one available; say so. Then preview the full payload; never guess fields
    d. Execute only after user confirms that exact preview (see context skill → Active Preview Confirmation)
 4. If "Roadmap":
    a. Explain which phase and what blocks it

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -100,7 +100,7 @@ For every Relay-Ready call in this skill:
 3. If "Relay-Ready":
    a. FIRST: Search web using the provided Search query — understand current payload schema before any call
    b. Show experimental relay call examples informed by search results
-   c. Preview full payload before any write — never guess fields
+   c. Classify the endpoint per Write Safety by Endpoint Type (below) BEFORE drafting — a full-document endpoint needs a read-merge-verify payload, not a partial one — then preview the full payload; never guess fields
    d. Execute only after user confirms that exact preview (see context skill → Active Preview Confirmation)
 4. If "Roadmap":
    a. Explain which phase and what blocks it

--- a/skills/fallback/SKILL.md
+++ b/skills/fallback/SKILL.md
@@ -100,7 +100,7 @@ For every Relay-Ready call in this skill:
 3. If "Relay-Ready":
    a. FIRST: Search web using the provided Search query — understand current payload schema before any call
    b. Show experimental relay call examples informed by search results
-   c. Classify the endpoint per Write Safety by Endpoint Type (below) BEFORE drafting — a full-document endpoint needs a read-merge-verify payload, not a partial one — then preview the full payload; never guess fields
+   c. If the endpoint matches a row in Write Safety by Endpoint Type (below), classify it BEFORE drafting — a full-document endpoint needs a read-merge-verify payload, not a partial one. Endpoints the table does not cover (response-driven config-entry flows, `blueprint/save`, resource replacement) follow the schema the research step returned: submit exactly the fields that step named, one flow step at a time. Then preview the full payload; never guess fields
    d. Execute only after user confirms that exact preview (see context skill → Active Preview Confirmation)
 4. If "Roadmap":
    a. Explain which phase and what blocks it

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -285,7 +285,10 @@ Match user intent to exactly one skill:
 **"Add a zone for work"** → `ha-nova:admin`
 **"Create a template sensor that averages my three thermometers"** → `ha-nova:helper` first (a template helper can do it); only `ha-nova:yaml-config` when the helper cannot express it
 **"What was the average temperature last summer?"** → `ha-nova:history` if the recorder still has it; `ha-nova:external-sources` when it was purged and InfluxDB has it
-**"Is my sensor even sending anything?"** → `ha-nova:mqtt` (listen to its topic); "why did my automation not run" stays `ha-nova:diagnose`
+**"Is my sensor even sending anything?"** → transport decides: an MQTT/Zigbee2MQTT device goes to `ha-nova:mqtt` (listen to its topic); anything else starts at `ha-nova:health` (is it unavailable?) or `ha-nova:diagnose`. "Why did my automation not run" always stays `ha-nova:diagnose`
+**"Install browser_mod from HACS"** → `ha-nova:hacs` (add, pin, or remove a HACS package)
+**"Update my HACS integration to the latest"** → `ha-nova:updates` (an update entity, like any other update); an explicit version or a downgrade goes to `ha-nova:hacs`
+**"HA NOVA is not connecting"** / **"relay auth error"** → `ha-nova:onboarding` (diagnostics only, never a config write)
 **"Is everything OK with my home?"** → `ha-nova:health` (current status, no concrete incident)
 **"Why are devices unavailable?"** → `ha-nova:health`
 **"Add milk to my shopping list"** → `ha-nova:todo`

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -285,7 +285,7 @@ Match user intent to exactly one skill:
 **"Add a zone for work"** → `ha-nova:admin`
 **"Create a template sensor that averages my three thermometers"** → `ha-nova:helper` first (a template helper can do it); only `ha-nova:yaml-config` when the helper cannot express it
 **"What was the average temperature last summer?"** → `ha-nova:history` if the recorder still has it; `ha-nova:external-sources` when it was purged and InfluxDB has it
-**"Is my sensor even sending anything?"** → transport decides: an MQTT/Zigbee2MQTT device goes to `ha-nova:mqtt` (listen to its topic); anything else starts at `ha-nova:health` (is it unavailable?) or `ha-nova:diagnose`. "Why did my automation not run" always stays `ha-nova:diagnose`
+**"Is my sensor even sending anything?"** → `ha-nova:mqtt` for an MQTT/Zigbee2MQTT device (listen to its topic); for any other transport `ha-nova:diagnose` — a sensor that stopped updating is a concrete incident. Only a general "is anything wrong in my home" goes to `ha-nova:health`. "Why did my automation not run" always stays `ha-nova:diagnose`
 **"Install browser_mod from HACS"** → `ha-nova:hacs` (add, pin, or remove a HACS package)
 **"Update my HACS integration to the latest"** → `ha-nova:updates` (an update entity, like any other update); an explicit version or a downgrade goes to `ha-nova:hacs`
 **"HA NOVA is not connecting"** / **"relay auth error"** → `ha-nova:onboarding` (diagnostics only, never a config write)

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -23,6 +23,8 @@ Not in scope:
 - restart, reload, update, backup, or service calls
 - YAML/filesystem diagnostics
 - historical timelines (use `ha-nova:history`)
+- root-causing one named item's concrete incident (`ha-nova:diagnose`) — this skill reports what is wrong across the home right now, not why one thing failed
+- how long an entity has been unavailable, and whether it is a cleanup candidate (`ha-nova:maintenance` long-unavailable report)
 
 ## Bootstrap (once per session)
 

--- a/skills/helper/SKILL.md
+++ b/skills/helper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: helper
-description: Use when creating, updating, deleting, or listing Home Assistant helpers (storage-based helpers plus the supported config-entry helper family) through HA NOVA Relay.
+description: Use when creating, updating, deleting, or listing Home Assistant helpers — timers, counters, toggles, dropdowns, text and number inputs, schedules, plus template, threshold, utility-meter and other config-entry helpers — through HA NOVA Relay.
 license: MIT
 compatibility: Requires the ha-nova CLI (run 'ha-nova setup' first) and the HA NOVA Relay in Home Assistant (App, or standalone container on Container/Core).
 ---

--- a/skills/history/SKILL.md
+++ b/skills/history/SKILL.md
@@ -23,7 +23,7 @@ Not in scope:
 - calendar queries (use `ha-nova:calendar`)
 - giant raw exports
 
-Use `ha-nova:read` for traces, `ha-nova:calendar` for calendars, and `ha-nova:fallback` for subscriptions.
+Use `ha-nova:diagnose` for traces (it owns trace analysis; `ha-nova:read` only surfaces raw trace data when the user explicitly asks for it with no failure question attached), `ha-nova:calendar` for calendars, and `ha-nova:fallback` for subscriptions.
 
 ## Bootstrap (once per session)
 

--- a/skills/maintenance/SKILL.md
+++ b/skills/maintenance/SKILL.md
@@ -22,7 +22,7 @@ Gated writes:
 
 Not in scope:
 - energy source/device config (`ha-nova:energy`)
-- repairs/status overview (`ha-nova:health`)
+- repairs/status overview and current unavailability summaries (`ha-nova:health`); the long-unavailable report here exists to qualify cleanup candidates, not to answer "is everything OK"
 - backups (`ha-nova:backup`), updates (`ha-nova:updates`)
 - device deletion — no generic API; report and route to the owning integration/UI
 

--- a/skills/maintenance/SKILL.md
+++ b/skills/maintenance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintenance
-description: Use when repairing Home Assistant recorder statistics (orphaned statistics, unit mismatches, sum spikes), purging recorder history, or cleaning up dead entity-registry entries through HA NOVA Relay.
+description: Use when repairing Home Assistant recorder statistics (orphaned statistics, unit mismatches, sum spikes), purging recorder history, cleaning up dead entity-registry entries, or answering how long an entity has been unavailable or dead — through HA NOVA Relay. For what is unavailable right now, use ha-nova:health.
 license: MIT
 compatibility: Requires the ha-nova CLI (run 'ha-nova setup' first) and the HA NOVA Relay in Home Assistant (App, or standalone container on Container/Core).
 ---

--- a/skills/notify/SKILL.md
+++ b/skills/notify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notify
-description: Use when sending Home Assistant notifications — discovering notify targets, sending messages to phones or speakers, building mobile-app notifications, and managing persistent notifications — through HA NOVA Relay.
+description: Use when sending a Home Assistant notification NOW — discovering notify targets, sending a message to a phone or speaker, building mobile-app notifications, and managing persistent notifications — through HA NOVA Relay. For "notify me WHEN something happens" use ha-nova:write, which builds the automation.
 license: MIT
 compatibility: Requires the ha-nova CLI (run 'ha-nova setup' first) and the HA NOVA Relay in Home Assistant (App, or standalone container on Container/Core).
 ---

--- a/skills/organize/SKILL.md
+++ b/skills/organize/SKILL.md
@@ -23,7 +23,7 @@ Not in scope:
 - entity removal (`ha-nova:maintenance` — dead registry entries only)
 - removing config entries from devices
 - device category assignment
-- zones, persons, tags
+- zones, persons, tags (`ha-nova:admin`)
 - energy management (`ha-nova:energy`) or calendar management (`ha-nova:calendar`)
 
 Hand off to the skill named per line; surfaces without one go to `ha-nova:fallback`.

--- a/skills/read/SKILL.md
+++ b/skills/read/SKILL.md
@@ -172,6 +172,8 @@ Never show raw JSON to the user.
 
 ## Trace Debugging
 
+Trace ANALYSIS belongs to `ha-nova:diagnose` — hand off whenever the question is why something failed or misbehaved. Stay here only when the user explicitly asks to see raw trace data with no failure question attached.
+
 For trace queries:
 
 Prefer CLI helpers: `ha-nova trace latest <entity> --json`, `ha-nova trace list <entity> --json`, `ha-nova trace get <entity> <run_id> --json`. They resolve `unique_id` and normalize trace shapes. If none exist, explain that Home Assistant keeps only recent traces and YAML automations/scripts need an `id`.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -207,12 +207,16 @@ Before analyzing, consult these sources:
 
 Only fetch pages relevant to the triggers, actions, and templates found in the config. Cross-check against documented gotchas and constraints — this catches issues beyond the hardcoded checks below.
 
-**Verify-before-flag rule:** Before reporting ANY issue:
-1. Check local reference doc
-2. If not found, check the official HA docs above
-3. Only flag as error if confirmed invalid after both checks
+**Verify-before-flag rule:** the canonical sequence lives in
+`skills/review/checks.md` → Verify Before Flagging, because the post-write
+phases load that file without this one. Resolve every finding against a source
+before reporting it, and flag it when the source confirms the CLAIM you are
+making — semantics or risk for behavioral checks, schema invalidity only for
+schema-shaped ones.
 
-Do NOT flag valid HA builtins or documented behavior as errors.
+Do NOT flag valid HA builtins or documented behavior as errors — but "valid"
+alone never clears a behavioral finding: much of the catalog describes config
+Home Assistant accepts and that still misbehaves.
 
 ### Step 1: Config Quality Review
 
@@ -257,9 +261,15 @@ Branch by target family:
    ```
 5. If no related items found, report "no conflicts" in the Conflicts section and skip Step 3. On a filter error, report the collision scan as inconclusive — never as "no conflicts".
 
-### Trace Analysis (on request)
+### Trace Evidence (only when the user asked for a review)
 
-When the user reports runtime issues ("automation didn't fire", "wrong behavior last night"):
+Trace ANALYSIS belongs to `ha-nova:diagnose`: a runtime complaint ("didn't
+fire", "wrong behavior last night") is a concrete incident and routes there,
+not here. Stay in this skill only when the user asked for a review and traces
+are supporting evidence for a config finding — never as the answer to a
+failure question.
+
+In that case:
 1. Follow the trace procedure in `skills/read/SKILL.md` → Trace Debugging
 2. Prefer the normalized CLI helper fields from `ha-nova trace latest/list/get --json`; they are enough for run selection, result status, timestamp, item binding, and most review findings.
 3. Inspect raw trace internals only when step-level evidence is required. Raw trace nodes can be arrays of event records; type-check before reading `path`, `result`, `changed_variables`, or `error`, and avoid large jq projections as the standard path.

--- a/skills/review/checks.md
+++ b/skills/review/checks.md
@@ -40,11 +40,17 @@ against a source rather than memory, in this order:
      in `lovelace/resources`, this scene captures two colour attributes, this
      entity_id appears in three automations — come from the live data the run
      already read. Nothing else can prove them.
-   - The BEHAVIOURAL claim attached to them — that mixed colour attributes
-     reproduce wrong, that a domain is not reproducible, that a field is
-     required — comes from `skills/scene/SKILL.md` → Capture attributes
-     deliberately, `skills/dashboard/SKILL.md` → Critical behavior, and the
-     Lovelace and scene pages on home-assistant.io.
+   - The BEHAVIOURAL claim attached to them comes from a named source, and
+     each claim has exactly one: that mixed colour attributes reproduce wrong
+     or a domain is not reproducible — `skills/scene/SKILL.md` → Capture
+     attributes deliberately; that a built-in card field is required — the
+     D-07 allowlist above, which is the only schema pin in this repo and is
+     deliberately closed (a type not on it has no known required field, so it
+     produces no finding); that a save loses omitted content or a custom-card
+     schema cannot be invented — `skills/dashboard/SKILL.md` → Critical
+     behavior. Beyond those, the Lovelace and scene pages on
+     home-assistant.io. Citing a section that does not carry the claim is the
+     same error as citing nothing.
    State the observation from the data and the consequence from the source.
    If only the observation holds, report the observation.
 5. Unresolved means unresolved: report it as a question, never as an error.

--- a/skills/review/checks.md
+++ b/skills/review/checks.md
@@ -11,6 +11,14 @@ Self-contained catalog: load this file before evaluating findings — from `skil
 - Instead, describe each finding in plain language: a short descriptive title plus why it matters and how to fix it.
 - This guardrail applies whenever check knowledge is used, not only during formal review runs.
 
+## Verify Before Flagging (Critical)
+
+A finding that turns out to be valid Home Assistant costs the user more trust
+than a missed one costs them behavior. Before reporting ANY issue: check the
+local reference doc, then the official HA docs if it is not there, and flag it
+only when both confirm it is genuinely invalid. This applies wherever findings
+are generated — the standalone review flow and the post-write phases alike.
+
 ## Check Taxonomy (internal only)
 
 - Format: `{CATEGORY}-{NN}` (example: `H-09`)

--- a/skills/review/checks.md
+++ b/skills/review/checks.md
@@ -14,10 +14,25 @@ Self-contained catalog: load this file before evaluating findings — from `skil
 ## Verify Before Flagging (Critical)
 
 A finding that turns out to be valid Home Assistant costs the user more trust
-than a missed one costs them behavior. Before reporting ANY issue: check the
-local reference doc, then the official HA docs if it is not there, and flag it
-only when both confirm it is genuinely invalid. This applies wherever findings
-are generated — the standalone review flow and the post-write phases alike.
+than a missed one costs them behavior. Before reporting ANY issue, resolve it
+against a source rather than memory, in this order:
+
+1. `skills/ha-nova/template-guidelines.md` for template and Jinja questions,
+   `skills/ha-nova/best-practices.md` and `automation-patterns.md` for
+   trigger/action/mode shapes, `skills/ha-nova/helper-schemas.md` and
+   `helper-flow-schemas.md` for helper fields.
+2. If the local reference does not settle it, the official documentation page
+   for that surface: triggers <https://www.home-assistant.io/docs/automation/trigger/>,
+   modes <https://www.home-assistant.io/docs/automation/modes/>, scripts
+   <https://www.home-assistant.io/docs/scripts/>, templating
+   <https://www.home-assistant.io/docs/configuration/templating/>, YAML schema
+   <https://www.home-assistant.io/docs/automation/yaml/>.
+3. Flag it only when whichever source settled it says the config is invalid.
+   Unresolved means unresolved: report it as a question, never as an error.
+
+This applies wherever findings are generated — the standalone review flow and
+the post-write phases in write, helper, and yaml-config alike, which load this
+file directly and never see the review skill's copy of the rule.
 
 ## Check Taxonomy (internal only)
 

--- a/skills/review/checks.md
+++ b/skills/review/checks.md
@@ -34,11 +34,19 @@ against a source rather than memory, in this order:
    misbehave, deprecate, or fire at the wrong moment. For those the source
    must confirm the semantics or the risk — "valid YAML" never clears them.
    Only schema-shaped checks need the source to call the config invalid.
-4. For families the reference docs do not cover — SC (scenes), D
-   (dashboards), HX (cross-item) — the authoritative source is the live
-   evidence this run already read: the stored config, the registry, the
-   entity state. A scene capturing two mixed colour attributes or a card
-   pointing at a missing resource is proven by that data, not by a doc page.
+4. Scene, dashboard and cross-item families split their evidence in two, and
+   conflating the halves is how an unsupported finding gets shipped:
+   - EXISTENCE and JOIN facts — this card references a resource that is not
+     in `lovelace/resources`, this scene captures two colour attributes, this
+     entity_id appears in three automations — come from the live data the run
+     already read. Nothing else can prove them.
+   - The BEHAVIOURAL claim attached to them — that mixed colour attributes
+     reproduce wrong, that a domain is not reproducible, that a field is
+     required — comes from `skills/scene/SKILL.md` → Capture attributes
+     deliberately, `skills/dashboard/SKILL.md` → Critical behavior, and the
+     Lovelace and scene pages on home-assistant.io.
+   State the observation from the data and the consequence from the source.
+   If only the observation holds, report the observation.
 5. Unresolved means unresolved: report it as a question, never as an error.
 
 This applies wherever findings are generated — the standalone review flow and

--- a/skills/review/checks.md
+++ b/skills/review/checks.md
@@ -34,7 +34,12 @@ against a source rather than memory, in this order:
    misbehave, deprecate, or fire at the wrong moment. For those the source
    must confirm the semantics or the risk — "valid YAML" never clears them.
    Only schema-shaped checks need the source to call the config invalid.
-4. Unresolved means unresolved: report it as a question, never as an error.
+4. For families the reference docs do not cover — SC (scenes), D
+   (dashboards), HX (cross-item) — the authoritative source is the live
+   evidence this run already read: the stored config, the registry, the
+   entity state. A scene capturing two mixed colour attributes or a card
+   pointing at a missing resource is proven by that data, not by a doc page.
+5. Unresolved means unresolved: report it as a question, never as an error.
 
 This applies wherever findings are generated — the standalone review flow and
 the post-write phases in write, helper, and yaml-config alike, which load this

--- a/skills/review/checks.md
+++ b/skills/review/checks.md
@@ -27,8 +27,13 @@ against a source rather than memory, in this order:
    <https://www.home-assistant.io/docs/scripts/>, templating
    <https://www.home-assistant.io/docs/configuration/templating/>, YAML schema
    <https://www.home-assistant.io/docs/automation/yaml/>.
-3. Flag it only when whichever source settled it says the config is invalid.
-   Unresolved means unresolved: report it as a question, never as an error.
+3. Flag it when the settling source confirms the CLAIM you are making. Most
+   of this catalog is not about schema validity: R-02, R-06, P-04 and M-05
+   describe configurations Home Assistant accepts happily and that still
+   misbehave, deprecate, or fire at the wrong moment. For those the source
+   must confirm the semantics or the risk — "valid YAML" never clears them.
+   Only schema-shaped checks need the source to call the config invalid.
+4. Unresolved means unresolved: report it as a question, never as an error.
 
 This applies wherever findings are generated — the standalone review flow and
 the post-write phases in write, helper, and yaml-config alike, which load this

--- a/skills/review/checks.md
+++ b/skills/review/checks.md
@@ -18,9 +18,10 @@ than a missed one costs them behavior. Before reporting ANY issue, resolve it
 against a source rather than memory, in this order:
 
 1. `skills/ha-nova/template-guidelines.md` for template and Jinja questions,
-   `skills/ha-nova/best-practices.md` and `automation-patterns.md` for
-   trigger/action/mode shapes, `skills/ha-nova/helper-schemas.md` and
-   `helper-flow-schemas.md` for helper fields.
+   `skills/ha-nova/best-practices.md` and
+   `skills/ha-nova/automation-patterns.md` for trigger/action/mode shapes,
+   `skills/ha-nova/helper-schemas.md` and
+   `skills/ha-nova/helper-flow-schemas.md` for helper fields.
 2. If the local reference does not settle it, the official documentation page
    for that surface: triggers <https://www.home-assistant.io/docs/automation/trigger/>,
    modes <https://www.home-assistant.io/docs/automation/modes/>, scripts

--- a/skills/service-call/SKILL.md
+++ b/skills/service-call/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: service-call
-description: Use when the user wants to call Home Assistant services, fire custom events, trigger known webhooks, or control alarm panels and locks through HA NOVA Relay.
+description: Use when the user wants to control something in Home Assistant right now — turn lights, switches, covers, climate, vacuums, or any device on, off, up, down, open, or closed; run a scene, script, or automation; call any service by name; fire custom events or known webhooks; operate alarm panels and locks — through HA NOVA Relay.
 license: MIT
 compatibility: Requires the ha-nova CLI (run 'ha-nova setup' first) and the HA NOVA Relay in Home Assistant (App, or standalone container on Container/Core).
 ---

--- a/tests/skills/routing-contract.test.ts
+++ b/tests/skills/routing-contract.test.ts
@@ -154,6 +154,15 @@ describe("load-bearing rules referenced from where they apply (#518)", () => {
     // Live data proves the observation; only a source proves the consequence.
     expect(checks).toContain("EXISTENCE and JOIN facts");
     expect(checks).toContain("The BEHAVIOURAL claim attached to them");
+    // Each claim class cites the section that actually carries it: the
+    // required-field pin lives in D-07, not in the dashboard skill's
+    // save-overwrite notes.
+    expect(flat(checks)).toContain(
+      "that a built-in card field is required — the D-07 allowlist above",
+    );
+    expect(flat(checks)).toContain(
+      "Citing a section that does not carry the claim is the same error as citing nothing",
+    );
     expect(checks).toContain(
       "State the observation from the data and the consequence from the source",
     );

--- a/tests/skills/routing-contract.test.ts
+++ b/tests/skills/routing-contract.test.ts
@@ -1,0 +1,128 @@
+// tests/skills/routing-contract.test.ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const read = (p: string): string =>
+  readFileSync(resolve(__dirname, "../../", p), "utf-8");
+const context = read("skills/ha-nova/SKILL.md");
+const flat = (text: string): string => text.replace(/\s+/g, " ");
+const description = (skill: string): string => {
+  const line = read(`skills/${skill}/SKILL.md`)
+    .split("\n")
+    .find((l) => l.startsWith("description:"));
+  return line ?? "";
+};
+
+describe("description-level routing (#518)", () => {
+  // In most clients the frontmatter description IS the routing signal — the
+  // dispatch table only loads together with the context skill. A description
+  // written in implementation vocabulary loses the intents users actually
+  // speak.
+  it("gives service-call the words users say for device control", () => {
+    const d = description("service-call");
+    for (const word of ["turn", "lights", "covers", "climate", "on, off"]) {
+      expect(d, `service-call description missing "${word}"`).toContain(word);
+    }
+  });
+
+  it("puts the one-off vs automation split into the notify description", () => {
+    const d = description("notify");
+    expect(d).toContain("NOW");
+    expect(d).toContain('For "notify me WHEN something happens" use ha-nova:write');
+  });
+
+  it("names concrete helper types instead of the word helper alone", () => {
+    const d = description("helper");
+    for (const t of ["timers", "counters", "toggles", "dropdowns"]) {
+      expect(d, `helper description missing "${t}"`).toContain(t);
+    }
+  });
+
+  it("excludes Alexa and Google from the assist description", () => {
+    expect(description("assist")).toContain(
+      "Not for Alexa or Google Assistant",
+    );
+  });
+});
+
+describe("boundary statements between neighbouring skills (#518)", () => {
+  it("gives trace analysis exactly one owner", () => {
+    // history pointed at read, dispatch pointed at diagnose, and read never
+    // claimed traces — three pointers, no owner.
+    expect(flat(read("skills/history/SKILL.md"))).toContain(
+      "Use `ha-nova:diagnose` for traces",
+    );
+    expect(flat(read("skills/read/SKILL.md"))).toContain(
+      "Trace ANALYSIS belongs to `ha-nova:diagnose`",
+    );
+    expect(flat(read("skills/read/SKILL.md"))).toContain(
+      "with no failure question attached",
+    );
+  });
+
+  it("gives health the reverse boundaries it was missing", () => {
+    const h = flat(read("skills/health/SKILL.md"));
+    expect(h).toContain("root-causing one named item's concrete incident (`ha-nova:diagnose`)");
+    expect(h).toContain("not why one thing failed");
+    expect(h).toContain("how long an entity has been unavailable");
+    expect(flat(read("skills/maintenance/SKILL.md"))).toContain(
+      "the long-unavailable report here exists to qualify cleanup candidates",
+    );
+  });
+
+  it("names admin as the target organize sends zones, persons, and tags to", () => {
+    expect(read("skills/organize/SKILL.md")).toContain(
+      "- zones, persons, tags (`ha-nova:admin`)",
+    );
+  });
+});
+
+describe("dispatch examples for the rows that had none (#518)", () => {
+  it("encodes the hacs/updates boundary as examples, not only inside the skills", () => {
+    expect(context).toContain('**"Install browser_mod from HACS"** → `ha-nova:hacs`');
+    expect(context).toContain('**"Update my HACS integration to the latest"** → `ha-nova:updates`');
+    expect(context).toContain("an explicit version or a downgrade goes to `ha-nova:hacs`");
+  });
+
+  it("gives onboarding an example and hedges the sensor question by transport", () => {
+    expect(context).toContain("`ha-nova:onboarding` (diagnostics only, never a config write)");
+    // "Is my sensor sending?" → mqtt is right only for MQTT transports.
+    expect(flat(context)).toContain("transport decides: an MQTT/Zigbee2MQTT device goes to `ha-nova:mqtt`");
+  });
+});
+
+describe("load-bearing rules referenced from where they apply (#518)", () => {
+  it("points the fallback execute step at its own endpoint-type table", () => {
+    expect(flat(read("skills/fallback/SKILL.md"))).toContain(
+      "Classify the endpoint per Write Safety by Endpoint Type (below) BEFORE drafting",
+    );
+  });
+
+  it("echoes verify-before-flag where findings are generated", () => {
+    // checks.md is loaded standalone by write, helper, and yaml-config, which
+    // never see the review skill's copy of the rule.
+    const checks = flat(read("skills/review/checks.md"));
+    expect(checks).toContain("## Verify Before Flagging (Critical)");
+    expect(checks).toContain("costs the user more trust than a missed one");
+    expect(checks).toContain("the standalone review flow and the post-write phases alike");
+  });
+
+  it("names the payload shapes that were documented nowhere", () => {
+    expect(read("skills/admin/SKILL.md")).toContain('"type":"config/auth/create"');
+    expect(flat(read("skills/admin/SKILL.md"))).toContain(
+      "`system-admin` in `group_ids` makes the account an administrator",
+    );
+    expect(read("skills/dashboard/SKILL.md")).toContain('"type":"lovelace/config/save"');
+    expect(flat(read("skills/dashboard/SKILL.md"))).toContain(
+      "the whole document goes under `config`",
+    );
+  });
+
+  it("restricts what may be interpolated into the diagnose log filter", () => {
+    expect(flat(read("skills/diagnose/SKILL.md"))).toContain(
+      "Substitute only an `entity_id`, domain, or integration slug",
+    );
+    expect(flat(read("skills/diagnose/SKILL.md"))).toContain("A friendly name can contain");
+  });
+});

--- a/tests/skills/routing-contract.test.ts
+++ b/tests/skills/routing-contract.test.ts
@@ -121,7 +121,7 @@ describe("load-bearing rules referenced from where they apply (#518)", () => {
     // The table has no row for response-driven flows or blueprint/save, so a
     // blanket classification requirement would stall documented operations.
     expect(fb).toContain("Endpoints the table does not cover");
-    expect(fb).toContain("follow the schema the research step returned");
+    expect(fb).toContain("split by where their schema comes from");
   });
 
   it("echoes verify-before-flag where findings are generated", () => {
@@ -247,5 +247,16 @@ describe("load-bearing rules referenced from where they apply (#518)", () => {
     expect(diagnose).not.toContain('test("<entity_or_integration>|ERROR"');
     // Finding nothing is an answer, not a reason to loosen the filter.
     expect(diagnose).toContain("rather than widening the filter until something appears");
+  });
+
+  it("answers a config-entry flow from the live response, not from research", () => {
+    const fallback = flat(read("skills/fallback/SKILL.md"));
+    // Fields vary by domain and HA version; the flow response is the only
+    // authority for the step being answered.
+    expect(fallback).toContain("submit exactly the fields the LIVE response named");
+    expect(fallback).toContain("never the fields the research step suggested");
+    expect(fallback).toContain(
+      "research is how you understand the flow, the response is what you answer",
+    );
   });
 });

--- a/tests/skills/routing-contract.test.ts
+++ b/tests/skills/routing-contract.test.ts
@@ -87,8 +87,14 @@ describe("dispatch examples for the rows that had none (#518)", () => {
 
   it("gives onboarding an example and hedges the sensor question by transport", () => {
     expect(context).toContain("`ha-nova:onboarding` (diagnostics only, never a config write)");
-    // "Is my sensor sending?" → mqtt is right only for MQTT transports.
-    expect(flat(context)).toContain("transport decides: an MQTT/Zigbee2MQTT device goes to `ha-nova:mqtt`");
+    // "Is my sensor sending?" → mqtt is right only for MQTT transports, and
+    // the example must still resolve to exactly ONE skill per transport.
+    expect(flat(context)).toContain(
+      "`ha-nova:mqtt` for an MQTT/Zigbee2MQTT device",
+    );
+    expect(flat(context)).toContain(
+      "for any other transport `ha-nova:diagnose` — a sensor that stopped updating is a concrete incident",
+    );
   });
 });
 
@@ -105,7 +111,18 @@ describe("load-bearing rules referenced from where they apply (#518)", () => {
     const checks = flat(read("skills/review/checks.md"));
     expect(checks).toContain("## Verify Before Flagging (Critical)");
     expect(checks).toContain("costs the user more trust than a missed one");
-    expect(checks).toContain("the standalone review flow and the post-write phases alike");
+    expect(checks).toContain(
+      "the standalone review flow and the post-write phases in write, helper, and yaml-config alike",
+    );
+    // A standalone loader cannot follow "check the local reference doc" unless
+    // the doc is named, and the sequence must not demand two confirmations
+    // for something the first source already settled.
+    expect(checks).toContain("skills/ha-nova/template-guidelines.md");
+    expect(checks).toContain("home-assistant.io/docs/automation/trigger/");
+    expect(checks).toContain(
+      "Flag it only when whichever source settled it says the config is invalid",
+    );
+    expect(checks).toContain("Unresolved means unresolved");
   });
 
   it("names the payload shapes that were documented nowhere", () => {

--- a/tests/skills/routing-contract.test.ts
+++ b/tests/skills/routing-contract.test.ts
@@ -227,4 +227,13 @@ describe("load-bearing rules referenced from where they apply (#518)", () => {
       `these skills cannot be loaded by a YAML-parsing client:\n  ${broken.join("\n  ")}`,
     ).toEqual([]);
   });
+
+  it("advertises the long-unavailable boundary on both sides", () => {
+    // Subskills are selected from their own frontmatter, so moving a boundary
+    // in one skill's prose does nothing until the OTHER skill's description
+    // says it owns the request.
+    const maintenance = read("skills/maintenance/SKILL.md").split("---")[1] ?? "";
+    expect(maintenance).toContain("how long an entity has been unavailable");
+    expect(maintenance).toContain("use ha-nova:health");
+  });
 });

--- a/tests/skills/routing-contract.test.ts
+++ b/tests/skills/routing-contract.test.ts
@@ -47,6 +47,17 @@ describe("description-level routing (#518)", () => {
 });
 
 describe("boundary statements between neighbouring skills (#518)", () => {
+  it("does not leave a second executable trace-analysis owner", () => {
+    // review is independently discoverable, so narrowing read/history alone
+    // would leave the same failure question with two owners.
+    const review = flat(read("skills/review/SKILL.md"));
+    expect(review).toContain("Trace ANALYSIS belongs to `ha-nova:diagnose`");
+    expect(review).toContain("never as the answer to a failure question");
+    // And the entrypoint must not keep its own contradicting verify gate.
+    expect(review).toContain("the canonical sequence lives in");
+    expect(review).not.toContain("Only flag as error if confirmed invalid after both checks");
+  });
+
   it("gives trace analysis exactly one owner", () => {
     // history pointed at read, dispatch pointed at diagnose, and read never
     // claimed traces — three pointers, no owner.
@@ -123,6 +134,10 @@ describe("load-bearing rules referenced from where they apply (#518)", () => {
     // the doc is named, and the sequence must not demand two confirmations
     // for something the first source already settled.
     expect(checks).toContain("skills/ha-nova/template-guidelines.md");
+    // Every local reference needs its full path: a direct loader cannot open
+    // "automation-patterns.md" relative to nothing.
+    expect(checks).toContain("skills/ha-nova/automation-patterns.md");
+    expect(checks).toContain("skills/ha-nova/helper-flow-schemas.md");
     expect(checks).toContain("home-assistant.io/docs/automation/trigger/");
     // Most of the catalog flags valid-but-risky config, so demanding schema
     // invalidity would suppress even HIGH runtime hazards.

--- a/tests/skills/routing-contract.test.ts
+++ b/tests/skills/routing-contract.test.ts
@@ -100,9 +100,14 @@ describe("dispatch examples for the rows that had none (#518)", () => {
 
 describe("load-bearing rules referenced from where they apply (#518)", () => {
   it("points the fallback execute step at its own endpoint-type table", () => {
-    expect(flat(read("skills/fallback/SKILL.md"))).toContain(
-      "Classify the endpoint per Write Safety by Endpoint Type (below) BEFORE drafting",
+    const fb = flat(read("skills/fallback/SKILL.md"));
+    expect(fb).toContain(
+      "If the endpoint matches a row in Write Safety by Endpoint Type (below), classify it BEFORE drafting",
     );
+    // The table has no row for response-driven flows or blueprint/save, so a
+    // blanket classification requirement would stall documented operations.
+    expect(fb).toContain("Endpoints the table does not cover");
+    expect(fb).toContain("follow the schema the research step returned");
   });
 
   it("echoes verify-before-flag where findings are generated", () => {
@@ -119,9 +124,13 @@ describe("load-bearing rules referenced from where they apply (#518)", () => {
     // for something the first source already settled.
     expect(checks).toContain("skills/ha-nova/template-guidelines.md");
     expect(checks).toContain("home-assistant.io/docs/automation/trigger/");
+    // Most of the catalog flags valid-but-risky config, so demanding schema
+    // invalidity would suppress even HIGH runtime hazards.
+    expect(checks).toContain("Flag it when the settling source confirms the CLAIM you are making");
     expect(checks).toContain(
-      "Flag it only when whichever source settled it says the config is invalid",
+      "configurations Home Assistant accepts happily and that still misbehave",
     );
+    expect(checks).toContain('"valid YAML" never clears them');
     expect(checks).toContain("Unresolved means unresolved");
   });
 
@@ -140,6 +149,10 @@ describe("load-bearing rules referenced from where they apply (#518)", () => {
     expect(flat(read("skills/diagnose/SKILL.md"))).toContain(
       "Substitute only an `entity_id`, domain, or integration slug",
     );
-    expect(flat(read("skills/diagnose/SKILL.md"))).toContain("A friendly name can contain");
+    expect(flat(read("skills/diagnose/SKILL.md"))).toContain("never a friendly name");
+    // entity_id is not literal either: the domain separator is a wildcard.
+    expect(flat(read("skills/diagnose/SKILL.md"))).toContain(
+      "the `.` in `sensor.kitchen` is a regex wildcard",
+    );
   });
 });

--- a/tests/skills/routing-contract.test.ts
+++ b/tests/skills/routing-contract.test.ts
@@ -1,6 +1,7 @@
 // tests/skills/routing-contract.test.ts
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "fs";
+import { parse as parseYaml } from "yaml";
+import { readFileSync, readdirSync } from "fs";
 import { resolve } from "path";
 
 const read = (p: string): string =>
@@ -189,5 +190,41 @@ describe("load-bearing rules referenced from where they apply (#518)", () => {
     expect(flat(read("skills/diagnose/SKILL.md"))).toContain(
       "the `.` in `sensor.kitchen` is a regex wildcard",
     );
+  });
+
+  // The suite's own frontmatter helper is a regex, which is more permissive
+  // than the YAML parser a client actually uses to discover skills. An
+  // unquoted "Assistant: setting" made assist unloadable while every
+  // description test still passed.
+  it("parses every skill frontmatter with a real YAML parser", () => {
+    const broken: string[] = [];
+    for (const file of readdirSync("skills")) {
+      const path = `skills/${file}/SKILL.md`;
+      let raw: string;
+      try {
+        raw = read(path);
+      } catch {
+        continue;
+      }
+      if (!raw.startsWith("---")) continue;
+      const frontmatter = raw.split("---")[1] ?? "";
+      try {
+        const parsed = parseYaml(frontmatter) as unknown;
+        if (typeof parsed !== "object" || parsed === null) {
+          broken.push(`${path}: frontmatter is not a mapping`);
+          continue;
+        }
+        const { name, description } = parsed as Record<string, unknown>;
+        if (typeof name !== "string" || typeof description !== "string") {
+          broken.push(`${path}: name/description missing or not a string`);
+        }
+      } catch (error) {
+        broken.push(`${path}: ${(error as Error).message.split("\n")[0]}`);
+      }
+    }
+    expect(
+      broken,
+      `these skills cannot be loaded by a YAML-parsing client:\n  ${broken.join("\n  ")}`,
+    ).toEqual([]);
   });
 });

--- a/tests/skills/routing-contract.test.ts
+++ b/tests/skills/routing-contract.test.ts
@@ -236,4 +236,16 @@ describe("load-bearing rules referenced from where they apply (#518)", () => {
     expect(maintenance).toContain("how long an entity has been unavailable");
     expect(maintenance).toContain("use ha-nova:health");
   });
+
+  it("keeps the log filter bound to the identifier, never OR-ed with a severity", () => {
+    const diagnose = flat(read("skills/diagnose/SKILL.md"));
+    // `id|ERROR` matches every error line in the log; each one then reads as
+    // evidence for an incident it has nothing to do with.
+    expect(diagnose).toContain("The identifier is the ONLY selector");
+    expect(diagnose).toContain("never OR a severity into it");
+    expect(diagnose).toContain("To narrow by severity, AND it");
+    expect(diagnose).not.toContain('test("<entity_or_integration>|ERROR"');
+    // Finding nothing is an answer, not a reason to loosen the filter.
+    expect(diagnose).toContain("rather than widening the filter until something appears");
+  });
 });

--- a/tests/skills/routing-contract.test.ts
+++ b/tests/skills/routing-contract.test.ts
@@ -151,8 +151,13 @@ describe("load-bearing rules referenced from where they apply (#518)", () => {
     expect(checks).toContain("Unresolved means unresolved");
     // Scene/dashboard/cross-item families have no doc page; their evidence is
     // the live data, or the gate silences them by construction.
-    expect(checks).toContain("the authoritative source is the live");
-    expect(checks).toContain("proven by that data, not by a doc page");
+    // Live data proves the observation; only a source proves the consequence.
+    expect(checks).toContain("EXISTENCE and JOIN facts");
+    expect(checks).toContain("The BEHAVIOURAL claim attached to them");
+    expect(checks).toContain(
+      "State the observation from the data and the consequence from the source",
+    );
+    expect(checks).toContain("If only the observation holds, report the observation");
   });
 
   it("names the payload shapes that were documented nowhere", () => {

--- a/tests/skills/routing-contract.test.ts
+++ b/tests/skills/routing-contract.test.ts
@@ -40,9 +40,11 @@ describe("description-level routing (#518)", () => {
   });
 
   it("excludes Alexa and Google from the assist description", () => {
-    expect(description("assist")).toContain(
-      "Not for Alexa or Google Assistant",
-    );
+    const d = description("assist");
+    expect(d).toContain("Not for Alexa or Google Assistant");
+    // Setup and failure are different intents with different owners; a
+    // blanket handoff would route an incident away from root-cause analysis.
+    expect(d).toContain("one that STOPPED working is a concrete failure for `ha-nova:diagnose`");
   });
 });
 
@@ -147,6 +149,10 @@ describe("load-bearing rules referenced from where they apply (#518)", () => {
     );
     expect(checks).toContain('"valid YAML" never clears them');
     expect(checks).toContain("Unresolved means unresolved");
+    // Scene/dashboard/cross-item families have no doc page; their evidence is
+    // the live data, or the gate silences them by construction.
+    expect(checks).toContain("the authoritative source is the live");
+    expect(checks).toContain("proven by that data, not by a doc page");
   });
 
   it("names the payload shapes that were documented nowhere", () => {

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -136,7 +136,9 @@ const WORD_BUDGETS: Record<string, number> = {
   // step, and the prerelease-toggle rule (measured 2217).
   hacs: 2250,
   // Cards adoption pointer (#389).
-  diagnose: 1500,
+  // Charset restriction on the value interpolated into the log-filter regex
+  // — a friendly name can break or widen it (#518, measured 1515).
+  diagnose: 1530,
   // Report-shape declaration line (shared output shapes); repair dedup,
   // attention-threshold definition, cause↔symptom linking (2026-h2 Wave 1c).
   // Table-first redesign: report modes, block shape, ten-block order,
@@ -164,7 +166,9 @@ const WORD_BUDGETS: Record<string, number> = {
   // Grouped-change-set opt-in + grouped-menu exception (#391).
   // Threshold-calibration hook incl. scene.apply coverage (#484 R10).
   // #452 draft rule on top of the branch ratchet (measured 2780).
-  "service-call": 2800,
+  // Description rewritten in the user's own control vocabulary (#518,
+  // measured 2811). #513 and #530 raise this further in the same train.
+  "service-call": 2830,
   // Carries the canonical File-Change Preview example — the only layout
   // source for file edits; concrete examples are what make a card renderable.
   // Sibling-survival verification (Wave 1b) + yaml snapshot capture with
@@ -177,7 +181,9 @@ const WORD_BUDGETS: Record<string, number> = {
   // safety-backup offer (Wave 0) + drift check before the full-document
   // save (Wave 1a) + pre-delete/pre-save snapshot capture (Wave 2).
   // Cards adoption pointer (#389).
-  dashboard: 1450,
+  // lovelace/config/save payload shape — the `config` key that carries the
+  // whole document was named nowhere (#518, measured 1454).
+  dashboard: 1470,
   // Cards adoption pointer (#389); pre-write update-state drift gate.
   // #452 canonical smallest-solution draft rule (17 words).
   // HA 2026.7 "Update all" semantics: guardrails mirrored, call shape
@@ -189,13 +195,18 @@ const WORD_BUDGETS: Record<string, number> = {
   // batch-safety alignment: batch code format + cap-split rule (#327);
   // purge quantification, glob expansion, apply_filter semantics
   // (2026-h2 Wave 1b).
-  maintenance: 1400,
+  // Reverse boundary against health, so the long-unavailable report reads as
+  // a cleanup qualifier rather than a status answer (#518, measured 1408).
+  maintenance: 1420,
   // blueprint payload examples; integration onboarding and runtime
   // events/webhooks moved to owning skills in Wave 4.
   // Custom-integration configuration APIs section + write-probing
   // asymmetry guardrails (#493), incl. the parameterless-WS-write
   // restriction (Codex P1).
-  fallback: 2750,
+  // Flow step 3c now names the endpoint-type table it depends on instead of
+  // leaving the file's load-bearing content unreferenced (#518, measured
+  // 2763).
+  fallback: 2790,
   // semantic-slot note on the read templates (Wave 0); pre-write cross-field
   // constraint checks + drift-check step (Wave 1); pre-delete snapshot
   // capture (Wave 2).

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -222,7 +222,12 @@ const WORD_BUDGETS: Record<string, number> = {
   // Suggestion Block item-shape pointer (shared output shapes); scene/
   // dashboard first-class targets with flow adaptation (2026-h2 Wave 3).
   // Quick-fix Preview Card reference (#389).
-  review: 4575,
+  // Codex round 2 (#518): the entrypoint carried its own copy of the
+  // verify-before-flag gate, which contradicted the corrected one in
+  // checks.md and could suppress accepted-but-dangerous findings; trace
+  // ANALYSIS moved to diagnose, leaving review with trace evidence only
+  // (measured 4650).
+  review: 4680,
   // #452 wires the canonical 17-word smallest-solution draft rule into every
   // write-flow skill; calendar and integration-setup sat within 17 words of
   // the default cap (review/todo/updates ratchets applied on their entries).

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -200,7 +200,9 @@ const WORD_BUDGETS: Record<string, number> = {
   // (2026-h2 Wave 1b).
   // Reverse boundary against health, so the long-unavailable report reads as
   // a cleanup qualifier rather than a status answer (#518, measured 1408).
-  maintenance: 1420,
+  // Codex round 6: the long-unavailable boundary has to be advertised on the
+  // receiving side too, or routing never reaches it (measured 1427).
+  maintenance: 1470,
   // blueprint payload examples; integration onboarding and runtime
   // events/webhooks moved to owning skills in Wave 4.
   // Custom-integration configuration APIs section + write-probing

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -214,7 +214,9 @@ const WORD_BUDGETS: Record<string, number> = {
   // leaving the file's load-bearing content unreferenced; Codex round 1
   // scoped that requirement to endpoints the table actually covers and named
   // the researched-schema path for the rest (#518, measured 2799).
-  fallback: 2830,
+  // Codex round 8: a config-entry flow answers from its own live response,
+  // never from the research schema (measured 2863).
+  fallback: 2920,
   // semantic-slot note on the read templates (Wave 0); pre-write cross-field
   // constraint checks + drift-check step (Wave 1); pre-delete snapshot
   // capture (Wave 2).

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -183,7 +183,9 @@ const WORD_BUDGETS: Record<string, number> = {
   // Cards adoption pointer (#389).
   // lovelace/config/save payload shape — the `config` key that carries the
   // whole document was named nowhere (#518, measured 1454).
-  dashboard: 1470,
+  // Codex round 1: the default dashboard is selected by OMITTING url_path;
+  // an explicit null is rejected (measured 1471).
+  dashboard: 1490,
   // Cards adoption pointer (#389); pre-write update-state drift gate.
   // #452 canonical smallest-solution draft rule (17 words).
   // HA 2026.7 "Update all" semantics: guardrails mirrored, call shape

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -227,7 +227,10 @@ const WORD_BUDGETS: Record<string, number> = {
   // checks.md and could suppress accepted-but-dangerous findings; trace
   // ANALYSIS moved to diagnose, leaving review with trace evidence only
   // (measured 4650).
-  review: 4680,
+  // Ceiling covers the COMBINED merge: #525, #513 and #518 all add to review
+  // and each measured itself in isolation. Trial-merging the train lands at
+  // 4758.
+  review: 4820,
   // #452 wires the canonical 17-word smallest-solution draft rule into every
   // write-flow skill; calendar and integration-setup sat within 17 words of
   // the default cap (review/todo/updates ratchets applied on their entries).

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -207,9 +207,10 @@ const WORD_BUDGETS: Record<string, number> = {
   // asymmetry guardrails (#493), incl. the parameterless-WS-write
   // restriction (Codex P1).
   // Flow step 3c now names the endpoint-type table it depends on instead of
-  // leaving the file's load-bearing content unreferenced (#518, measured
-  // 2763).
-  fallback: 2790,
+  // leaving the file's load-bearing content unreferenced; Codex round 1
+  // scoped that requirement to endpoints the table actually covers and named
+  // the researched-schema path for the rest (#518, measured 2799).
+  fallback: 2830,
   // semantic-slot note on the read templates (Wave 0); pre-write cross-field
   // constraint checks + drift-check step (Wave 1); pre-delete snapshot
   // capture (Wave 2).

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -136,9 +136,10 @@ const WORD_BUDGETS: Record<string, number> = {
   // step, and the prerelease-toggle rule (measured 2217).
   hacs: 2250,
   // Cards adoption pointer (#389).
-  // Charset restriction on the value interpolated into the log-filter regex
-  // — a friendly name can break or widen it (#518, measured 1515).
-  diagnose: 1530,
+  // Charset restriction on the value interpolated into the log-filter regex,
+  // plus the escaping rule Codex round 1 added: an entity_id is not literal
+  // either, since its domain separator is a regex wildcard (#518, 1536).
+  diagnose: 1560,
   // Report-shape declaration line (shared output shapes); repair dedup,
   // attention-threshold definition, cause↔symptom linking (2026-h2 Wave 1c).
   // Table-first redesign: report modes, block shape, ten-block order,

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -139,7 +139,9 @@ const WORD_BUDGETS: Record<string, number> = {
   // Charset restriction on the value interpolated into the log-filter regex,
   // plus the escaping rule Codex round 1 added: an entity_id is not literal
   // either, since its domain separator is a regex wildcard (#518, 1536).
-  diagnose: 1560,
+  // Codex round 7: the log filter OR-ed a severity into the identifier, so
+  // every unrelated error line read as evidence (measured 1611).
+  diagnose: 1660,
   // Report-shape declaration line (shared output shapes); repair dedup,
   // attention-threshold definition, cause↔symptom linking (2026-h2 Wave 1c).
   // Table-first redesign: report modes, block shape, ten-block order,


### PR DESCRIPTION
Closes #518 — the routing layer from the audit's agent-effectiveness charter (C6-01/02/07/12/13, C3-07/08/13/16/18, C6-08/14, C4-10).

## Why descriptions, not the dispatch table

In most clients the frontmatter `description` **is** the routing signal — the dispatch table only loads together with the context skill. Four of the highest-traffic descriptions were written in implementation vocabulary:

- **service-call** contained no device-control words at all. "Call a Home Assistant service" is not a sentence any user says; "mach das Wohnzimmerlicht an" routed on the model bridging that gap unaided, and "pause the vacuum" actively collided with media's `pause`. `README.md:248` already had the right wording ("Control lights, climate, covers, switches…") — the skill now uses it.
- **notify** carried only its own half of the one-off-vs-automation split the dispatch table relies on, so "notify me when the door opens" loaded notify, hit the Scope exclusion, and redirected to write — an extra hop on a top-frequency class.
- **helper** named zero helper types. "Helper" is HA jargon; users say Timer, Zähler, Schalter. The designed "create a timer" tie-break was unreachable without the dispatch table.
- **assist** did not exclude Alexa/Google, so "die Alexa-Integration spinnt" pulled assist ahead of diagnose.

## Boundaries with an actual owner

**Trace analysis had three pointers and no owner**: history said `read`, the dispatch table said `diagnose`, and `read` — which holds the mechanics — never claimed traces in its description. Diagnose owns analysis now; read keeps raw-trace-on-request and says so. **health** gained the two reverse boundaries it lacked (vs diagnose for "why did this one thing fail", vs maintenance for "how long has it been unavailable"), and maintenance says its long-unavailable report qualifies cleanup candidates rather than answering "is everything OK". **organize** names `ha-nova:admin` for zones/persons/tags instead of falling through to its generic fallback line.

## Rules that existed but nothing pointed at

- **fallback's Flow** now names the endpoint-type table in its execute step. The Write Routing Gate sends agents to fallback *because* it holds endpoint-specific write behavior — and the step that drafts the write never referenced it.
- **checks.md** echoes verify-before-flag. That gate lived once, mid-file, in the review skill; `checks.md` is loaded standalone by write, helper, and yaml-config, which never see it — and it is the primary false-positive guard for the product's flagship feature.
- **Payload shapes** for `config/auth/create` (the skill's own words: "the most dangerous writes in HA NOVA" — and its field set was named nowhere) and `lovelace/config/save` (the `config` key carrying the whole document was never named).
- **diagnose** restricts what may be interpolated into its log-filter regex: entity_id/domain/slug only, because a friendly name can contain `(`, `.`, or `|` and would break or silently widen the filter.

Dispatch examples added for the two rows that had none — including the hacs-vs-updates boundary, the subtlest in the corpus, which until now lived only inside the two skills. The sensor example no longer presumes MQTT transport.

## Verification

- `npx vitest run tests/skills` — **435 passed** (415 on main; 20 new pins in a new file, so this branch does not collide with #532/#533 in the shared suites)
- `tests/onboarding/safe-test-system-contract.test.ts` green after registering the file
- `bash scripts/check-docs.sh` green · `npm run typecheck` green before push
- Budgets: dashboard, diagnose, fallback, maintenance, service-call — each with its measurement. service-call's ceiling here is the description rewrite only; #532 and #533 raise it further in the same train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K333rh8GtsnFVAGL8Py3Ac