### PR TITLE
ci: run the Go suite in parallel instead of inside the verify chain

### DIFF
--- a/.github/policy/repo-policy.json
+++ b/.github/policy/repo-policy.json
@@ -59,6 +59,7 @@
       "ci-gate",
       "cloud-source-gate",
       "dependency-review",
+      "go-test",
       "manifest-review-gate",
       "readme-release-gate"
     ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,10 @@ jobs:
         run: npm ci
 
       - name: Verify repository
-        run: npm run verify
+        # verify:ci is `verify` without `test:cli`; the Go suite runs in the
+        # parallel go-test job below. `npm run verify` stays whole for the
+        # pre-tag checklist and the release workflows.
+        run: npm run verify:ci
 
   go-build:
     name: go-build
@@ -134,6 +137,25 @@ jobs:
           GOOS=windows GOARCH=amd64 go build -o /dev/null .
           GOOS=linux GOARCH=amd64 go build -o /dev/null .
           GOOS=linux GOARCH=arm64 go build -o /dev/null .
+
+  # Split out of ci-gate: `go test ./...` was 142 s of that job's ~4.5 min
+  # serial verify chain and needs nothing the chain produces. Actions are
+  # SHA-pinned here to match ci-gate rather than the looser tags below.
+  go-test:
+    name: go-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.5"
+          cache-dependency-path: cli/go.sum
+
+      - name: Run the Go test suite
+        run: npm run test:cli
 
   macos-native-secret-boundary:
     name: macos-native-secret-boundary

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "verify:security": "bash scripts/release/verify-npm-audit.sh",
     "verify:next-release-version": "bash scripts/release/verify-next-release-version.sh",
     "verify": "npm run verify:security && bash scripts/release/verify-blocked-files.sh && npm run typecheck && npm run verify:docs && npm run test:safe:core && npm run verify:onboarding && npm run build && npm run test:cli && npm run verify:release-contracts",
+    "verify:ci": "npm run verify:security && bash scripts/release/verify-blocked-files.sh && npm run typecheck && npm run verify:docs && npm run test:safe:core && npm run verify:onboarding && npm run build && npm run verify:release-contracts",
     "release:rc:local": "bash scripts/release/build-sign-darwin-binaries.sh \"${HA_NOVA_RC_TAG:?set HA_NOVA_RC_TAG to vX.Y.Z-rcN}\" && bash scripts/release/build-rc-binaries.sh \"${HA_NOVA_RC_TAG}\" && bash scripts/release/build-install-bundle.sh \"${HA_NOVA_RC_TAG#v}\"",
     "prepare": "husky"
   },

--- a/scripts/release/resolve-cloud-candidate-source.sh
+++ b/scripts/release/resolve-cloud-candidate-source.sh
@@ -126,6 +126,7 @@ verify_checks() {
     case "${check_name}" in
       analyze) expected_workflow=".github/workflows/codeql.yml"; expected_event="pull_request" ;;
       ci-gate) expected_workflow=".github/workflows/ci.yml"; expected_event="pull_request" ;;
+      go-test) expected_workflow=".github/workflows/ci.yml"; expected_event="pull_request" ;;
       dependency-review) expected_workflow=".github/workflows/dependency-review.yml"; expected_event="pull_request" ;;
       manifest-review-gate) expected_workflow=".github/workflows/manifest-review-gate.yml"; expected_event="pull_request_target" ;;
       readme-release-gate) expected_workflow=".github/workflows/readme-release-gate.yml"; expected_event="pull_request_target" ;;

--- a/tests/onboarding/dependabot-automation-contract.test.ts
+++ b/tests/onboarding/dependabot-automation-contract.test.ts
@@ -329,7 +329,7 @@ describe("dependabot automation contract", () => {
   });
 
   it("pins the expected main branch protection policy for maintainer verification", () => {
-    expect(policy.main_branch_protection.required_status_checks).toEqual(["analyze", "ci-gate", "cloud-source-gate", "dependency-review", "manifest-review-gate", "readme-release-gate"]);
+    expect(policy.main_branch_protection.required_status_checks).toEqual(["analyze", "ci-gate", "cloud-source-gate", "dependency-review", "go-test", "manifest-review-gate", "readme-release-gate"]);
     expect(policy.main_branch_protection.required_status_check_apps).toEqual({
       "cloud-source-gate": 4400145,
     });

--- a/tests/onboarding/guarded-workflows-contract.test.ts
+++ b/tests/onboarding/guarded-workflows-contract.test.ts
@@ -16,6 +16,7 @@ const policy = JSON.parse(
 // check whose workflow is disabled never appears, so PRs hang BLOCKED forever.
 const requiredCheckWorkflows: Record<string, string> = {
   "ci-gate": ".github/workflows/ci.yml",
+  "go-test": ".github/workflows/ci.yml",
   analyze: ".github/workflows/codeql.yml",
   "dependency-review": ".github/workflows/dependency-review.yml",
   "manifest-review-gate": ".github/workflows/manifest-review-gate.yml",

--- a/tests/onboarding/safe-test-system-contract.test.ts
+++ b/tests/onboarding/safe-test-system-contract.test.ts
@@ -260,6 +260,15 @@ describe("safe test system contract", () => {
     ]);
     expectNoFullVitestSweep(verify);
     expect(verify).not.toContain("test:desktop");
+
+    // CI runs verify:ci, but the coverage checks above derive from verify.
+    // Pin the relationship so the two cannot drift: verify:ci must be verify
+    // with exactly the Go suite removed (it runs in the parallel go-test job,
+    // which is a required check). Any other omission would silently leave CI
+    // covering less than this contract believes.
+    const verifyCi = pkg.scripts?.["verify:ci"] ?? "";
+    expect(verifyCi).toBe(verify.replace(" && npm run test:cli", ""));
+    expect(verifyCi).not.toContain("test:cli");
   });
 
   it("fails scripted Vitest runs before missing files can be skipped", () => {


### PR DESCRIPTION
## What

`go test ./...` was **142 s of ci-gate's ~4.5 min** serial `verify` chain — the critical path on every push — and needs nothing that chain produces. It now runs in its own parallel `go-test` job.

`npm run verify` is **unchanged**: the pre-tag checklist, `.husky/pre-push` and both release workflows depend on it. CI runs a new `verify:ci` (= `verify` minus `npm run test:cli`).

Expected effect: `ci-gate` drops from ~4.5 to ~2.2 min, `go-test` runs ~2.5 min alongside it, so CI wall clock goes from ~4.5 to ~2.5 min per push.

## Manifest disclosure (for `manifest-review:approved`)

`package.json`: **one line added**, the `verify:ci` script. No dependency added, removed or version-bumped; no lockfile change.

## What the review caught

The local Codex review found that moving the Go suite out of the required `ci-gate` job would have let a **red Go suite merge** — `go-test` was not a required check. It is now added to `required_status_checks`, its workflow mapping, and the policy pin. That was a real regression this PR introduced and would have shipped without the review.

Second finding, also fixed: coverage contracts derive from `verify`, so a future `verify:ci` that silently omitted more would still have passed. `safe-test-system-contract.ts` now pins `verify:ci === verify` with exactly `test:cli` removed.

## Sequencing — needs one action right after merge

`verify-github-main-protection.sh` compares the policy in **trusted `main`** against live branch protection. During this PR both are still the old set, so the gate passes. After merge, `main` lists `go-test` while live protection does not, and every subsequent PR's `cloud-source-gate` fails until live protection is updated. Live protection will therefore be updated immediately after merging, then verified with that script.

## What was dropped from the original plan, and why

- **Merging the two Windows jobs:** they run in parallel at ~1 min each, far below the critical path. Consolidating saves billing and runner pressure, not wall clock.
- **The `concurrency` change on `main`:** presented in an earlier analysis as a correctness bug. It is not — if a merge train cancels the previous `main` run, the successor commit contains it and is itself verified, so the current state stays verified.

## Verification

- 72/72 contract tests green, including the two that pin the `verify` chain in exact order and the branch-protection policy
- `npm run verify:ci` and `npm run test:cli` both run green locally as separate chains
- `npm run typecheck` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrTBG6YEqXqWXAiLwm2e1B