### PR TITLE
ci: allow one-time candidate run-name quote fix (round 1 for #574)

### DIFF
--- a/scripts/release/verify-cloud-workflow-uses-only.mjs
+++ b/scripts/release/verify-cloud-workflow-uses-only.mjs
@@ -42,7 +42,13 @@ function git(args, encoding = "utf8") {
 // pins the ENTIRE file transformation: the inert line must occur exactly
 // once, the after-image must equal the before-image with only that line
 // replaced, and the caller additionally requires it to be the sole workflow
-// delta. Remove this block in the follow-up PR that applies the fix.
+// delta. The follow-up PR that applies the fix must make THREE coordinated
+// edits: (1) quote the run-name line in the workflow, (2) update the
+// inert-line pin in scripts/release/verify-cloud-candidate-workflow.mjs to
+// the quoted form (it runs in the weekly audit and the release rehearsal),
+// and (3) remove this block plus
+// tests/onboarding/cloud-candidate-runname-handoff-behavior.ts and its
+// side-effect import in cloud-release-gate-behavior.ts.
 function isOneTimeRunNameQuoteFix(path, baseRef, targetRef) {
   if (path !== candidateBundlePath) {
     return false;

--- a/scripts/release/verify-cloud-workflow-uses-only.mjs
+++ b/scripts/release/verify-cloud-workflow-uses-only.mjs
@@ -12,6 +12,11 @@ const policy = JSON.parse(
 );
 const sensitive = new Set(policy.cloud_source_gate?.sensitive_workflows ?? []);
 const resolvedTags = new Map();
+const candidateBundlePath = ".github/workflows/cloud-candidate-bundle.yml";
+const inertRunName =
+  "run-name: Cloud candidate PR #${{ inputs.pull_request }} ${{ inputs.version_tag }} (${{ inputs.request_id }})";
+const quotedRunName =
+  'run-name: "Cloud candidate PR #${{ inputs.pull_request }} ${{ inputs.version_tag }} (${{ inputs.request_id }})"';
 
 function fail(message) {
   console.error(`[verify-cloud-workflow-uses-only] ERROR: ${message}`);
@@ -27,6 +32,27 @@ function git(args, encoding = "utf8") {
   } catch {
     fail(`git ${args[0]} failed`);
   }
+}
+
+// One-time exception (#574): the candidate-bundle workflow may change EXACTLY
+// its run-name line from the inert unquoted form (the unquoted `#` starts a
+// YAML comment, so the interpolations never reach any run) to the quoted
+// form. The path is Cloud-release-sensitive, so unlike the #552 precedent
+// this predicate is consulted BEFORE the sensitive denylist — which is why it
+// pins the ENTIRE file transformation: the inert line must occur exactly
+// once, the after-image must equal the before-image with only that line
+// replaced, and the caller additionally requires it to be the sole workflow
+// delta. Remove this block in the follow-up PR that applies the fix.
+function isOneTimeRunNameQuoteFix(path, baseRef, targetRef) {
+  if (path !== candidateBundlePath) {
+    return false;
+  }
+  const before = git(["show", `${baseRef}:${path}`]);
+  const after = git(["show", `${targetRef}:${path}`]);
+  if (before.split(inertRunName).length - 1 !== 1) {
+    return false;
+  }
+  return after === before.split(inertRunName).join(quotedRunName);
 }
 
 function workflowEntries(ref) {
@@ -222,6 +248,10 @@ if (
 ) {
   fail("enabled Cloud source may not add, delete, or rename workflows");
 }
+const changedWorkflowCount = [...base].filter(
+  ([path, entry]) => target.get(path).blob !== entry.blob,
+).length;
+
 let changed = 0;
 for (const [path, baseEntry] of base) {
   const targetEntry = target.get(path);
@@ -232,6 +262,12 @@ for (const [path, baseEntry] of base) {
     continue;
   }
   changed += 1;
+  if (isOneTimeRunNameQuoteFix(path, baseCommit, targetCommit)) {
+    if (changedWorkflowCount !== 1) {
+      fail(`${path} one-time run-name quote fix must be the sole workflow delta`);
+    }
+    continue;
+  }
   if (sensitive.has(path)) {
     fail(`${path} is Cloud-release-sensitive`);
   }

--- a/tests/onboarding/cloud-candidate-runname-handoff-behavior.ts
+++ b/tests/onboarding/cloud-candidate-runname-handoff-behavior.ts
@@ -1,0 +1,164 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const workflowPath = ".github/workflows/cloud-candidate-bundle.yml";
+const otherSensitivePath = ".github/workflows/ci.yml";
+const maintenancePath = ".github/workflows/maintenance.yml";
+const actionBefore = "1111111111111111111111111111111111111111";
+const actionAfter = "2222222222222222222222222222222222222222";
+const inertRunName =
+  "run-name: Cloud candidate PR #${{ inputs.pull_request }} ${{ inputs.version_tag }} (${{ inputs.request_id }})";
+const quotedRunName =
+  'run-name: "Cloud candidate PR #${{ inputs.pull_request }} ${{ inputs.version_tag }} (${{ inputs.request_id }})"';
+const workflow = [
+  "name: Cloud Candidate Bundle",
+  inertRunName,
+  "on:",
+  "  workflow_dispatch: {}",
+  "",
+].join("\n");
+const otherWorkflow = ["name: CI", "on:", "  push: {}", ""].join("\n");
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "ha-nova-runname-handoff-"));
+  const script = join(
+    root,
+    "scripts",
+    "release",
+    "verify-cloud-workflow-uses-only.mjs",
+  );
+  mkdirSync(join(root, "scripts", "release"), { recursive: true });
+  mkdirSync(join(root, ".github", "policy"), { recursive: true });
+  mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+  copyFileSync("scripts/release/verify-cloud-workflow-uses-only.mjs", script);
+  writeFileSync(join(root, workflowPath), workflow, "utf8");
+  writeFileSync(join(root, otherSensitivePath), otherWorkflow, "utf8");
+  writeFileSync(
+    join(root, maintenancePath),
+    `steps:\n  - uses: example/action@${actionBefore} # v1.2.3\n`,
+    "utf8",
+  );
+  // The production reality this suite must model: the candidate-bundle
+  // workflow IS on the sensitive denylist, and the one-time exception is the
+  // only thing that may carry its exact rewrite past it.
+  writeFileSync(
+    join(root, ".github", "policy", "repo-policy.json"),
+    JSON.stringify({
+      cloud_source_gate: {
+        sensitive_workflows: [workflowPath, otherSensitivePath],
+      },
+    }),
+    "utf8",
+  );
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: root,
+  });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: root });
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["commit", "-qm", "base"], { cwd: root });
+  const base = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
+  const fakeBin = mkdtempSync(join(tmpdir(), "ha-nova-runname-handoff-gh-"));
+  const gh = join(fakeBin, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+case "$*" in
+  *git/ref/tags/v1.2.3*) printf '%s\\n' '{"object":{"type":"commit","sha":"${actionBefore}"}}' ;;
+  *git/ref/tags/v1.2.4*) printf '%s\\n' '{"object":{"type":"commit","sha":"${actionAfter}"}}' ;;
+  *) exit 1 ;;
+esac
+`,
+    "utf8",
+  );
+  chmodSync(gh, 0o755);
+  return {
+    root,
+    script,
+    base,
+    env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH ?? ""}` },
+  };
+}
+
+function verify(mutation: (root: string) => void): ReturnType<typeof spawnSync> {
+  const { root, script, base, env } = fixture();
+  mutation(root);
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["commit", "-qm", "target"], { cwd: root });
+  const target = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
+  return spawnSync(
+    process.execPath,
+    [script, root, base, target, "workflow-tree-only"],
+    { cwd: root, encoding: "utf8", env },
+  );
+}
+
+function rewrite(root: string, path: string, body: string): void {
+  writeFileSync(join(root, path), body, "utf8");
+}
+
+describe("one-time candidate run-name quote fix handoff", () => {
+  it("accepts exactly the quote fix on the sensitive candidate workflow", () => {
+    const result = verify((root) => {
+      rewrite(root, workflowPath, workflow.replace(inertRunName, quotedRunName));
+    });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
+  it.each([
+    ["an extra trailing change", `${workflow.replace(inertRunName, quotedRunName)}# extra\n`],
+    ["a different replacement", workflow.replace(inertRunName, "run-name: Something else")],
+    ["an unrelated edit with the line kept inert", workflow.replace("workflow_dispatch: {}", "workflow_dispatch: {}\n  push: {}")],
+  ])("rejects %s as Cloud-release-sensitive", (_name, changed) => {
+    const result = verify((root) => rewrite(root, workflowPath, changed));
+    expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+    expect(result.stderr).toContain("is Cloud-release-sensitive");
+  });
+
+  it("rejects the fix when a sensitive sibling changes too", () => {
+    const result = verify((root) => {
+      rewrite(root, workflowPath, workflow.replace(inertRunName, quotedRunName));
+      rewrite(root, otherSensitivePath, `${otherWorkflow}# touched\n`);
+    });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+  });
+
+  it("rejects the fix even when the sibling change is a valid uses bump", () => {
+    // Without the sole-delta guard this combination would pass: the candidate
+    // file rides the exception and the maintenance bump passes verifyUsesOnly.
+    const result = verify((root) => {
+      rewrite(root, workflowPath, workflow.replace(inertRunName, quotedRunName));
+      rewrite(
+        root,
+        maintenancePath,
+        `steps:\n  - uses: example/action@${actionAfter} # v1.2.4\n`,
+      );
+    });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+    expect(result.stderr).toContain("must be the sole workflow delta");
+  });
+
+  it("rejects the same rewrite smuggled into another workflow", () => {
+    const result = verify((root) => {
+      rewrite(root, otherSensitivePath, `${otherWorkflow}${quotedRunName}\n`);
+    });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+    expect(result.stderr).toContain("is Cloud-release-sensitive");
+  });
+});

--- a/tests/onboarding/cloud-candidate-runname-handoff-behavior.ts
+++ b/tests/onboarding/cloud-candidate-runname-handoff-behavior.ts
@@ -154,6 +154,56 @@ describe("one-time candidate run-name quote fix handoff", () => {
     expect(result.stderr).toContain("must be the sole workflow delta");
   });
 
+  it("rejects the fix when the inert line occurs twice in the base", () => {
+    const doubled = `${workflow}${inertRunName}\n`;
+    const result = verify((root) => {
+      rewrite(root, workflowPath, doubled);
+    });
+    // Baseline sanity: committing the doubled base itself must fail…
+    expect(result.status).not.toBe(0);
+    const { root, script, base } = (() => {
+      const f = fixture();
+      rewrite(f.root, workflowPath, doubled);
+      execFileSync("git", ["add", "."], { cwd: f.root });
+      execFileSync("git", ["commit", "-qm", "doubled base"], { cwd: f.root });
+      return { ...f, base: execFileSync("git", ["rev-parse", "HEAD"], { cwd: f.root, encoding: "utf8" }).trim() };
+    })();
+    // …and from a doubled base, replacing BOTH occurrences must stay denied:
+    // the occurs-exactly-once guard is what makes the transformation unique.
+    rewrite(root, workflowPath, doubled.split(inertRunName).join(quotedRunName));
+    execFileSync("git", ["add", "."], { cwd: root });
+    execFileSync("git", ["commit", "-qm", "target"], { cwd: root });
+    const target = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    const doubledResult = spawnSync(
+      process.execPath,
+      [script, root, base, target, "workflow-tree-only"],
+      { cwd: root, encoding: "utf8" },
+    );
+    expect(doubledResult.status, `${doubledResult.stdout}\n${doubledResult.stderr}`).not.toBe(0);
+    expect(doubledResult.stderr).toContain("is Cloud-release-sensitive");
+  });
+
+  it("stays inert after the fix: the reverse direction is denied", () => {
+    const { root, script, base } = (() => {
+      const f = fixture();
+      rewrite(f.root, workflowPath, workflow.replace(inertRunName, quotedRunName));
+      execFileSync("git", ["add", "."], { cwd: f.root });
+      execFileSync("git", ["commit", "-qm", "quoted base"], { cwd: f.root });
+      return { ...f, base: execFileSync("git", ["rev-parse", "HEAD"], { cwd: f.root, encoding: "utf8" }).trim() };
+    })();
+    rewrite(root, workflowPath, workflow);
+    execFileSync("git", ["add", "."], { cwd: root });
+    execFileSync("git", ["commit", "-qm", "target"], { cwd: root });
+    const target = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    const result = spawnSync(
+      process.execPath,
+      [script, root, base, target, "workflow-tree-only"],
+      { cwd: root, encoding: "utf8" },
+    );
+    expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+    expect(result.stderr).toContain("is Cloud-release-sensitive");
+  });
+
   it("rejects the same rewrite smuggled into another workflow", () => {
     const result = verify((root) => {
       rewrite(root, otherSensitivePath, `${otherWorkflow}${quotedRunName}\n`);

--- a/tests/onboarding/cloud-release-gate-behavior.ts
+++ b/tests/onboarding/cloud-release-gate-behavior.ts
@@ -8,6 +8,7 @@ import {
   validCloudEvidence,
 } from "./cloud-release-gate-fixture.js";
 import { registerCloudReleaseCommitGateBehaviorTests } from "./cloud-release-commit-gate-behavior.js";
+import "./cloud-candidate-runname-handoff-behavior.js";
 import { registerCloudNonsensitiveSourceBehaviorTests } from "./cloud-nonsensitive-source-behavior.js";
 import { registerCloudNonsensitiveGateIntegrationTests } from "./cloud-nonsensitive-gate-integration.js";
 export function registerCloudReleaseGateBehaviorTests(): void {


### PR DESCRIPTION
## What

Round 1 of the two-round path for #574 (precedent: #552/#554): `verify-cloud-workflow-uses-only.mjs` learns exactly ONE transformation — `cloud-candidate-bundle.yml`'s `run-name:` line changes from the inert unquoted form (the unquoted `#` starts a YAML comment, so the interpolations never reach any run and every run is titled just "Cloud candidate PR") to the quoted form.

Unlike the #552 precedent, the target path is Cloud-release-sensitive, so the predicate is consulted BEFORE the denylist — and is pinned accordingly harder: the inert line must occur exactly once in the trusted before-image, the after-image must byte-equal the before-image with only that line replaced, and the fix must be the sole workflow delta. The in-code comment carries the full four-edit checklist for round 2, including the inert-line pin in `verify-cloud-candidate-workflow.mjs` whose omission would turn round 2's ci-gate red and leave the release rehearsal failing.

## Review provenance

Local Codex CLI (clean) + two adversarial subagents (exception-abuse lens; round-2-viability lens), both empirical: no smuggling path — before-images are trusted in every call path (broker checks out the default branch; mint pins trusted HEAD; release path anchors via the envelope), byte tricks (CRLF/BOM/homoglyphs/mode/symlink) all die before or at the strict equality, the exception is structurally inert after the fix (the inert line is not a substring of the quoted one), and re-arming it requires a reviewed change to this very script. The round-2 shape was executed against the real verifier in a sandbox: exit 0.

## Tests

`tests/onboarding/cloud-candidate-runname-handoff-behavior.ts` (side-effect import in the registered `cloud-release-gate-behavior.ts`, no package.json change): exact fix accepted on the sensitive-listed path; extra/different/unrelated edits, the rewrite in another workflow, a doubled inert base, and the reverse direction all stay denied; a sensitive sibling AND a valid sibling uses-bump both trip the sole-delta guard. Guards seen red via mutation probes (exception removed, sole-delta guard removed, pin loosened, occurs-once guard removed). Full `release-gates-behavior.test.ts`: 283 passed. `npm run typecheck` green.

## Evidence plan

`scripts/release/` + tests → outside both stale escapes → fresh envelope, minted with `build-cloud-evidence.sh` (third real session), repointed after the squash merge. Round 2 follows as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df49DjAXiqgu8QvuP94K5n