### PR TITLE
test(skills): strengthen contract pins

### DIFF
--- a/tests/skills/ha-nova-contract.test.ts
+++ b/tests/skills/ha-nova-contract.test.ts
@@ -1160,9 +1160,10 @@ describe("ha-nova contract", () => {
     const context = readFileSync("skills/ha-nova/SKILL.md", "utf8");
     const content = readFileSync("skills/ha-nova/session-bootstrap.md", "utf8");
     expect(context).toContain("../ha-nova/session-bootstrap.md");
-    expect(context.indexOf("## Session Bootstrap")).toBeLessThan(
-      context.indexOf("## Runtime Prerequisite"),
-    );
+    const bootstrapHeading = context.indexOf("## Session Bootstrap");
+    const prerequisiteHeading = context.indexOf("## Runtime Prerequisite");
+    expect(bootstrapHeading).toBeGreaterThan(-1);
+    expect(prerequisiteHeading).toBeGreaterThan(bootstrapHeading);
     expect(content).toContain("ha-nova check-update --quiet");
     expect(content).toContain(
       "before the first Home Assistant task in a session",

--- a/tests/skills/helper-contract.test.ts
+++ b/tests/skills/helper-contract.test.ts
@@ -112,7 +112,7 @@ describe("helper contract", () => {
     });
 
     it("documents full config-entry helper ownership for the 10 supported domains", () => {
-      for (const domain of [
+      const expectedDomains = [
         "utility_meter",
         "derivative",
         "integration",
@@ -123,10 +123,19 @@ describe("helper contract", () => {
         "group",
         "history_stats",
         "template",
-      ]) {
-        expect(skillDoc).toContain(domain);
-        expect(flowSchemasDoc).toContain(domain);
-      }
+      ];
+      expect(skillDoc).toContain(
+        `- \`${expectedDomains.join("\`, \`")}\``,
+      );
+      const domainListStart = flowSchemasDoc.indexOf("(10 domains):");
+      const domainListEnd = flowSchemasDoc.indexOf("This file is an observed");
+      expect(domainListStart).toBeGreaterThan(-1);
+      expect(domainListEnd).toBeGreaterThan(domainListStart);
+      expect(
+        [...flowSchemasDoc.slice(domainListStart, domainListEnd).matchAll(/^- `([^`]+)`$/gm)].map(
+          (match) => match[1],
+        ),
+      ).toEqual(expectedDomains);
 
       expect(skillDoc).toContain("CRUD support for 10 domains:");
       expect(skillDoc).toContain("verified for the `sensor` subtype");

--- a/tests/skills/helper-contract.test.ts
+++ b/tests/skills/helper-contract.test.ts
@@ -124,9 +124,13 @@ describe("helper contract", () => {
         "history_stats",
         "template",
       ];
-      expect(skillDoc).toContain(
-        `- \`${expectedDomains.join("\`, \`")}\``,
-      );
+      const skillDomainLine = skillDoc
+        .split("\n")
+        .find((line) => line.startsWith("  - `utility_meter`"));
+      expect(skillDomainLine).toBeDefined();
+      expect(
+        [...(skillDomainLine ?? "").matchAll(/`([^`]+)`/g)].map((match) => match[1]),
+      ).toEqual(expectedDomains);
       const domainListStart = flowSchemasDoc.indexOf("(10 domains):");
       const domainListEnd = flowSchemasDoc.indexOf("This file is an observed");
       expect(domainListStart).toBeGreaterThan(-1);

--- a/tests/skills/test-run-contract.test.ts
+++ b/tests/skills/test-run-contract.test.ts
@@ -93,14 +93,15 @@ describe("post-write test-offer contract", () => {
     expect(testRun).toContain("POST /api/events/<event_type>");
     expect(testRun).toContain("`ha-nova:mqtt`");
     // Time-based triggers cannot be faked; never bend the clock or the config.
-    expect(testRun).toContain("cannot be");
+    expect(testRun).toContain("the real path cannot be\n  faked honestly");
     expect(testRun).toContain("Never change the system");
     expect(testRun).toContain("clock or temporarily edit the trigger");
     // Blast radius: fired states/events reach every listener. Live-verified:
     // search/related does NOT index event listeners — events need a config scan.
     expect(testRun).toContain("reaches every listener");
-    expect(testRun).toContain("search/related");
-    expect(testRun).toContain("does not index\nlisteners");
+    expect(testRun).toContain(
+      "for fired events `search/related` does not index\nlisteners",
+    );
   });
 
   it("runs the consented post-run follow-up: trace, state verify, restore", () => {


### PR DESCRIPTION
## Summary

- fail when required headings disappear instead of comparing -1 offsets
- pin complete time-trigger and event-listener guidance
- compare the exact ten-domain helper lists

Partial fix for #542 (items 8 and 10, excluding the stacked routing pins).

## Verification

- npx vitest run tests/skills/ha-nova-contract.test.ts tests/skills/test-run-contract.test.ts tests/skills/helper-contract.test.ts (74 passed)
- npm run typecheck
- mutation probes for every repaired guard class