### PR TITLE
fix(skills): batch-drained refinement train — 30 contract fixes across the first-hour surfaces

### DIFF
--- a/skills/ha-nova/SKILL.md
+++ b/skills/ha-nova/SKILL.md
@@ -89,7 +89,7 @@ Skills reference this section as "context skill → Active Preview Confirmation"
 - Treat those phrases only as permission to prepare the draft, run checks, and show the preview.
 - A live HA write requires confirmation after the concrete preview is shown: diff for updates, payload summary for creates/service calls/experimental writes, delete impact plus confirmation code, or grouped manifest for allowed multi-target writes.
 - A preview is a valid confirmation basis only if it explains the behavioral effect of every collection it touches. A touched collection explained only as a count change (`5 items → 3 items`, `… and N more`) or by low-level type names cannot proceed to confirmation — complete the behavior narrative (`skills/ha-nova/write-safety.md` → Behavior narrative) first, then ask.
-- Confirmation is bound to the displayed operation, target set, endpoint/service, and exact payload/diff/manifest. If target, scope, endpoint, payload, draft, or manifest changes, confirmation expires; show the updated preview and ask again.
+- Confirmation is bound to the displayed operation, target set, endpoint/service, and exact payload/diff/manifest (a masked secret value — output-rules.md webhook masking — binds to the stored real value behind the mask). If target, scope, endpoint, payload, draft, or manifest changes, confirmation expires; show the updated preview and ask again.
 - Multi-target confirmation is valid only where the owning skill supports multi-target writes (destructive batches: `skills/ha-nova/batch-safety.md`; non-destructive grouped change sets and the cross-family destructive cleanup manifest: `skills/ha-nova/grouped-change-set.md`). Otherwise process targets sequentially with separate preview and confirmation.
 
 ### Confirmation Tiers
@@ -312,7 +312,7 @@ Match user intent to exactly one skill:
 **"Show my helpers"** → `ha-nova:helper` (NOT read)
 **"Revert that"** / **"Undo the last change"** → re-invoke the skill that made it: `ha-nova:write` (automation/script) or `ha-nova:helper` (helper). `revert` is update-only and lives there (see `write-safety.md` → Update-Revert), never `ha-nova:fallback`; create cleanup uses delete flow, and a deleted item in a snapshot-covered family restores from its auto config snapshot in the owning skill (`config-snapshots.md`); config-entry helpers stay Backup/recreate.
 **"Delete these obsolete config snapshots"** → `ha-nova` context skill using `config-snapshots.md`; exact multi-file cleanup may use its declared `config-snapshots` batch family.
-**"Do the same for the kitchen"** (right after a verified AUTOMATION create) → `ha-nova:write`, replicate-across-rooms pattern (`skills/ha-nova/automation-patterns.md`) — resolve the kitchen's OWN entities, never copy entity ids; after any other create, treat it as a fresh request to the owning skill
+**"Do the same for the kitchen"** (right after a verified AUTOMATION create) → `ha-nova:write`, replicate-across-rooms pattern (`skills/ha-nova/automation-patterns.md`) — resolve the kitchen's OWN entities, never copy entity ids; after any other operation (updates, deletes, failed verifications included), treat it as a fresh request to the owning skill
 **"Create a scene called Movie Night"** → `ha-nova:scene`
 **"Activate the scene Movie Night"** → `ha-nova:service-call` (runtime action, not a config change)
 **"Unlock the front door"** → `ha-nova:service-call` (high-consequence: typed confirmation code)

--- a/skills/ha-nova/automation-patterns.md
+++ b/skills/ha-nova/automation-patterns.md
@@ -330,15 +330,19 @@ actions:
 "Do the same for the kitchen" after a verified create. Replication is
 re-resolution, never copy-paste:
 
-1. Resolve the TARGET room's own entities for every role the source
+1. Resolve the TARGET room's own entities (and devices, for device-trigger
+   roles) for every role the source
    automation uses (motion sensor, light, …) by EFFECTIVE area membership —
    an entity with an empty `area_id` inherits its device's area, so join the
-   device registry (or use `search/related` on the area);
+   device registry (or use `search/related` on the area). Skip
+   registry-disabled entities when resolving — a disabled counterpart counts
+   as "no counterpart" (say so);
    a ROOM-BOUND role with no counterpart in that room stops the replication
    for that room with a plain sentence — never substitute a neighboring
    room's entity. Home-wide roles (`sun.sun`, zones, household presence,
    global mode helpers) have no per-room counterpart by design: carry them
-   over unchanged. A source that embeds its room in a template or non-entity
+   over unchanged. A source that embeds its room in a template, a group/label
+   target (`light.living_room_group`, `label_id: ambient`), or a non-entity
    literal (`area_entities('living_room')`, area names inside Jinja) stops
    the replication unless that reference re-resolves to the target room —
    never string-replace room names.
@@ -356,7 +360,10 @@ re-resolution, never copy-paste:
 3. Before each room's preview, run the duplicate check for THAT room
    (config evidence per `starter-proposals.md`'s gate — the offer may be
    stale, or the user may have asked directly without an offer); an already
-   automated pairing stops that room with a plain sentence.
+   automated pairing stops that room with a plain sentence — a pairing
+   found only in a DISABLED automation stops that room's write with the
+   enable offer instead of a duplicate stop. A PARTIAL scan
+   does not stop the room — name it in that room's preview.
 4. One normal preview/confirm per room. Multiple rooms are sequential
    single writes, each individually verified — never one batch.
 5. The offer side of this pattern is the Replication Line

--- a/skills/ha-nova/automation-patterns.md
+++ b/skills/ha-nova/automation-patterns.md
@@ -361,8 +361,9 @@ re-resolution, never copy-paste:
    (config evidence per `starter-proposals.md`'s gate — the offer may be
    stale, or the user may have asked directly without an offer); an already
    automated pairing stops that room with a plain sentence — a pairing
-   found only in a DISABLED automation stops that room's write with the
-   enable offer instead of a duplicate stop. A PARTIAL scan
+   found only in an automation that cannot fire (registry-disabled or
+   state off) stops that room's write with the enable offer instead of a
+   duplicate stop. A PARTIAL scan
    does not stop the room — name it in that room's preview.
 4. One normal preview/confirm per room. Multiple rooms are sequential
    single writes, each individually verified — never one batch.

--- a/skills/ha-nova/capability-answer.md
+++ b/skills/ha-nova/capability-answer.md
@@ -54,15 +54,17 @@ Aggregate counts are List-Frame-legal; entity dumps are not.
 
 ## Structure Check — "Is my setup tidy?"
 
-Read-only audit from bounded registry reads (entity registry + area
-registry), owned here; every FIX hands to `ha-nova:organize`'s normal
+Read-only audit from bounded registry reads (FULL entity registry — the
+compact list lacks `original_name` — plus the device and area registries),
+owned here; every FIX hands to `ha-nova:organize`'s normal
 preview/confirm flow:
 
 - count AREA-ASSIGNABLE entities without an EFFECTIVE area: device-bound
   ones (an empty entity `area_id` inherits the device's area — join the
   device registry first) AND device-less entities that accept an
   entity-level `area_id` (template sensors and the like); persons,
-  automations, scripts, and scenes legitimately have no area and are never
+  automations, scripts, scenes, and other non-room service entities (sun,
+  zones, update/assist engines) legitimately have no area and are never
   counted as untidy.
 - name provenance: an entity whose registry `name` is null runs on its
   integration default (`original_name`) — that IS the provenance signal.
@@ -78,14 +80,17 @@ Render the ENFORCED guarantees user-facing, on request only, in about five
 lines:
 
 - Nothing is written without a preview you confirm first; confirmations bind
-  to exactly what was shown.
+  to exactly what was shown (secret values stay masked and bind to the
+  stored value behind the mask).
 - Deleting an automation, scene, helper, dashboard, or similar config needs
-  a typed confirmation code — a plain "yes" is never enough there.
+  a typed confirmation code — a plain "yes" is never enough there; the same
+  code gates high-consequence actions like unlocking doors or opening the
+  garage.
 - Automation, script, and storage-helper updates keep a revert path; deleted
   items in snapshot-covered families restore from automatic config snapshots.
 - Reads are bounded; pairing and authentication secrets never appear in
-  chat, and secret-bearing config values (webhook ids) are masked even in
-  raw YAML you explicitly ask for.
+  chat, and webhook trigger ids are masked even in raw YAML you explicitly
+  ask for.
 - When something is outside these guarantees (scene, dashboard, energy, and
   calendar writes have no revert; config-entry helpers have no snapshot), the
   owning skill names the limit — the honest limit is part of the story.

--- a/skills/ha-nova/output-rules.md
+++ b/skills/ha-nova/output-rules.md
@@ -16,7 +16,7 @@ Apply these rules to every user-facing HA NOVA response, including direct sub-sk
 ## Technical Noise
 
 - Do not dump raw JSON, full logs, full entity lists, full component lists, or full registry/config-entry lists unless the user explicitly asks.
-- Webhook ids are secret-bearing (an unauthenticated trigger URL): redact them in ANY shown YAML or config excerpt — explicitly requested YAML included — replacing the value with a masked placeholder and saying one was masked; webhook mechanics stay in `ha-nova:service-call`'s client-private flow.
+- Webhook ids are secret-bearing (an unauthenticated trigger URL): redact them in ANY shown YAML or config excerpt — explicitly requested YAML included — replacing the value with a masked placeholder and saying one was masked; masking the webhook value is the ONE legal edit to otherwise-verbatim diff rows and previews — confirmation still binds to the stored real value; webhook mechanics stay in `ha-nova:service-call`'s client-private flow.
 - Summarize long inventories by counts, groups, and a few relevant examples.
 - If raw automation IDs, helper IDs, config IDs, or entity IDs make the response more technical than helpful, summarize them in natural language or by count instead of echoing every raw identifier.
 - Show precise identifiers only when they are needed for safety, disambiguation, or evidence.
@@ -192,8 +192,9 @@ keeps its plain sectioned header — review output is sectioned, not card-framed
 
 Pre-preview candidates where the owning skill names none of its own — same
 caps, same evidence bar (registry/capability reads from this session):
-scene create — a same-area ACTIONABLE entity the scene plausibly misses (a
-scene members only controllable domains, never a read-only sensor; storage
+scene create — a same-area (EFFECTIVE membership — starter-proposals rule
+2c) ACTIONABLE entity the scene plausibly misses (a scene admits only
+controllable domains, never a read-only sensor; storage
 scenes persist entity STATES, so never suggest service parameters like
 `transition`);
 dashboard shell create — a strategy config for the empty shell (accepting
@@ -214,7 +215,9 @@ resolves automation roles, so script creates make no offer. After a VERIFIED
 create (never after an update, delete, or a failed verification), exactly ONE
 closing line may point out replication potential —
 and only when the registries actually prove it: other areas holding the same
-device pairing the new item uses, checked in the same session's reads — AND
+device pairing the new item uses, checked in the same session's reads and
+still current (a later write touching those registries invalidates them —
+re-read or make no offer) — AND
 the target room's pairing is not already automated per the config-level
 duplicate evidence, AND the target devices pass the replicate pattern's
 capability check for the source's capability-specific triggers/actions
@@ -227,7 +230,8 @@ from name patterns. Accepting hands to `ha-nova:write`'s replicate pattern
 
 ## Session Recap ("what did you do today?")
 
-Answer ONLY from this conversation's writes: item, operation, and
+Answer ONLY from this conversation's writes AND runtime actions (service
+calls, update installs, notifications sent): item, operation, and
 verification state as reported at the time. No memory of other sessions, no
 inference from current HA state, no filling gaps — when the conversation
 window no longer covers everything, say exactly that — earlier changes may

--- a/skills/ha-nova/starter-proposals.md
+++ b/skills/ha-nova/starter-proposals.md
@@ -33,8 +33,8 @@ proposed. Read-only until the user accepts an item.
    candidate's role entities AND every selector value that resolves to them
    — `device_id`, `area_id`, `label_id`, `floor_id`, from the candidates'
    own EFFECTIVE registry memberships: a device-inherited area — plus that
-   area's floor — and device-level labels count (a selector-targeted
-   automation never names the entity). A selector hit counts only in the role's FUNCTION: a device_id
+   area's floor — and device- or area-level labels count (a
+   selector-targeted automation never names the entity). A selector hit counts only in the role's FUNCTION: a device_id
    match on the source side needs that sensor's own trigger type, and an
    area/label-targeted action needs the action role's domain service —
    otherwise it is no pairing evidence. A candidate drops only when ONE config references its COMPLETE

--- a/skills/ha-nova/starter-proposals.md
+++ b/skills/ha-nova/starter-proposals.md
@@ -64,7 +64,8 @@ proposed. Read-only until the user accepts an item.
    only when the config covers the role's FUNCTION aggregate-wide (a
    template, group, or label over the whole role); coverage of single
    entities is named in the evidence line ('2 of 12 batteries already
-   alerted'), never a drop. Service-shaped roles (a `notify.*` target) match by
+   alerted') and those covered members are excluded from the accepted
+   item's target set, never a drop. Service-shaped roles (a `notify.*` target) match by
    SERVICE NAME in the config's actions, not by entity id — and a modern
    notify ENTITY also matches as the `target`/`entity_id` of a
    `notify.send_message` call. Two more equivalence expansions: a group target

--- a/skills/ha-nova/starter-proposals.md
+++ b/skills/ha-nova/starter-proposals.md
@@ -13,14 +13,15 @@ proposed. Read-only until the user accepts an item.
    (`config/entity_registry/list` — the compact list carries no `unique_id`,
    which IS the disabled rows' config key) — disabled automations have no
    states row, and a states row proves nothing about WHAT an automation
-   does. A YAML automation without an explicit `id` has no readable config:
-   count it and report the duplicate scan as PARTIAL, never as complete. Scene candidates use the `scene.*` rows from the same pull for the id
+   does. A YAML automation or scene without an explicit `id` has no readable
+   config: count it and report the duplicate scan as PARTIAL, never as
+   complete. Scene candidates use the `scene.*` rows from the same pull for the id
    list only — members come from config reads (rule 2b).
 2b. Duplicate gate, config-evidence only: before a candidate enters the
    Suggestion Block, read the existing automations' configs — the config key
    is each automation's `id` ATTRIBUTE from its states row (registry
    `unique_id` for disabled rows), never the entity id. Bound the pass: cap
-   the config reads (default 50, newest-updated first) and report anything
+   the config reads (default 50) and report anything
    beyond the cap as PARTIAL — the cap line names how many configs went
    unread. Scan each read WHOLE config document: triggers, conditions,
    actions, selector targets, and `use_blueprint.input` all carry entity ids
@@ -31,8 +32,9 @@ proposed. Read-only until the user accepts an item.
    closed PARTIAL rule, never a drop; match the
    candidate's role entities AND every selector value that resolves to them
    — `device_id`, `area_id`, `label_id`, `floor_id`, from the candidates'
-   own registry memberships (a selector-targeted automation never names the
-   entity). A selector hit counts only in the role's FUNCTION: a device_id
+   own EFFECTIVE registry memberships: a device-inherited area — plus that
+   area's floor — and device-level labels count (a selector-targeted
+   automation never names the entity). A selector hit counts only in the role's FUNCTION: a device_id
    match on the source side needs that sensor's own trigger type, and an
    area/label-targeted action needs the action role's domain service —
    otherwise it is no pairing evidence. A candidate drops only when ONE config references its COMPLETE
@@ -44,24 +46,37 @@ proposed. Read-only until the user accepts an item.
    trigger is no source role
    plus the ACTION role in the actions that branch actually runs — in
    configs with trigger-id/choose branches, cross-branch co-occurrence does
-   not drop the candidate (name it in the evidence line instead). The pairing must also match the candidate's behavior
+   not drop the candidate (name it in the evidence line instead) — and role
+   co-occurrence in any executable shape this rule does not recognize
+   (`wait_for_trigger`, wait templates, nested branches) never lets the
+   pass claim "not automated yet" silently: name the co-occurrence in the
+   evidence line the same way. The pairing must also match the candidate's behavior
    DIRECTION: a no-motion→off automation is the complement of motion→on,
    not its duplicate — complements are named in the evidence line, never a
-   drop. A single shared entity in an unrelated automation is no duplicate. Service-shaped roles (a `notify.*` target) match by
+   drop. A pairing found only in a DISABLED automation is never a silent
+   drop and never a duplicate drop: the candidate keeps its menu slot
+   reframed as the enable offer ("already built but disabled — enable it
+   instead?"); accepting hands to `ha-nova:organize`'s enable flow.
+   A single shared entity in an unrelated automation is no duplicate. An
+   aggregate role (battery levels, the room's lights) drops the candidate
+   only when the config covers the role's FUNCTION aggregate-wide (a
+   template, group, or label over the whole role); coverage of single
+   entities is named in the evidence line ('2 of 12 batteries already
+   alerted'), never a drop. Service-shaped roles (a `notify.*` target) match by
    SERVICE NAME in the config's actions, not by entity id — and a modern
    notify ENTITY also matches as the `target`/`entity_id` of a
    `notify.send_message` call. Two more equivalence expansions: a group target
    matches when its membership PROVABLY contains the candidate — the
-   `entity_id` states attribute where present, else the group helper's
-   config read; membership the pass cannot prove falls into the closed
-   PARTIAL rule; a presence source role matches zone-count
+   `entity_id` states attribute where present; membership the pass cannot
+   prove falls into the closed PARTIAL rule; a presence source role matches zone-count
    guards (`zone.home` state) and direct `person.*`/`device_tracker.*`
    conditions alike — but only with the POLARITY the candidate needs: an
    at-home guard (zone count > 0, or state `home`) never evidences an away
    alert. CLOSED RULE
    for everything else: any config whose references the pass cannot FULLY
    resolve — dynamic Jinja-computed targets, unexpanded groups, delegation
-   through items it could not read — makes the duplicate scan PARTIAL, and a
+   through items whose configs this pass did not read and resolve — makes
+   the duplicate scan PARTIAL, and a
    PARTIAL scan downgrades every affected evidence line from "not automated
    yet" to "no duplicate found (scan partial)". Never enumerate past this
    rule: unresolvable evidence fails closed into honesty, not into a claim. When the pass is capped, say the

--- a/skills/ha-nova/starter-proposals.md
+++ b/skills/ha-nova/starter-proposals.md
@@ -53,10 +53,12 @@ proposed. Read-only until the user accepts an item.
    evidence line the same way. The pairing must also match the candidate's behavior
    DIRECTION: a no-motion→off automation is the complement of motion→on,
    not its duplicate — complements are named in the evidence line, never a
-   drop. A pairing found only in a DISABLED automation is never a silent
-   drop and never a duplicate drop: the candidate keeps its menu slot
-   reframed as the enable offer ("already built but disabled — enable it
-   instead?"); accepting hands to `ha-nova:organize`'s enable flow.
+   drop. A pairing found only in an automation that cannot fire is never a
+   silent drop and never a duplicate drop: the candidate keeps its menu
+   slot reframed as the enable offer ("already built but disabled — enable
+   it instead?"); accepting hands a registry-disabled row to
+   `ha-nova:organize`'s enable flow and a state-off row to the
+   service-call path (`automation.turn_on`).
    A single shared entity in an unrelated automation is no duplicate. An
    aggregate role (battery levels, the room's lights) drops the candidate
    only when the config covers the role's FUNCTION aggregate-wide (a

--- a/skills/ha-nova/write-safety.md
+++ b/skills/ha-nova/write-safety.md
@@ -40,7 +40,8 @@ Best-practice freshness (`bp_status`) is an **internal gate input only**:
 The diff is rendered by the CLI, not by you — so it is byte-identical on every
 run, every model, every client. It emits GFM table data rows
 (`| Field | before | after |`; an empty side shows `—`). Treat the `ha-nova diff`
-output like `git diff`: a stable artifact you print **verbatim**. Do not
+output like `git diff`: a stable artifact you print **verbatim** (sole exception: webhook-id
+masking, output-rules.md → Technical Noise). Do not
 hand-format, reorder, relabel, translate, merge, or summarize the rows —
 do not re-align pipes or pad cells. The table rows come ONLY from the command's
 output this turn — if you did not just run `ha-nova diff`, do not print a

--- a/tests/skills/first-hour-contract.test.ts
+++ b/tests/skills/first-hour-contract.test.ts
@@ -51,7 +51,7 @@ describe("first-hour pack (#528)", () => {
     expect(proposals).toContain("not from name-string guessing");
     expect(proposals).toContain("Duplicate gate, config-evidence only");
     expect(proposals).toContain("Scan each read WHOLE config document");
-    expect(proposals).toContain("cap the config reads (default 50, newest-updated first)");
+    expect(proposals).toContain("cap the config reads (default 50)");
     expect(proposals).toContain("AND every selector value that resolves to them");
     expect(proposals).toContain("ON ONE EXECUTABLE PATH");
     expect(proposals).toContain('never claim "not automated yet" from states rows or aliases');
@@ -102,7 +102,9 @@ describe("first-hour pack (#528)", () => {
   });
 
   it("fuels the suggestion budget for scene, dashboard, and failure alerts (P3-09)", () => {
-    expect(outputRules).toContain("a same-area ACTIONABLE entity the scene plausibly misses");
+    expect(outputRules).toContain(
+      "a same-area (EFFECTIVE membership — starter-proposals rule 2c) ACTIONABLE entity the scene plausibly misses",
+    );
     expect(outputRules).toContain("never a read-only sensor");
     expect(outputRules).toContain("a strategy config for the empty shell");
     expect(flat(read("skills/ha-nova/agents/resolve-agent.md"))).toContain("outcome alert");


### PR DESCRIPTION
## What

One batched pass over `skills/ha-nova/{starter-proposals,output-rules,automation-patterns,capability-answer,write-safety}.md` + `SKILL.md`: 22 pre-drained findings from the exhaustive Codex-simulator drain (quote → scenario → smallest fix), plus 8 findings from the adversarial pre-PR review of this exact diff. Covered-class items (A9, A10, B5, B6, D5) intentionally get no text — they are already closed by existing rules.

## Classes

- **Evidence-surface deletions:** "newest-updated first" ordering (no read computes it), the group-helper config read (options only reachable via a write-initiating flow — broke the read-only header contract).
- **Sibling-class sweeps:** YAML scenes without `id` join the PARTIAL rule; device-inherited labels and floors join effective membership; scene-create suggestions get the effective-membership qualifier; replication resolves devices for device-trigger roles and skips registry-disabled entities.
- **Closed-rule generalizations:** unrecognized executable shapes (`wait_for_trigger`, wait templates, nested branches) never claim "not automated yet" silently; aggregate roles drop only on aggregate-wide coverage; a disabled-only pairing becomes the enable offer (handoff `ha-nova:organize`) instead of a silent drop — in the menu AND in replication; PARTIAL scans never stop a replication room silently.
- **Contract consistency:** webhook masking is the ONE legal edit to verbatim diff rows — declared at the masking rule, the verbatim contract (write-safety), the binding rule (SKILL.md Active Preview Confirmation), and the user-facing Safety Story; Structure Check read list names the FULL entity registry + device registry it actually needs; Safety Story narrowed to enforced guarantees (webhook ids only) and extended by the high-consequence typed-code tier; Session Recap covers runtime actions; the "do the same for the kitchen" routing fallback covers every non-create operation.

## Tests

- `npx vitest run tests/skills`: 67 files, 778 tests green (exit code checked).
- `npm run typecheck` green.
- Two pins in `tests/skills/first-hour-contract.test.ts` updated to the new contract wording (test-hygiene rule: contract change = fixture change).

## Known limits

- The drain report's covered-class items are documented as in-thread answers, not text.
- No German in any skill file; all edits are English contract text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4pMfMeo3VUTUZhD6xr4h1