### PR TITLE
build(deps): runtime train — ws 8.21.3, jose 6.2.8 (#509, #511, #512)

### DIFF
--- a/nova/package-lock.json
+++ b/nova/package-lock.json
@@ -10,7 +10,7 @@
         "@serenity-kit/opaque": "^1.1.0",
         "home-assistant-js-websocket": "^9.6.0",
         "reflect-metadata": "^0.2.2",
-        "ws": "^8.21.1"
+        "ws": "^8.21.3"
       },
       "devDependencies": {
         "@types/node": "^25.9.5",
@@ -654,9 +654,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/nova/package.json
+++ b/nova/package.json
@@ -10,7 +10,7 @@
     "@serenity-kit/opaque": "^1.1.0",
     "home-assistant-js-websocket": "^9.6.0",
     "reflect-metadata": "^0.2.2",
-    "ws": "^8.21.1"
+    "ws": "^8.21.3"
   },
   "devDependencies": {
     "@types/node": "^25.9.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "@peculiar/x509": "^2.0.0",
         "@serenity-kit/opaque": "^1.1.0",
         "home-assistant-js-websocket": "^9.6.0",
-        "jose": "^6.2.4",
+        "jose": "^6.2.8",
         "reflect-metadata": "^0.2.2",
-        "ws": "^8.21.1",
+        "ws": "^8.21.3",
         "yaml": "^2.9.0"
       },
       "devDependencies": {
@@ -1670,9 +1670,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
-      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -2439,9 +2439,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -96,9 +96,9 @@
     "@peculiar/x509": "^2.0.0",
     "@serenity-kit/opaque": "^1.1.0",
     "home-assistant-js-websocket": "^9.6.0",
-    "jose": "^6.2.4",
+    "jose": "^6.2.8",
     "reflect-metadata": "^0.2.2",
-    "ws": "^8.21.1",
+    "ws": "^8.21.3",
     "yaml": "^2.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

The runtime half of the Dependabot consolidation, deliberately parked out of #580 until the reference-platform smoke became agent-drivable (#584's persistent smoke profile is authorized since today).

## Manifest changes (exact lines, per the manifest-label rule)

- `package.json` dependencies: `ws` `^8.21.1` → `^8.21.3` (#512), `jose` `^6.2.4` → `^6.2.8` (#511) — patch-class upstream bugfix releases
- `nova/package.json` dependencies: `ws` `^8.21.1` → `^8.21.3` (#509 proposed `8.21.2`; normalized to root's version so Dependabot does not immediately reopen)
- Both lockfiles follow. No dependency added or removed.

## Verification

Full vitest suite **1813/1813** and `npm run typecheck` green; local Codex CLI additionally ran installs, builds, targeted tests and the census-worker dry-run — clean.

## Evidence plan (the first fully agent-driven transport/OAuth qualification)

`ws` hits the Cloud/Relay-transport row and `jose` the OAuth row of the invalidation map — both with real-platform scope. This session runs the REAL reference smoke without any manual step: the candidate build's own Windows binary executes `relay health --via cloud` and `internal-cloud-stress` (10,000 authenticated requests) over SSH against the persistent smoke profile on the dedicated test machine. Fresh checks land in the ledger; the remaining checks carry per map. Envelope via `build-cloud-evidence.sh`, repoint after the squash merge; #509/#511/#512 get closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df49DjAXiqgu8QvuP94K5n