### PR TITLE
release: prepare v0.24.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "ha-nova",
   "metadata": {
     "description": "HA NOVA plugins for safe Home Assistant control through a local relay",
-    "version": "0.23.0"
+    "version": "0.24.0"
   },
   "owner": {
     "name": "Markus Leben"
@@ -11,7 +11,7 @@
     {
       "name": "ha-nova",
       "source": "./",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "description": "AI-powered Home Assistant control through LLM skills and a local relay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "AI-powered Home Assistant control through LLM skills and a local relay",
   "author": {
     "name": "Markus Leben"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,22 +71,17 @@ release:
     Windows uses a single supported install path: `install.ps1`. Return an RC install to stable later with `ha-nova update`.
     {{ else }}## What To Watch
 
-    - **Home Status output changed deliberately.** Reports are table-first with visible detail/privacy modes; the default names affected entities and integrations. Say "aggregate" for count-only output.
-    - **Update NOVA Relay first.** Update the App — or pull the new standalone relay container image on Container/Core installs — before using the new client, and take a backup first, as always.
+    - **Indirect access changes now use the strict gate.** Scenes, scripts, automations, groups, and timer-driven flows that can ultimately unlock, open, or disarm list the affected member and require typed confirmation.
 
     ## New Features
 
-    - **Manage HACS from chat.** Browse, install, update, pin, and remove custom integrations and frontend packages — with safety previews, honest restart reporting, and a mandatory backup before store migrations.
-    - **Add another Home Assistant server.** The completed-setup screen now offers a wizard that discovers additional servers and pairs them as named profiles — switch anytime with `--server <name>`.
-    - **Revoking a device now asks first.** Revoking a paired device shows exactly which computer you are disconnecting — name, added, last used, cloud badge. Registry reset requires typing RESET.
-    - **Home Status you can act on.** Table-first, cause-oriented reports name exact integrations and entities; large groups stay summarized with precise follow-ups; detail and privacy modes are yours.
-    - **Thresholds calibrated against your real history.** Changing a threshold, debounce, or timeout on a physical process reads up to 30 days of history and shows ranges and both failure directions first.
-    - **Checkpoints tell you what they did.** Every checkpoint save prints a receipt — created or replaced, for which item, when — and the list shows names, saved times, and what one `revert` covers.
-    - **The smallest solution that completely works.** Every skill designs the simplest safe configuration that fully covers your request and offers at most two evidence-backed improvements.
+    - **Temporary automations now clean up after themselves.** One-shot reminders disable themselves, while duration-bound actions restore the previous state and recover safely across Home Assistant restarts.
+    - **Entity discovery understands the way a household talks.** Searches now use aliases, rooms, labels, spelling variants, and honest state snapshots without treating unavailable sensors as proof that everything is fine.
 
     ## Bug Fixes
 
-    - **Write previews fail closed.** A failed consumer scan reads "consumer check inconclusive" instead of claiming nothing is affected; unfamiliar write endpoints are never probed in ways that create objects.
+    - **Service calls respect the target's real capabilities.** Lights, climate devices, covers, fans, vacuums, and sirens use fields and values reported by Home Assistant instead of guessed payloads.
+    - **Routing and previews fail closed more consistently.** Downstream consumers, template entities, timer event families, group changes, and concurrent state changes can no longer silently lower the required confirmation.
 
     Stable install commands are release-pinned for this tag.
 

--- a/docs/archive/work/0.24.0-release-body.md
+++ b/docs/archive/work/0.24.0-release-body.md
@@ -1,0 +1,27 @@
+# 0.24.0 Release Body
+
+Status: active
+
+## What To Watch
+
+- **Indirect access changes now use the strict gate.** Scenes, scripts,
+  automations, groups, and timer-driven flows that can ultimately unlock, open,
+  or disarm list the affected member and require typed confirmation.
+
+## New Features
+
+- **Temporary automations now clean up after themselves.** One-shot reminders
+  disable themselves, while duration-bound actions restore the previous state
+  and recover safely across Home Assistant restarts.
+- **Entity discovery understands the way a household talks.** Searches now use
+  aliases, rooms, labels, spelling variants, and honest state snapshots without
+  treating unavailable sensors as proof that everything is fine.
+
+## Bug Fixes
+
+- **Service calls respect the target's real capabilities.** Lights, climate
+  devices, covers, fans, vacuums, and sirens use fields and values reported by
+  Home Assistant instead of guessed payloads.
+- **Routing and previews fail closed more consistently.** Downstream consumers,
+  template entities, timer event families, group changes, and concurrent state
+  changes can no longer silently lower the required confirmation.

--- a/docs/work/upstream-drift-log.md
+++ b/docs/work/upstream-drift-log.md
@@ -107,3 +107,18 @@ stopped.
 - Next window starts AFTER HA 2026.8 + HACS 2.0.5; watch items: device
   registry compat shims harden 2027.8; device-tracker deprecations land
   2027.7; `unit_class` omission breaks 2026.11.
+
+## 2026-08-12 — HA 2026.8.1 patch + developer blog + HACS
+
+- Window screened: Home Assistant Core 2026.8.1, developer-blog posts after
+  the 2026-08-09 screening, and HACS releases after 2.0.5.
+- CLEAN — Core 2026.8.1 changes no pinned WS response or request shape. The
+  REST service-call fix in core PR #178377 retains the shielded task to prevent
+  mid-run garbage collection; it does not change the `/api/services/*` contract.
+- CLEAN — no new developer-blog post after the July 22 entry and no HACS
+  release after 2.0.5.
+- Existing HIT remains tracked: `media_source/search_media` is issue #519.
+- Sources: github.com/home-assistant/core/releases/tag/2026.8.1;
+  github.com/home-assistant/core/pull/178377;
+  developers.home-assistant.io/blog/; github.com/hacs/integration/releases.
+- Next window starts AFTER HA 2026.8.1 + HACS 2.0.5.

--- a/nova/version.json
+++ b/nova/version.json
@@ -1,5 +1,5 @@
 {
-  "skill_version": "0.23.0",
+  "skill_version": "0.24.0",
   "min_relay_version": "0.9.0",
   "cloud_remote_enabled": true,
   "cloud_remote_platforms": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-nova",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-nova",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-nova",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "AI-powered Home Assistant management through LLM coding agents",
   "private": true,
   "type": "module",

--- a/tests/onboarding/release-notes-contract.test.ts
+++ b/tests/onboarding/release-notes-contract.test.ts
@@ -37,15 +37,21 @@ describe("release notes contract", () => {
     expect(goreleaser).not.toContain("winget");
   });
 
-  it("keeps v0.23.0 release-facing wording aligned to the shipped stack", () => {
-    expect(goreleaser).toContain("Home Status output changed deliberately");
-    expect(goreleaser).toContain("Update NOVA Relay first");
-    expect(goreleaser).toContain("Revoking a device now asks first");
-    expect(goreleaser).toContain("typing RESET");
-    expect(goreleaser).toContain("Thresholds calibrated against your real history");
-    expect(goreleaser).toContain("Checkpoints tell you what they did");
-    expect(goreleaser).toContain("smallest solution that completely works");
-    expect(goreleaser).toContain("consumer check inconclusive");
+  it("keeps v0.24.0 release-facing wording aligned to the shipped stack", () => {
+    expect(goreleaser).toContain(
+      "Indirect access changes now use the strict gate",
+    );
+    expect(goreleaser).toContain("require typed confirmation");
+    expect(goreleaser).toContain("Temporary automations now clean up");
+    expect(goreleaser).toContain(
+      "recover safely across Home Assistant restarts",
+    );
+    expect(goreleaser).toContain("Entity discovery understands");
+    expect(goreleaser).toContain("unavailable sensors");
+    expect(goreleaser).toContain(
+      "Service calls respect the target's real capabilities",
+    );
+    expect(goreleaser).toContain("Routing and previews fail closed");
     expect(readme).toContain(
       "Optional remote access with Home Assistant Cloud (Beta)",
     );

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "skill_version": "0.23.0",
+  "skill_version": "0.24.0",
   "min_relay_version": "0.9.0",
   "cloud_remote_enabled": true,
   "cloud_remote_platforms": [


### PR DESCRIPTION
## Spec

Publish the merged skill-audit train as the next minor release, v0.24.0. This PR changes only release metadata, curated release notes, their contract test, and the required upstream-drift log.

No Relay runtime, installer, update flow, workflow, README, or dependency changes. The shipped delta since v0.23.0 is skills/docs/tests, so the documented conditional rehearsal rule permits a direct final tag without an RC.

## Manifest review

- `package.json`: root version only, `0.23.0` -> `0.24.0`; no dependency changes.
- `package-lock.json`: root package/version metadata only, `0.23.0` -> `0.24.0`; no resolved package changes.
- `.claude-plugin/plugin.json`: plugin version only, `0.23.0` -> `0.24.0`.
- `.claude-plugin/marketplace.json`: marketplace/plugin versions only, `0.23.0` -> `0.24.0`; local `source: "./"` unchanged.
- `nova/version.json` and `version.json`: skill version only, `0.23.0` -> `0.24.0`; Relay minimum and Cloud metadata unchanged.

## Release notes

- strict typed confirmation for indirect access-changing flows
- restart-safe one-shot and duration-bound automations
- alias/area/label-aware entity discovery with honest unavailable-state reporting
- capability-aware service fields
- fail-closed routing and preview fixes

## Verification

- `npm run verify` — 121 core files / 1105 tests; 16 onboarding files / 126 tests; 14 release files / 433 tests
- targeted release contracts — 44 passed
- `npm run typecheck`
- `bash scripts/check-docs.sh`
- `npm run verify:release-metadata`
- `npm run verify:next-release-version -- v0.24.0`
- local Codex review — clean
- upstream drift screened through HA 2026.8.1 and HACS 2.0.5

## Release preflight

Open Dependabot PRs #508-#512 are separate-later, not release blockers. PR #552 / issue #542 is a non-release-blocking workflow-message correction and remains separate.

Exact Cloud candidate provenance, installed-App proof, and evidence ledger will be added for this PR's synthetic merge tree before merge.
