### PR TITLE
docs: record why the merge queue is not viable here

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -254,41 +254,27 @@ Actions minor/patch lane without allowing mutable action refs or arbitrary
 commits under stale evidence. Disabled targets remain compatible with normal
 reviewed workflow maintenance.
 
-### What the workflow freeze costs, in practice
-
-While Cloud remote is enabled, that last sentence is the expensive one: **every
-workflow change that is not a forward `uses:` bump is blocked**, no matter how
-harmless. Adding a trigger, renaming a step, splitting a job — all of it fails
-the gate, because the target's `.github/workflows` tree must either match
-trusted `main` byte for byte or contain nothing but `uses:` version bumps.
-
-The only such change on `main` since Cloud was enabled is `32b4ffa`, and it
-landed only because a bespoke one-time allowlist was added to the trusted
-verifier — which the same commit then removed again. There is no general
-escape hatch, and the non-sensitive source escape does not help: it covers
-Markdown, not workflow YAML.
-
-So a CI or workflow improvement is never a one-PR change. It costs, in order:
-a first pull request that widens the trusted verifier for that exact shape,
-merged to `main` first (the gate compares against `main`, so the exemption has
-to be there before the change arrives), then a second pull request carrying
-the workflow edit — and a fresh evidence envelope for each. Budget for that
-before starting, or the required check reads as an unexplained failure.
-
-This is a deliberate trade: the freeze is what stops a pull request from
-rewriting the machinery that judges it. It is written down here because the
-price was previously invisible, and discovering it costs hours.
+Read that scope correctly: it constrains **carried** evidence only. A workflow
+change is not blocked — it simply cannot ride an envelope minted for an older
+tree, so it needs a fresh exact-target one like any other non-Markdown change
+(`034d60c` and `be0c5e2` both rewrote release workflows this way after Cloud
+was enabled). Only `32b4ffa` needed more, because it deliberately reused stale
+evidence via a one-time allowlist that the same commit then removed.
 
 ### Merge queue: investigated, not viable while Cloud is enabled
 
-Do not re-investigate without solving these first (audited 2026-08-13):
+The rule above already says a `merge_group` synthetic commit follows the normal
+evidence rules. What makes that impractical rather than merely strict, audited
+2026-08-13 — do not re-investigate without solving these first:
 
-- **No mint path for a queue commit.** The envelope binds a tree; a merge
-  group's target is the `gh-readonly-queue` commit, and `refs/pull/N/merge` is
-  never its ancestor, so both stale-evidence escapes fail their ancestor check.
-  `cloud-candidate-bundle.yml` accepts only a pull request number, so no
-  envelope can be produced for a queue commit at all. The queue could therefore
-  never batch — and batching is its only purpose.
+- **No operational way to mint the envelope a queue commit would need.**
+  `cloud-candidate-bundle.yml` accepts a pull request number and resolves
+  `refs/pull/N/merge`; a queue commit is neither, and it exists only for the
+  minutes the merge group runs. Carrying evidence forward does not help either:
+  `refs/pull/N/merge` is never an ancestor of the queue commit, so both
+  stale-evidence escapes fail their ancestor check. In practice the queue could
+  only ever pass with one pull request per group and an unchanged base — and
+  batching is its only purpose.
 - **`strict` is mandatory here.** `verify-cloud-target-source-gate.sh` requires
   strict up-to-date protection while Cloud is enabled; a merge queue does not
   coexist with it.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -267,14 +267,16 @@ The rule above already says a `merge_group` synthetic commit follows the normal
 evidence rules. What makes that impractical rather than merely strict, audited
 2026-08-13 — do not re-investigate without solving these first:
 
-- **No operational way to mint the envelope a queue commit would need.**
-  `cloud-candidate-bundle.yml` accepts a pull request number and resolves
-  `refs/pull/N/merge`; a queue commit is neither, and it exists only for the
-  minutes the merge group runs. Carrying evidence forward does not help either:
-  `refs/pull/N/merge` is never an ancestor of the queue commit, so both
-  stale-evidence escapes fail their ancestor check. In practice the queue could
-  only ever pass with one pull request per group and an unchanged base — and
-  batching is its only purpose.
+- **No operational way to mint the envelope a queue commit would need.** The
+  envelope stored for the current `main` after a merge *is* an ancestor of a
+  queue commit, so a merge group whose aggregate base-to-target delta stays
+  inside the permitted classes — Markdown under the non-sensitive escape, or
+  safe `uses:` bumps — passes on carried evidence, batched or not. Any group
+  containing anything else needs its own exact-target envelope, and there is no
+  way to produce one: `cloud-candidate-bundle.yml` mints from a pull request
+  number and `refs/pull/N/merge`, while a queue commit is neither and exists
+  only for the minutes the group runs. So the queue would serve documentation
+  trains and nothing else.
 - **`strict` is mandatory here.** `verify-cloud-target-source-gate.sh` requires
   strict up-to-date protection while Cloud is enabled; a merge queue does not
   coexist with it.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -254,6 +254,50 @@ Actions minor/patch lane without allowing mutable action refs or arbitrary
 commits under stale evidence. Disabled targets remain compatible with normal
 reviewed workflow maintenance.
 
+### What the workflow freeze costs, in practice
+
+While Cloud remote is enabled, that last sentence is the expensive one: **every
+workflow change that is not a forward `uses:` bump is blocked**, no matter how
+harmless. Adding a trigger, renaming a step, splitting a job — all of it fails
+the gate, because the target's `.github/workflows` tree must either match
+trusted `main` byte for byte or contain nothing but `uses:` version bumps.
+
+The only such change on `main` since Cloud was enabled is `32b4ffa`, and it
+landed only because a bespoke one-time allowlist was added to the trusted
+verifier — which the same commit then removed again. There is no general
+escape hatch, and the non-sensitive source escape does not help: it covers
+Markdown, not workflow YAML.
+
+So a CI or workflow improvement is never a one-PR change. It costs, in order:
+a first pull request that widens the trusted verifier for that exact shape,
+merged to `main` first (the gate compares against `main`, so the exemption has
+to be there before the change arrives), then a second pull request carrying
+the workflow edit — and a fresh evidence envelope for each. Budget for that
+before starting, or the required check reads as an unexplained failure.
+
+This is a deliberate trade: the freeze is what stops a pull request from
+rewriting the machinery that judges it. It is written down here because the
+price was previously invisible, and discovering it costs hours.
+
+### Merge queue: investigated, not viable while Cloud is enabled
+
+Do not re-investigate without solving these first (audited 2026-08-13):
+
+- **No mint path for a queue commit.** The envelope binds a tree; a merge
+  group's target is the `gh-readonly-queue` commit, and `refs/pull/N/merge` is
+  never its ancestor, so both stale-evidence escapes fail their ancestor check.
+  `cloud-candidate-bundle.yml` accepts only a pull request number, so no
+  envelope can be produced for a queue commit at all. The queue could therefore
+  never batch — and batching is its only purpose.
+- **`strict` is mandatory here.** `verify-cloud-target-source-gate.sh` requires
+  strict up-to-date protection while Cloud is enabled; a merge queue does not
+  coexist with it.
+- **A merge group runs workflows from the queue branch**, i.e. from pull-request
+  content. The `pull_request_target` property that a pull request cannot
+  rewrite its own gate does not extend there.
+- **The queue ref names exactly one pull request**, so a batched group would
+  leave the others unasserted by any gate that resolves the ref by name.
+
 The broker and both release workflows require
 `HA_NOVA_CLOUD_GATE_EVIDENCE_JSON` from the `production` environment. The
 normal CI job reads the repository secret only for direct `main` pushes; pull


### PR DESCRIPTION
## What

One paragraph in the release runbook, plus a correction to a claim this pull request originally made.

**The merge queue, investigated and dropped.** The runbook already states that a `merge_group` synthetic commit follows the normal evidence rules. What it did not say is why that is impractical rather than merely strict: `cloud-candidate-bundle.yml` mints envelopes from a pull request number and `refs/pull/N/merge`, and a queue commit is neither — it exists only for the minutes the merge group runs. Carrying evidence forward does not help either, because `refs/pull/N/merge` is never an ancestor of a queue commit. Plus three further blockers (strict protection is mandatory here, merge groups run workflows from pull-request content, the queue ref names a single pull request). Recorded so it is not re-derived every few months.

**Correction, and it matters.** The first draft of this pull request claimed workflow changes are effectively frozen while Cloud is enabled. That was wrong, and Codex caught it with counter-evidence from this repository's own history. `verify-cloud-release-gate.sh:243` returns unconditionally on an exact tree match, so the `uses:`-only scope constrains **carried** evidence only. A workflow edit with a fresh envelope passes like any other non-Markdown change — `034d60c` and `be0c5e2` both rewrote release workflows that way after Cloud was enabled. Only `32b4ffa` needed a one-time allowlist, because it deliberately reused stale evidence.

The practical consequence is the opposite of what the first draft implied: CI and workflow improvements are available at the cost of one evidence envelope each, not two pull requests and a verifier change.

## Verification

- Docs-only; `verify-cloud-nonsensitive-source.mjs` accepts the delta, so this rides the carried envelope with no maintainer evidence session.
- 43/43 docs and release contract tests green, including the existing assertion that pins the `merge_group` sentence this text now refines rather than contradicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrTBG6YEqXqWXAiLwm2e1B