### PR TITLE
test(skills): pin routing description words

### DIFF
--- a/tests/skills/routing-contract.test.ts
+++ b/tests/skills/routing-contract.test.ts
@@ -22,14 +22,15 @@ describe("description-level routing (#518)", () => {
   // speak.
   it("gives service-call the words users say for device control", () => {
     const d = description("service-call");
-    for (const word of ["turn", "lights", "covers", "climate", "on, off"]) {
+    expect(d).toMatch(/\bturn lights\b/);
+    for (const word of ["covers", "climate", "on, off"]) {
       expect(d, `service-call description missing "${word}"`).toContain(word);
     }
   });
 
   it("puts the one-off vs automation split into the notify description", () => {
     const d = description("notify");
-    expect(d).toContain("NOW");
+    expect(d).toContain("notification NOW —");
     expect(d).toContain('For "notify me WHEN something happens" use ha-nova:write');
   });
 


### PR DESCRIPTION
## Summary

- require turn as a real word instead of accepting return
- bind NOW to the notification routing phrase instead of accepting KNOWN

Completes the remaining routing assertions from #542 item 10. Stacked on #543 so its diff stays one test file.

## Verification

- npx vitest run tests/skills/routing-contract.test.ts (19 passed)
- npm run typecheck
- mutation probes for return lights and notification KNOWN