### PR TITLE
fix(relay/docs): one consistent inline-JSON, data-file, and jq extraction contract (#587)

### DIFF
--- a/cli/help_test.go
+++ b/cli/help_test.go
@@ -145,7 +145,7 @@ func TestRelayHelpContractMatchesSkillDoc(t *testing.T) {
 		{"acceptable only for tiny, unambiguously read-only diagnostics", wsOut, "ws"},
 		{"acceptable only for tiny, unambiguously read-only diagnostics", coreOut, "core"},
 		{"mutations, complex bodies, reusable payloads, and cross-platform examples use --data-file", wsOut, "ws"},
-		{"--body-file", coreOut, "core"},
+		{"mutations, complex bodies, reusable payloads, and cross-platform examples use --body-file", coreOut, "core"},
 		{"upstream payload is in .data directly", wsOut, "ws"},
 		{"--jq '.data.version' on a ws get_config result", wsOut, "ws"},
 		{"upstream payload is in .data.body", coreOut, "core"},
@@ -156,8 +156,10 @@ func TestRelayHelpContractMatchesSkillDoc(t *testing.T) {
 		{"never call external jq", wsOut, "ws"},
 		{"never call external jq", coreOut, "core"},
 	}
+	docWS := strings.ReplaceAll(doc, " (ws) / --body-file (core)", "")
+	docCore := strings.ReplaceAll(strings.ReplaceAll(doc, "--data-file (ws) / ", ""), "--body-file (core)", "--body-file")
 	for _, tc := range shared {
-		if !strings.Contains(doc, tc.span) {
+		if !strings.Contains(doc, tc.span) && !strings.Contains(docWS, tc.span) && !strings.Contains(docCore, tc.span) {
 			t.Fatalf("relay-api.md missing contract span %q", tc.span)
 		}
 		if !strings.Contains(tc.help, tc.span) {

--- a/cli/help_test.go
+++ b/cli/help_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -64,6 +66,107 @@ func TestSubcommandHelpFlagPrintsUsageAndFlags(t *testing.T) {
 		if !strings.Contains(out, tc.wantFlag) {
 			t.Fatalf("%s --help missing flag %q:\n%s", tc.name, tc.wantFlag, out)
 		}
+	}
+}
+
+// relayProxyHelp captures the --help output of one relay proxy subcommand.
+func relayProxyHelp(t *testing.T, command string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := detectPaths()
+	if err != nil {
+		t.Fatalf("detectPaths() error: %v", err)
+	}
+	exit := 0
+	out := captureStdout(t, func() {
+		exit = runRelayCommand(paths, []string{command, "--help"})
+	})
+	if exit != 0 {
+		t.Fatalf("relay %s --help exit = %d, want 0\noutput:\n%s", command, exit, out)
+	}
+	return out
+}
+
+// ws/core --help must teach the one body-and-extraction contract: inline JSON
+// only for tiny read-only diagnostics, file flags for everything else, the
+// response envelope with .data vs .data.body, native jq extraction, and (core)
+// the strict-status exit semantics.
+func TestRelayProxyHelpTeachesBodyAndEnvelopeContract(t *testing.T) {
+	wsOut := relayProxyHelp(t, "ws")
+	for _, want := range []string{
+		"inline -d/--data JSON is acceptable only for tiny, unambiguously read-only diagnostics",
+		"Mutations, complex bodies, reusable payloads, and cross-platform examples use --data-file.",
+		`{"ok":true,"data":...}`,
+		"the upstream payload is in .data directly",
+		"--jq '.data.version' on a ws get_config result",
+		"Extraction: use --jq, --jq-file, or 'ha-nova relay jq'; never call external jq.",
+	} {
+		if !strings.Contains(wsOut, want) {
+			t.Fatalf("relay ws --help missing %q:\n%s", want, wsOut)
+		}
+	}
+
+	coreOut := relayProxyHelp(t, "core")
+	for _, want := range []string{
+		"inline -d/--body JSON is acceptable only for tiny, unambiguously read-only diagnostics",
+		"Mutations, complex bodies, reusable payloads, and cross-platform examples use --body-file.",
+		`{"ok":true,"data":{"status":200,"body":...}}`,
+		"the upstream payload is in .data.body",
+		"the upstream HTTP status in .data.status",
+		"--jq '.data.body.state' on a core GET /api/states/<entity_id> result",
+		"upstream 5xx always exits nonzero",
+		"--strict-status exits nonzero for any upstream error status",
+		"The response envelope is still printed either way.",
+		"Extraction: use --jq, --jq-file, or 'ha-nova relay jq'; never call external jq.",
+	} {
+		if !strings.Contains(coreOut, want) {
+			t.Fatalf("relay core --help missing %q:\n%s", want, coreOut)
+		}
+	}
+}
+
+// The skill doc and the generated CLI help must carry the same contract
+// sentences (backticks stripped, case-insensitive) so neither can drift.
+func TestRelayHelpContractMatchesSkillDoc(t *testing.T) {
+	docBytes, err := os.ReadFile(filepath.Join("..", "skills", "ha-nova", "relay-api.md"))
+	if err != nil {
+		t.Fatalf("reading relay-api.md: %v", err)
+	}
+	doc := strings.ToLower(strings.ReplaceAll(string(docBytes), "`", ""))
+	wsOut := strings.ToLower(relayProxyHelp(t, "ws"))
+	coreOut := strings.ToLower(relayProxyHelp(t, "core"))
+
+	shared := []struct {
+		span string
+		help string
+		name string
+	}{
+		{"acceptable only for tiny, unambiguously read-only diagnostics", wsOut, "ws"},
+		{"acceptable only for tiny, unambiguously read-only diagnostics", coreOut, "core"},
+		{"mutations, complex bodies, reusable payloads, and cross-platform examples use --data-file", wsOut, "ws"},
+		{"--body-file", coreOut, "core"},
+		{"upstream payload is in .data directly", wsOut, "ws"},
+		{"--jq '.data.version' on a ws get_config result", wsOut, "ws"},
+		{"upstream payload is in .data.body", coreOut, "core"},
+		{"--jq '.data.body.state' on a core get /api/states/<entity_id> result", coreOut, "core"},
+		{"upstream 5xx always exits nonzero", coreOut, "core"},
+		{"exits nonzero for any upstream error status", coreOut, "core"},
+		{"the response envelope is still printed either way", coreOut, "core"},
+		{"never call external jq", wsOut, "ws"},
+		{"never call external jq", coreOut, "core"},
+	}
+	for _, tc := range shared {
+		if !strings.Contains(doc, tc.span) {
+			t.Fatalf("relay-api.md missing contract span %q", tc.span)
+		}
+		if !strings.Contains(tc.help, tc.span) {
+			t.Fatalf("relay %s --help missing contract span %q:\n%s", tc.name, tc.span, tc.help)
+		}
+	}
+	// The false absolutism this contract replaced must not come back.
+	if strings.Contains(doc, "must use --data-file") {
+		t.Fatalf("relay-api.md reintroduces the inline-JSON absolutism (%q)", "MUST use --data-file")
 	}
 }
 

--- a/cli/relay.go
+++ b/cli/relay.go
@@ -137,7 +137,7 @@ func parseRelayFlags(command string, args []string) (relayRequestOptions, error)
 	fs.StringVar(&opts.Via, "via", "", "relay transport override: local or cloud")
 
 	if err := fs.Parse(args); err != nil {
-		if helpRequested(err, fs, "ha-nova relay "+command+" [flags]") {
+		if helpRequested(err, fs, "ha-nova relay "+command+" [flags]"+relayProxyHelpNotes(command)) {
 			return opts, errHelpShown
 		}
 		return opts, err
@@ -193,6 +193,35 @@ func parseRelayFlags(command string, args []string) (relayRequestOptions, error)
 		}
 	}
 	return opts, nil
+}
+
+// relayProxyHelpNotes appends the shared body/extraction contract to ws/core
+// --help. The wording mirrors skills/ha-nova/relay-api.md verbatim; the
+// agreement is pinned by TestRelayHelpContractMatchesSkillDoc so the CLI help
+// and the skill doc cannot drift apart.
+func relayProxyHelpNotes(command string) string {
+	const extraction = "Extraction: use --jq, --jq-file, or 'ha-nova relay jq'; never call external jq."
+	switch command {
+	case "ws":
+		return "\n\n" +
+			"Body: inline -d/--data JSON is acceptable only for tiny, unambiguously read-only diagnostics.\n" +
+			"Mutations, complex bodies, reusable payloads, and cross-platform examples use --data-file.\n" +
+			"Envelope: {\"ok\":true,\"data\":...} - the upstream payload is in .data directly\n" +
+			"(example: --jq '.data.version' on a ws get_config result).\n" +
+			extraction
+	case "core":
+		return "\n\n" +
+			"Body: inline -d/--body JSON is acceptable only for tiny, unambiguously read-only diagnostics.\n" +
+			"Mutations, complex bodies, reusable payloads, and cross-platform examples use --body-file.\n" +
+			"Envelope: {\"ok\":true,\"data\":{\"status\":200,\"body\":...}} - the upstream payload is in .data.body,\n" +
+			"the upstream HTTP status in .data.status\n" +
+			"(example: --jq '.data.body.state' on a core GET /api/states/<entity_id> result).\n" +
+			"Exit codes: upstream 5xx always exits nonzero; --strict-status exits nonzero for any upstream error status\n" +
+			"(.data.status >= 400). The response envelope is still printed either way.\n" +
+			extraction
+	default:
+		return ""
+	}
 }
 
 func loadRelayPayload(opts relayRequestOptions) ([]byte, error) {

--- a/cli/relay_test.go
+++ b/cli/relay_test.go
@@ -36,6 +36,20 @@ func TestApplyHealthTimeoutsRewritesPinnedClient(t *testing.T) {
 	}
 }
 
+// relay ws accepts inline JSON via -d and --data (issue #587): the contract
+// allows inline bodies for tiny read-only diagnostics, so the flags must parse.
+func TestParseRelayFlagsWSSupportsInlineData(t *testing.T) {
+	for _, flagName := range []string{"-d", "--data"} {
+		opts, err := parseRelayFlags("ws", []string{flagName, `{"type":"ping"}`})
+		if err != nil {
+			t.Fatalf("parseRelayFlags(ws %s) error: %v", flagName, err)
+		}
+		if !opts.InlineJSONSet || opts.InlineJSON != `{"type":"ping"}` {
+			t.Fatalf("ws %s: InlineJSONSet = %v, InlineJSON = %q", flagName, opts.InlineJSONSet, opts.InlineJSON)
+		}
+	}
+}
+
 func TestLoadRelayPayloadAcceptsSingleQuotedInlineJSON(t *testing.T) {
 	payload, err := loadRelayPayload(relayRequestOptions{
 		InlineJSON: `'{"type":"ping"}'`,

--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -64,7 +64,7 @@ Rules:
 - Use client-private scratch storage outside the project workspace for relay payload/result files; never allocate scratch directories or files from visible shell commands.
 - Scratch files are internal. Do not create them under the repo working tree, and do not mention scratch paths, payload files, filter files, or "edited files" in user-facing output unless the user asks for debugging details.
 - If command text is visible to the user, set the tool working directory to the scratch directory outside the command text, then run relay commands with local filenames, not absolute scratch paths.
-- Use inline `-d` / `--body` only for tiny diagnostics when shell quoting is already known-good.
+- Use inline JSON (`-d`/`--data` for ws, `-d`/`--body` for core) only for tiny, unambiguously read-only diagnostics when shell quoting is already known-good.
 
 ## Safety Baseline
 

--- a/skills/ha-nova/relay-api.md
+++ b/skills/ha-nova/relay-api.md
@@ -104,8 +104,7 @@ ha-nova relay core --method POST --path /api/services/light/turn_on --body-file 
 ```
 
 The wrapper handles auth (OS credential store), headers, timeouts, and base URL internally.
-Inline `--body` is not supported for WebSocket relay calls; WS request bodies MUST use `--data-file`.
-Inline `--body` may be used only for tiny `ha-nova relay core` diagnostics when quoting is already known-good; it is not the canonical cross-platform path.
+Inline JSON (`-d`/`--data` for ws, `-d`/`--body` for core; ws has no `--body` flag) is acceptable only for tiny, unambiguously read-only diagnostics when quoting is already known-good; it is never the canonical cross-platform path. Mutations, complex bodies, reusable payloads, and cross-platform examples use `--data-file` (ws) / `--body-file` (core).
 Relay API examples are not write authorization. Any live write still needs the owning skill's active-preview confirmation flow before execution.
 
 ## Standard Envelope
@@ -116,6 +115,7 @@ Relay API examples are not write authorization. Any live write still needs the o
 Parsing varies by endpoint:
 - `/ws` responses: upstream payload is in `.data` directly; the exact shape depends on the WS message type
 - `/core` responses: upstream payload is in `.data.body` (with `.data.status` for HTTP status)
+- Example: `--jq '.data.version'` on a ws `get_config` result; `--jq '.data.body.state'` on a core `GET /api/states/<entity_id>` result
 
 ## ID Types & Resolution
 
@@ -573,6 +573,8 @@ When the relay successfully proxies to HA but HA itself returns an error, the re
 
 Check: envelope `.ok == true`, then inspect `.data.status` for non-2xx values.
 
+Exit codes: upstream 5xx always exits nonzero; `ha-nova relay core --strict-status` exits nonzero for any upstream error status (`.data.status` >= 400). The response envelope is still printed either way.
+
 ## Timeout and Retry Guidance
 
 The CLI has hardcoded timeouts (not user-configurable):
@@ -594,7 +596,7 @@ For bulk inspection or review preparation:
 3. iterate over the saved shortlist with native file/loop tools
 4. follow selector semantics, stable ordering, and workset limits from `skills/ha-nova/bulk-patterns.md`
 
-Do not rely on external `jq` pipes as the canonical path.
+Do not rely on external `jq` pipes as the canonical path. Never call external `jq`; use `--jq`, `--jq-file`, or `ha-nova relay jq`.
 
 ## `relay jq` Usage
 

--- a/tests/skills/ha-nova-contract.test.ts
+++ b/tests/skills/ha-nova-contract.test.ts
@@ -395,13 +395,17 @@ describe("ha-nova contract", () => {
     expect(relayApi).toContain("POST /core");
     expect(relayApi).toContain("--data-file");
     expect(relayApi).toContain("--body-file");
+    // One inline-vs-file contract (issue #587): the wording is shared verbatim
+    // with the ws/core --help notes (cli/relay.go relayProxyHelpNotes, pinned
+    // by TestRelayHelpContractMatchesSkillDoc on the Go side).
     expect(relayApi).toContain(
-      "Inline `--body` is not supported for WebSocket relay calls",
+      "acceptable only for tiny, unambiguously read-only diagnostics",
     );
-    expect(relayApi).toContain("WS request bodies MUST use `--data-file`");
     expect(relayApi).toContain(
-      "Inline `--body` may be used only for tiny `ha-nova relay core` diagnostics",
+      "Mutations, complex bodies, reusable payloads, and cross-platform examples use `--data-file` (ws) / `--body-file` (core)",
     );
+    // The former false absolutism must not come back: relay ws supports -d/--data.
+    expect(relayApi).not.toContain("MUST use `--data-file`");
     expect(relayApi).toContain("--out");
     expect(relayApi).toContain("--jq-file <filter-file>");
     expect(relayApi).toContain("Supported flags are `-r`, `-e`, `-c`");


### PR DESCRIPTION
## Summary

The relay CLI, its help text, and the skill docs described conflicting body/extraction contracts. Reality check: `relay ws -d/--data` exists and works; strict-status semantics were undocumented; ws/core --help taught neither the envelope nor the inline-vs-file rule.

- `cli/relay.go`: ws/core --help now teach the contract — inline `-d` only for tiny, unambiguously read-only diagnostics; mutations/complex bodies use `--data-file`/`--body-file`; the response envelope (`.data` vs `.data.body`, `.data.status`) with a `--jq` example each; strict-status exit semantics (upstream 5xx always nonzero, `--strict-status` extends to any ≥400, envelope printed either way); native `--jq`/`--jq-file`/`relay jq` as the only extraction path. Help-text only, no behavior change.
- `skills/ha-nova/relay-api.md`: the false "WS bodies MUST use --data-file" absolutism replaced with the real contract; envelope example and strict-status paragraph added; external-jq ban stated.
- `skills/ha-nova/SKILL.md`: tiny-diagnostics line harmonized.
- Tests: `TestRelayProxyHelpTeachesBodyAndEnvelopeContract`, `TestRelayHelpContractMatchesSkillDoc` (machine-pins the SHARED sentences in both help and doc, per-flag normalization; bans the old absolutism), `TestParseRelayFlagsWSSupportsInlineData`; vitest pins updated with a re-drift guard.
- Pre-PR local Codex CLI review ran over the diff (release-bound rule); its one P2 (agreement test too loose on the core mutation sentence) is fixed — the full sentence is now pinned per flag.

## Tests
- `go test ./cli` — full suite green (203s). `npx vitest run tests/skills tests/onboarding/safe-test-system-contract.test.ts` — 581 passed. Typecheck green.

Closes #587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDuBAp45HgvBbZ9RxFrzwd