### PR TITLE
build(deps): runtime train — jose 6.2.10, workers-types 5.20260825.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
         "@peculiar/x509": "^2.0.0",
         "@serenity-kit/opaque": "^1.1.0",
         "home-assistant-js-websocket": "^9.6.0",
-        "jose": "^6.2.8",
+        "jose": "^6.2.10",
         "reflect-metadata": "^0.2.2",
         "ws": "^8.21.3",
         "yaml": "^2.9.0"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^5.20260810.1",
+        "@cloudflare/workers-types": "^5.20260825.1",
         "@types/node": "^25.9.5",
         "@types/ws": "^8.18.1",
         "husky": "^9.1.7",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260810.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260810.1.tgz",
-      "integrity": "sha512-aD0hEU6HaiG4wy4hDoPoLXMH963nHD4MsIY566pGkWO2dL/yeYEiMN7SeJ24t+wBmLDnh16yQ7IPos5opGkIoA==",
+      "version": "5.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260825.1.tgz",
+      "integrity": "sha512-/XZntbK+BlJWC5jxkaDNhnDLr2Bf2627sZ6VMrxqKrnc84pc6gNu5NdAyaTkZn1LzQVFIa3SL7V/7veLF59P7w==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -1670,9 +1670,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
-      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -96,13 +96,13 @@
     "@peculiar/x509": "^2.0.0",
     "@serenity-kit/opaque": "^1.1.0",
     "home-assistant-js-websocket": "^9.6.0",
-    "jose": "^6.2.8",
+    "jose": "^6.2.10",
     "reflect-metadata": "^0.2.2",
     "ws": "^8.21.3",
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^5.20260810.1",
+    "@cloudflare/workers-types": "^5.20260825.1",
     "@types/node": "^25.9.5",
     "@types/ws": "^8.18.1",
     "husky": "^9.1.7",


### PR DESCRIPTION
## Manifest gate

Changed manifest lines (root `package.json` + lockfile only; `nova/` untouched):
- `jose`: `^6.2.8` → `^6.2.10` (runtime; sole consumer `census-worker/src/access.ts`). 6.2.9/6.2.10 are upstream JWE hardening fixes (reject colliding Key Management Parameters, reject empty protected/AAD members) — patch-level, no API change.
- `@cloudflare/workers-types`: `^5.20260810.1` → `^5.20260825.1` (devDependencies; type surface only).

Supersedes Dependabot #608 and #589 at the current patch level so one evidence envelope covers both bumps (same pattern as #588's runtime train).

## Verification
- `vitest run tests/census-worker` (30/30) — the jose consumer's suite
- `npm run typecheck` (root + census-worker tsconfig) green
- Local Codex CLI review over the diff: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4pMfMeo3VUTUZhD6xr4h1