### PR TITLE
fix(release): evidence preflight refuses unresolved threads before burning the dispatch

### DIFF
--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -180,6 +180,19 @@ base_ref="$(jq -r '.base.ref // ""' <<<"$pr_json")"
 head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
 [ "$head_repo" = "$REPO" ] \
   || die "PR #$PR's head lives in '${head_repo:-unknown}', not $REPO — the candidate workflow only builds same-repo branches"
+# The resolver also refuses requested-changes reviews and unresolved review
+# threads; server-side that verdict lands only AFTER the dispatch and burns
+# the run (#609/rc22: a stale bot thread from a pre-session review). GraphQL
+# because REST cannot see thread resolution; first:100 is capacity, not a
+# filter — an over-100 tail still fails server-side.
+review_json="$(gh api graphql -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision reviewThreads(first:100){nodes{isResolved}}}}}' -F owner="${REPO%%/*}" -F name="${REPO##*/}" -F number="$PR")" \
+  || die "cannot read #$PR's review threads"
+unresolved="$(jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' <<<"$review_json")"
+[ "$unresolved" = 0 ] \
+  || die "PR #$PR carries $unresolved unresolved review thread(s) — the candidate workflow refuses the dispatch; resolve them first (stale bot threads from earlier reviews count)"
+review_decision="$(jq -r '.data.repository.pullRequest.reviewDecision // ""' <<<"$review_json")"
+[ "$review_decision" != "CHANGES_REQUESTED" ] \
+  || die "PR #$PR has a requested-changes review — the candidate workflow refuses the dispatch"
 case "$mergeable" in
   # `blocked` is the EXPECTED state here: cloud-source-gate is a required check
   # and it is red precisely because the envelope this script prepares does not

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -183,20 +183,30 @@ head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
 # The resolver also refuses requested-changes reviews and unresolved review
 # threads; server-side that verdict lands only AFTER the dispatch and burns
 # the run (#609/rc22: a stale bot thread from a pre-session review). GraphQL
-# because REST cannot see thread resolution; first:100 is capacity, not a
-# filter — an over-100 tail still fails server-side. Called here at resolve
-# time and again at the moment of spending (dispatch_and_bind): review state
-# arriving during envelope/reachability work would still burn the dispatch.
+# because REST cannot see thread resolution. Called here at resolve time and
+# again at the moment of spending (dispatch_and_bind): review state arriving
+# during envelope/reachability work would still burn the dispatch.
 require_reviewable_pr() {
-  local review_json unresolved review_decision
-  review_json="$(gh api graphql -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision reviewThreads(first:100){nodes{isResolved}}}}}' -F owner="${REPO%%/*}" -F name="${REPO##*/}" -F number="$PR")" \
+  local thread_pages
+  # Same --paginate --slurp + $endCursor shape as the server resolver
+  # (resolve-cloud-candidate-source.sh), so the preflight sees EVERY thread
+  # page, and the same reviewDecision allowlist.
+  thread_pages="$(gh api graphql --paginate --slurp \
+    -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F number="$PR" \
+    -f query='query($owner:String!,$name:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision reviewThreads(first:100,after:$endCursor){nodes{isResolved} pageInfo{hasNextPage endCursor}}}}}')" \
     || die "cannot read #$PR's review threads"
-  unresolved="$(jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' <<<"$review_json")"
-  [ "$unresolved" = 0 ] \
-    || die "PR #$PR carries $unresolved unresolved review thread(s) — the candidate workflow refuses the dispatch; resolve them first (stale bot threads from earlier reviews count)"
-  review_decision="$(jq -r '.data.repository.pullRequest.reviewDecision // ""' <<<"$review_json")"
-  [ "$review_decision" != "CHANGES_REQUESTED" ] \
-    || die "PR #$PR has a requested-changes review — the candidate workflow refuses the dispatch"
+  jq -e '
+    length > 0
+    and all(.[];
+      .data.repository.pullRequest != null
+      and (
+        .data.repository.pullRequest.reviewDecision == "APPROVED"
+        or .data.repository.pullRequest.reviewDecision == "REVIEW_REQUIRED"
+        or .data.repository.pullRequest.reviewDecision == null
+      )
+      and all(.data.repository.pullRequest.reviewThreads.nodes[]; .isResolved == true)
+    )' >/dev/null <<<"$thread_pages" \
+    || die "PR #$PR has requested changes or unresolved review threads — the candidate workflow refuses the dispatch; resolve them first (stale bot threads from earlier reviews count)"
 }
 require_reviewable_pr
 case "$mergeable" in

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -184,15 +184,21 @@ head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
 # threads; server-side that verdict lands only AFTER the dispatch and burns
 # the run (#609/rc22: a stale bot thread from a pre-session review). GraphQL
 # because REST cannot see thread resolution; first:100 is capacity, not a
-# filter — an over-100 tail still fails server-side.
-review_json="$(gh api graphql -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision reviewThreads(first:100){nodes{isResolved}}}}}' -F owner="${REPO%%/*}" -F name="${REPO##*/}" -F number="$PR")" \
-  || die "cannot read #$PR's review threads"
-unresolved="$(jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' <<<"$review_json")"
-[ "$unresolved" = 0 ] \
-  || die "PR #$PR carries $unresolved unresolved review thread(s) — the candidate workflow refuses the dispatch; resolve them first (stale bot threads from earlier reviews count)"
-review_decision="$(jq -r '.data.repository.pullRequest.reviewDecision // ""' <<<"$review_json")"
-[ "$review_decision" != "CHANGES_REQUESTED" ] \
-  || die "PR #$PR has a requested-changes review — the candidate workflow refuses the dispatch"
+# filter — an over-100 tail still fails server-side. Called here at resolve
+# time and again at the moment of spending (dispatch_and_bind): review state
+# arriving during envelope/reachability work would still burn the dispatch.
+require_reviewable_pr() {
+  local review_json unresolved review_decision
+  review_json="$(gh api graphql -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision reviewThreads(first:100){nodes{isResolved}}}}}' -F owner="${REPO%%/*}" -F name="${REPO##*/}" -F number="$PR")" \
+    || die "cannot read #$PR's review threads"
+  unresolved="$(jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length' <<<"$review_json")"
+  [ "$unresolved" = 0 ] \
+    || die "PR #$PR carries $unresolved unresolved review thread(s) — the candidate workflow refuses the dispatch; resolve them first (stale bot threads from earlier reviews count)"
+  review_decision="$(jq -r '.data.repository.pullRequest.reviewDecision // ""' <<<"$review_json")"
+  [ "$review_decision" != "CHANGES_REQUESTED" ] \
+    || die "PR #$PR has a requested-changes review — the candidate workflow refuses the dispatch"
+}
+require_reviewable_pr
 case "$mergeable" in
   # `blocked` is the EXPECTED state here: cloud-source-gate is a required check
   # and it is red precisely because the envelope this script prepares does not
@@ -359,6 +365,9 @@ download_run() {  # <run-id> ; hard-fails
 dispatch_and_bind() {  # sets run_id
   local max_before
   max_before="$(jq -r '[.[].databaseId] | max // 0' <<<"$runs_json")"
+  # Recheck at the moment of spending: the resolve-time snapshot can go stale
+  # while the envelope, reachability, and reuse probes run.
+  require_reviewable_pr
   echo "  dispatching (request_id=$request_id)"
   gh workflow run cloud-candidate-bundle.yml --repo "$REPO" \
     -f "pull_request=$PR" -f "version_tag=$version_tag" -f "request_id=$request_id" \

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -105,6 +105,10 @@ case "$args" in
   "api repos/${REPO_SLUG}/pulls/"*)
     trace "read:pr"
     cat "\${FAKE_GH_STATE}/pr.json" ;;
+  "api graphql -f query="*" -F owner="*" -F name="*" -F number="*)
+    trace "read:review-threads"
+    cat "\${FAKE_GH_STATE}/review.json" 2>/dev/null \\
+      || printf '{"data":{"repository":{"pullRequest":{"reviewDecision":null,"reviewThreads":{"nodes":[]}}}}}\\n' ;;
   "run list --repo ${REPO_SLUG} --workflow cloud-candidate-bundle.yml --json databaseId,status,conclusion,event --limit 30")
     trace "run-list"
     n="$(cat "\${FAKE_GH_STATE}/list.count" 2>/dev/null || echo 0)"
@@ -455,6 +459,50 @@ describe("cloud evidence PR target binding", () => {
     const result = runScript(fixture, fake, ["7"]);
     expect(result.status, result.stdout).not.toBe(0);
     expect(result.stderr).toContain("same-repo branches");
+  });
+
+  it("refuses unresolved review threads before spending a dispatch", () => {
+    // #609/rc22: a stale bot thread from a pre-session review burned the
+    // dispatch — server-side the resolver rejects only AFTER the run started.
+    const { fixture, fake } = prFixture();
+    writeFileSync(
+      join(fake.state, "review.json"),
+      JSON.stringify({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewDecision: null,
+              reviewThreads: { nodes: [{ isResolved: true }, { isResolved: false }] },
+            },
+          },
+        },
+      }),
+    );
+    const result = runScript(fixture, fake, ["7"]);
+    expect(result.status, result.stdout).not.toBe(0);
+    expect(result.stderr).toContain("unresolved review thread");
+    expect(readFileSync(fake.trace, "utf8")).not.toContain("dispatch");
+  });
+
+  it("refuses a requested-changes review before spending a dispatch", () => {
+    const { fixture, fake } = prFixture();
+    writeFileSync(
+      join(fake.state, "review.json"),
+      JSON.stringify({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewDecision: "CHANGES_REQUESTED",
+              reviewThreads: { nodes: [] },
+            },
+          },
+        },
+      }),
+    );
+    const result = runScript(fixture, fake, ["7"]);
+    expect(result.status, result.stdout).not.toBe(0);
+    expect(result.stderr).toContain("requested-changes review");
+    expect(readFileSync(fake.trace, "utf8")).not.toContain("dispatch");
   });
 
   it("refuses an envelope whose commit_sha is not the resolved target commit", () => {

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -105,10 +105,10 @@ case "$args" in
   "api repos/${REPO_SLUG}/pulls/"*)
     trace "read:pr"
     cat "\${FAKE_GH_STATE}/pr.json" ;;
-  "api graphql -f query="*" -F owner="*" -F name="*" -F number="*)
+  "api graphql --paginate --slurp -f owner="*" -f name="*" -F number="*" -f query="*)
     trace "read:review-threads"
     cat "\${FAKE_GH_STATE}/review.json" 2>/dev/null \\
-      || printf '{"data":{"repository":{"pullRequest":{"reviewDecision":null,"reviewThreads":{"nodes":[]}}}}}\\n' ;;
+      || printf '[{"data":{"repository":{"pullRequest":{"reviewDecision":null,"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]\\n' ;;
   "run list --repo ${REPO_SLUG} --workflow cloud-candidate-bundle.yml --json databaseId,status,conclusion,event --limit 30")
     trace "run-list"
     n="$(cat "\${FAKE_GH_STATE}/list.count" 2>/dev/null || echo 0)"
@@ -465,22 +465,42 @@ describe("cloud evidence PR target binding", () => {
     // #609/rc22: a stale bot thread from a pre-session review burned the
     // dispatch — server-side the resolver rejects only AFTER the run started.
     const { fixture, fake } = prFixture();
+    // Slurp shape: the unresolved thread sits on the SECOND page, so a
+    // first-page-only preflight would pass and burn the dispatch.
     writeFileSync(
       join(fake.state, "review.json"),
-      JSON.stringify({
-        data: {
-          repository: {
-            pullRequest: {
-              reviewDecision: null,
-              reviewThreads: { nodes: [{ isResolved: true }, { isResolved: false }] },
+      JSON.stringify([
+        {
+          data: {
+            repository: {
+              pullRequest: {
+                reviewDecision: null,
+                reviewThreads: {
+                  nodes: [{ isResolved: true }],
+                  pageInfo: { hasNextPage: true, endCursor: "c1" },
+                },
+              },
             },
           },
         },
-      }),
+        {
+          data: {
+            repository: {
+              pullRequest: {
+                reviewDecision: null,
+                reviewThreads: {
+                  nodes: [{ isResolved: false }],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          },
+        },
+      ]),
     );
     const result = runScript(fixture, fake, ["7"]);
     expect(result.status, result.stdout).not.toBe(0);
-    expect(result.stderr).toContain("unresolved review thread");
+    expect(result.stderr).toContain("unresolved review threads");
     expect(readFileSync(fake.trace, "utf8")).not.toContain("dispatch");
   });
 
@@ -488,20 +508,25 @@ describe("cloud evidence PR target binding", () => {
     const { fixture, fake } = prFixture();
     writeFileSync(
       join(fake.state, "review.json"),
-      JSON.stringify({
-        data: {
-          repository: {
-            pullRequest: {
-              reviewDecision: "CHANGES_REQUESTED",
-              reviewThreads: { nodes: [] },
+      JSON.stringify([
+        {
+          data: {
+            repository: {
+              pullRequest: {
+                reviewDecision: "CHANGES_REQUESTED",
+                reviewThreads: {
+                  nodes: [],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
             },
           },
         },
-      }),
+      ]),
     );
     const result = runScript(fixture, fake, ["7"]);
     expect(result.status, result.stdout).not.toBe(0);
-    expect(result.stderr).toContain("requested-changes review");
+    expect(result.stderr).toContain("requested changes");
     expect(readFileSync(fake.trace, "utf8")).not.toContain("dispatch");
   });
 


### PR DESCRIPTION
## What

`build-cloud-evidence.sh` already mirrors the candidate resolver's eligibility predicate locally (draft, base branch, same-repo head) so a doomed dispatch is refused before it burns a run. The thread check was missing: #609/rc22 burned a dispatch on a stale bot review thread from a pre-session review, discovered only in the workflow log. This adds the missing mirror — GraphQL `reviewThreads.isResolved` + `reviewDecision != CHANGES_REQUESTED` — right next to the existing checks, before any dispatch or provenance work.

## Verification
- `tests/onboarding/cloud-evidence-behavior.test.ts`: 27/27 green — two new regressions (unresolved thread → refuse before dispatch; requested-changes → refuse), gh stub extended with the GraphQL case (clean default keeps the pipeline tests meaningful).
- Local Codex CLI review + one adversarial subagent over the diff; the subagent verified empirically that `gh api graphql` exits non-zero on GraphQL-level errors (partial-data fail-open impossible) and that `--repoint` never reaches the guard.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4pMfMeo3VUTUZhD6xr4h1
