### PR TITLE
docs: the evidence secret lives in two places

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -259,7 +259,23 @@ The broker and both release workflows require
 normal CI job reads the repository secret only for direct `main` pushes; pull
 requests and merge groups are covered by the trusted broker, so Dependabot
 never needs a repository secret. Disabled metadata exits before reading the
-value. All paths run:
+value.
+
+Because the value lives in those two places, set BOTH — otherwise the pull
+request goes green and `main` fails `ci-gate` seconds after the squash merge,
+with the stale-evidence message, which reads like a tree mismatch and sends
+you looking in the wrong place (observed on #559):
+
+```bash
+gh secret set HA_NOVA_CLOUD_GATE_EVIDENCE_JSON -R markusleben/ha-nova --body "$(cat envelope.json)"
+gh secret set HA_NOVA_CLOUD_GATE_EVIDENCE_JSON --env production -R markusleben/ha-nova --body "$(cat envelope.json)"
+gh secret list -R markusleben/ha-nova | grep EVIDENCE
+gh api repos/markusleben/ha-nova/environments/production/secrets --jq '.secrets[] | select(.name|startswith("HA_NOVA_CLOUD_GATE")) | .updated_at'
+```
+
+Both timestamps must be from the current session.
+
+All paths run:
 
 ```bash
 bash scripts/release/verify-cloud-release-gate.sh

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -275,6 +275,17 @@ gh api repos/markusleben/ha-nova/environments/production/secrets --jq '.secrets[
 
 Both timestamps must be from the current session.
 
+Then, right after the squash merge, rewrite `commit_sha` and
+`relay_app.source_commit` to the resulting `main` commit and store the
+envelope again in both places. The tree is unchanged, so this attests
+exactly the same content — but the name has to survive. A pull request's
+synthetic merge commit is thrown away at merge time and is an ancestor of
+nothing afterwards, and BOTH stale-evidence escapes require the evidence
+commit to be an ancestor of their target. Leave the envelope pointing at
+the merge commit and every later pull request fails the gate with the
+stale-evidence message, even a docs-only one that the escape should carry
+(observed on #560, the first pull request after the escape landed).
+
 All paths run:
 
 ```bash


### PR DESCRIPTION
One paragraph in the release runbook: `HA_NOVA_CLOUD_GATE_EVIDENCE_JSON` exists as a repository secret AND in the `production` environment. Setting only one lets the pull request go green and drops `main` into a red `ci-gate` seconds after the squash merge — with the stale-evidence message, which reads like a tree mismatch. Observed on #559 tonight.

A 234-line helper was drafted to automate the whole envelope flow and is deliberately dropped instead of shipped: its first adversarial review found four HIGH issues, including that it bound the newest candidate-bundle run rather than this PR's merge commit, and that it hard-coded qualification booleans nobody had verified. Automating an attestation is the wrong shape — the knowledge is worth six lines of runbook, the machine to apply it is not.

**Also the first pull request to ride the new non-sensitive source escape:** docs-only delta, so `cloud-source-gate` should pass on the carried envelope with no maintainer session at all. That is the whole point of #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrTBG6YEqXqWXAiLwm2e1B