### PR TITLE
ci: guard the relay image workflow, document the wrangler login prerequisite

### DIFF
--- a/.github/policy/repo-policy.json
+++ b/.github/policy/repo-policy.json
@@ -9,7 +9,8 @@
     ".github/workflows/dependabot-safe-lane-prepare.yml",
     ".github/workflows/dependabot-safe-auto-merge.yml",
     ".github/workflows/release.yml",
-    ".github/workflows/release-candidate.yml"
+    ".github/workflows/release-candidate.yml",
+    ".github/workflows/relay-image.yml"
   ],
   "manifest_review": {
     "label": "manifest-review:approved",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -844,6 +844,14 @@ release changes the census Worker.
    service-token policy, plus `ACCESS_TEAM_DOMAIN`/`ACCESS_AUD` secrets set
    via `wrangler secret put … --env test` (secrets are per-worker; without
    them the fail-closed Worker answers 403).
+
+   Machine prerequisite, easy to miss on a fresh setup: the deploy scripts set
+   `CLOUDFLARE_ACCOUNT_ID` but never `CLOUDFLARE_API_TOKEN`. Unless the shell
+   already exports that token (it takes precedence), Wrangler falls back to its
+   own stored OAuth session — so on a machine that has never run it, do
+   `npx wrangler@4.113.0 login` first. Without either, the run fails early at
+   the `secret list` step rather than at the deploy, which makes the cause look
+   unrelated. Confirm with `npx wrangler@4.113.0 whoami` before starting.
 6. Only after the rehearsal and every applicable external gate are clean — or
    the RC was skipped per the conditional gate above (skills/docs-only delta) —
    cut the final tag (see "Final Publish"). A skipped RC never skips the


### PR DESCRIPTION
Two gaps found while auditing the deploy flow end to end for the improvement plan. Both are one-liners; both were invisible until something broke at release time.

## 1. `relay-image.yml` was not guarded

It publishes the Relay container to GHCR, and `docs/releasing.md` makes `verify-relay-image.sh` a **hard pre-RC blocker**. But the workflow was missing from `guarded_workflows` in `.github/policy/repo-policy.json`, so `verify-required-workflows-active.sh` never checked it was still enabled. A disabled publish workflow would have shown up as an unexplained release-day failure — the exact failure mode the guarded list exists to prevent (see AGENTS.md on disabled workflows delivering no events).

Verified live against GitHub after the change: `All 11 guarded workflows are active.`

## 2. The census deploy has an undocumented auth prerequisite

`deploy-census-worker.sh` sets `CLOUDFLARE_ACCOUNT_ID` but never `CLOUDFLARE_API_TOKEN`, so Wrangler authenticates through its own stored OAuth session. On a machine that has never run it, the release stops — and it stops at `secret list` (`deploy-census-worker.sh:195`), which reads like a permissions problem rather than a missing login.

The runbook now names the prerequisite, the precedence (an exported token wins over the stored session), and the `whoami` check. Wording corrected after the local Codex review pointed out that the first draft overstated the failure mode.

## Context

Both came out of a measured audit of the release flow. The larger findings — the merge queue being the actual bottleneck (17 h of a 30 h PR is idle time in a serial hand-driven merge window) and the installer never being executed before publish — are separate, larger changes and are not in this PR.

## Note on the gate

This PR needs a fresh evidence envelope: `repo-policy.json` is outside the non-sensitive escape, and the added documentation contains `npx wrangler … login`, which correctly trips the install-command guard. Both changes therefore ride in one PR rather than two, to spend one envelope instead of two.

## Verification

- 43/43 contract tests green (guarded-workflows, release-contract, dependabot-automation); `npm run typecheck` green
- `bash scripts/release/verify-required-workflows-active.sh markusleben/ha-nova` run live: 11/11 active
- Local Codex review: one finding (overstated auth claim), fixed; `secret list` location verified in the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrTBG6YEqXqWXAiLwm2e1B