### PR TITLE
feat(cli): cloud add --remote-resume — finish a cloud_verified checkpoint over SSH

### DIFF
--- a/cli/cloud_config_flow.go
+++ b/cli/cloud_config_flow.go
@@ -49,7 +49,7 @@ func connectExistingDeviceToCloud(
 		ctx,
 		cfg.RelayInstanceID,
 		false,
-		SecretStoreAllowUI,
+		secretStoreUIPolicyForSetup(SecretStoreAllowUI),
 	); err != nil {
 		return cfg, err
 	}
@@ -190,13 +190,13 @@ func connectRemoteToCloud(
 		expectedRelayInstanceID,
 		true,
 		true,
-		SecretStoreAllowUI,
+		secretStoreUIPolicyForSetup(SecretStoreAllowUI),
 	); err != nil {
 		return cfg, err
 	}
 	if _, err := probeCloudDeviceStorageForSetup(
 		ctx,
-		SecretStoreAllowUI,
+		secretStoreUIPolicyForSetup(SecretStoreAllowUI),
 	); err != nil {
 		return cfg, err
 	}

--- a/cli/cloud_remote_resume.go
+++ b/cli/cloud_remote_resume.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+)
+
+// cloudRemoteResumeCheckpointReady reports whether the selected profile holds
+// a pending Cloud authorization at "cloud_verified" or later. Only such a
+// checkpoint may be resumed from a remote (SSH) session: the OAuth token
+// already exists — the flow refreshes it without a browser — and every
+// secret-store operation after explicit preflight is a no-UI operation by
+// the cloudSetupCoordinator contract.
+func cloudRemoteResumeCheckpointReady(cfg runtimeConfig) bool {
+	if cfg.Cloud == nil || cfg.Cloud.Pending == nil {
+		return false
+	}
+	switch cfg.Cloud.State {
+	case cloudStateCloudVerified, cloudStateDeviceBoundOrPaired:
+		return true
+	default:
+		return false
+	}
+}
+
+// enableCloudRemoteResumeSession relaxes ONLY the SSH detection of the
+// desktop-session gate for one explicitly requested checkpoint resume.
+// Elevated processes and WSL stay refused, a TTY is still required, and the
+// OAuth browser opener is replaced by a hard failure so a broken token
+// refresh can never silently fall back to a desktop-only round — the
+// operator is told to run the remaining OAuth round on a desktop instead.
+var cloudRemoteResumeStdoutTTY = stdoutIsInteractiveTTY
+
+// cloudRemoteResumeProcessElevated checks real process elevation only —
+// on Windows it tolerates session 0 (see the platform implementation).
+var cloudRemoteResumeProcessElevated = platformRemoteResumeProcessElevated
+
+// cloudRemoteResumeActive gates the secret-store UI mode: a remote resume
+// must never trigger a native credential prompt (on macOS a Keychain prompt
+// raised from an SSH session would authorize remote-triggered access), so
+// every store preflight downgrades AllowUI to ForbidUI while it is set.
+var cloudRemoteResumeActive bool
+
+// cloudRemoteResumeElevationEnvPresent keeps the ORIGINAL gate's
+// privilege-escalation environment checks: only the SSH markers are
+// tolerated in a remote resume — sudo/doas/pkexec launchers stay refused.
+func cloudRemoteResumeElevationEnvPresent() bool {
+	for _, name := range []string{
+		"SUDO_USER",
+		"SUDO_UID",
+		"SUDO_GID",
+		"DOAS_USER",
+		"PKEXEC_UID",
+	} {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// secretStoreUIPolicyForSetup downgrades AllowUI to ForbidUI while a remote
+// resume is active: no native credential prompt may ever be raised from a
+// remote session. Outside that mode the requested policy passes through.
+func secretStoreUIPolicyForSetup(ui SecretStoreUIPolicy) SecretStoreUIPolicy {
+	if cloudRemoteResumeActive {
+		return SecretStoreForbidUI
+	}
+	return ui
+}
+
+func enableCloudRemoteResumeSession() {
+	cloudRemoteResumeActive = true
+	cloudInteractivePromptSessionForSetup = func() bool {
+		return uiInputSupportsTTY() &&
+			cloudRemoteResumeStdoutTTY() &&
+			!cloudRemoteResumeElevationEnvPresent() &&
+			!cloudRemoteResumeProcessElevated() &&
+			!nativePromptRunsUnderWSL()
+	}
+	openCloudOAuthBrowserForSetup = func(
+		_ context.Context,
+		_ string,
+	) error {
+		return newCloudError(
+			CloudErrUnsupportedPlatform,
+			"open the OAuth browser in a remote resume session — the saved "+
+				"authorization could not be refreshed, so the remaining OAuth "+
+				"round needs an interactive desktop session",
+			nil,
+		)
+	}
+}

--- a/cli/cloud_remote_resume_elevation_unix.go
+++ b/cli/cloud_remote_resume_elevation_unix.go
@@ -1,0 +1,11 @@
+//go:build darwin || linux
+
+package main
+
+import "os"
+
+// platformRemoteResumeProcessElevated matches the native-prompt elevation
+// check on Unix: a remote resume never tolerates running as root.
+func platformRemoteResumeProcessElevated() bool {
+	return os.Geteuid() == 0
+}

--- a/cli/cloud_remote_resume_elevation_unsupported.go
+++ b/cli/cloud_remote_resume_elevation_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !darwin && !linux && !windows
+
+package main
+
+func platformRemoteResumeProcessElevated() bool {
+	// Cloud setup is unavailable on these platforms; fail closed.
+	return true
+}

--- a/cli/cloud_remote_resume_elevation_windows.go
+++ b/cli/cloud_remote_resume_elevation_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// platformRemoteResumeProcessElevated checks ONLY real token elevation.
+// Unlike the native-prompt gate it tolerates session 0: Windows OpenSSH runs
+// there by design, DPAPI works prompt-free in that session, and the remote
+// resume forces every secret-store operation to ForbidUI anyway — the
+// session-0 refusal exists to keep native PROMPTS off service sessions, a
+// concern the resume mode has already eliminated.
+func platformRemoteResumeProcessElevated() bool {
+	var sessionID uint32
+	if err := windows.ProcessIdToSessionId(
+		uint32(os.Getpid()),
+		&sessionID,
+	); err != nil {
+		return true
+	}
+	var elevated uint32
+	var resultSize uint32
+	err := windows.GetTokenInformation(
+		windows.GetCurrentProcessToken(),
+		windows.TokenElevation,
+		(*byte)(unsafe.Pointer(&elevated)),
+		uint32(unsafe.Sizeof(elevated)),
+		&resultSize,
+	)
+	return err != nil ||
+		resultSize != uint32(unsafe.Sizeof(elevated)) ||
+		elevated != 0
+}

--- a/cli/cloud_remote_resume_test.go
+++ b/cli/cloud_remote_resume_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestCloudRemoteResumeCheckpointReady(t *testing.T) {
+	if cloudRemoteResumeCheckpointReady(runtimeConfig{}) {
+		t.Fatal("empty config must not be resumable")
+	}
+	for state, want := range map[cloudLifecycleState]bool{
+		cloudStateAuthorizing:         false,
+		cloudStateTokenStored:         false,
+		cloudStateCloudVerified:       true,
+		cloudStateDeviceBoundOrPaired: true,
+	} {
+		cfg := pendingCloudOnlyCommandConfig(state)
+		if got := cloudRemoteResumeCheckpointReady(cfg); got != want {
+			t.Fatalf("state %s: ready=%v want %v", state, got, want)
+		}
+	}
+	cfg := pendingCloudOnlyCommandConfig(cloudStateCloudVerified)
+	cfg.Cloud.Pending = nil
+	if cloudRemoteResumeCheckpointReady(cfg) {
+		t.Fatal("cloud_verified without pending metadata must not be resumable")
+	}
+}
+
+func TestRemoteResumeRefusedWithoutResumableCheckpoint(t *testing.T) {
+	for name, state := range map[string]cloudLifecycleState{
+		"authorizing":  cloudStateAuthorizing,
+		"token_stored": cloudStateTokenStored,
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetServerProfileSelection(t)
+			paths := setupServerCommandTest(t, `{"schema_version":1}`)
+			if err := saveConfig(
+				paths,
+				pendingCloudOnlyCommandConfig(state),
+			); err != nil {
+				t.Fatal(err)
+			}
+			coordinator := successfulCloudCoordinatorForTest()
+			installCloudCommandCoordinator(t, coordinator)
+			installCloudCommandPromptSession(t, false)
+
+			exit, output := captureCommandOutput(t, func() int {
+				return runCloudConnectCommand(
+					paths,
+					[]string{"--remote-resume"},
+					false,
+				)
+			})
+			if exit != 1 ||
+				!strings.Contains(output, "--remote-resume only resumes an existing checkpoint") {
+				t.Fatalf("early-checkpoint resume exit=%d output=%s", exit, output)
+			}
+			if coordinator.preflightCalls != 0 || coordinator.addCalls != 0 {
+				t.Fatalf(
+					"refused resume reached secure storage: calls=%d/%d",
+					coordinator.preflightCalls,
+					coordinator.addCalls,
+				)
+			}
+		})
+	}
+}
+
+func TestRemoteResumeSessionGateToleratesSSHOnly(t *testing.T) {
+	oldGate := cloudInteractivePromptSessionForSetup
+	oldOpener := openCloudOAuthBrowserForSetup
+	oldInput := uiInputSupportsTTY
+	oldStdout := cloudRemoteResumeStdoutTTY
+	oldElevated := cloudRemoteResumeProcessElevated
+	oldWSL := nativePromptRunsUnderWSL
+	t.Cleanup(func() {
+		cloudInteractivePromptSessionForSetup = oldGate
+		openCloudOAuthBrowserForSetup = oldOpener
+		uiInputSupportsTTY = oldInput
+		cloudRemoteResumeStdoutTTY = oldStdout
+		cloudRemoteResumeProcessElevated = oldElevated
+		nativePromptRunsUnderWSL = oldWSL
+	})
+	uiInputSupportsTTY = func() bool { return true }
+	cloudRemoteResumeStdoutTTY = func() bool { return true }
+	cloudRemoteResumeProcessElevated = func() bool { return false }
+	nativePromptRunsUnderWSL = func() bool { return false }
+	t.Setenv("SSH_CONNECTION", "10.0.0.1 1 10.0.0.2 22")
+
+	oldActive := cloudRemoteResumeActive
+	t.Cleanup(func() { cloudRemoteResumeActive = oldActive })
+	enableCloudRemoteResumeSession()
+
+	if !cloudInteractivePromptSessionForSetup() {
+		t.Fatal("remote-resume gate must tolerate an SSH session with a TTY")
+	}
+	if secretStoreUIPolicyForSetup(SecretStoreAllowUI) != SecretStoreForbidUI {
+		t.Fatal("remote resume must downgrade AllowUI to ForbidUI")
+	}
+	t.Setenv("SUDO_USER", "root")
+	if cloudInteractivePromptSessionForSetup() {
+		t.Fatal("remote-resume gate must still refuse sudo launchers")
+	}
+	t.Setenv("SUDO_USER", "")
+	cloudRemoteResumeProcessElevated = func() bool { return true }
+	if cloudInteractivePromptSessionForSetup() {
+		t.Fatal("remote-resume gate must still refuse elevated processes")
+	}
+	cloudRemoteResumeProcessElevated = func() bool { return false }
+	nativePromptRunsUnderWSL = func() bool { return true }
+	if cloudInteractivePromptSessionForSetup() {
+		t.Fatal("remote-resume gate must still refuse WSL")
+	}
+	if err := openCloudOAuthBrowserForSetup(
+		context.Background(),
+		"https://example.invalid",
+	); err == nil {
+		t.Fatal("remote-resume must never open an OAuth browser")
+	}
+}

--- a/cli/cloud_selected_secret_preflight.go
+++ b/cli/cloud_selected_secret_preflight.go
@@ -79,7 +79,7 @@ func preflightSelectedCloudSecret(
 	case OAuthSecretRetiring:
 		return preflightRetiringOrCurrentCloudSecret(ctx, store, cfg)
 	default:
-		return PreflightOAuthSecretStore(ctx, store, SecretStoreAllowUI)
+		return PreflightOAuthSecretStore(ctx, store, secretStoreUIPolicyForSetup(SecretStoreAllowUI))
 	}
 }
 
@@ -153,7 +153,7 @@ func preflightPendingCloudSecret(
 		)
 	case IsCloudErrorCode(err, CloudErrSecretUIForbidden),
 		IsCloudErrorCode(err, CloudErrSecretStoreLocked):
-		pending, exists, err = store.LoadPending(ctx, SecretStoreAllowUI)
+		pending, exists, err = store.LoadPending(ctx, secretStoreUIPolicyForSetup(SecretStoreAllowUI))
 		if err != nil {
 			return err
 		}
@@ -245,7 +245,7 @@ func preflightCloudSecretStep(
 			!IsCloudErrorCode(err, CloudErrSecretStoreLocked)) {
 		return err
 	}
-	return step(SecretStoreAllowUI)
+	return step(secretStoreUIPolicyForSetup(SecretStoreAllowUI))
 }
 
 func preflightCloudSecretAfterMissingPending(
@@ -268,7 +268,7 @@ func preflightCloudSecretAfterMissingPending(
 			},
 		)
 	}
-	return PreflightOAuthSecretStore(ctx, store, SecretStoreAllowUI)
+	return PreflightOAuthSecretStore(ctx, store, secretStoreUIPolicyForSetup(SecretStoreAllowUI))
 }
 
 func validatePendingCloudPreflight(

--- a/cli/cloud_setup_production.go
+++ b/cli/cloud_setup_production.go
@@ -81,7 +81,7 @@ func (productionCloudSetupCoordinator) Preflight(
 			return err
 		}
 	}
-	return PreflightOAuthSecretStore(ctx, store, SecretStoreAllowUI)
+	return PreflightOAuthSecretStore(ctx, store, secretStoreUIPolicyForSetup(SecretStoreAllowUI))
 }
 
 func (coordinator productionCloudSetupCoordinator) AddAwayWithExistingDevice(

--- a/cli/cloud_setup_remote_preflight.go
+++ b/cli/cloud_setup_remote_preflight.go
@@ -72,7 +72,7 @@ func reopenRemoteCloudDeviceAccess(
 		ctx,
 		relayInstanceID,
 		true,
-		SecretStoreAllowUI,
+		secretStoreUIPolicyForSetup(SecretStoreAllowUI),
 	); err != nil {
 		return fmt.Errorf(
 			"re-open device secure storage after %s: %w",

--- a/cli/command_cloud_connect.go
+++ b/cli/command_cloud_connect.go
@@ -75,6 +75,12 @@ func runCloudConnectCommand(
 				loadedCfg,
 				true,
 			)
+			if cloudRemoteResumeCheckpointReady(loadedCfg) {
+				fmt.Fprintln(
+					os.Stdout,
+					"  This checkpoint can also finish over SSH: add --remote-resume to the resume command above.",
+				)
+			}
 		}
 		return 1
 	}

--- a/cli/command_cloud_connect.go
+++ b/cli/command_cloud_connect.go
@@ -55,6 +55,15 @@ func runCloudConnectCommand(
 		printHumanErr("%s", err)
 		return 1
 	}
+	if options.remoteResume {
+		if loadedCfgErr != nil || !cloudRemoteResumeCheckpointReady(loadedCfg) {
+			printHumanErr(
+				"--remote-resume only resumes an existing checkpoint at \"cloud_verified\" or later: run the authorization once from an interactive desktop session first; no authorization was changed.",
+			)
+			return 1
+		}
+		enableCloudRemoteResumeSession()
+	}
 	if !cloudInteractivePromptSessionForSetup() {
 		printHumanErr(
 			"Home Assistant Cloud setup requires an interactive desktop session: use a local, non-elevated graphical desktop terminal (not SSH, sudo/root, or WSL); no authorization was changed.",

--- a/cli/command_cloud_dispatch.go
+++ b/cli/command_cloud_dispatch.go
@@ -57,7 +57,7 @@ func printCloudUsage() {
 	)
 	fmt.Fprintln(
 		os.Stdout,
-		"  reconnect [--server <name>] [--url https://…]  Rotate the Home Assistant authorization",
+		"  reconnect [--server <name>] [--url https://…] [--remote-resume]  Rotate the Home Assistant authorization",
 	)
 	fmt.Fprintln(
 		os.Stdout,
@@ -81,7 +81,7 @@ func parseCloudCommandFlags(
 			"Home Assistant Cloud URL for remote-first setup",
 		)
 	}
-	if command == "add" {
+	if command == "add" || command == "reconnect" {
 		fs.BoolVar(
 			&result.remoteResume,
 			"remote-resume",

--- a/cli/command_cloud_dispatch.go
+++ b/cli/command_cloud_dispatch.go
@@ -14,6 +14,7 @@ type cloudCommandFlags struct {
 	url                        string
 	json                       bool
 	yes                        bool
+	remoteResume               bool
 	confirmRemoteAccessRevoked string
 }
 
@@ -48,7 +49,7 @@ func printCloudUsage() {
 		os.Stdout,
 		"Usage: ha-nova cloud <add|status|unlock|reconnect|remove>",
 	)
-	fmt.Fprintln(os.Stdout, "  add [--server <name>] [--url https://…]")
+	fmt.Fprintln(os.Stdout, "  add [--server <name>] [--url https://…] [--remote-resume]")
 	fmt.Fprintln(os.Stdout, "  status [--server <name>] [--json]")
 	fmt.Fprintln(
 		os.Stdout,
@@ -78,6 +79,14 @@ func parseCloudCommandFlags(
 			"url",
 			"",
 			"Home Assistant Cloud URL for remote-first setup",
+		)
+	}
+	if command == "add" {
+		fs.BoolVar(
+			&result.remoteResume,
+			"remote-resume",
+			false,
+			"resume a checkpoint at cloud_verified or later from a remote (SSH) session",
 		)
 	}
 	if command == "status" {


### PR DESCRIPTION
## What

`ha-nova cloud add --remote-resume` resumes an EXISTING Cloud-authorization checkpoint at `cloud_verified` or `device_bound_or_paired` from a remote (SSH) session. Both reasons for the desktop gate are absent on this path: the OAuth token refreshes without a browser (the opener is swapped for a hard error — a failed refresh says 'finish on a desktop', never falls through to a new authorization), and native credential prompts are impossible (every store preflight downgrades AllowUI→ForbidUI while the mode is active, including the remote device-access reopen). The relaxed gate tolerates ONLY SSH markers: TTY required, sudo/doas/pkexec and WSL refused, elevation still checked — on Windows via the real token check, tolerating session 0 (OpenSSH's home; DPAPI is prompt-free there).

## Security review already applied (high-risk pre-PR pass)
Local Codex CLI + adversarial subagent with full flow trace. Fixed: raw `SecretStoreAllowUI` in `reopenRemoteCloudDeviceAccess` (the cloud-only resume path — the #584 scenario — would have failed closed), env-escalation markers kept, platform-split elevation. Traced clean: profile binding order, crafted-config resistance (envelope binding pins profile/origin/generation/relay/user), invalid-grant cleanup unreachable from the admitted states, no gate leakage across commands (one command per process), no prompt hangs (ForbidUI + bounded contexts). Calibration: the original SSH detection is env-based and locally defeatable anyway — this flag is a narrower, browserless, promptless, checkpoint-gated formalization.

## Accepted residual
Checkpoint validation races a concurrent local config change (same-user, local-only; worst case: a stale `authorizing` checkpoint plus a hard error, recoverable via the existing checkpoint UX).

## Tests
`go test ./cli/...` green (146s) incl. new: checkpoint-readiness matrix, refused early checkpoints never touch secure storage, gate tolerates SSH-with-TTY while refusing sudo/elevated/WSL, browser opener hard-fails, AllowUI downgrade pinned. `GOOS=windows` build green. Motivation: #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4pMfMeo3VUTUZhD6xr4h1