### PR TITLE
feat(release): scope Cloud publication to darwin (validation infrastructure loss)

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -332,7 +332,7 @@ The JSON is commit-specific and has this exact schema:
     "parity": true,
     "stress_10000": true,
     "keyrings": {
-      "linux": true
+      "darwin": true
     },
     "roles": true,
     "domains_mfa": true,

--- a/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
+++ b/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
@@ -704,8 +704,11 @@ Prompt (via `codex exec`, edit-referenced with
 ## Supported beta contexts
 
 - macOS desktop terminal
-- Windows console and RDP after real-device validation
-- validated Linux desktop Secret Service providers
+
+Windows (console and RDP) and validated Linux desktop Secret Service
+providers were supported contexts while their validation machines were
+available; since 2026-08-19 they are out of publication scope with the
+platform list below and return with it.
 
 WSL, SSH, services, gateways, and containers remain local-only until a separate
 credential-broker design is reviewed and validated.

--- a/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
+++ b/docs/work/2026-07-25-home-assistant-cloud-remote-spec.md
@@ -717,9 +717,16 @@ credential-broker design is reviewed and validated.
 ```json
 {
   "cloud_remote_enabled": true,
-  "cloud_remote_platforms": ["darwin", "linux", "windows"]
+  "cloud_remote_platforms": ["darwin"]
 }
 ```
+
+Since 2026-08-19 the validated platform list is `["darwin"]`: the Windows and
+Linux validation machines left the maintainer's reach, and per-platform
+candidate provenance is non-waivable, so publication is scoped to the
+platform that can still prove it. Windows and Linux return to the list
+through a reviewed pull request once their infrastructure is available
+again.
 
 The root and App copies must match. Ordinary `go build` output is compile-time
 disabled. Public builds fail closed unless they use the

--- a/docs/work/next-release-body.md
+++ b/docs/work/next-release-body.md
@@ -1,0 +1,21 @@
+# Next release — draft body
+
+Status: active
+
+Version-free by design; the release-prep PR renames this file once it picks
+the number.
+
+## What To Watch
+
+- **Cloud Remote is macOS-only in this release.** The validated platform
+  list shrank to `darwin` (2026-08-19): the Windows and Linux validation
+  machines are no longer available, and Cloud publication stays gated on
+  per-platform proof. Windows and Linux clients keep full local
+  functionality; their Cloud Remote option returns once validation
+  infrastructure is available again. Existing older installs are unaffected.
+
+## Internal
+
+- Runtime dependency train: `ws` 8.21.3 (root + nova), `jose` 6.2.8 (#588).
+- Evidence contract: ledger-recorded reference-smoke waiver for unavailable
+  validation infrastructure (#592).

--- a/nova/DOCS.md
+++ b/nova/DOCS.md
@@ -275,9 +275,10 @@ before destructive local cleanup.
 
 ## Cloud Beta Availability
 
-Enabled release builds support Cloud Remote only on macOS desktop terminals,
-Windows console/RDP sessions, and validated Linux desktop Secret Service
-providers. SSH, WSL, containers, services, gateways, and other headless
+Enabled release builds support Cloud Remote only on macOS desktop terminals.
+Windows and Linux are outside the validated platform list since 2026-08-19
+and return once their validation infrastructure is available again. SSH,
+WSL, containers, services, gateways, and other headless
 contexts stay local-only. Every publication remains gated on exact-source Home
 Assistant Cloud parity, native-keyring, user-role, redirect, lifecycle, App
 restart/update/reinstall, and 10,000-command Ingress-session stress evidence.

--- a/nova/version.json
+++ b/nova/version.json
@@ -3,8 +3,6 @@
   "min_relay_version": "0.9.0",
   "cloud_remote_enabled": true,
   "cloud_remote_platforms": [
-    "darwin",
-    "linux",
-    "windows"
+    "darwin"
   ]
 }

--- a/tests/onboarding/cloud-release-gate-contract.ts
+++ b/tests/onboarding/cloud-release-gate-contract.ts
@@ -67,17 +67,11 @@ export function registerCloudReleaseGateContractTests(): void {
       cloud_remote_platforms?: unknown;
     };
     expect(version.cloud_remote_enabled).toBe(true);
-    expect(version.cloud_remote_platforms).toEqual([
-      "darwin",
-      "linux",
-      "windows",
-    ]);
+    expect(version.cloud_remote_platforms).toEqual(["darwin"]);
     expect(appVersion.cloud_remote_enabled).toBe(version.cloud_remote_enabled);
     expect(appVersion.cloud_remote_platforms).toEqual(version.cloud_remote_platforms);
     expect(cloudSpec).toContain('"cloud_remote_enabled": true');
-    expect(cloudSpec).toContain(
-      '"cloud_remote_platforms": ["darwin", "linux", "windows"]',
-    );
+    expect(cloudSpec).toContain('"cloud_remote_platforms": ["darwin"]');
 
     for (const workflow of [releaseWorkflow, rcWorkflow]) {
       const protectionIndex = workflow.indexOf(

--- a/version.json
+++ b/version.json
@@ -3,8 +3,6 @@
   "min_relay_version": "0.9.0",
   "cloud_remote_enabled": true,
   "cloud_remote_platforms": [
-    "darwin",
-    "linux",
-    "windows"
+    "darwin"
   ]
 }


### PR DESCRIPTION
## What

`cloud_remote_platforms` shrinks from `["darwin", "linux", "windows"]` to `["darwin"]` in `version.json` and `nova/version.json`. `cloud_remote_enabled` stays `true`. The release-contract test pin, the Cloud remote spec's release-availability snippet, and the runbook's canonical envelope example follow.

## Why

The Windows and Linux validation machines left the maintainer's reach permanently. Per-platform candidate provenance is non-waivable under the reference-smoke waiver (#592) — an enabled platform whose provenance host is gone would leave every product PR unmergeable. Publication scope therefore shrinks to the platform that can still prove provenance locally: darwin. This is exactly the lever the risk-scope spec documents for this case.

## Consequences

- Future releases enable the Cloud remote feature only on macOS clients; Windows/Linux CLI builds gate it off (existing releases unaffected).
- Evidence sessions become fully local: darwin provenance on the maintainer workstation, no SSH lab hosts.
- Windows and Linux return through a reviewed PR once their infrastructure is available again; keyring/lifecycle qualifications for them then rerun per the map.

## Verification

vitest `tests/app` + `tests/onboarding` 736/736, full `go test ./...` in `cli/` green, `scripts/check-docs.sh` green, local Codex CLI review (1 finding — stale envelope example — fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDuBAp45HgvBbZ9RxFrzwd