### PR TITLE
ci: allow one-time README gate hint correction

### DIFF
--- a/scripts/release/verify-cloud-workflow-uses-only.mjs
+++ b/scripts/release/verify-cloud-workflow-uses-only.mjs
@@ -12,6 +12,9 @@ const policy = JSON.parse(
 );
 const sensitive = new Set(policy.cloud_source_gate?.sensitive_workflows ?? []);
 const resolvedTags = new Map();
+const readmeReleaseGatePath = ".github/workflows/readme-release-gate.yml";
+const versionedReleaseBodyPath = "docs/work/<version>-release-body.md";
+const activeReleaseBodyPath = "docs/work/next-release-body.md";
 
 function fail(message) {
   console.error(`[verify-cloud-workflow-uses-only] ERROR: ${message}`);
@@ -86,6 +89,21 @@ function compareVersions(left, right) {
     }
   }
   return 0;
+}
+
+function isOneTimeReadmeReleaseHintRewrite(path, baseRef, targetRef) {
+  if (path !== readmeReleaseGatePath) {
+    return false;
+  }
+  const before = git(["show", `${baseRef}:${path}`]);
+  const after = git(["show", `${targetRef}:${path}`]);
+  if (before.split(versionedReleaseBodyPath).length - 1 !== 2) {
+    return false;
+  }
+  return (
+    after ===
+    before.split(versionedReleaseBodyPath).join(activeReleaseBodyPath)
+  );
 }
 
 function ghJSON(endpoint) {
@@ -222,6 +240,9 @@ if (
 ) {
   fail("enabled Cloud source may not add, delete, or rename workflows");
 }
+const changedWorkflowCount = [...base].filter(
+  ([path, entry]) => target.get(path).blob !== entry.blob,
+).length;
 
 let changed = 0;
 for (const [path, baseEntry] of base) {
@@ -235,6 +256,12 @@ for (const [path, baseEntry] of base) {
   changed += 1;
   if (sensitive.has(path)) {
     fail(`${path} is Cloud-release-sensitive`);
+  }
+  if (isOneTimeReadmeReleaseHintRewrite(path, baseCommit, targetCommit)) {
+    if (changedWorkflowCount !== 1) {
+      fail(`${path} one-time hint rewrite must be the sole workflow delta`);
+    }
+    continue;
   }
   verifyUsesOnly(path, baseCommit, targetCommit);
 }

--- a/tests/onboarding/cloud-release-gate-behavior.ts
+++ b/tests/onboarding/cloud-release-gate-behavior.ts
@@ -8,6 +8,7 @@ import {
   validCloudEvidence,
 } from "./cloud-release-gate-fixture.js";
 import { registerCloudReleaseCommitGateBehaviorTests } from "./cloud-release-commit-gate-behavior.js";
+import "./cloud-workflow-maintenance-handoff-behavior.js";
 export function registerCloudReleaseGateBehaviorTests(): void {
   describe("Home Assistant Cloud release gate behavior", () => {
     it("allows a disabled release without external evidence", () => {

--- a/tests/onboarding/cloud-workflow-maintenance-handoff-behavior.ts
+++ b/tests/onboarding/cloud-workflow-maintenance-handoff-behavior.ts
@@ -1,0 +1,156 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const workflowPath = ".github/workflows/readme-release-gate.yml";
+const otherWorkflowPath = ".github/workflows/other.yml";
+const beforePath = "docs/work/<version>-release-body.md";
+const afterPath = "docs/work/next-release-body.md";
+const actionBefore = "1111111111111111111111111111111111111111";
+const actionAfter = "2222222222222222222222222222222222222222";
+const workflow = [
+  `# Claims collect in ${beforePath}.`,
+  "steps:",
+  `  - run: echo 'Move the claim to ${beforePath}.'`,
+  "",
+].join("\n");
+
+function fixture(sensitive = false) {
+  const root = mkdtempSync(join(tmpdir(), "ha-nova-workflow-handoff-"));
+  const script = join(
+    root,
+    "scripts",
+    "release",
+    "verify-cloud-workflow-uses-only.mjs",
+  );
+  mkdirSync(join(root, "scripts", "release"), { recursive: true });
+  mkdirSync(join(root, ".github", "policy"), { recursive: true });
+  mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+  copyFileSync("scripts/release/verify-cloud-workflow-uses-only.mjs", script);
+  writeFileSync(join(root, workflowPath), workflow, "utf8");
+  writeFileSync(join(root, otherWorkflowPath), workflow, "utf8");
+  writeFileSync(
+    join(root, ".github", "workflows", "maintenance.yml"),
+    `steps:\n  - uses: example/action@${actionBefore} # v1.2.3\n`,
+    "utf8",
+  );
+  writeFileSync(
+    join(root, ".github", "policy", "repo-policy.json"),
+    JSON.stringify({
+      cloud_source_gate: {
+        sensitive_workflows: sensitive ? [workflowPath] : [],
+      },
+    }),
+    "utf8",
+  );
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: root,
+  });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: root });
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["commit", "-qm", "base"], { cwd: root });
+  const base = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
+  const fakeBin = mkdtempSync(join(tmpdir(), "ha-nova-workflow-handoff-gh-"));
+  const gh = join(fakeBin, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+case "$*" in
+  *git/ref/tags/v1.2.3*) printf '%s\\n' '{"object":{"type":"commit","sha":"${actionBefore}"}}' ;;
+  *git/ref/tags/v1.2.4*) printf '%s\\n' '{"object":{"type":"commit","sha":"${actionAfter}"}}' ;;
+  *) exit 1 ;;
+esac
+`,
+    "utf8",
+  );
+  chmodSync(gh, 0o755);
+  return {
+    root,
+    script,
+    base,
+    env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH ?? ""}` },
+  };
+}
+
+function verify(
+  mutation: (root: string) => void,
+  sensitive = false,
+): ReturnType<typeof spawnSync> {
+  const { root, script, base, env } = fixture(sensitive);
+  mutation(root);
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["commit", "-qm", "target"], { cwd: root });
+  const target = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
+  return spawnSync(
+    process.execPath,
+    [script, root, base, target, "workflow-tree-only"],
+    { cwd: root, encoding: "utf8", env },
+  );
+}
+
+function rewrite(root: string, path: string, body: string): void {
+  writeFileSync(join(root, path), body, "utf8");
+}
+
+describe("one-time README workflow maintenance handoff", () => {
+  it("accepts only the complete two-token rewrite", () => {
+    const result = verify((root) => {
+      rewrite(root, workflowPath, workflow.replaceAll(beforePath, afterPath));
+    });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
+  it.each([
+    ["partial", workflow.replace(beforePath, afterPath)],
+    ["extra", `${workflow.replaceAll(beforePath, afterPath)}# extra\n`],
+    ["different", workflow.replaceAll(beforePath, "docs/work/future.md")],
+  ])("rejects a %s rewrite", (_name, changed) => {
+    const result = verify((root) => rewrite(root, workflowPath, changed));
+    expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+  });
+
+  it("rejects the same rewrite in another workflow", () => {
+    const result = verify((root) => {
+      rewrite(root, otherWorkflowPath, workflow.replaceAll(beforePath, afterPath));
+    });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+  });
+
+  it("rejects an otherwise valid sibling uses bump", () => {
+    const result = verify((root) => {
+      rewrite(root, workflowPath, workflow.replaceAll(beforePath, afterPath));
+      rewrite(
+        root,
+        ".github/workflows/maintenance.yml",
+        `steps:\n  - uses: example/action@${actionAfter} # v1.2.4\n`,
+      );
+    });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+    expect(result.stderr).toContain("must be the sole workflow delta");
+  });
+
+  it("does not override the sensitive-workflow denylist", () => {
+    const result = verify((root) => {
+      rewrite(root, workflowPath, workflow.replaceAll(beforePath, afterPath));
+    }, true);
+    expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+    expect(result.stderr).toContain("is Cloud-release-sensitive");
+  });
+});


### PR DESCRIPTION
## Spec

Permit exactly one maintenance handoff needed to correct the frozen README release-gate hint:

- only `.github/workflows/readme-release-gate.yml`
- exactly the two existing `docs/work/<version>-release-body.md` tokens
- exact replacement with `docs/work/next-release-body.md`
- no other content or workflow delta
- never bypass the Cloud-sensitive-workflow denylist

The follow-up PR performs the two-token rewrite and removes this exception and its focused tests in the same reviewed change.

## Verification

- `npx vitest run tests/onboarding/release-gates-behavior.test.ts` — 207 passed
- focused handoff mutation suite — 7 passed
- `npx vitest run tests/onboarding/safe-test-system-contract.test.ts` — 7 passed
- `npm run typecheck`
- `git diff --check`
- local Codex review — clean
- two-lens adversarial batch — one shared real finding fixed: the rewrite must be the sole workflow delta

## Risk

Release-workflow policy change. The exception is intentionally single-use, exact-blob constrained, and removed by the immediate follow-up PR. Home Assistant Cloud evidence for the exact synthetic merge tree will be attached before merge.

Refs #542
