### PR TITLE
docs(release): reference-smoke waiver for unavailable validation infrastructure

### DIFF
--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -180,7 +180,8 @@ Required evidence is exact-target plus risk-scoped qualification, except the
 ancestor-bound `uses:`-only and guarded non-sensitive source escapes
 (`docs/releasing.md`). Repeat a real-device row only for first support or
 after a relevant implementation
-or evidence-harness change — or carry it under the risk-scope spec's
+or evidence-harness change — or, for reruns only and never first support,
+carry it under the risk-scope spec's
 ledger-recorded reference-smoke waiver when no validation infrastructure is
 available; exact-target CI, signed provenance on all enabled
 OSes, and the installed Relay App always run, and the reference Cloud health

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -100,7 +100,9 @@ reference-platform `relay health --via cloud` against the exact installed
 Relay App. The proof parses the JSON and requires the expected App version
 plus `ha_ws_connected: true`; command success alone is insufficient. This
 smoke is separate from full route parity; maintenance deltas refresh the
-envelope and provenance without it.
+envelope and provenance without it. When no validation infrastructure is
+available, the risk-scope spec's reference-smoke waiver may replace the
+smoke with a ledger-recorded maintainer decision.
 
 This isolation procedure serves the real-device qualification runs below. The
 exact-candidate provenance check and health smoke follow a different layout:

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -182,7 +182,9 @@ ancestor-bound `uses:`-only and guarded non-sensitive source escapes
 after a relevant implementation
 or evidence-harness change; exact-target CI, signed provenance on all enabled
 OSes, and the installed Relay App always run, and the reference Cloud health
-smoke runs for deltas with real-platform scope:
+smoke runs for deltas with real-platform scope — or is replaced by the
+risk-scope spec's ledger-recorded reference-smoke waiver when no validation
+infrastructure is available:
 
 - `/health`, `/ws`, `/core`, `/files`, and `/backups` parity through a real
   Home Assistant Cloud route on one reference platform after a transport

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -180,7 +180,9 @@ Required evidence is exact-target plus risk-scoped qualification, except the
 ancestor-bound `uses:`-only and guarded non-sensitive source escapes
 (`docs/releasing.md`). Repeat a real-device row only for first support or
 after a relevant implementation
-or evidence-harness change; exact-target CI, signed provenance on all enabled
+or evidence-harness change — or carry it under the risk-scope spec's
+ledger-recorded reference-smoke waiver when no validation infrastructure is
+available; exact-target CI, signed provenance on all enabled
 OSes, and the installed Relay App always run, and the reference Cloud health
 smoke runs for deltas with real-platform scope — or is replaced by the
 risk-scope spec's ledger-recorded reference-smoke waiver when no validation

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -565,7 +565,9 @@ commit/tree identity, candidate provenance on every enabled platform, and
 the exact installed Relay App check stay mandatory. Under the waiver,
 satisfy the live installed-App read with `relay health` over a non-Cloud
 route from any host that reaches the installed App, asserting the same
-version and `ha_ws_connected` fields as the smoke below — then skip
+version and `ha_ws_connected` fields as the smoke below; the Cloud-route
+reachability half of that check cannot be proven without a Cloud call and
+travels with the waiver's ledger-recorded residual risk — then skip
 everything from the smoke-authorization setup through the cleanup step and
 continue at the evidence-binding rules; the `internal-cloud-stress` proof is
 waived together with the smoke, in the same ledger entry.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -351,12 +351,17 @@ qualification. Before carrying a qualification forward, inspect the complete
 qualification-to-target diff. In the activation or release pull request,
 record each carried check and keyring OS with its qualified commit/tree,
 non-secret evidence reference, inspected target, and change-class decision.
-Missing or uncertain ledger data means rerun.
+Missing or uncertain ledger data means rerun. A reference-smoke waiver
+(risk-scope spec) replaces only the rerun itself, never the ledger: it is
+valid only with a complete entry naming the unavailable infrastructure, the
+waived checks, and the crossing delta.
 
 Every target still runs CI, candidate signature/provenance checks on all
 enabled platforms, and the exact installed Relay App. A target whose delta
 matches an invalidation-map row with real-platform scope also runs one real
-Cloud health smoke on a reference platform; maintenance deltas skip it. The
+Cloud health smoke on a reference platform — or records the spec's
+reference-smoke waiver when no validation infrastructure is available;
+maintenance deltas skip it. The
 smoke uses the downloaded candidate binary, `--via cloud`, the exact installed
 App, and `HA_NOVA_NO_CENSUS=1`; its JSON must report the expected App version
 and `ha_ws_connected: true`.
@@ -402,7 +407,9 @@ provenance, and `installed_relay_app` are never carried forward. The Cloud
 health smoke repeats only when the delta matches an invalidation-map row with
 real-platform scope; deltas matching only the map's `None` and
 release-machinery rows refresh the envelope and provenance without it. The
-map, not any summary, decides. See
+map, not any summary, decides. The spec's reference-smoke waiver is the one
+exception, and it never covers CI, candidate provenance, or
+`installed_relay_app`. See
 `docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md`.
 Carry-forward applies only to the qualification behind a check boolean: create
 a new exact-target JSON envelope and never copy an older commit/tree identity.
@@ -545,7 +552,13 @@ Choose exactly one reference platform for the exact-target Cloud health smoke.
 The smoke is required only when the delta matches an invalidation-map row with
 real-platform scope; deltas matching only the map's `None` and
 release-machinery rows refresh the envelope and provenance without it. Consult
-the map in the evidence risk-scope spec rather than any shorthand.
+the map in the evidence risk-scope spec rather than any shorthand. When no
+validation infrastructure is available, the maintainer may waive the smoke
+and the real-platform qualification reruns required by the delta's matched
+map rows, under the spec's reference-smoke waiver — the waiver lives in the
+PR ledger and must name the unavailable infrastructure; the envelope, the
+commit/tree identity, candidate provenance on every enabled platform, and
+the exact installed Relay App check stay mandatory.
 
 The smoke needs its own Cloud authorization inside the smoke HOME. NEVER copy
 the production `~/.config/ha-nova` there: the copied profile keeps the

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -354,7 +354,8 @@ non-secret evidence reference, inspected target, and change-class decision.
 Missing or uncertain ledger data means rerun. A reference-smoke waiver
 (risk-scope spec) replaces only the rerun itself, never the ledger: it is
 valid only with a complete entry naming the unavailable infrastructure, the
-waived checks, and the crossing delta.
+waived checks, the last real qualification they carry from, the exact
+crossing delta, and the maintainer's acceptance of the residual risk.
 
 Every target still runs CI, candidate signature/provenance checks on all
 enabled platforms, and the exact installed Relay App. A target whose delta

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -355,7 +355,9 @@ Missing or uncertain ledger data means rerun. A reference-smoke waiver
 (risk-scope spec) replaces only the rerun itself, never the ledger: it is
 valid only with a complete entry naming the unavailable infrastructure, the
 waived checks, the last real qualification they carry from, the exact
-crossing delta, and the maintainer's acceptance of the residual risk.
+crossing delta, and the maintainer's acceptance of the residual risk. Under
+the waiver, the affected boolean stays `true` and attests the carried
+qualification plus the ledger-recorded waiver.
 
 Every target still runs CI, candidate signature/provenance checks on all
 enabled platforms, and the exact installed Relay App. A target whose delta
@@ -409,7 +411,8 @@ health smoke repeats only when the delta matches an invalidation-map row with
 real-platform scope; deltas matching only the map's `None` and
 release-machinery rows refresh the envelope and provenance without it. The
 map, not any summary, decides. The spec's reference-smoke waiver is the one
-exception, and it never covers CI, candidate provenance, or
+exception, and it never covers CI, the JSON envelope, the commit/tree
+identity, candidate provenance, or
 `installed_relay_app`. See
 `docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md`.
 Carry-forward applies only to the qualification behind a check boolean: create
@@ -559,7 +562,13 @@ and the real-platform qualification reruns required by the delta's matched
 map rows, under the spec's reference-smoke waiver — the waiver lives in the
 PR ledger and must name the unavailable infrastructure; the envelope, the
 commit/tree identity, candidate provenance on every enabled platform, and
-the exact installed Relay App check stay mandatory.
+the exact installed Relay App check stay mandatory. Under the waiver,
+satisfy the live installed-App read with `relay health` over a non-Cloud
+route from any host that reaches the installed App, asserting the same
+version and `ha_ws_connected` fields as the smoke below — then skip
+everything from the smoke-authorization setup through the cleanup step and
+continue at the evidence-binding rules; the `internal-cloud-stress` proof is
+waived together with the smoke, in the same ledger entry.
 
 The smoke needs its own Cloud authorization inside the smoke HOME. NEVER copy
 the production `~/.config/ha-nova` there: the copied profile keeps the
@@ -677,9 +686,12 @@ cannot attest the enabled runtime. The activation PR must reach a stable head,
 but in `pull_request` CI that checked-out head is GitHub's synthetic
 `refs/pull/<number>/merge` commit, not the PR branch head. Product, release
 metadata, or sensitive workflow changes require a new exact-target evidence
-envelope and every qualification row invalidated by that delta, followed by a
+envelope and every qualification row invalidated by that delta — each row
+satisfied by a real rerun or by the spec's ledger-recorded reference-smoke
+waiver — followed by a
 repository-secret update and a CI rerun without changing the PR or its base.
-If the merge commit changes, rebuild the exact-target envelope; repeat only
+If the merge commit changes, rebuild the exact-target envelope; repeat — or
+carry under the reference-smoke waiver — only
 the qualification rows invalidated by the new delta. A target containing only
 the narrowly verified existing non-sensitive `uses:` version changes, or
 only the non-sensitive source delta defined above, may reuse evidence from

--- a/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
+++ b/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
@@ -790,7 +790,9 @@ Exact-target CI, candidate provenance on all enabled OSes, and the installed
 Relay App never carry forward. One downloaded-candidate
 `relay health --via cloud` smoke with Census suppressed repeats for deltas
 that match an invalidation-map row with real-platform scope; maintenance
-deltas refresh the envelope and provenance without it. The smoke must parse
+deltas refresh the envelope and provenance without it, and the risk-scope
+spec's reference-smoke waiver is the one ledger-recorded exception. The
+smoke must parse
 the JSON and require the expected App version and `ha_ws_connected: true`; a
 zero exit code alone is not evidence. See
 `2026-07-30-cloud-release-evidence-risk-scope-spec.md`.

--- a/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
+++ b/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
@@ -785,7 +785,10 @@ Real-device qualifications remain applicable across unrelated changes only
 after reviewing the complete qualification-to-target diff and recording the
 non-secret qualification ledger in the activation or release pull request.
 Changes to a deterministic substitute or real evidence harness invalidate its
-qualification.
+qualification. When validation infrastructure is unavailable, the risk-scope
+spec's reference-smoke waiver may carry an invalidated qualification across
+the recorded delta instead of a real rerun — ledger-recorded, per that spec's
+conditions.
 Exact-target CI, candidate provenance on all enabled OSes, and the installed
 Relay App never carry forward. One downloaded-candidate
 `relay health --via cloud` smoke with Census suppressed repeats for deltas

--- a/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
+++ b/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
@@ -19,7 +19,8 @@ into two layers:
    candidate provenance on every enabled platform, and the exact installed
    Relay App. For deltas that match an invalidation-map row with
    real-platform scope, one real reference-platform Cloud health smoke also
-   runs, using the downloaded candidate binary with Census suppressed.
+   runs, using the downloaded candidate binary with Census suppressed —
+   unless the reference-smoke waiver below applies.
 2. Risk-scoped qualification runs on first support and after a relevant
    implementation or evidence-harness change. A passing qualification remains
    applicable across unrelated changes.
@@ -37,7 +38,8 @@ or uncertain ledger data means rerun.
 Carry-forward applies only to the qualification behind a check boolean. The
 JSON envelope, commit/tree identity, candidate provenance, and installed App
 remain exact-target; the reference health smoke is exact-target for deltas
-with real-platform scope. Never reuse an older JSON envelope, except through
+with real-platform scope, waivable only under the reference-smoke waiver
+below. Never reuse an older JSON envelope, except through
 the ancestor-bound `uses:`-only and non-sensitive source escapes (see the
 escape section below and `docs/releasing.md`).
 The verifier binds that new envelope to the exact target. Reviewers verify the
@@ -48,6 +50,24 @@ qualification ledger before the boolean is set to `true`.
 Use the narrowest matching row. A change that matches multiple rows invalidates
 their union. A qualification trigger includes changes to every deterministic
 substitute and real evidence collection/validation harness it relies on.
+
+### Reference-smoke waiver (2026-08-19)
+
+When no validation infrastructure is available — no reachable reference
+platform, or the human-gated Cloud authorization cannot be completed because
+no interactive desktop session exists — the maintainer may waive the real
+reference-platform Cloud health smoke and exactly those real-platform
+qualification reruns that the delta's matched invalidation-map rows require.
+Nothing outside those rows is waivable, and every deterministic exact-target
+test still runs. Each waived check must itself be blocked by the named
+unavailable infrastructure; a check that can still run, runs. A waiver is never implicit: the PR ledger must name the
+unavailable infrastructure that makes the waiver eligible, the waived
+checks, the last real qualification they carry from, the exact crossing
+delta, and state that the maintainer accepts the residual risk. Four things
+are never waivable: the JSON envelope, the commit/tree identity, candidate
+provenance on every enabled platform, and the live `installed_relay_app`
+check. Waived checks remain first in line for a real rerun once
+infrastructure is available again.
 
 | Changed surface | Qualification to repeat | Real platform scope |
 |---|---|---|
@@ -163,7 +183,9 @@ deltas fail closed.
   mandatory.
 
 No mock may replace the required real positive path. No carried
-qualification may cross a relevant implementation change.
+qualification may cross a relevant implementation change, except under the
+reference-smoke waiver, which records that crossing explicitly in the
+ledger.
 
 The exact-target Cloud health smoke is not `parity`. It repeats only for a
 target whose delta matches an invalidation-map row with real-platform scope;
@@ -190,3 +212,5 @@ WebSocket. Do not retain the private Cloud URL.
 - Repository documentation checks pass.
 - No product, workflow, version metadata, README, or tag changes; the
   release-gate verifier extension is the 2026-08-12 escape itself.
+- The 2026-08-19 reference-smoke waiver changes only the maintainer
+  contract; the verifier and gate code are untouched.

--- a/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
+++ b/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
@@ -53,11 +53,13 @@ substitute and real evidence collection/validation harness it relies on.
 
 ### Reference-smoke waiver (2026-08-19)
 
-When no validation infrastructure is available — no reachable reference
-platform, or the human-gated Cloud authorization cannot be completed because
-no interactive desktop session exists — the maintainer may waive the real
-reference-platform Cloud health smoke and exactly those real-platform
+When no validation infrastructure is available, the maintainer may waive the
+real reference-platform Cloud health smoke and exactly those real-platform
 qualification reruns that the delta's matched invalidation-map rows require.
+Eligible infrastructure gaps are exactly these three: no reachable reference
+platform; no completable human-gated Cloud authorization (no interactive
+desktop session exists); or — for rows scoped "Affected OS only" — no
+reachable machine of the affected OS.
 Nothing outside those rows is waivable, and every deterministic exact-target
 test still runs. Each waived check must itself be blocked by the named
 unavailable infrastructure; a check that can still run, runs. A waiver is never implicit: the PR ledger must name the
@@ -73,9 +75,16 @@ installed Relay App. The map rows' "one reference platform" scope governs
 only the waivable qualification repeats — including the Relay-App row's —
 never this live read, which is a separate, platform-independent, mandatory
 proof. If even one of the four cannot be completed, there is
-no waiver and the delta stays unmergeable — the one remaining lever is then
-shrinking `cloud_remote_platforms` through a reviewed pull request. Waived checks remain first in
-line for a real rerun once infrastructure is available again.
+no waiver and the delta stays unmergeable. The remaining levers are then a
+reviewed pull request that removes the unavailable platform from
+`cloud_remote_platforms` — which relieves only that platform's candidate
+provenance — or one that disables Cloud remote entirely; full disable is the
+only lever when the envelope, the commit/tree identity, or the live
+`installed_relay_app` read cannot be completed. Waived checks remain first in
+line for a real rerun once infrastructure is available again: the backlog
+rerun is then due before the next release tag, and while it is pending no
+evidence session may set the affected check booleans without either running
+it or recording in the ledger why it is still blocked.
 
 | Changed surface | Qualification to repeat | Real platform scope |
 |---|---|---|
@@ -191,8 +200,8 @@ deltas fail closed.
   mandatory.
 
 No mock may replace the required real positive path. No carried
-qualification may cross a relevant implementation change, except under the
-reference-smoke waiver, which records that crossing explicitly in the
+qualification may cross a relevant implementation change, except those the
+reference-smoke waiver covers, which records that crossing explicitly in the
 ledger.
 
 The exact-target Cloud health smoke is not `parity`. It repeats only for a

--- a/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
+++ b/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
@@ -66,8 +66,12 @@ checks, the last real qualification they carry from, the exact crossing
 delta, and state that the maintainer accepts the residual risk. Four things
 are never waivable: the JSON envelope, the commit/tree identity, candidate
 provenance on every enabled platform, and the live `installed_relay_app`
-check. Waived checks remain first in line for a real rerun once
-infrastructure is available again.
+check. None of the four requires the reference platform: provenance runs
+locally or over any remote shell per enabled OS, and `installed_relay_app`
+is a live relay health read that may run from any host that reaches the
+installed Relay App. If even one of the four cannot be completed, there is
+no waiver and the delta stays unmergeable. Waived checks remain first in
+line for a real rerun once infrastructure is available again.
 
 | Changed surface | Qualification to repeat | Real platform scope |
 |---|---|---|

--- a/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
+++ b/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
@@ -59,7 +59,9 @@ qualification reruns that the delta's matched invalidation-map rows require.
 Eligible infrastructure gaps are exactly these three: no reachable reference
 platform; no completable human-gated Cloud authorization (no interactive
 desktop session exists); or — for rows scoped "Affected OS only" — no
-reachable machine of the affected OS.
+interactive desktop session on the affected OS, whose machine must still be
+provenance-reachable, because a fully unreachable enabled platform already
+fails the non-waivable provenance requirement.
 Nothing outside those rows is waivable, and every deterministic exact-target
 test still runs. Each waived check must itself be blocked by the named
 unavailable infrastructure; a check that can still run, runs. A waiver is never implicit: the PR ledger must name the

--- a/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
+++ b/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
@@ -69,7 +69,10 @@ provenance on every enabled platform, and the live `installed_relay_app`
 check. None of the four requires the reference platform: provenance runs
 locally or over any remote shell per enabled OS, and `installed_relay_app`
 is a live relay health read that may run from any host that reaches the
-installed Relay App. If even one of the four cannot be completed, there is
+installed Relay App. The map rows' "one reference platform" scope governs
+only the waivable qualification repeats — including the Relay-App row's —
+never this live read, which is a separate, platform-independent, mandatory
+proof. If even one of the four cannot be completed, there is
 no waiver and the delta stays unmergeable. Waived checks remain first in
 line for a real rerun once infrastructure is available again.
 

--- a/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
+++ b/docs/work/2026-07-30-cloud-release-evidence-risk-scope-spec.md
@@ -73,7 +73,8 @@ installed Relay App. The map rows' "one reference platform" scope governs
 only the waivable qualification repeats — including the Relay-App row's —
 never this live read, which is a separate, platform-independent, mandatory
 proof. If even one of the four cannot be completed, there is
-no waiver and the delta stays unmergeable. Waived checks remain first in
+no waiver and the delta stays unmergeable — the one remaining lever is then
+shrinking `cloud_remote_platforms` through a reviewed pull request. Waived checks remain first in
 line for a real rerun once infrastructure is available again.
 
 | Changed surface | Qualification to repeat | Real platform scope |


### PR DESCRIPTION
## What

Amends the Cloud evidence risk-scope contract with an explicit, ledger-recorded **reference-smoke waiver**: when no validation infrastructure is available (no reachable reference platform, or the human-gated Cloud authorization cannot complete because no interactive desktop session exists), the maintainer may waive the real reference-platform smoke and exactly those real-platform qualification reruns the delta's matched invalidation-map rows require.

Docs-only — the verifier and gate code are untouched, `cloud_remote_enabled` stays true.

## Why

The maintainer lost access to the validation lab. Without a documented waiver, every transport/OAuth-class delta (e.g. the parked runtime train #588) is permanently unmergeable, and the only alternatives were disabling Cloud remote in the product (rejected — Cloud stays enabled) or weakening the gate scripts (worse: silent, global, larger attack surface). A waiver is per-PR, explicit, and reviewable in the ledger.

## Guardrails kept

- Never waivable: JSON envelope, commit/tree identity, candidate provenance on every enabled platform, live `installed_relay_app` check.
- Each waived check must itself be blocked by the named unavailable infrastructure; a check that can still run, runs.
- The waiver never excuses ledger data — it is valid only with a complete entry (unavailable infrastructure, waived checks, carry source, crossing delta, accepted residual risk).
- Waived checks are first in line for a real rerun once infrastructure returns.

## Review

Two local Codex CLI passes; 8 consistency findings fixed (exact-target contradiction, waiver scope binding, carry-rule exception, runbook remainder incl. `installed_relay_app`, ledger eligibility reason, alignment of `docs/reference/testing.md` and the Cloud remote spec, acceptance section). `scripts/check-docs.sh` green.

**Known limit:** the waiver's eligibility ("no validation infrastructure") is self-attested by the maintainer; nothing machine-verifies it. That is inherent to a maintainer-attestation contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDuBAp45HgvBbZ9RxFrzwd