### PR TITLE
fix(release): dispatch preflight requires ci-gate green on a fresh head read

### DIFF
--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -234,11 +234,16 @@ require_ci_workflow_green() {
   # still fails server-side; ci-gate has no needs: on its siblings). Bind to
   # THIS PR's own run: the same head sha can carry a run from a stacked
   # branch, and an unattributed run fails closed.
+  # The resolver also binds the run to the CURRENT base: a run recorded
+  # against an older main is rejected server-side even when the merge is
+  # unchanged, so mirror the base predicate too.
+  main_now="$(git -C "$ROOT_DIR" ls-remote origin refs/heads/main 2>/dev/null | awk 'NR==1{print $1}')"
+  [ -n "$main_now" ] || die "cannot resolve origin/main for the CI-run base binding"
   gate_state="$(gh api "repos/$REPO/actions/runs?head_sha=$resolved_head_sha&event=pull_request&per_page=30" \
-      --jq '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml" and ([.pull_requests[]? | select(.number == '"$PR"')] | length) > 0)] | max_by(.id) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+      --jq '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml" and ([.pull_requests[]? | select(.number == '"$PR"' and (.base.sha // "") == "'"$main_now"'")] | length) > 0)] | max_by(.id) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
     || die "cannot read the CI workflow run for #$PR's head"
   [ "$gate_state" = "completed:success" ] \
-    || die "the CI workflow run is '$gate_state' on #$PR's head — the resolver refuses the dispatch until the whole run is completed:success"
+    || die "the CI workflow run is '$gate_state' for #$PR's head against the current base — rerun CI (or wait for it) before dispatching; the resolver refuses anything else"
 }
 require_reviewable_pr
 # Only the plain pipeline mode gates here: --set with a reusable candidate

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -239,8 +239,8 @@ require_ci_workflow_green() {
   # unchanged, so mirror the base predicate too.
   main_now="$(git -C "$ROOT_DIR" ls-remote origin refs/heads/main 2>/dev/null | awk 'NR==1{print $1}')"
   [ -n "$main_now" ] || die "cannot resolve origin/main for the CI-run base binding"
-  run_info="$(gh api "repos/$REPO/actions/runs?head_sha=$resolved_head_sha&event=pull_request&per_page=30" \
-      --jq '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml" and ([.pull_requests[]? | select(.number == '"$PR"' and (.base.sha // "") == "'"$main_now"'")] | length) > 0)] | max_by(.id) | if . == null then "absent" else "\(.check_suite_id // 0) \(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+  run_info="$(gh api --paginate --slurp "repos/$REPO/actions/runs?head_sha=$resolved_head_sha&event=pull_request&per_page=100" \
+      --jq '[.[] | .workflow_runs[] | select(.path == ".github/workflows/ci.yml" and ([.pull_requests[]? | select(.number == '"$PR"' and (.base.sha // "") == "'"$main_now"'")] | length) > 0)] | max_by(.id) | if . == null then "absent" else "\(.check_suite_id // 0) \(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
     || die "cannot read the CI workflow run for #$PR's head"
   suite_id="${run_info%% *}"; gate_state="${run_info#* }"
   [ "$gate_state" = "completed:success" ] \

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -216,7 +216,7 @@ require_reviewable_pr() {
 # actually burned a dispatch, and the slowest of the set; the resolver stays
 # the authority for the full policy list and its workflow bindings.
 require_ci_workflow_green() {
-  local gate_state fresh_merge main_now check_state
+  local gate_state fresh_merge main_now check_state run_info suite_id
   # Staleness stop at the moment of spending: the synthetic merge moves when
   # the PR head OR main advances, and request_id/target identity are bound to
   # the RESOLVED merge. Once the fresh merge matches, the resolved head sha is
@@ -239,19 +239,21 @@ require_ci_workflow_green() {
   # unchanged, so mirror the base predicate too.
   main_now="$(git -C "$ROOT_DIR" ls-remote origin refs/heads/main 2>/dev/null | awk 'NR==1{print $1}')"
   [ -n "$main_now" ] || die "cannot resolve origin/main for the CI-run base binding"
-  gate_state="$(gh api "repos/$REPO/actions/runs?head_sha=$resolved_head_sha&event=pull_request&per_page=30" \
-      --jq '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml" and ([.pull_requests[]? | select(.number == '"$PR"' and (.base.sha // "") == "'"$main_now"'")] | length) > 0)] | max_by(.id) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+  run_info="$(gh api "repos/$REPO/actions/runs?head_sha=$resolved_head_sha&event=pull_request&per_page=30" \
+      --jq '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml" and ([.pull_requests[]? | select(.number == '"$PR"' and (.base.sha // "") == "'"$main_now"'")] | length) > 0)] | max_by(.id) | if . == null then "absent" else "\(.check_suite_id // 0) \(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
     || die "cannot read the CI workflow run for #$PR's head"
+  suite_id="${run_info%% *}"; gate_state="${run_info#* }"
   [ "$gate_state" = "completed:success" ] \
-    || die "the CI workflow run is '$gate_state' for #$PR's head against the current base — rerun CI (or wait for it) before dispatching; the resolver refuses anything else"
-  # AND the ci-gate check run itself: a workflow edit that renames or drops
-  # the ci-gate job could leave the run green without the required check —
-  # the resolver demands the named check, so mirror both predicates.
+    || die "the CI workflow run is '${run_info}' for #$PR's head against the current base — rerun CI (or wait for it) before dispatching; the resolver refuses anything else"
+  # AND the named ci-gate check FROM THAT RUN's check suite: a workflow edit
+  # that renames or drops the job could leave the run green without the
+  # required check, and a check emitted by a different workflow on the same
+  # head must not satisfy it — suite binding covers both.
   check_state="$(gh api "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=10" \
-      --jq '[.check_runs[] | select((.app.slug // "") == "github-actions" and ([.pull_requests[]? | select(.number == '"$PR"')] | length) > 0)] | max_by(.started_at) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+      --jq '[.check_runs[] | select((.check_suite.id // 0) == '"$suite_id"')] | max_by(.started_at) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
     || die "cannot read the ci-gate check run for #$PR's head"
   [ "$check_state" = "completed:success" ] \
-    || die "the named ci-gate check is '$check_state' on #$PR's head — the resolver requires the check itself, not just a green workflow run"
+    || die "the named ci-gate check is '$check_state' inside the selected CI run's suite — the resolver requires the check itself, from this run"
 }
 require_reviewable_pr
 # Only the plain pipeline mode gates here: --set with a reusable candidate

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -216,7 +216,7 @@ require_reviewable_pr() {
 # actually burned a dispatch, and the slowest of the set; the resolver stays
 # the authority for the full policy list and its workflow bindings.
 require_ci_workflow_green() {
-  local gate_state fresh_merge main_now check_state run_info suite_id
+  local gate_state fresh_merge main_now check_state run_info suite_id check_info check_suite
   # Staleness stop at the moment of spending: the synthetic merge moves when
   # the PR head OR main advances, and request_id/target identity are bound to
   # the RESOLVED merge. Once the fresh merge matches, the resolved head sha is
@@ -249,13 +249,20 @@ require_ci_workflow_green() {
   # that renames or drops the job could leave the run green without the
   # required check, and a check emitted by a different workflow on the same
   # head must not satisfy it — suite binding covers both.
-  check_state="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=100" \
-      --jq '[.[] | .check_runs[] | select((.check_suite.id // 0) == '"$suite_id"')] | max_by(.started_at) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+  # The resolver binds the GLOBALLY latest ci-gate check and then verifies
+  # its workflow binding — so select the newest check first, and require that
+  # it belongs to the chosen CI run's suite (a newer check from any other
+  # suite would shadow it server-side).
+  check_info="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=100" \
+      --jq '[.[] | .check_runs[]] | max_by(.started_at) | if . == null then "absent" else "\(.check_suite.id // 0) \(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
     || die "cannot read the ci-gate check run for #$PR's head"
+  check_suite="${check_info%% *}"; check_state="${check_info#* }"
+  [ "$check_suite" = "$suite_id" ] \
+    || die "the newest ci-gate check on the head (suite ${check_suite}) does not come from the selected CI run's suite ($suite_id) — the resolver binds the newest check and would reject; investigate before dispatching"
   case "$check_state" in
     # The resolver's conclusion allowlist for the named check.
     completed:success|completed:skipped|completed:neutral) : ;;
-    *) die "the named ci-gate check is '$check_state' inside the selected CI run's suite — the resolver requires the check itself, from this run" ;;
+    *) die "the named ci-gate check is '$check_state' — the resolver requires it from this run" ;;
   esac
 }
 require_reviewable_pr

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -216,7 +216,7 @@ require_reviewable_pr() {
 # actually burned a dispatch, and the slowest of the set; the resolver stays
 # the authority for the full policy list and its workflow bindings.
 require_ci_workflow_green() {
-  local gate_state fresh_merge
+  local gate_state fresh_merge main_now check_state
   # Staleness stop at the moment of spending: the synthetic merge moves when
   # the PR head OR main advances, and request_id/target identity are bound to
   # the RESOLVED merge. Once the fresh merge matches, the resolved head sha is
@@ -244,6 +244,14 @@ require_ci_workflow_green() {
     || die "cannot read the CI workflow run for #$PR's head"
   [ "$gate_state" = "completed:success" ] \
     || die "the CI workflow run is '$gate_state' for #$PR's head against the current base — rerun CI (or wait for it) before dispatching; the resolver refuses anything else"
+  # AND the ci-gate check run itself: a workflow edit that renames or drops
+  # the ci-gate job could leave the run green without the required check —
+  # the resolver demands the named check, so mirror both predicates.
+  check_state="$(gh api "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=10" \
+      --jq '[.check_runs[] | select((.app.slug // "") == "github-actions" and ([.pull_requests[]? | select(.number == '"$PR"')] | length) > 0)] | max_by(.started_at) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+    || die "cannot read the ci-gate check run for #$PR's head"
+  [ "$check_state" = "completed:success" ] \
+    || die "the named ci-gate check is '$check_state' on #$PR's head — the resolver requires the check itself, not just a green workflow run"
 }
 require_reviewable_pr
 # Only the plain pipeline mode gates here: --set with a reusable candidate

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -177,6 +177,7 @@ merge_commit="$(jq -r '.merge_commit_sha // ""' <<<"$pr_json")"
 base_ref="$(jq -r '.base.ref // ""' <<<"$pr_json")"
 [ "$base_ref" = "main" ] \
   || die "PR #$PR targets '${base_ref:-unknown}', not main — the candidate workflow only builds PRs into main"
+resolved_head_sha="$(jq -r '.head.sha // ""' <<<"$pr_json")"
 head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
 [ "$head_repo" = "$REPO" ] \
   || die "PR #$PR's head lives in '${head_repo:-unknown}', not $REPO — the candidate workflow only builds same-repo branches"
@@ -216,10 +217,14 @@ require_reviewable_pr() {
 require_ci_gate_green() {
   local head_sha_pr gate_state
   # Fresh head read, not $pr_json: the spend-time recheck exists precisely
-  # because the resolve-time snapshot goes stale during the pipeline.
+  # because the resolve-time snapshot goes stale during the pipeline. A moved
+  # head is a hard stop, not something to accept — request_id, target_commit,
+  # and the artifact identity are all bound to the RESOLVED head's merge.
   head_sha_pr="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha // ""' 2>/dev/null)" \
     || die "cannot re-read PR #$PR's head"
   [ -n "$head_sha_pr" ] || die "PR #$PR has no head sha in the API response"
+  [ "$head_sha_pr" = "$resolved_head_sha" ] \
+    || die "PR #$PR's head moved since resolve ($resolved_head_sha -> $head_sha_pr) — the bound target is stale; re-run the pipeline"
   # filter defaults to latest: re-run attempts are collapsed server-side, so
   # this returns at most the newest ci-gate run for the head.
   gate_state="$(gh api "repos/$REPO/commits/$head_sha_pr/check-runs?check_name=ci-gate&per_page=10" \

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -216,7 +216,7 @@ require_reviewable_pr() {
 # actually burned a dispatch, and the slowest of the set; the resolver stays
 # the authority for the full policy list and its workflow bindings.
 require_ci_workflow_green() {
-  local gate_state fresh_merge main_now check_state run_info suite_id check_info check_suite status_shadow policy_file required_names head_checks required_check shadow_count
+  local gate_state fresh_merge main_now check_state run_info suite_id check_info check_suite policy_file required_names head_checks required_check shadow_count run_pages check_pages status_pages
   # The resolver requires the OWNING CI workflow run successful — the whole
   # run, not just the ci-gate job (a green ci-gate next to a red sibling job
   # still fails server-side; ci-gate has no needs: on its siblings). Bind to
@@ -227,9 +227,11 @@ require_ci_workflow_green() {
   # unchanged, so mirror the base predicate too.
   main_now="$(git -C "$ROOT_DIR" ls-remote origin refs/heads/main 2>/dev/null | awk 'NR==1{print $1}')"
   [ -n "$main_now" ] || die "cannot resolve origin/main for the CI-run base binding"
-  run_info="$(gh api --paginate --slurp "repos/$REPO/actions/runs?head_sha=$resolved_head_sha&event=pull_request&per_page=100" \
-      --jq '[.[] | .workflow_runs[] | select(.path == ".github/workflows/ci.yml" and ([.pull_requests[]? | select(.number == '"$PR"' and (.base.sha // "") == "'"$main_now"'")] | length) > 0)] | max_by(.id) | if . == null then "absent" else "\(.check_suite_id // 0) \(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
-    || die "cannot read the CI workflow run for #$PR's head"
+  # NOTE: gh refuses --slurp together with --jq — fetch raw pages, jq locally.
+  run_pages="$(gh api --paginate --slurp "repos/$REPO/actions/runs?head_sha=$resolved_head_sha&event=pull_request&per_page=100" 2>/dev/null)" \
+    || die "cannot read the CI workflow runs for #$PR's head"
+  run_info="$(jq -r --arg base "$main_now" --argjson pr "$PR" \
+      '[.[] | .workflow_runs[] | select(.path == ".github/workflows/ci.yml" and ([.pull_requests[]? | select(.number == $pr and (.base.sha // "") == $base)] | length) > 0)] | max_by(.id) | if . == null then "absent" else "\(.check_suite_id // 0) \(.status):\(.conclusion // "-")" end' <<<"$run_pages")"
   suite_id="${run_info%% *}"; gate_state="${run_info#* }"
   [ "$gate_state" = "completed:success" ] \
     || die "the CI workflow run is '${run_info}' for #$PR's head against the current base — rerun CI (or wait for it) before dispatching; the resolver refuses anything else"
@@ -245,9 +247,10 @@ require_ci_workflow_green() {
   [ -f "$policy_file" ] || die "repository policy is missing ($policy_file)"
   required_names="$(jq -c '.main_branch_protection | ((.required_status_checks - ["cloud-source-gate"]) + .advisory_checks) | unique' "$policy_file")" \
     || die "cannot read the required-check list from $policy_file"
-  head_checks="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/check-runs?per_page=100" \
-      --jq '[.[] | .check_runs[] | select((.app.slug // "") == "github-actions" and ([.pull_requests[]? | select(.number == '"$PR"')] | length) > 0)]' 2>/dev/null)" \
+  check_pages="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/check-runs?per_page=100" 2>/dev/null)" \
     || die "cannot read the check runs for #$PR's head"
+  head_checks="$(jq --argjson pr "$PR" \
+      '[.[] | .check_runs[] | select((.app.slug // "") == "github-actions" and ([.pull_requests[]? | select(.number == $pr)] | length) > 0)]' <<<"$check_pages")"
   while IFS= read -r required_check; do
     check_info="$(jq -r --arg n "$required_check" '[.[] | select(.name == $n)] | max_by(.id) | if . == null then "absent" else "\(.check_suite.id // 0) \(.status):\(.conclusion // "-")" end' <<<"$head_checks")"
     check_suite="${check_info%% *}"; check_state="${check_info#* }"
@@ -263,10 +266,9 @@ require_ci_workflow_green() {
   done < <(jq -r '.[]' <<<"$required_names")
   # The resolver also refuses any required check shadowed by a legacy commit
   # STATUS of the same name.
-  status_shadow="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/status?per_page=100" \
-      --jq '[.[] | .statuses[]?.context]' 2>/dev/null)" \
+  status_pages="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/status?per_page=100" 2>/dev/null)" \
     || die "cannot read commit statuses for #$PR's head"
-  shadow_count="$(jq --argjson names "$required_names" '[.[] | select(. as $c | $names | index($c))] | length' <<<"$status_shadow")"
+  shadow_count="$(jq --argjson names "$required_names" '[.[] | .statuses[]?.context | select(. as $c | $names | index($c))] | length' <<<"$status_pages")"
   [ "${shadow_count:-0}" = "0" ] \
     || die "a legacy commit status shadows a required check on #$PR's head — the resolver refuses; remove the status source first"
   # Staleness stop LAST — after every API read above: the synthetic merge

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -229,10 +229,12 @@ require_ci_gate_green() {
     [ "$fresh_merge" = "$target_commit" ] \
       || die "the synthetic merge moved since resolve ($target_commit -> $fresh_merge) — head or base advanced; re-run the pipeline"
   fi
-  # filter defaults to latest: re-run attempts are collapsed server-side, so
-  # this returns at most the newest ci-gate run for the head.
+  # filter defaults to latest: re-run attempts are collapsed server-side.
+  # Bind to THIS PR's own GitHub-Actions run — the same head sha can carry a
+  # ci-gate result from another PR (stacked branch) or another app; the
+  # resolver verifies that binding and would reject after the spend.
   gate_state="$(gh api "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=10" \
-      --jq '[.check_runs[]] | max_by(.started_at) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+      --jq '[.check_runs[] | select((.app.slug // "") == "github-actions" and ([.pull_requests[]? | select(.number == '"$PR"')] | length) > 0)] | max_by(.started_at) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
     || die "cannot read ci-gate's check run for #$PR's head"
   [ "$gate_state" = "completed:success" ] \
     || die "required pre-evidence check ci-gate is '$gate_state' on the head — the resolver refuses the dispatch until it is completed:success"

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -458,9 +458,12 @@ dispatch_and_bind() {  # sets run_id
   local max_before
   max_before="$(jq -r '[.[].databaseId] | max // 0' <<<"$runs_json")"
   # Recheck at the moment of spending: the resolve-time snapshot can go stale
-  # while the envelope, reachability, and reuse probes run.
-  require_reviewable_pr
+  # while the envelope, reachability, and reuse probes run. CI reads first,
+  # the cheap reviewability read LAST — its window to the dispatch is the
+  # smallest, so review state arriving during the slower CI reads still
+  # refuses.
   require_ci_workflow_green
+  require_reviewable_pr
   echo "  dispatching (request_id=$request_id)"
   gh workflow run cloud-candidate-bundle.yml --repo "$REPO" \
     -f "pull_request=$PR" -f "version_tag=$version_tag" -f "request_id=$request_id" \

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -241,10 +241,12 @@ require_ci_workflow_green() {
     || die "the CI workflow run is '$gate_state' on #$PR's head — the resolver refuses the dispatch until the whole run is completed:success"
 }
 require_reviewable_pr
-# --set with a reusable candidate dispatches nothing, and checklist step 8
-# reruns CI AFTER --set (ci-gate goes pending) — a repeat --set in that window
-# must not be refused. The dispatch itself stays guarded in dispatch_and_bind.
-[ "$MODE" = "--set" ] || require_ci_workflow_green
+# Only the plain pipeline mode gates here: --set with a reusable candidate
+# dispatches nothing (and checklist step 8 reruns CI AFTER --set — a repeat
+# --set in that window must not be refused), and --dry-run exits before any
+# spend. The dispatch itself stays guarded in dispatch_and_bind, which also
+# covers --set's expired-artifact fresh-dispatch fallback.
+if [ -z "$MODE" ]; then require_ci_workflow_green; fi
 case "$mergeable" in
   # `blocked` is the EXPECTED state here: cloud-source-gate is a required check
   # and it is red precisely because the envelope this script prepares does not

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -215,7 +215,7 @@ require_reviewable_pr() {
 # seconds after a push, CI unfinished). Mirror only ci-gate — the one that
 # actually burned a dispatch, and the slowest of the set; the resolver stays
 # the authority for the full policy list and its workflow bindings.
-require_ci_gate_green() {
+require_ci_workflow_green() {
   local gate_state fresh_merge
   # Staleness stop at the moment of spending: the synthetic merge moves when
   # the PR head OR main advances, and request_id/target identity are bound to
@@ -229,21 +229,22 @@ require_ci_gate_green() {
     [ "$fresh_merge" = "$target_commit" ] \
       || die "the synthetic merge moved since resolve ($target_commit -> $fresh_merge) — head or base advanced; re-run the pipeline"
   fi
-  # filter defaults to latest: re-run attempts are collapsed server-side.
-  # Bind to THIS PR's own GitHub-Actions run — the same head sha can carry a
-  # ci-gate result from another PR (stacked branch) or another app; the
-  # resolver verifies that binding and would reject after the spend.
-  gate_state="$(gh api "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=10" \
-      --jq '[.check_runs[] | select((.app.slug // "") == "github-actions" and ([.pull_requests[]? | select(.number == '"$PR"')] | length) > 0)] | max_by(.started_at) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
-    || die "cannot read ci-gate's check run for #$PR's head"
+  # The resolver requires the OWNING CI workflow run successful — the whole
+  # run, not just the ci-gate job (a green ci-gate next to a red sibling job
+  # still fails server-side; ci-gate has no needs: on its siblings). Bind to
+  # THIS PR's own run: the same head sha can carry a run from a stacked
+  # branch, and an unattributed run fails closed.
+  gate_state="$(gh api "repos/$REPO/actions/runs?head_sha=$resolved_head_sha&event=pull_request&per_page=30" \
+      --jq '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml" and ([.pull_requests[]? | select(.number == '"$PR"')] | length) > 0)] | max_by(.id) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+    || die "cannot read the CI workflow run for #$PR's head"
   [ "$gate_state" = "completed:success" ] \
-    || die "required pre-evidence check ci-gate is '$gate_state' on the head — the resolver refuses the dispatch until it is completed:success"
+    || die "the CI workflow run is '$gate_state' on #$PR's head — the resolver refuses the dispatch until the whole run is completed:success"
 }
 require_reviewable_pr
 # --set with a reusable candidate dispatches nothing, and checklist step 8
 # reruns CI AFTER --set (ci-gate goes pending) — a repeat --set in that window
 # must not be refused. The dispatch itself stays guarded in dispatch_and_bind.
-[ "$MODE" = "--set" ] || require_ci_gate_green
+[ "$MODE" = "--set" ] || require_ci_workflow_green
 case "$mergeable" in
   # `blocked` is the EXPECTED state here: cloud-source-gate is a required check
   # and it is red precisely because the envelope this script prepares does not
@@ -413,7 +414,7 @@ dispatch_and_bind() {  # sets run_id
   # Recheck at the moment of spending: the resolve-time snapshot can go stale
   # while the envelope, reachability, and reuse probes run.
   require_reviewable_pr
-  require_ci_gate_green
+  require_ci_workflow_green
   echo "  dispatching (request_id=$request_id)"
   gh workflow run cloud-candidate-bundle.yml --repo "$REPO" \
     -f "pull_request=$PR" -f "version_tag=$version_tag" -f "request_id=$request_id" \

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -195,12 +195,13 @@ require_reviewable_pr() {
   # page, and the same reviewDecision allowlist.
   thread_pages="$(gh api graphql --paginate --slurp \
     -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F number="$PR" \
-    -f query='query($owner:String!,$name:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision reviewThreads(first:100,after:$endCursor){nodes{isResolved} pageInfo{hasNextPage endCursor}}}}}')" \
+    -f query='query($owner:String!,$name:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$name){pullRequest(number:$number){isDraft reviewDecision reviewThreads(first:100,after:$endCursor){nodes{isResolved} pageInfo{hasNextPage endCursor}}}}}')" \
     || die "cannot read #$PR's review threads"
   jq -e '
     length > 0
     and all(.[];
       .data.repository.pullRequest != null
+      and .data.repository.pullRequest.isDraft == false
       and (
         .data.repository.pullRequest.reviewDecision == "APPROVED"
         or .data.repository.pullRequest.reviewDecision == "REVIEW_REQUIRED"
@@ -208,7 +209,7 @@ require_reviewable_pr() {
       )
       and all(.data.repository.pullRequest.reviewThreads.nodes[]; .isResolved == true)
     )' >/dev/null <<<"$thread_pages" \
-    || die "PR #$PR has requested changes or unresolved review threads — the candidate workflow refuses the dispatch; resolve them first (stale bot threads from earlier reviews count)"
+    || die "PR #$PR is a draft, has requested changes, or carries unresolved review threads — the candidate workflow refuses the dispatch; resolve that first (stale bot threads from earlier reviews count)"
 }
 # The resolver requires every pre-evidence check green before it builds;
 # dispatching while ci-gate still runs burns the run (#611/rc23: dispatched

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -178,6 +178,7 @@ base_ref="$(jq -r '.base.ref // ""' <<<"$pr_json")"
 [ "$base_ref" = "main" ] \
   || die "PR #$PR targets '${base_ref:-unknown}', not main — the candidate workflow only builds PRs into main"
 resolved_head_sha="$(jq -r '.head.sha // ""' <<<"$pr_json")"
+[ -n "$resolved_head_sha" ] || die "PR #$PR has no head sha in the API response"
 head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
 [ "$head_repo" = "$REPO" ] \
   || die "PR #$PR's head lives in '${head_repo:-unknown}', not $REPO — the candidate workflow only builds same-repo branches"
@@ -215,19 +216,22 @@ require_reviewable_pr() {
 # actually burned a dispatch, and the slowest of the set; the resolver stays
 # the authority for the full policy list and its workflow bindings.
 require_ci_gate_green() {
-  local head_sha_pr gate_state
-  # Fresh head read, not $pr_json: the spend-time recheck exists precisely
-  # because the resolve-time snapshot goes stale during the pipeline. A moved
-  # head is a hard stop, not something to accept — request_id, target_commit,
-  # and the artifact identity are all bound to the RESOLVED head's merge.
-  head_sha_pr="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha // ""' 2>/dev/null)" \
-    || die "cannot re-read PR #$PR's head"
-  [ -n "$head_sha_pr" ] || die "PR #$PR has no head sha in the API response"
-  [ "$head_sha_pr" = "$resolved_head_sha" ] \
-    || die "PR #$PR's head moved since resolve ($resolved_head_sha -> $head_sha_pr) — the bound target is stale; re-run the pipeline"
+  local gate_state fresh_merge
+  # Staleness stop at the moment of spending: the synthetic merge moves when
+  # the PR head OR main advances, and request_id/target identity are bound to
+  # the RESOLVED merge. Once the fresh merge matches, the resolved head sha is
+  # proven current — no separate head re-read needed. At resolve time
+  # target_commit is not set yet; the freshly resolved state needs no check.
+  if [ -n "${target_commit:-}" ]; then
+    git -C "$ROOT_DIR" fetch --quiet --force origin "+refs/pull/$PR/merge:refs/cloud-evidence/$PR" 2>/dev/null \
+      || die "cannot re-fetch the synthetic merge ref for #$PR"
+    fresh_merge="$(git -C "$ROOT_DIR" rev-parse "refs/cloud-evidence/$PR")"
+    [ "$fresh_merge" = "$target_commit" ] \
+      || die "the synthetic merge moved since resolve ($target_commit -> $fresh_merge) — head or base advanced; re-run the pipeline"
+  fi
   # filter defaults to latest: re-run attempts are collapsed server-side, so
   # this returns at most the newest ci-gate run for the head.
-  gate_state="$(gh api "repos/$REPO/commits/$head_sha_pr/check-runs?check_name=ci-gate&per_page=10" \
+  gate_state="$(gh api "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=10" \
       --jq '[.check_runs[]] | max_by(.started_at) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
     || die "cannot read ci-gate's check run for #$PR's head"
   [ "$gate_state" = "completed:success" ] \

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -216,19 +216,7 @@ require_reviewable_pr() {
 # actually burned a dispatch, and the slowest of the set; the resolver stays
 # the authority for the full policy list and its workflow bindings.
 require_ci_workflow_green() {
-  local gate_state fresh_merge main_now check_state run_info suite_id check_info check_suite
-  # Staleness stop at the moment of spending: the synthetic merge moves when
-  # the PR head OR main advances, and request_id/target identity are bound to
-  # the RESOLVED merge. Once the fresh merge matches, the resolved head sha is
-  # proven current — no separate head re-read needed. At resolve time
-  # target_commit is not set yet; the freshly resolved state needs no check.
-  if [ -n "${target_commit:-}" ]; then
-    git -C "$ROOT_DIR" fetch --quiet --force origin "+refs/pull/$PR/merge:refs/cloud-evidence/$PR" 2>/dev/null \
-      || die "cannot re-fetch the synthetic merge ref for #$PR"
-    fresh_merge="$(git -C "$ROOT_DIR" rev-parse "refs/cloud-evidence/$PR")"
-    [ "$fresh_merge" = "$target_commit" ] \
-      || die "the synthetic merge moved since resolve ($target_commit -> $fresh_merge) — head or base advanced; re-run the pipeline"
-  fi
+  local gate_state fresh_merge main_now check_state run_info suite_id check_info check_suite status_shadow
   # The resolver requires the OWNING CI workflow run successful — the whole
   # run, not just the ci-gate job (a green ci-gate next to a red sibling job
   # still fails server-side; ci-gate has no needs: on its siblings). Bind to
@@ -254,7 +242,7 @@ require_ci_workflow_green() {
   # it belongs to the chosen CI run's suite (a newer check from any other
   # suite would shadow it server-side).
   check_info="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=100" \
-      --jq '[.[] | .check_runs[]] | max_by(.id) | if . == null then "absent" else "\(.check_suite.id // 0) \(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+      --jq '[.[] | .check_runs[] | select((.app.slug // "") == "github-actions")] | max_by(.id) | if . == null then "absent" else "\(.check_suite.id // 0) \(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
     || die "cannot read the ci-gate check run for #$PR's head"
   check_suite="${check_info%% *}"; check_state="${check_info#* }"
   [ "$check_suite" = "$suite_id" ] \
@@ -264,6 +252,24 @@ require_ci_workflow_green() {
     completed:success|completed:skipped|completed:neutral) : ;;
     *) die "the named ci-gate check is '$check_state' — the resolver requires it from this run" ;;
   esac
+  # The resolver also refuses a ci-gate shadowed by a legacy commit STATUS.
+  status_shadow="$(gh api "repos/$REPO/commits/$resolved_head_sha/status" \
+      --jq '[.statuses[]? | select(.context == "ci-gate")] | length' 2>/dev/null)" \
+    || die "cannot read commit statuses for #$PR's head"
+  [ "${status_shadow:-0}" = "0" ] \
+    || die "a legacy commit status named ci-gate shadows the check on #$PR's head — the resolver refuses; remove the status source first"
+  # Staleness stop LAST — after every API read above: the synthetic merge
+  # moves when the PR head OR main advances, and request_id/target identity
+  # are bound to the RESOLVED merge; a match here proves the reads above ran
+  # against the still-current state. At resolve time target_commit is not set
+  # yet; the freshly resolved state needs no check.
+  if [ -n "${target_commit:-}" ]; then
+    git -C "$ROOT_DIR" fetch --quiet --force origin "+refs/pull/$PR/merge:refs/cloud-evidence/$PR" 2>/dev/null \
+      || die "cannot re-fetch the synthetic merge ref for #$PR"
+    fresh_merge="$(git -C "$ROOT_DIR" rev-parse "refs/cloud-evidence/$PR")"
+    [ "$fresh_merge" = "$target_commit" ] \
+      || die "the synthetic merge moved since resolve ($target_commit -> $fresh_merge) — head or base advanced; re-run the pipeline"
+  fi
 }
 require_reviewable_pr
 # Only the plain pipeline mode gates here: --set with a reusable candidate

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -195,12 +195,13 @@ require_reviewable_pr() {
   # page, and the same reviewDecision allowlist.
   thread_pages="$(gh api graphql --paginate --slurp \
     -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F number="$PR" \
-    -f query='query($owner:String!,$name:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$name){pullRequest(number:$number){isDraft reviewDecision reviewThreads(first:100,after:$endCursor){nodes{isResolved} pageInfo{hasNextPage endCursor}}}}}')" \
+    -f query='query($owner:String!,$name:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$name){pullRequest(number:$number){state isDraft reviewDecision reviewThreads(first:100,after:$endCursor){nodes{isResolved} pageInfo{hasNextPage endCursor}}}}}')" \
     || die "cannot read #$PR's review threads"
   jq -e '
     length > 0
     and all(.[];
       .data.repository.pullRequest != null
+      and .data.repository.pullRequest.state == "OPEN"
       and .data.repository.pullRequest.isDraft == false
       and (
         .data.repository.pullRequest.reviewDecision == "APPROVED"
@@ -209,7 +210,7 @@ require_reviewable_pr() {
       )
       and all(.data.repository.pullRequest.reviewThreads.nodes[]; .isResolved == true)
     )' >/dev/null <<<"$thread_pages" \
-    || die "PR #$PR is a draft, has requested changes, or carries unresolved review threads — the candidate workflow refuses the dispatch; resolve that first (stale bot threads from earlier reviews count)"
+    || die "PR #$PR is not an open non-draft PR with clean review state (closed/draft/requested-changes/unresolved threads) — the candidate workflow refuses the dispatch; resolve that first (stale bot threads from earlier reviews count)"
 }
 # The resolver requires every pre-evidence check green before it builds;
 # dispatching while ci-gate still runs burns the run (#611/rc23: dispatched
@@ -244,10 +245,15 @@ require_ci_workflow_green() {
   # must sit in the allowlist, and ci-gate's must come from the selected CI
   # run's suite (a workflow edit that drops the job, or a check emitted by
   # another workflow, fails closed).
-  policy_file="$ROOT_DIR/.github/policy/repo-policy.json"
-  [ -f "$policy_file" ] || die "repository policy is missing ($policy_file)"
-  required_names="$(jq -c '.main_branch_protection | ((.required_status_checks - ["cloud-source-gate"]) + .advisory_checks) | unique' "$policy_file")" \
-    || die "cannot read the required-check list from $policy_file"
+  # Policy from TRUSTED origin/main, never the working tree: a PR that edits
+  # the policy file must not feed the preflight its own check list (the
+  # server-side resolver reads main's policy the same way).
+  git -C "$ROOT_DIR" fetch --quiet --force origin "+refs/heads/main:refs/cloud-evidence/policy-main" 2>/dev/null \
+    || die "cannot fetch origin/main for the check policy"
+  required_names="$(git -C "$ROOT_DIR" show "refs/cloud-evidence/policy-main:.github/policy/repo-policy.json" 2>/dev/null \
+      | jq -c '.main_branch_protection | ((.required_status_checks - ["cloud-source-gate"]) + .advisory_checks) | unique')" \
+    || die "cannot read the required-check list from origin/main's repo policy"
+  [ -n "$required_names" ] || die "origin/main's repo policy yields no required-check list"
   check_pages="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/check-runs?per_page=100" 2>/dev/null)" \
     || die "cannot read the check runs for #$PR's head"
   head_checks="$(jq --argjson pr "$PR" \

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -252,8 +252,11 @@ require_ci_workflow_green() {
   check_state="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=100" \
       --jq '[.[] | .check_runs[] | select((.check_suite.id // 0) == '"$suite_id"')] | max_by(.started_at) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
     || die "cannot read the ci-gate check run for #$PR's head"
-  [ "$check_state" = "completed:success" ] \
-    || die "the named ci-gate check is '$check_state' inside the selected CI run's suite — the resolver requires the check itself, from this run"
+  case "$check_state" in
+    # The resolver's conclusion allowlist for the named check.
+    completed:success|completed:skipped|completed:neutral) : ;;
+    *) die "the named ci-gate check is '$check_state' inside the selected CI run's suite — the resolver requires the check itself, from this run" ;;
+  esac
 }
 require_reviewable_pr
 # Only the plain pipeline mode gates here: --set with a reusable candidate

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -208,7 +208,31 @@ require_reviewable_pr() {
     )' >/dev/null <<<"$thread_pages" \
     || die "PR #$PR has requested changes or unresolved review threads — the candidate workflow refuses the dispatch; resolve them first (stale bot threads from earlier reviews count)"
 }
+# The resolver requires every pre-evidence check green before it builds;
+# dispatching while ci-gate still runs burns the run (#611/rc23: dispatched
+# seconds after a push, CI unfinished). Mirror only ci-gate — the one that
+# actually burned a dispatch, and the slowest of the set; the resolver stays
+# the authority for the full policy list and its workflow bindings.
+require_ci_gate_green() {
+  local head_sha_pr gate_state
+  # Fresh head read, not $pr_json: the spend-time recheck exists precisely
+  # because the resolve-time snapshot goes stale during the pipeline.
+  head_sha_pr="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha // ""' 2>/dev/null)" \
+    || die "cannot re-read PR #$PR's head"
+  [ -n "$head_sha_pr" ] || die "PR #$PR has no head sha in the API response"
+  # filter defaults to latest: re-run attempts are collapsed server-side, so
+  # this returns at most the newest ci-gate run for the head.
+  gate_state="$(gh api "repos/$REPO/commits/$head_sha_pr/check-runs?check_name=ci-gate&per_page=10" \
+      --jq '[.check_runs[]] | max_by(.started_at) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+    || die "cannot read ci-gate's check run for #$PR's head"
+  [ "$gate_state" = "completed:success" ] \
+    || die "required pre-evidence check ci-gate is '$gate_state' on the head — the resolver refuses the dispatch until it is completed:success"
+}
 require_reviewable_pr
+# --set with a reusable candidate dispatches nothing, and checklist step 8
+# reruns CI AFTER --set (ci-gate goes pending) — a repeat --set in that window
+# must not be refused. The dispatch itself stays guarded in dispatch_and_bind.
+[ "$MODE" = "--set" ] || require_ci_gate_green
 case "$mergeable" in
   # `blocked` is the EXPECTED state here: cloud-source-gate is a required check
   # and it is red precisely because the envelope this script prepares does not
@@ -378,6 +402,7 @@ dispatch_and_bind() {  # sets run_id
   # Recheck at the moment of spending: the resolve-time snapshot can go stale
   # while the envelope, reachability, and reuse probes run.
   require_reviewable_pr
+  require_ci_gate_green
   echo "  dispatching (request_id=$request_id)"
   gh workflow run cloud-candidate-bundle.yml --repo "$REPO" \
     -f "pull_request=$PR" -f "version_tag=$version_tag" -f "request_id=$request_id" \

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -242,7 +242,7 @@ require_ci_workflow_green() {
   # it belongs to the chosen CI run's suite (a newer check from any other
   # suite would shadow it server-side).
   check_info="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=100" \
-      --jq '[.[] | .check_runs[] | select((.app.slug // "") == "github-actions")] | max_by(.id) | if . == null then "absent" else "\(.check_suite.id // 0) \(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+      --jq '[.[] | .check_runs[] | select((.app.slug // "") == "github-actions" and ([.pull_requests[]? | select(.number == '"$PR"')] | length) > 0)] | max_by(.id) | if . == null then "absent" else "\(.check_suite.id // 0) \(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
     || die "cannot read the ci-gate check run for #$PR's head"
   check_suite="${check_info%% *}"; check_state="${check_info#* }"
   [ "$check_suite" = "$suite_id" ] \
@@ -253,8 +253,8 @@ require_ci_workflow_green() {
     *) die "the named ci-gate check is '$check_state' — the resolver requires it from this run" ;;
   esac
   # The resolver also refuses a ci-gate shadowed by a legacy commit STATUS.
-  status_shadow="$(gh api "repos/$REPO/commits/$resolved_head_sha/status" \
-      --jq '[.statuses[]? | select(.context == "ci-gate")] | length' 2>/dev/null)" \
+  status_shadow="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/status?per_page=100" \
+      --jq '[.[] | .statuses[]? | select(.context == "ci-gate")] | length' 2>/dev/null)" \
     || die "cannot read commit statuses for #$PR's head"
   [ "${status_shadow:-0}" = "0" ] \
     || die "a legacy commit status named ci-gate shadows the check on #$PR's head — the resolver refuses; remove the status source first"

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -216,7 +216,7 @@ require_reviewable_pr() {
 # actually burned a dispatch, and the slowest of the set; the resolver stays
 # the authority for the full policy list and its workflow bindings.
 require_ci_workflow_green() {
-  local gate_state fresh_merge main_now check_state run_info suite_id check_info check_suite status_shadow
+  local gate_state fresh_merge main_now check_state run_info suite_id check_info check_suite status_shadow policy_file required_names head_checks required_check shadow_count
   # The resolver requires the OWNING CI workflow run successful — the whole
   # run, not just the ci-gate job (a green ci-gate next to a red sibling job
   # still fails server-side; ci-gate has no needs: on its siblings). Bind to
@@ -233,31 +233,42 @@ require_ci_workflow_green() {
   suite_id="${run_info%% *}"; gate_state="${run_info#* }"
   [ "$gate_state" = "completed:success" ] \
     || die "the CI workflow run is '${run_info}' for #$PR's head against the current base — rerun CI (or wait for it) before dispatching; the resolver refuses anything else"
-  # AND the named ci-gate check FROM THAT RUN's check suite: a workflow edit
-  # that renames or drops the job could leave the run green without the
-  # required check, and a check emitted by a different workflow on the same
-  # head must not satisfy it — suite binding covers both.
-  # The resolver binds the GLOBALLY latest ci-gate check and then verifies
-  # its workflow binding — so select the newest check first, and require that
-  # it belongs to the chosen CI run's suite (a newer check from any other
-  # suite would shadow it server-side).
-  check_info="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=100" \
-      --jq '[.[] | .check_runs[] | select((.app.slug // "") == "github-actions" and ([.pull_requests[]? | select(.number == '"$PR"')] | length) > 0)] | max_by(.id) | if . == null then "absent" else "\(.check_suite.id // 0) \(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
-    || die "cannot read the ci-gate check run for #$PR's head"
-  check_suite="${check_info%% *}"; check_state="${check_info#* }"
-  [ "$check_suite" = "$suite_id" ] \
-    || die "the newest ci-gate check on the head (suite ${check_suite}) does not come from the selected CI run's suite ($suite_id) — the resolver binds the newest check and would reject; investigate before dispatching"
-  case "$check_state" in
-    # The resolver's conclusion allowlist for the named check.
-    completed:success|completed:skipped|completed:neutral) : ;;
-    *) die "the named ci-gate check is '$check_state' — the resolver requires it from this run" ;;
-  esac
-  # The resolver also refuses a ci-gate shadowed by a legacy commit STATUS.
+  # AND every resolver-required pre-evidence check from the repo policy —
+  # not just ci-gate: any pending or failed sibling check (analyze,
+  # dependency-review, the gates) rejects the dispatch server-side. The
+  # resolver binds the GLOBALLY latest check per name and verifies its
+  # workflow binding; locally, the newest github-actions check of THIS PR
+  # must sit in the allowlist, and ci-gate's must come from the selected CI
+  # run's suite (a workflow edit that drops the job, or a check emitted by
+  # another workflow, fails closed).
+  policy_file="$ROOT_DIR/.github/policy/repo-policy.json"
+  [ -f "$policy_file" ] || die "repository policy is missing ($policy_file)"
+  required_names="$(jq -c '.main_branch_protection | ((.required_status_checks - ["cloud-source-gate"]) + .advisory_checks) | unique' "$policy_file")" \
+    || die "cannot read the required-check list from $policy_file"
+  head_checks="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/check-runs?per_page=100" \
+      --jq '[.[] | .check_runs[] | select((.app.slug // "") == "github-actions" and ([.pull_requests[]? | select(.number == '"$PR"')] | length) > 0)]' 2>/dev/null)" \
+    || die "cannot read the check runs for #$PR's head"
+  while IFS= read -r required_check; do
+    check_info="$(jq -r --arg n "$required_check" '[.[] | select(.name == $n)] | max_by(.id) | if . == null then "absent" else "\(.check_suite.id // 0) \(.status):\(.conclusion // "-")" end' <<<"$head_checks")"
+    check_suite="${check_info%% *}"; check_state="${check_info#* }"
+    case "$check_state" in
+      # The resolver's conclusion allowlist.
+      completed:success|completed:skipped|completed:neutral) : ;;
+      *) die "required pre-evidence check '$required_check' is '$check_state' on #$PR's head — the resolver refuses the dispatch" ;;
+    esac
+    if [ "$required_check" = "ci-gate" ]; then
+      [ "$check_suite" = "$suite_id" ] \
+        || die "the newest ci-gate check (suite ${check_suite}) does not come from the selected CI run's suite ($suite_id) — the resolver binds the newest check and would reject"
+    fi
+  done < <(jq -r '.[]' <<<"$required_names")
+  # The resolver also refuses any required check shadowed by a legacy commit
+  # STATUS of the same name.
   status_shadow="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/status?per_page=100" \
-      --jq '[.[] | .statuses[]? | select(.context == "ci-gate")] | length' 2>/dev/null)" \
+      --jq '[.[] | .statuses[]?.context]' 2>/dev/null)" \
     || die "cannot read commit statuses for #$PR's head"
-  [ "${status_shadow:-0}" = "0" ] \
-    || die "a legacy commit status named ci-gate shadows the check on #$PR's head — the resolver refuses; remove the status source first"
+  shadow_count="$(jq --argjson names "$required_names" '[.[] | select(. as $c | $names | index($c))] | length' <<<"$status_shadow")"
+  [ "${shadow_count:-0}" = "0" ] \
+    || die "a legacy commit status shadows a required check on #$PR's head — the resolver refuses; remove the status source first"
   # Staleness stop LAST — after every API read above: the synthetic merge
   # moves when the PR head OR main advances, and request_id/target identity
   # are bound to the RESOLVED merge; a match here proves the reads above ran

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -254,7 +254,7 @@ require_ci_workflow_green() {
   # it belongs to the chosen CI run's suite (a newer check from any other
   # suite would shadow it server-side).
   check_info="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=100" \
-      --jq '[.[] | .check_runs[]] | max_by(.started_at) | if . == null then "absent" else "\(.check_suite.id // 0) \(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+      --jq '[.[] | .check_runs[]] | max_by(.id) | if . == null then "absent" else "\(.check_suite.id // 0) \(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
     || die "cannot read the ci-gate check run for #$PR's head"
   check_suite="${check_info%% *}"; check_state="${check_info#* }"
   [ "$check_suite" = "$suite_id" ] \

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -249,8 +249,8 @@ require_ci_workflow_green() {
   # that renames or drops the job could leave the run green without the
   # required check, and a check emitted by a different workflow on the same
   # head must not satisfy it — suite binding covers both.
-  check_state="$(gh api "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=10" \
-      --jq '[.check_runs[] | select((.check_suite.id // 0) == '"$suite_id"')] | max_by(.started_at) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
+  check_state="$(gh api --paginate --slurp "repos/$REPO/commits/$resolved_head_sha/check-runs?check_name=ci-gate&per_page=100" \
+      --jq '[.[] | .check_runs[] | select((.check_suite.id // 0) == '"$suite_id"')] | max_by(.started_at) | if . == null then "absent" else "\(.status):\(.conclusion // "-")" end' 2>/dev/null)" \
     || die "cannot read the ci-gate check run for #$PR's head"
   [ "$check_state" = "completed:success" ] \
     || die "the named ci-gate check is '$check_state' inside the selected CI run's suite — the resolver requires the check itself, from this run"

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -108,6 +108,9 @@ case "$args" in
   "api repos/${REPO_SLUG}/actions/runs?head_sha="*"&event=pull_request&per_page=30 --jq "*)
     trace "read:ci-workflow"
     cat "\${FAKE_GH_STATE}/cigate.state" 2>/dev/null || printf 'completed:success\\n' ;;
+  "api repos/${REPO_SLUG}/commits/"*"/check-runs?check_name=ci-gate&per_page=10 --jq "*)
+    trace "read:ci-gate-check"
+    cat "\${FAKE_GH_STATE}/cigate-check.state" 2>/dev/null || printf 'completed:success\\n' ;;
   "api graphql --paginate --slurp -f owner="*" -f name="*" -F number="*" -f query="*)
     trace "read:review-threads"
     cat "\${FAKE_GH_STATE}/review.json" 2>/dev/null \\

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -116,14 +116,17 @@ case "$args" in
   "api repos/${REPO_SLUG}/pulls/"*)
     trace "read:pr"
     cat "\${FAKE_GH_STATE}/pr.json" ;;
-  "api --paginate --slurp repos/${REPO_SLUG}/actions/runs?head_sha="*"&event=pull_request&per_page=100 --jq "*)
+  "api --paginate --slurp repos/${REPO_SLUG}/actions/runs?head_sha="*"&event=pull_request&per_page=100")
     trace "read:ci-workflow"
-    cat "\${FAKE_GH_STATE}/cigate.state" 2>/dev/null || printf '777 completed:success\\n' ;;
-  "api --paginate --slurp repos/${REPO_SLUG}/commits/"*"/check-runs?per_page=100 --jq "*)
+    if [ -f "\${FAKE_GH_STATE}/ci-run-pages.json" ]; then cat "\${FAKE_GH_STATE}/ci-run-pages.json"; else
+      msha="$(cat "\${FAKE_GH_STATE}/main.sha" 2>/dev/null || echo unknown)"
+      printf '[{"workflow_runs":[{"id":9,"path":".github/workflows/ci.yml","check_suite_id":777,"status":"completed","conclusion":"success","pull_requests":[{"number":7,"base":{"sha":"%s"}}]}]}]\\n' "\$msha"
+    fi ;;
+  "api --paginate --slurp repos/${REPO_SLUG}/commits/"*"/check-runs?per_page=100")
     trace "read:head-checks"
     cat "\${FAKE_GH_STATE}/head-checks.json" 2>/dev/null \\
-      || printf '[{"name":"ci-gate","id":1,"check_suite":{"id":777},"app":{"slug":"github-actions"},"pull_requests":[{"number":7}],"status":"completed","conclusion":"success"}]\\n' ;;
-  "api --paginate --slurp repos/${REPO_SLUG}/commits/"*"/status?per_page=100 --jq "*)
+      || printf '[{"check_runs":[{"name":"ci-gate","id":1,"check_suite":{"id":777},"app":{"slug":"github-actions"},"pull_requests":[{"number":7}],"status":"completed","conclusion":"success"}]}]\\n' ;;
+  "api --paginate --slurp repos/${REPO_SLUG}/commits/"*"/status?per_page=100")
     trace "read:commit-status"
     cat "\${FAKE_GH_STATE}/status-shadow.state" 2>/dev/null || printf '[]\\n' ;;
   "api graphql --paginate --slurp -f owner="*" -f name="*" -F number="*" -f query="*)
@@ -461,6 +464,7 @@ describe("cloud evidence PR target binding", () => {
   function prFixture() {
     const fixture = initFixture(platforms);
     const fake = makeFakeBin(prJson(fixture));
+    writeFileSync(join(fake.state, "main.sha"), `${fixture.mainCommit}\n`);
     // GitHub's synthetic merge ref, served by the local bare origin.
     git(fixture.originGit, "update-ref", "refs/pull/7/merge", fixture.mainCommit);
     return { fixture, fake };
@@ -555,7 +559,23 @@ describe("cloud evidence PR target binding", () => {
     // #611/rc23: dispatched seconds after a push, CI unfinished — the server
     // resolver rejected AFTER the run started.
     const { fixture, fake } = prFixture();
-    writeFileSync(join(fake.state, "cigate.state"), "777 in_progress:-\n");
+    writeFileSync(
+      join(fake.state, "ci-run-pages.json"),
+      JSON.stringify([
+        {
+          workflow_runs: [
+            {
+              id: 9,
+              path: ".github/workflows/ci.yml",
+              check_suite_id: 777,
+              status: "in_progress",
+              conclusion: null,
+              pull_requests: [{ number: 7, base: { sha: fixture.mainCommit } }],
+            },
+          ],
+        },
+      ]),
+    );
     const result = runScript(fixture, fake, ["7"]);
     expect(result.status, result.stdout).not.toBe(0);
     expect(result.stderr).toContain("CI workflow run");

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -50,6 +50,17 @@ function initFixture(platforms: string[]): Fixture {
     copyFileSync(lib, join(repo, lib));
   }
   writeFileSync(join(repo, "nova", "config.yaml"), 'name: HA NOVA\nversion: "0.9.0"\n');
+  // The dispatch preflight reads the same policy file as the server resolver.
+  mkdirSync(join(repo, ".github", "policy"), { recursive: true });
+  writeFileSync(
+    join(repo, ".github", "policy", "repo-policy.json"),
+    `${JSON.stringify({
+      main_branch_protection: {
+        required_status_checks: ["ci-gate", "cloud-source-gate"],
+        advisory_checks: [],
+      },
+    })}\n`,
+  );
   writeFileSync(
     join(repo, "version.json"),
     `${JSON.stringify({ skill_version: "0.24.0", cloud_remote_platforms: platforms }, null, 2)}\n`,
@@ -108,12 +119,13 @@ case "$args" in
   "api --paginate --slurp repos/${REPO_SLUG}/actions/runs?head_sha="*"&event=pull_request&per_page=100 --jq "*)
     trace "read:ci-workflow"
     cat "\${FAKE_GH_STATE}/cigate.state" 2>/dev/null || printf '777 completed:success\\n' ;;
-  "api --paginate --slurp repos/${REPO_SLUG}/commits/"*"/check-runs?check_name=ci-gate&per_page=100 --jq "*)
-    trace "read:ci-gate-check"
-    cat "\${FAKE_GH_STATE}/cigate-check.state" 2>/dev/null || printf '777 completed:success\\n' ;;
+  "api --paginate --slurp repos/${REPO_SLUG}/commits/"*"/check-runs?per_page=100 --jq "*)
+    trace "read:head-checks"
+    cat "\${FAKE_GH_STATE}/head-checks.json" 2>/dev/null \\
+      || printf '[{"name":"ci-gate","id":1,"check_suite":{"id":777},"app":{"slug":"github-actions"},"pull_requests":[{"number":7}],"status":"completed","conclusion":"success"}]\\n' ;;
   "api --paginate --slurp repos/${REPO_SLUG}/commits/"*"/status?per_page=100 --jq "*)
     trace "read:commit-status"
-    cat "\${FAKE_GH_STATE}/status-shadow.state" 2>/dev/null || printf '0\\n' ;;
+    cat "\${FAKE_GH_STATE}/status-shadow.state" 2>/dev/null || printf '[]\\n' ;;
   "api graphql --paginate --slurp -f owner="*" -f name="*" -F number="*" -f query="*)
     trace "read:review-threads"
     cat "\${FAKE_GH_STATE}/review.json" 2>/dev/null \\
@@ -547,6 +559,15 @@ describe("cloud evidence PR target binding", () => {
     const result = runScript(fixture, fake, ["7"]);
     expect(result.status, result.stdout).not.toBe(0);
     expect(result.stderr).toContain("CI workflow run");
+    expect(readFileSync(fake.trace, "utf8")).not.toContain("dispatch");
+  });
+
+  it("refuses when a policy-required check is missing from the head's suite", () => {
+    const { fixture, fake } = prFixture();
+    writeFileSync(join(fake.state, "head-checks.json"), "[]\n");
+    const result = runScript(fixture, fake, ["7"]);
+    expect(result.status, result.stdout).not.toBe(0);
+    expect(result.stderr).toContain("required pre-evidence check 'ci-gate' is 'absent'");
     expect(readFileSync(fake.trace, "utf8")).not.toContain("dispatch");
   });
 

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -111,7 +111,7 @@ case "$args" in
   "api --paginate --slurp repos/${REPO_SLUG}/commits/"*"/check-runs?check_name=ci-gate&per_page=100 --jq "*)
     trace "read:ci-gate-check"
     cat "\${FAKE_GH_STATE}/cigate-check.state" 2>/dev/null || printf '777 completed:success\\n' ;;
-  "api repos/${REPO_SLUG}/commits/"*"/status --jq "*)
+  "api --paginate --slurp repos/${REPO_SLUG}/commits/"*"/status?per_page=100 --jq "*)
     trace "read:commit-status"
     cat "\${FAKE_GH_STATE}/status-shadow.state" 2>/dev/null || printf '0\\n' ;;
   "api graphql --paginate --slurp -f owner="*" -f name="*" -F number="*" -f query="*)

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -111,6 +111,9 @@ case "$args" in
   "api --paginate --slurp repos/${REPO_SLUG}/commits/"*"/check-runs?check_name=ci-gate&per_page=100 --jq "*)
     trace "read:ci-gate-check"
     cat "\${FAKE_GH_STATE}/cigate-check.state" 2>/dev/null || printf '777 completed:success\\n' ;;
+  "api repos/${REPO_SLUG}/commits/"*"/status --jq "*)
+    trace "read:commit-status"
+    cat "\${FAKE_GH_STATE}/status-shadow.state" 2>/dev/null || printf '0\\n' ;;
   "api graphql --paginate --slurp -f owner="*" -f name="*" -F number="*" -f query="*)
     trace "read:review-threads"
     cat "\${FAKE_GH_STATE}/review.json" 2>/dev/null \\

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -105,8 +105,8 @@ case "$args" in
   "api repos/${REPO_SLUG}/pulls/"*)
     trace "read:pr"
     cat "\${FAKE_GH_STATE}/pr.json" ;;
-  "api repos/${REPO_SLUG}/commits/"*"/check-runs?check_name=ci-gate&per_page=10 --jq "*)
-    trace "read:ci-gate"
+  "api repos/${REPO_SLUG}/actions/runs?head_sha="*"&event=pull_request&per_page=30 --jq "*)
+    trace "read:ci-workflow"
     cat "\${FAKE_GH_STATE}/cigate.state" 2>/dev/null || printf 'completed:success\\n' ;;
   "api graphql --paginate --slurp -f owner="*" -f name="*" -F number="*" -f query="*)
     trace "read:review-threads"
@@ -540,7 +540,7 @@ describe("cloud evidence PR target binding", () => {
     writeFileSync(join(fake.state, "cigate.state"), "in_progress:-\n");
     const result = runScript(fixture, fake, ["7"]);
     expect(result.status, result.stdout).not.toBe(0);
-    expect(result.stderr).toContain("ci-gate");
+    expect(result.stderr).toContain("CI workflow run");
     expect(readFileSync(fake.trace, "utf8")).not.toContain("dispatch");
   });
 

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -110,7 +110,7 @@ case "$args" in
     cat "\${FAKE_GH_STATE}/cigate.state" 2>/dev/null || printf '777 completed:success\\n' ;;
   "api --paginate --slurp repos/${REPO_SLUG}/commits/"*"/check-runs?check_name=ci-gate&per_page=100 --jq "*)
     trace "read:ci-gate-check"
-    cat "\${FAKE_GH_STATE}/cigate-check.state" 2>/dev/null || printf 'completed:success\\n' ;;
+    cat "\${FAKE_GH_STATE}/cigate-check.state" 2>/dev/null || printf '777 completed:success\\n' ;;
   "api graphql --paginate --slurp -f owner="*" -f name="*" -F number="*" -f query="*)
     trace "read:review-threads"
     cat "\${FAKE_GH_STATE}/review.json" 2>/dev/null \\

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -132,7 +132,7 @@ case "$args" in
   "api graphql --paginate --slurp -f owner="*" -f name="*" -F number="*" -f query="*)
     trace "read:review-threads"
     cat "\${FAKE_GH_STATE}/review.json" 2>/dev/null \\
-      || printf '[{"data":{"repository":{"pullRequest":{"reviewDecision":null,"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]\\n' ;;
+      || printf '[{"data":{"repository":{"pullRequest":{"isDraft":false,"reviewDecision":null,"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]\\n' ;;
   "run list --repo ${REPO_SLUG} --workflow cloud-candidate-bundle.yml --json databaseId,status,conclusion,event --limit 30")
     trace "run-list"
     n="$(cat "\${FAKE_GH_STATE}/list.count" 2>/dev/null || echo 0)"
@@ -499,6 +499,7 @@ describe("cloud evidence PR target binding", () => {
           data: {
             repository: {
               pullRequest: {
+                isDraft: false,
                 reviewDecision: null,
                 reviewThreads: {
                   nodes: [{ isResolved: true }],
@@ -512,6 +513,7 @@ describe("cloud evidence PR target binding", () => {
           data: {
             repository: {
               pullRequest: {
+                isDraft: false,
                 reviewDecision: null,
                 reviewThreads: {
                   nodes: [{ isResolved: false }],
@@ -538,6 +540,7 @@ describe("cloud evidence PR target binding", () => {
           data: {
             repository: {
               pullRequest: {
+                isDraft: false,
                 reviewDecision: "CHANGES_REQUESTED",
                 reviewThreads: {
                   nodes: [],

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -132,7 +132,7 @@ case "$args" in
   "api graphql --paginate --slurp -f owner="*" -f name="*" -F number="*" -f query="*)
     trace "read:review-threads"
     cat "\${FAKE_GH_STATE}/review.json" 2>/dev/null \\
-      || printf '[{"data":{"repository":{"pullRequest":{"isDraft":false,"reviewDecision":null,"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]\\n' ;;
+      || printf '[{"data":{"repository":{"pullRequest":{"state":"OPEN","isDraft":false,"reviewDecision":null,"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]\\n' ;;
   "run list --repo ${REPO_SLUG} --workflow cloud-candidate-bundle.yml --json databaseId,status,conclusion,event --limit 30")
     trace "run-list"
     n="$(cat "\${FAKE_GH_STATE}/list.count" 2>/dev/null || echo 0)"
@@ -499,6 +499,7 @@ describe("cloud evidence PR target binding", () => {
           data: {
             repository: {
               pullRequest: {
+                state: "OPEN",
                 isDraft: false,
                 reviewDecision: null,
                 reviewThreads: {
@@ -513,6 +514,7 @@ describe("cloud evidence PR target binding", () => {
           data: {
             repository: {
               pullRequest: {
+                state: "OPEN",
                 isDraft: false,
                 reviewDecision: null,
                 reviewThreads: {
@@ -527,7 +529,7 @@ describe("cloud evidence PR target binding", () => {
     );
     const result = runScript(fixture, fake, ["7"]);
     expect(result.status, result.stdout).not.toBe(0);
-    expect(result.stderr).toContain("unresolved review threads");
+    expect(result.stderr).toContain("unresolved threads");
     expect(readFileSync(fake.trace, "utf8")).not.toContain("dispatch");
   });
 
@@ -540,6 +542,7 @@ describe("cloud evidence PR target binding", () => {
           data: {
             repository: {
               pullRequest: {
+                state: "OPEN",
                 isDraft: false,
                 reviewDecision: "CHANGES_REQUESTED",
                 reviewThreads: {
@@ -554,7 +557,7 @@ describe("cloud evidence PR target binding", () => {
     );
     const result = runScript(fixture, fake, ["7"]);
     expect(result.status, result.stdout).not.toBe(0);
-    expect(result.stderr).toContain("requested changes");
+    expect(result.stderr).toContain("requested-changes");
     expect(readFileSync(fake.trace, "utf8")).not.toContain("dispatch");
   });
 

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -102,9 +102,15 @@ last_arg() { local a v=""; for a in "$@"; do v="$a"; done; printf '%s' "$v"; }
 case "$args" in
   "api user --jq .login")
     printf '%s\\n' "\${FAKE_GH_LOGIN}" ;;
+  "api repos/${REPO_SLUG}/pulls/"*" --jq .head.sha"*)
+    trace "read:pr-head"
+    jq -r '.head.sha // ""' "\${FAKE_GH_STATE}/pr.json" ;;
   "api repos/${REPO_SLUG}/pulls/"*)
     trace "read:pr"
     cat "\${FAKE_GH_STATE}/pr.json" ;;
+  "api repos/${REPO_SLUG}/commits/"*"/check-runs?check_name=ci-gate&per_page=10 --jq "*)
+    trace "read:ci-gate"
+    cat "\${FAKE_GH_STATE}/cigate.state" 2>/dev/null || printf 'completed:success\\n' ;;
   "api graphql --paginate --slurp -f owner="*" -f name="*" -F number="*" -f query="*)
     trace "read:review-threads"
     cat "\${FAKE_GH_STATE}/review.json" 2>/dev/null \\
@@ -432,7 +438,7 @@ describe("cloud evidence PR target binding", () => {
       mergeable_state: "clean",
       merge_commit_sha: fixture.mainCommit,
       base: { ref: "main" },
-      head: { repo: { full_name: REPO_SLUG } },
+      head: { sha: fixture.mainCommit, repo: { full_name: REPO_SLUG } },
       ...overrides,
     };
   }
@@ -527,6 +533,17 @@ describe("cloud evidence PR target binding", () => {
     const result = runScript(fixture, fake, ["7"]);
     expect(result.status, result.stdout).not.toBe(0);
     expect(result.stderr).toContain("requested changes");
+    expect(readFileSync(fake.trace, "utf8")).not.toContain("dispatch");
+  });
+
+  it("refuses to dispatch while ci-gate has not succeeded on the head", () => {
+    // #611/rc23: dispatched seconds after a push, CI unfinished — the server
+    // resolver rejected AFTER the run started.
+    const { fixture, fake } = prFixture();
+    writeFileSync(join(fake.state, "cigate.state"), "in_progress:-\n");
+    const result = runScript(fixture, fake, ["7"]);
+    expect(result.status, result.stdout).not.toBe(0);
+    expect(result.stderr).toContain("ci-gate");
     expect(readFileSync(fake.trace, "utf8")).not.toContain("dispatch");
   });
 

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -102,9 +102,6 @@ last_arg() { local a v=""; for a in "$@"; do v="$a"; done; printf '%s' "$v"; }
 case "$args" in
   "api user --jq .login")
     printf '%s\\n' "\${FAKE_GH_LOGIN}" ;;
-  "api repos/${REPO_SLUG}/pulls/"*" --jq .head.sha"*)
-    trace "read:pr-head"
-    jq -r '.head.sha // ""' "\${FAKE_GH_STATE}/pr.json" ;;
   "api repos/${REPO_SLUG}/pulls/"*)
     trace "read:pr"
     cat "\${FAKE_GH_STATE}/pr.json" ;;
@@ -461,7 +458,7 @@ describe("cloud evidence PR target binding", () => {
 
   it("refuses a fork-headed PR", () => {
     const fixture = initFixture(platforms);
-    const fake = makeFakeBin(prJson(fixture, { head: { repo: { full_name: "someone/fork" } } }));
+    const fake = makeFakeBin(prJson(fixture, { head: { sha: fixture.mainCommit, repo: { full_name: "someone/fork" } } }));
     const result = runScript(fixture, fake, ["7"]);
     expect(result.status, result.stdout).not.toBe(0);
     expect(result.stderr).toContain("same-repo branches");

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -108,7 +108,7 @@ case "$args" in
   "api --paginate --slurp repos/${REPO_SLUG}/actions/runs?head_sha="*"&event=pull_request&per_page=100 --jq "*)
     trace "read:ci-workflow"
     cat "\${FAKE_GH_STATE}/cigate.state" 2>/dev/null || printf '777 completed:success\\n' ;;
-  "api repos/${REPO_SLUG}/commits/"*"/check-runs?check_name=ci-gate&per_page=10 --jq "*)
+  "api --paginate --slurp repos/${REPO_SLUG}/commits/"*"/check-runs?check_name=ci-gate&per_page=100 --jq "*)
     trace "read:ci-gate-check"
     cat "\${FAKE_GH_STATE}/cigate-check.state" 2>/dev/null || printf 'completed:success\\n' ;;
   "api graphql --paginate --slurp -f owner="*" -f name="*" -F number="*" -f query="*)

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -107,7 +107,7 @@ case "$args" in
     cat "\${FAKE_GH_STATE}/pr.json" ;;
   "api repos/${REPO_SLUG}/actions/runs?head_sha="*"&event=pull_request&per_page=30 --jq "*)
     trace "read:ci-workflow"
-    cat "\${FAKE_GH_STATE}/cigate.state" 2>/dev/null || printf 'completed:success\\n' ;;
+    cat "\${FAKE_GH_STATE}/cigate.state" 2>/dev/null || printf '777 completed:success\\n' ;;
   "api repos/${REPO_SLUG}/commits/"*"/check-runs?check_name=ci-gate&per_page=10 --jq "*)
     trace "read:ci-gate-check"
     cat "\${FAKE_GH_STATE}/cigate-check.state" 2>/dev/null || printf 'completed:success\\n' ;;
@@ -540,7 +540,7 @@ describe("cloud evidence PR target binding", () => {
     // #611/rc23: dispatched seconds after a push, CI unfinished — the server
     // resolver rejected AFTER the run started.
     const { fixture, fake } = prFixture();
-    writeFileSync(join(fake.state, "cigate.state"), "in_progress:-\n");
+    writeFileSync(join(fake.state, "cigate.state"), "777 in_progress:-\n");
     const result = runScript(fixture, fake, ["7"]);
     expect(result.status, result.stdout).not.toBe(0);
     expect(result.stderr).toContain("CI workflow run");

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -105,7 +105,7 @@ case "$args" in
   "api repos/${REPO_SLUG}/pulls/"*)
     trace "read:pr"
     cat "\${FAKE_GH_STATE}/pr.json" ;;
-  "api repos/${REPO_SLUG}/actions/runs?head_sha="*"&event=pull_request&per_page=30 --jq "*)
+  "api --paginate --slurp repos/${REPO_SLUG}/actions/runs?head_sha="*"&event=pull_request&per_page=100 --jq "*)
     trace "read:ci-workflow"
     cat "\${FAKE_GH_STATE}/cigate.state" 2>/dev/null || printf '777 completed:success\\n' ;;
   "api repos/${REPO_SLUG}/commits/"*"/check-runs?check_name=ci-gate&per_page=10 --jq "*)


### PR DESCRIPTION
## What

Closes the second burned-dispatch class from the #611 session: the resolver requires every pre-evidence check green and rejects only AFTER the run started. `require_ci_gate_green()` mirrors ci-gate locally — the one check that actually burned a dispatch and the slowest of the set; the resolver stays the authority for the full policy list and its workflow bindings.

Design points (from the pre-PR adversarial pass, both applied):
- **Fresh head read** inside the function — the spend-time recheck exists precisely because the resolve-time `pr_json` snapshot goes stale during the minutes-long pipeline.
- **`--set` skips the resolve-time call**: checklist step 8 reruns CI AFTER --set (ci-gate goes pending), and a #559-class repeat --set in that window must not be refused; --set with a reusable candidate dispatches nothing. The actual spend stays guarded inside `dispatch_and_bind` (covers --set's expired-artifact fresh-dispatch fallback too).
- `filter=latest` (API default) collapses rerun attempts server-side; absent/pending/failure all fail closed with the state named.

## Verification
- Behavior suite 28/28 (new regression: ci-gate in_progress → refused before any dispatch trace).
- Local Codex CLI review + adversarial subagent; findings (stale-sha recheck, --set window) fixed, max_by/rerun concerns refuted via the API's latest-filter semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4pMfMeo3VUTUZhD6xr4h1