### PR TITLE
test(skills): restore word-budget ratchets

### DIFF
--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -399,6 +399,40 @@ const FOLDED_INTO_BUDGET: Record<string, string[]> = {
   write: ["../ha-nova/one-shot-automations.md"],
 };
 
+// Secondary Markdown that is a standalone reference, not prose split out of
+// one owning SKILL.md. The classification is exhaustive so a new unregistered
+// file cannot silently reset a word budget.
+const STANDALONE_MARKDOWN = new Set([
+  "skills/energy/energy-reference.md",
+  "skills/ha-nova/agents/apply-agent.md",
+  "skills/ha-nova/agents/resolve-agent.md",
+  "skills/ha-nova/automation-patterns.md",
+  "skills/ha-nova/batch-safety.md",
+  "skills/ha-nova/best-practices.md",
+  "skills/ha-nova/bulk-patterns.md",
+  "skills/ha-nova/config-snapshots.md",
+  "skills/ha-nova/consumer-discovery-preflight.md",
+  "skills/ha-nova/grouped-change-set.md",
+  "skills/ha-nova/helper-flow-schemas.md",
+  "skills/ha-nova/helper-schemas.md",
+  "skills/ha-nova/input-capability-preflight.md",
+  "skills/ha-nova/output-rules.md",
+  "skills/ha-nova/payload-schemas.md",
+  "skills/ha-nova/relay-api.md",
+  "skills/ha-nova/safe-refactoring.md",
+  "skills/ha-nova/session-bootstrap.md",
+  "skills/ha-nova/smallest-solution.md",
+  "skills/ha-nova/template-guidelines.md",
+  "skills/ha-nova/test-run.md",
+  "skills/ha-nova/threshold-calibration.md",
+  "skills/ha-nova/update-revert.md",
+  "skills/ha-nova/write-safety.md",
+  "skills/hacs/hacs-commands.md",
+  "skills/health/availability-analysis.md",
+  "skills/maintenance/maintenance-reference.md",
+  "skills/review/checks.md",
+].map((file) => resolve(file)));
+
 // Internal review-check codes (S-01, R-18, H-09, ...) may flow only between
 // the reviewer/mutation files that implement the dedup logic; user-flow
 // skills must never carry them (output-rules.md forbids surfacing them).
@@ -702,6 +736,15 @@ describe("skill template v2 contract", () => {
       "service-call": ["domain-fields.md", "../ha-nova/indirect-actuation.md"],
       write: ["../ha-nova/one-shot-automations.md"],
     });
+    const folded = Object.entries(FOLDED_INTO_BUDGET).flatMap(([name, files]) => {
+      const dir = dirname(subskillPath(name));
+      return files.map((file) => resolve(dir, file));
+    });
+    const secondaryMarkdown = ALL_SKILL_MD_FILES
+      .filter((file) => basename(file) !== "SKILL.md")
+      .map((file) => resolve(file))
+      .sort();
+    expect([...folded, ...STANDALONE_MARKDOWN].sort()).toEqual(secondaryMarkdown);
   });
 
   it("keeps every sub-skill within its word budget", () => {

--- a/tests/skills/skill-template-contract.test.ts
+++ b/tests/skills/skill-template-contract.test.ts
@@ -113,7 +113,7 @@ const SAFETY_CORE_BLOCKS = ((): { mutation: string; readOnly: string } => {
 const WORD_BUDGETS: Record<string, number> = {
   // Platform-specific payloads plus presence-based household routing in the
   // combined audit train (measured 1382 before the bounded-wait removal).
-  notify: 1800,
+  notify: 1430,
   // State-snapshot queries ("is everything closed?") and the alias fallback
   // that finally reaches the names a household actually says (#527, 1318).
   // Codex round 3: a motorized window or garage door is a cover, so an
@@ -155,7 +155,9 @@ const WORD_BUDGETS: Record<string, number> = {
   // setters (Codex round 6). Merge-train combination with the #483 receipt
   // lines and the #452 draft rule (measured 2182).
   // One-shot intent routing to the self-disabling pattern (#527, 2221).
-  write: 2600,
+  // Includes one-shot-automations.md after the audit exposed that the split
+  // had reset this ratchet (measured 5356 on #543).
+  write: 5380,
   // HACS lifecycle: schema guard, reconcile loops, consumer discovery,
   // migration backup gate, category-appropriate verification (#478);
   // review rounds added pin-durability branches, the uninstall apply
@@ -253,7 +255,9 @@ const WORD_BUDGETS: Record<string, number> = {
   // merge. Measured 3963 at the time of writing.
   // Audit train: the ceiling is the MAX of both branches — each
   // measured only its own tree.
-  "service-call": 5200,  // folded with domain-fields.md: measured 5109
+  // Includes domain-fields.md and indirect-actuation.md; both are contracts
+  // split out of this skill (measured 8777 on #543).
+  "service-call": 8800,
   // Carries the canonical File-Change Preview example — the only layout
   // source for file edits; concrete examples are what make a card renderable.
   // Sibling-survival verification (Wave 1b) + yaml snapshot capture with
@@ -312,7 +316,6 @@ const WORD_BUDGETS: Record<string, number> = {
   // the researched-schema path for the rest (#518, measured 2799).
   // Codex round 8: a config-entry flow answers from its own live response,
   // never from the research schema (measured 2863).
-  fallback: 6000,
   // Capability-map completion (#516): the map is fallback's routing index, so
   // a missing row means Flow step 1 finds nothing and the agent improvises.
   // Added integration entry lifecycle (with its own Relay-Ready mechanics —
@@ -343,6 +346,8 @@ const WORD_BUDGETS: Record<string, number> = {
   // does not reopen this file. Measured 4413.
   // Audit train: the ceiling is the MAX of both branches — each
   // measured only its own tree.
+  // Includes relay-ready.md; measured 4938 on #543.
+  fallback: 5000,
   // semantic-slot note on the read templates (Wave 0); pre-write cross-field
   // constraint checks + drift-check step (Wave 1); pre-delete snapshot
   // capture (Wave 2).
@@ -390,7 +395,8 @@ const FOLDED_INTO_BUDGET: Record<string, string[]> = {
   // it unfolded did exactly what the comment above warns about: the ceiling
   // measured 4252 while the skill really costs 5109, and the next split would
   // have reset it again.
-  "service-call": ["domain-fields.md"],
+  "service-call": ["domain-fields.md", "../ha-nova/indirect-actuation.md"],
+  write: ["../ha-nova/one-shot-automations.md"],
 };
 
 // Internal review-check codes (S-01, R-18, H-09, ...) may flow only between
@@ -688,6 +694,14 @@ describe("skill template v2 contract", () => {
         ).toBe(false);
       }
     }
+  });
+
+  it("keeps split contracts folded into their owning skill budgets", () => {
+    expect(FOLDED_INTO_BUDGET).toEqual({
+      fallback: ["relay-ready.md"],
+      "service-call": ["domain-fields.md", "../ha-nova/indirect-actuation.md"],
+      write: ["../ha-nova/one-shot-automations.md"],
+    });
   });
 
   it("keeps every sub-skill within its word budget", () => {


### PR DESCRIPTION
## Summary

- tighten fallback and notify budgets to current measurements
- fold indirect-actuation into service-call and one-shot automations into write
- pin the complete fold map so moving prose cannot silently reset the ratchet
- restore the fallback budget rationale next to its actual entry

Fixes #542 items 12-14. Stacked on #543 for exact final word counts.

## Verification

- npx vitest run tests/skills/skill-template-contract.test.ts (19 passed)
- npm run typecheck
- mutation probe: removing the indirect-actuation fold fails the suite