### PR TITLE
fix(release): bind Cloud candidates to exact PR identity

### DIFF
--- a/.github/workflows/cloud-candidate-bundle.yml
+++ b/.github/workflows/cloud-candidate-bundle.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       request_id:
-        description: "Unique operator request ID used to recover this one dispatch"
+        description: "Exact PR/base/head/merge identity used to select this dispatch"
         required: true
         type: string
 
@@ -51,6 +51,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pull_request }}
+          REQUEST_ID: ${{ inputs.request_id }}
         run: |
           scripts/release/resolve-cloud-candidate-source.sh \
             "${PR_NUMBER}"
@@ -150,6 +151,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pull_request }}
+          REQUEST_ID: ${{ inputs.request_id }}
           HA_NOVA_CLOUD_CANDIDATE_EXPECTED_COMMIT: ${{ needs.resolve-source.outputs.commit_sha }}
           HA_NOVA_CLOUD_CANDIDATE_EXPECTED_TREE: ${{ needs.resolve-source.outputs.tree_sha }}
           HA_NOVA_CLOUD_CANDIDATE_EXPECTED_BASE: ${{ needs.resolve-source.outputs.base_sha }}
@@ -365,6 +367,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pull_request }}
+          REQUEST_ID: ${{ inputs.request_id }}
           HA_NOVA_CLOUD_CANDIDATE_EXPECTED_COMMIT: ${{ needs.resolve-source.outputs.commit_sha }}
           HA_NOVA_CLOUD_CANDIDATE_EXPECTED_TREE: ${{ needs.resolve-source.outputs.tree_sha }}
           HA_NOVA_CLOUD_CANDIDATE_EXPECTED_BASE: ${{ needs.resolve-source.outputs.base_sha }}
@@ -431,6 +434,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pull_request }}
+          REQUEST_ID: ${{ inputs.request_id }}
           HA_NOVA_CLOUD_CANDIDATE_EXPECTED_COMMIT: ${{ needs.resolve-source.outputs.commit_sha }}
           HA_NOVA_CLOUD_CANDIDATE_EXPECTED_TREE: ${{ needs.resolve-source.outputs.tree_sha }}
           HA_NOVA_CLOUD_CANDIDATE_EXPECTED_BASE: ${{ needs.resolve-source.outputs.base_sha }}

--- a/.github/workflows/cloud-candidate-bundle.yml
+++ b/.github/workflows/cloud-candidate-bundle.yml
@@ -26,7 +26,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: cloud-candidate-bundle-${{ inputs.pull_request }}
+  group: "cloud-candidate-bundle-${{ inputs.pull_request }}-${{ inputs.version_tag }}-${{ inputs.request_id }}"
   cancel-in-progress: true
 
 jobs:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -477,6 +477,17 @@ list_candidate_runs() {
   }
   jq '[.[] | .workflow_runs[]]' <<<"${pages}"
 }
+require_exact_run() {
+  gh api "repos/markusleben/ha-nova/actions/runs/$1" \
+    | jq -e --argjson id "$1" --arg title "${RUN_TITLE}" \
+        --arg trusted "${BASE_SHA}" '
+          .id == $id
+          and .event == "workflow_dispatch"
+          and .display_title == $title
+          and .head_sha == $trusted
+          and .run_attempt == 1
+        ' >/dev/null
+}
 RUNS_JSON="$(list_candidate_runs)" || exit 1
 MAX_BEFORE="$(jq '[.[].id] | max // 0' <<<"${RUNS_JSON}")"
 gh workflow run cloud-candidate-bundle.yml --ref main \
@@ -488,20 +499,26 @@ for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
   RUN_ID="$(list_candidate_runs \
     | jq -r --arg title "${RUN_TITLE}" --arg trusted "${BASE_SHA}" \
         --argjson floor "${MAX_BEFORE}" \
-        'map(select(.id > $floor and .display_title == $title and .head_sha == $trusted and .run_attempt == 1) | .id) | min // empty')"
+        'map(select(.id > $floor and .display_title == $title and .head_sha == $trusted and .run_attempt == 1) | .id) | max // empty')"
   [[ -n "${RUN_ID}" ]] && break
 done
 [[ "${RUN_ID}" =~ ^[0-9]+$ ]] || {
   echo "Dispatched run not found; do not dispatch again." >&2
   exit 1
 }
-if ! gh run watch "${RUN_ID}" --exit-status; then
+require_exact_run "${RUN_ID}" || exit 1
+WATCH_OK=true
+gh run watch "${RUN_ID}" --exit-status || WATCH_OK=false
+require_exact_run "${RUN_ID}" || exit 1
+if [[ "${WATCH_OK}" != true ]]; then
   gh run view "${RUN_ID}" --log
   exit 1
 fi
 gh run view "${RUN_ID}" --json url,headSha,status,conclusion
+require_exact_run "${RUN_ID}" || exit 1
 gh run download "${RUN_ID}" -n cloud-candidate-install-bundles \
   -D cloud-candidate-install-bundles
+require_exact_run "${RUN_ID}" || exit 1
 (
   cd cloud-candidate-install-bundles
   for checksum in *.sha256; do shasum -a 256 -c "${checksum}"; done

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -451,11 +451,18 @@ Dispatch, capture, and monitor that single run:
 ```bash
 PR_NUMBER=469 # replace
 VERSION_TAG=v0.22.0-rc1 # replace
-REQUEST_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
-# `gh workflow run` prints no run id, and every run before the #574 fix is
-# titled just "Cloud candidate PR", so recovery by name is unreliable. Fence
-# on the highest run id seen BEFORE the dispatch; the id fence plus the
-# bundle-identity checks below are the real binding.
+PR_JSON="$(gh api "repos/markusleben/ha-nova/pulls/${PR_NUMBER}")"
+BASE_SHA="$(jq -r .base.sha <<<"${PR_JSON}")"
+HEAD_SHA="$(jq -r .head.sha <<<"${PR_JSON}")"
+MERGE_SHA="$(jq -r .merge_commit_sha <<<"${PR_JSON}")"
+REQUEST_ID="pr${PR_NUMBER}-${BASE_SHA}-${HEAD_SHA}-${MERGE_SHA}"
+RUN_TITLE="Cloud candidate PR #${PR_NUMBER} ${VERSION_TAG} (${REQUEST_ID})"
+# `gh workflow run` prints no run id. The request ID must contain the PR plus
+# the complete base, head, and synthetic merge SHAs; the workflow resolver
+# validates that identity from one authoritative PR resolution. Select only a
+# run whose evaluated title has that exact request ID, whose head is the same
+# trusted main/base SHA, and whose attempt is 1. The id fence then distinguishes
+# the new dispatch; bundle identity remains an additional check.
 MAX_BEFORE="$(gh run list --workflow cloud-candidate-bundle.yml --limit 30 \
   --json databaseId --jq '[.[].databaseId] | max // 0')"
 gh workflow run cloud-candidate-bundle.yml --ref main \
@@ -465,8 +472,9 @@ RUN_ID=""
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
   sleep 5
   RUN_ID="$(gh run list --workflow cloud-candidate-bundle.yml \
-    --event workflow_dispatch --limit 30 --json databaseId \
-    --jq "map(.databaseId | select(. > ${MAX_BEFORE})) | min // empty")"
+    --event workflow_dispatch --limit 30 \
+    --json databaseId,displayTitle,headSha,attempt \
+    --jq "map(select(.databaseId > ${MAX_BEFORE} and .displayTitle == \"${RUN_TITLE}\" and .headSha == \"${BASE_SHA}\" and .attempt == 1) | .databaseId) | min // empty")"
   [[ -n "${RUN_ID}" ]] && break
 done
 [[ "${RUN_ID}" =~ ^[0-9]+$ ]] || {

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -463,18 +463,32 @@ RUN_TITLE="Cloud candidate PR #${PR_NUMBER} ${VERSION_TAG} (${REQUEST_ID})"
 # run whose evaluated title has that exact request ID, whose head is the same
 # trusted main/base SHA, and whose attempt is 1. The id fence then distinguishes
 # the new dispatch; bundle identity remains an additional check.
-MAX_BEFORE="$(gh run list --workflow cloud-candidate-bundle.yml --limit 30 \
-  --json databaseId --jq '[.[].databaseId] | max // 0')"
+RUNS_SINCE="$(node -e 'const d = new Date(Date.now() - 8 * 86400000); process.stdout.write(d.toISOString().slice(0, 10))')"
+list_candidate_runs() {
+  local pages total
+  pages="$(gh api --paginate --slurp --method GET \
+    "repos/markusleben/ha-nova/actions/workflows/cloud-candidate-bundle.yml/runs" \
+    -f event=workflow_dispatch -f "head_sha=${BASE_SHA}" \
+    -f "created=>=${RUNS_SINCE}" -F per_page=100)" || return
+  total="$(jq -r '[.[].total_count] | max // 0' <<<"${pages}")" || return
+  [[ "${total}" -le 1000 ]] || {
+    echo "Candidate-run search exceeds GitHub's 1,000-result cap." >&2
+    return 1
+  }
+  jq '[.[] | .workflow_runs[]]' <<<"${pages}"
+}
+RUNS_JSON="$(list_candidate_runs)" || exit 1
+MAX_BEFORE="$(jq '[.[].id] | max // 0' <<<"${RUNS_JSON}")"
 gh workflow run cloud-candidate-bundle.yml --ref main \
   -f pull_request="${PR_NUMBER}" -f version_tag="${VERSION_TAG}" \
   -f request_id="${REQUEST_ID}"
 RUN_ID=""
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
   sleep 5
-  RUN_ID="$(gh run list --workflow cloud-candidate-bundle.yml \
-    --event workflow_dispatch --limit 30 \
-    --json databaseId,displayTitle,headSha,attempt \
-    --jq "map(select(.databaseId > ${MAX_BEFORE} and .displayTitle == \"${RUN_TITLE}\" and .headSha == \"${BASE_SHA}\" and .attempt == 1) | .databaseId) | min // empty")"
+  RUN_ID="$(list_candidate_runs \
+    | jq -r --arg title "${RUN_TITLE}" --arg trusted "${BASE_SHA}" \
+        --argjson floor "${MAX_BEFORE}" \
+        'map(select(.id > $floor and .display_title == $title and .head_sha == $trusted and .run_attempt == 1) | .id) | min // empty')"
   [[ -n "${RUN_ID}" ]] && break
 done
 [[ "${RUN_ID}" =~ ^[0-9]+$ ]] || {

--- a/docs/work/2026-08-30-cloud-candidate-request-identity-spec.md
+++ b/docs/work/2026-08-30-cloud-candidate-request-identity-spec.md
@@ -14,15 +14,21 @@ the same Git tree.
   and synthetic merge SHAs.
 - The trusted-main workflow resolver must derive those SHAs from one pull
   request resolution and reject any different request identity.
+- Concurrency cancellation must match the pull request, version, and complete
+  request identity, so a stale request cannot cancel the exact run.
 - Local run selection must match the evaluated run name, the trusted-main
   workflow head, `workflow_dispatch`, and attempt 1 before watch, download, or
   reuse.
+- Candidate discovery must paginate the complete final-artifact retention
+  window and fail closed if GitHub reports more filtered results than it can
+  return.
 - Bundle version, signature, checksum, tree, and provenance checks remain
   mandatory after run selection.
 - A foreign run never delays or replaces a fresh exact-identity dispatch.
 
 ## Verification
 
-Behavior tests use parsed GitHub run-list records and real bundle archives to
-cover foreign successful and in-flight runs, two merge identities sharing one
-tree, an exact successful run, and the `--set` reuse path.
+Behavior tests use raw paginated GitHub workflow-run responses, distinct real
+base, head, and synthetic merge commits sharing one tree, and real bundle
+archives. They cover shifted identity fields, foreign successful and in-flight
+runs, an exact run behind more than 30 foreign runs, exact reuse, and `--set`.

--- a/docs/work/2026-08-30-cloud-candidate-request-identity-spec.md
+++ b/docs/work/2026-08-30-cloud-candidate-request-identity-spec.md
@@ -1,0 +1,28 @@
+# Cloud Candidate Request Identity
+
+Status: active
+
+## Goal
+
+Prevent a successful or in-flight Cloud Candidate run for another pull request
+or merge identity from being watched or reused, even when both candidates have
+the same Git tree.
+
+## Contract
+
+- The request identity is the pull request number plus the complete base, head,
+  and synthetic merge SHAs.
+- The trusted-main workflow resolver must derive those SHAs from one pull
+  request resolution and reject any different request identity.
+- Local run selection must match the evaluated run name, the trusted-main
+  workflow head, `workflow_dispatch`, and attempt 1 before watch, download, or
+  reuse.
+- Bundle version, signature, checksum, tree, and provenance checks remain
+  mandatory after run selection.
+- A foreign run never delays or replaces a fresh exact-identity dispatch.
+
+## Verification
+
+Behavior tests use parsed GitHub run-list records and real bundle archives to
+cover foreign successful and in-flight runs, two merge identities sharing one
+tree, an exact successful run, and the `--set` reuse path.

--- a/docs/work/2026-08-30-cloud-candidate-request-identity-spec.md
+++ b/docs/work/2026-08-30-cloud-candidate-request-identity-spec.md
@@ -22,6 +22,9 @@ the same Git tree.
 - Candidate discovery must paginate the complete final-artifact retention
   window and fail closed if GitHub reports more filtered results than it can
   return.
+- When several exact runs exist, selection uses the highest run ID. Individual
+  run metadata must still match the complete selector and attempt 1 before and
+  after watch, and before and after artifact download.
 - Bundle version, signature, checksum, tree, and provenance checks remain
   mandatory after run selection.
 - A foreign run never delays or replaces a fresh exact-identity dispatch.
@@ -31,4 +34,5 @@ the same Git tree.
 Behavior tests use raw paginated GitHub workflow-run responses, distinct real
 base, head, and synthetic merge commits sharing one tree, and real bundle
 archives. They cover shifted identity fields, foreign successful and in-flight
-runs, an exact run behind more than 30 foreign runs, exact reuse, and `--set`.
+runs, an exact run behind more than 30 foreign runs, competing exact runs,
+attempt changes, exact reuse, and `--set`.

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -453,17 +453,32 @@ MINT_LOCK_ACQUIRED=1
 # one tree.
 request_id="pr${PR}-${resolved_base_sha}-${resolved_head_sha}-${target_commit}"
 expected_run_title="Cloud candidate PR #${PR} ${version_tag} (${request_id})"
+# Final artifacts expire after seven days. Include one upload/runtime margin
+# day, then paginate every workflow-dispatch run on the trusted workflow head
+# so a burst of unrelated runs cannot hide an exact reusable candidate.
+candidate_since="$(node -e 'const d = new Date(Date.now() - 8 * 86400000); process.stdout.write(d.toISOString().slice(0, 10))')"
 list_candidate_runs() {
-  gh run list --repo "$REPO" --workflow cloud-candidate-bundle.yml \
-    --json databaseId,displayTitle,headSha,status,conclusion,event,attempt --limit 30
+  local pages total
+  pages="$(gh api --paginate --slurp --method GET \
+    "repos/$REPO/actions/workflows/cloud-candidate-bundle.yml/runs" \
+    -f event=workflow_dispatch \
+    -f "head_sha=$resolved_base_sha" \
+    -f "created=>=$candidate_since" \
+    -F per_page=100)" \
+    || return
+  total="$(jq -r '[.[].total_count] | max // 0' <<<"$pages")" \
+    || die "cannot count candidate runs"
+  [ "$total" -le 1000 ] \
+    || die "candidate run search returned $total results in the artifact window; GitHub caps filtered workflow searches at 1000 — narrow the retained run set before dispatching"
+  jq -c '[.[] | .workflow_runs[]]' <<<"$pages"
 }
 matching_candidate_runs() {
   jq -c --arg title "$expected_run_title" --arg trusted "$resolved_base_sha" '
     map(select(
       .event == "workflow_dispatch"
-      and .displayTitle == $title
-      and .headSha == $trusted
-      and .attempt == 1
+      and .display_title == $title
+      and .head_sha == $trusted
+      and .run_attempt == 1
     ))
   '
 }
@@ -471,7 +486,7 @@ matching_candidate_runs() {
 runs_json="$(list_candidate_runs)" || die "cannot list candidate runs"
 matching_runs_json="$(matching_candidate_runs <<<"$runs_json")" \
   || die "cannot filter candidate runs"
-inflight_id="$(jq -r 'map(select(.status != "completed")) | first | .databaseId // empty' <<<"$matching_runs_json")"
+inflight_id="$(jq -r 'map(select(.status != "completed")) | first | .id // empty' <<<"$matching_runs_json")"
 if [ -n "$inflight_id" ]; then
   echo "  matching run $inflight_id is in flight — watching it first"
   gh run watch "$inflight_id" --repo "$REPO" --exit-status >/dev/null \
@@ -491,7 +506,7 @@ download_run() {  # <run-id> ; hard-fails
 
 dispatch_and_bind() {  # sets run_id
   local max_before
-  max_before="$(jq -r '[.[].databaseId] | max // 0' <<<"$runs_json")"
+  max_before="$(jq -r '[.[].id] | max // 0' <<<"$runs_json")"
   # Recheck at the moment of spending: the resolve-time snapshot can go stale
   # while the envelope, reachability, and reuse probes run. CI reads first,
   # the cheap reviewability read LAST — its window to the dispatch is the
@@ -509,7 +524,7 @@ dispatch_and_bind() {  # sets run_id
     sleep "${HA_NOVA_POLL_SECONDS:-10}"
     run_id="$(list_candidate_runs | matching_candidate_runs \
       | jq -r --argjson m "$max_before" '
-          map(select(.databaseId > $m)) | min_by(.databaseId) | .databaseId // empty
+          map(select(.id > $m)) | min_by(.id) | .id // empty
         ')" \
       || die "cannot list candidate runs"
     [ -n "$run_id" ] && break
@@ -523,7 +538,7 @@ dispatch_and_bind() {  # sets run_id
 
 run_id="$(jq -r '
   map(select(.status == "completed" and .conclusion == "success"))
-  | first | .databaseId // empty
+  | first | .id // empty
 ' <<<"$matching_runs_json")"
 bundles_ok=false
 if [ -n "$run_id" ]; then

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -482,24 +482,66 @@ matching_candidate_runs() {
     ))
   '
 }
+matching_run_now() {  # <run-id>
+  local selected_id="$1" run matched
+  run="$(gh api "repos/$REPO/actions/runs/$selected_id")" \
+    || die "cannot revalidate candidate run $selected_id"
+  matched="$(matching_candidate_runs <<<"[$run]")" \
+    || die "cannot filter candidate run $selected_id"
+  jq -e --argjson id "$selected_id" \
+    'length == 1 and .[0].id == $id' >/dev/null <<<"$matched"
+}
+require_matching_run() {  # <run-id> <phase>
+  local selected_id="$1" phase="$2"
+  matching_run_now "$selected_id" \
+    || die "candidate run $selected_id no longer has the exact request identity and attempt 1 $phase"
+}
 
 runs_json="$(list_candidate_runs)" || die "cannot list candidate runs"
 matching_runs_json="$(matching_candidate_runs <<<"$runs_json")" \
   || die "cannot filter candidate runs"
-inflight_id="$(jq -r 'map(select(.status != "completed")) | first | .id // empty' <<<"$matching_runs_json")"
+inflight_id="$(jq -r 'map(select(.status != "completed")) | max_by(.id) | .id // empty' <<<"$matching_runs_json")"
 if [ -n "$inflight_id" ]; then
   echo "  matching run $inflight_id is in flight — watching it first"
-  gh run watch "$inflight_id" --repo "$REPO" --exit-status >/dev/null \
-    || echo "  in-flight run $inflight_id did not succeed — continuing"
+  if matching_run_now "$inflight_id"; then
+    watch_succeeded=true
+    gh run watch "$inflight_id" --repo "$REPO" --exit-status >/dev/null \
+      || watch_succeeded=false
+    if ! matching_run_now "$inflight_id"; then
+      echo "  in-flight run $inflight_id changed identity or attempt — discarding it"
+    elif [ "$watch_succeeded" != true ]; then
+      echo "  in-flight run $inflight_id did not succeed — continuing"
+    fi
+  else
+    echo "  in-flight run $inflight_id changed identity or attempt before watch — discarding it"
+  fi
   runs_json="$(list_candidate_runs)" || die "cannot list candidate runs"
   matching_runs_json="$(matching_candidate_runs <<<"$runs_json")" \
     || die "cannot filter candidate runs"
 fi
 
-download_run() {  # <run-id> ; hard-fails
+fetch_run_bundles() {  # <run-id> [quiet] ; missing artifact returns nonzero
+  matching_run_now "$1" || return 2
   rm -rf "$work/bundles"
-  gh run download "$1" --repo "$REPO" --name cloud-candidate-install-bundles --dir "$work/bundles" \
-    || die "cannot download the install bundles from run $1 (artifacts expire after 7 days)"
+  if [ "${2:-}" = quiet ]; then
+    gh run download "$1" --repo "$REPO" --name cloud-candidate-install-bundles --dir "$work/bundles" 2>/dev/null \
+      || return
+  else
+    gh run download "$1" --repo "$REPO" --name cloud-candidate-install-bundles --dir "$work/bundles" \
+      || return
+  fi
+  matching_run_now "$1" || return 2
+}
+download_run() {  # <run-id> ; hard-fails
+  local result
+  if fetch_run_bundles "$1"; then
+    :
+  else
+    result="$?"
+    [ "$result" != 2 ] \
+      || die "candidate run $1 changed identity or attempt before its artifact could be trusted"
+    die "cannot download the install bundles from run $1 (artifacts expire after 7 days)"
+  fi
   step "verifying the artifact's checksums"
   verify_bundle_checksums
 }
@@ -524,7 +566,7 @@ dispatch_and_bind() {  # sets run_id
     sleep "${HA_NOVA_POLL_SECONDS:-10}"
     run_id="$(list_candidate_runs | matching_candidate_runs \
       | jq -r --argjson m "$max_before" '
-          map(select(.id > $m)) | min_by(.id) | .id // empty
+          map(select(.id > $m)) | max_by(.id) | .id // empty
         ')" \
       || die "cannot list candidate runs"
     [ -n "$run_id" ] && break
@@ -532,18 +574,23 @@ dispatch_and_bind() {  # sets run_id
   [ -n "$run_id" ] \
     || die "the dispatched run never appeared within 300s. It may still be queued — check: gh run list --workflow cloud-candidate-bundle.yml --repo $REPO"
   echo "  run $run_id — waiting for completion"
+  require_matching_run "$run_id" "before watch"
+  watch_succeeded=true
   gh run watch "$run_id" --repo "$REPO" --exit-status >/dev/null \
+    || watch_succeeded=false
+  require_matching_run "$run_id" "after watch"
+  [ "$watch_succeeded" = true ] \
     || die "run $run_id failed — fix the cause in a reviewed PR, then dispatch once more"
 }
 
 run_id="$(jq -r '
   map(select(.status == "completed" and .conclusion == "success"))
-  | first | .id // empty
+  | max_by(.id) | .id // empty
 ' <<<"$matching_runs_json")"
 bundles_ok=false
 if [ -n "$run_id" ]; then
   step "reuse candidate: exact successful run $run_id — its artifact must also prove this target"
-  if gh run download "$run_id" --repo "$REPO" --name cloud-candidate-install-bundles --dir "$work/bundles" 2>/dev/null; then
+  if fetch_run_bundles "$run_id" quiet; then
     step "verifying the artifact's checksums"
     verify_bundle_checksums
     step "verifying bundle identity (before anything executes)"
@@ -554,7 +601,12 @@ if [ -n "$run_id" ]; then
       echo "  not this target's candidate — dispatching fresh"
     fi
   else
-    echo "  cannot download run $run_id's artifact (likely expired after 7 days) — dispatching fresh"
+    download_result="$?"
+    if [ "$download_result" = 2 ]; then
+      echo "  run $run_id changed identity or attempt — dispatching fresh"
+    else
+      echo "  cannot download run $run_id's artifact (likely expired after 7 days) — dispatching fresh"
+    fi
   fi
 fi
 

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -11,7 +11,7 @@
 # judgement:
 #
 #   resolve the exact target   refs/pull/<pr>/merge -> commit, tree, relay version
-#   bind the candidate run     request_id derived from the target commit
+#   bind the candidate run     exact PR/base/head/merge request identity
 #   verify the download        sha256 over the artifact's own checksum files
 #   prove identity FIRST       every bundle's embedded manifest must match the
 #                              target before any candidate binary executes
@@ -177,8 +177,12 @@ merge_commit="$(jq -r '.merge_commit_sha // ""' <<<"$pr_json")"
 base_ref="$(jq -r '.base.ref // ""' <<<"$pr_json")"
 [ "$base_ref" = "main" ] \
   || die "PR #$PR targets '${base_ref:-unknown}', not main — the candidate workflow only builds PRs into main"
+resolved_base_sha="$(jq -r '.base.sha // ""' <<<"$pr_json")"
+[[ "$resolved_base_sha" =~ ^[0-9a-f]{40}$ ]] \
+  || die "PR #$PR has no full lowercase base sha in the API response"
 resolved_head_sha="$(jq -r '.head.sha // ""' <<<"$pr_json")"
-[ -n "$resolved_head_sha" ] || die "PR #$PR has no head sha in the API response"
+[[ "$resolved_head_sha" =~ ^[0-9a-f]{40}$ ]] \
+  || die "PR #$PR has no full lowercase head sha in the API response"
 head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
 [ "$head_repo" = "$REPO" ] \
   || die "PR #$PR's head lives in '${head_repo:-unknown}', not $REPO — the candidate workflow only builds same-repo branches"
@@ -441,34 +445,40 @@ mkdir "$MINT_LOCK" 2>/dev/null \
   || die "another mint session appears to be running (lock: $MINT_LOCK) — if none is, remove that directory and re-run"
 MINT_LOCK_ACQUIRED=1
 
-# request_id is a REQUIRED dispatch input, derived deterministically for the
-# audit trail — but binding never relies on it: every run before the #574
-# fix is titled just "Cloud candidate PR" (the unquoted `#` in run-name
-# started a YAML comment), and `gh run list` cannot filter by dispatch
-# inputs either way. Binding works with what the API reliably has:
-#   - an in-flight run is watched to completion FIRST — dispatching would
-#     cancel it via the per-PR concurrency group, and in this
-#     single-maintainer repo it is almost certainly ours;
-#   - the newest completed success is only a REUSE CANDIDATE: its artifact
-#     must prove this exact target (embedded bundle version + tree) before
-#     anything trusts it, else we dispatch;
-#   - a dispatched run is bound as "the workflow_dispatch run that appeared
-#     above the highest run id seen before the dispatch".
-# A wrong pick can never attest anything: identity is proven from local bytes
-# before any binary executes, and check_identity guards every provenance run.
-request_id="pr${PR}-${target_commit:0:12}"
+# The workflow resolver validates this complete request_id against its own
+# authoritative PR resolution. GitHub exposes the evaluated run-name, trusted
+# workflow head, and attempt in run-list output, so selection can reject a run
+# before watching or downloading it. Tree identity remains an additional
+# artifact check; it is not a substitute because different commits can share
+# one tree.
+request_id="pr${PR}-${resolved_base_sha}-${resolved_head_sha}-${target_commit}"
+expected_run_title="Cloud candidate PR #${PR} ${version_tag} (${request_id})"
 list_candidate_runs() {
   gh run list --repo "$REPO" --workflow cloud-candidate-bundle.yml \
-    --json databaseId,status,conclusion,event --limit 30
+    --json databaseId,displayTitle,headSha,status,conclusion,event,attempt --limit 30
+}
+matching_candidate_runs() {
+  jq -c --arg title "$expected_run_title" --arg trusted "$resolved_base_sha" '
+    map(select(
+      .event == "workflow_dispatch"
+      and .displayTitle == $title
+      and .headSha == $trusted
+      and .attempt == 1
+    ))
+  '
 }
 
 runs_json="$(list_candidate_runs)" || die "cannot list candidate runs"
-inflight_id="$(jq -r 'map(select(.status != "completed")) | first | .databaseId // empty' <<<"$runs_json")"
+matching_runs_json="$(matching_candidate_runs <<<"$runs_json")" \
+  || die "cannot filter candidate runs"
+inflight_id="$(jq -r 'map(select(.status != "completed")) | first | .databaseId // empty' <<<"$matching_runs_json")"
 if [ -n "$inflight_id" ]; then
-  echo "  run $inflight_id is in flight — watching it first (a dispatch would cancel it via the concurrency group)"
+  echo "  matching run $inflight_id is in flight — watching it first"
   gh run watch "$inflight_id" --repo "$REPO" --exit-status >/dev/null \
     || echo "  in-flight run $inflight_id did not succeed — continuing"
   runs_json="$(list_candidate_runs)" || die "cannot list candidate runs"
+  matching_runs_json="$(matching_candidate_runs <<<"$runs_json")" \
+    || die "cannot filter candidate runs"
 fi
 
 download_run() {  # <run-id> ; hard-fails
@@ -497,9 +507,10 @@ dispatch_and_bind() {  # sets run_id
   run_id=""
   for _ in $(seq 1 30); do
     sleep "${HA_NOVA_POLL_SECONDS:-10}"
-    run_id="$(list_candidate_runs \
-      | jq -r --argjson m "$max_before" \
-          'map(select(.databaseId > $m and .event == "workflow_dispatch")) | last | .databaseId // empty')" \
+    run_id="$(list_candidate_runs | matching_candidate_runs \
+      | jq -r --argjson m "$max_before" '
+          map(select(.databaseId > $m)) | min_by(.databaseId) | .databaseId // empty
+        ')" \
       || die "cannot list candidate runs"
     [ -n "$run_id" ] && break
   done
@@ -510,10 +521,13 @@ dispatch_and_bind() {  # sets run_id
     || die "run $run_id failed — fix the cause in a reviewed PR, then dispatch once more"
 }
 
-run_id="$(jq -r 'map(select(.status == "completed" and .conclusion == "success" and .event == "workflow_dispatch")) | first | .databaseId // empty' <<<"$runs_json")"
+run_id="$(jq -r '
+  map(select(.status == "completed" and .conclusion == "success"))
+  | first | .databaseId // empty
+' <<<"$matching_runs_json")"
 bundles_ok=false
 if [ -n "$run_id" ]; then
-  step "reuse candidate: newest successful run $run_id — its artifact must prove this exact target"
+  step "reuse candidate: exact successful run $run_id — its artifact must also prove this target"
   if gh run download "$run_id" --repo "$REPO" --name cloud-candidate-install-bundles --dir "$work/bundles" 2>/dev/null; then
     step "verifying the artifact's checksums"
     verify_bundle_checksums

--- a/scripts/release/resolve-cloud-candidate-source.sh
+++ b/scripts/release/resolve-cloud-candidate-source.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REPO="${GITHUB_REPOSITORY:-}"
 PR_NUMBER="${1:-}"
 POLICY_FILE="${2:-.github/policy/repo-policy.json}"
+REQUEST_ID="${REQUEST_ID:-}"
 
 fail() {
   echo "[resolve-cloud-candidate-source] ERROR: $*" >&2
@@ -67,6 +68,9 @@ merge_sha="$(jq -r '.merge_commit_sha // empty' <<<"${pr}")"
 require_sha "${base_sha}" "pull request base SHA"
 require_sha "${head_sha}" "pull request head SHA"
 require_sha "${merge_sha}" "pull request merge commit SHA"
+expected_request_id="pr${PR_NUMBER}-${base_sha}-${head_sha}-${merge_sha}"
+[[ "${REQUEST_ID}" == "${expected_request_id}" ]] \
+  || fail "request_id must bind the exact pull request base, head, and merge identity"
 [[ "${base_sha}" == "${GITHUB_SHA}" ]] \
   || fail "pull request base must equal the current main workflow SHA"
 

--- a/scripts/release/verify-cloud-candidate-workflow.mjs
+++ b/scripts/release/verify-cloud-candidate-workflow.mjs
@@ -96,8 +96,8 @@ requireText(
 );
 requireText(
   workflow,
-  "group: cloud-candidate-bundle-${{ inputs.pull_request }}",
-  "per-pull-request concurrency",
+  'group: "cloud-candidate-bundle-${{ inputs.pull_request }}-${{ inputs.version_tag }}-${{ inputs.request_id }}"',
+  "exact-request concurrency",
 );
 requireText(workflow, "cancel-in-progress: true", "duplicate-run cancellation");
 requireText(

--- a/scripts/release/verify-cloud-candidate-workflow.mjs
+++ b/scripts/release/verify-cloud-candidate-workflow.mjs
@@ -82,7 +82,13 @@ requireText(
 );
 requireText(workflow, "pull_request:", "pull request input");
 requireText(workflow, "version_tag:", "version input");
-requireText(workflow, "request_id:", "dispatch recovery input");
+requireText(workflow, "request_id:", "exact dispatch request identity");
+requireCount(
+  workflow,
+  "REQUEST_ID: ${{ inputs.request_id }}",
+  4,
+  "request identity validation on every resolver pass",
+);
 requireText(
   workflow,
   'run-name: "Cloud candidate PR #${{ inputs.pull_request }} ${{ inputs.version_tag }} (${{ inputs.request_id }})"',

--- a/tests/onboarding/cloud-candidate-workflow-behavior.ts
+++ b/tests/onboarding/cloud-candidate-workflow-behavior.ts
@@ -46,6 +46,7 @@ type FixtureChange =
   | "moved-late"
   | "moved-during-final-checks"
   | "source-rejected"
+  | "wrong-request-id"
   | "identity-mismatch"
   | "cloud-success";
 
@@ -585,6 +586,10 @@ esac
         GITHUB_RUN_ATTEMPT: change === "rerun" ? "2" : "1",
         GITHUB_SHA: change === "stale-base" ? head : base,
         GITHUB_OUTPUT: output,
+        REQUEST_ID:
+          change === "wrong-request-id"
+            ? `pr42-${base}-${head}-${"0".repeat(40)}`
+            : `pr42-${base}-${head}-${merge}`,
         ...(change === "identity-mismatch"
           ? {
               HA_NOVA_CLOUD_CANDIDATE_EXPECTED_COMMIT:
@@ -656,6 +661,7 @@ describe("Cloud candidate source resolver", () => {
     ["a pull request that moves during resolution", "moved-late"],
     ["a pull request that moves during final check validation", "moved-during-final-checks"],
     ["a source rejected by the trusted bootstrap verifier", "source-rejected"],
+    ["a request ID for another merge identity", "wrong-request-id"],
     ["a changed expected identity", "identity-mismatch"],
     ["an already-successful evidence gate", "cloud-success"],
   ] as const)("rejects %s", (_label, change) => {

--- a/tests/onboarding/cloud-candidate-workflow-behavior.ts
+++ b/tests/onboarding/cloud-candidate-workflow-behavior.ts
@@ -705,6 +705,33 @@ describe("Cloud candidate workflow contract", () => {
     expect(runName).toContain("${{ inputs.request_id }}");
   });
 
+  it("cancels only the same PR, version, and exact request", () => {
+    expect(parse(workflow).concurrency).toEqual({
+      group:
+        "cloud-candidate-bundle-${{ inputs.pull_request }}-${{ inputs.version_tag }}-${{ inputs.request_id }}",
+      "cancel-in-progress": true,
+    });
+
+    const root = mkdtempSync(
+      join(tmpdir(), "ha-nova-cloud-candidate-contract-"),
+    );
+    const weakWorkflow = join(root, "cloud-candidate-bundle.yml");
+    writeFileSync(
+      weakWorkflow,
+      workflow.replace(
+        'group: "cloud-candidate-bundle-${{ inputs.pull_request }}-${{ inputs.version_tag }}-${{ inputs.request_id }}"',
+        "group: cloud-candidate-bundle-${{ inputs.pull_request }}",
+      ),
+    );
+    const result = spawnSync(
+      "node",
+      [verifierPath, weakWorkflow, resolverPath],
+      { encoding: "utf8" },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("exact-request concurrency is missing");
+  });
+
   it("rejects publication commands", () => {
     const root = mkdtempSync(
       join(tmpdir(), "ha-nova-cloud-candidate-contract-"),

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -32,6 +32,9 @@ interface Fixture {
   repo: string;
   originGit: string;
   mainCommit: string;
+  headCommit: string;
+  mergeCommit: string;
+  alternateCommit: string;
   mainTree: string;
 }
 
@@ -74,7 +77,46 @@ function initFixture(platforms: string[]): Fixture {
   git(repo, "remote", "add", "origin", originGit);
   const mainCommit = git(repo, "rev-parse", "HEAD").trim();
   const mainTree = git(repo, "rev-parse", "HEAD^{tree}").trim();
-  return { repo, originGit, mainCommit, mainTree };
+  git(originGit, "config", "user.email", "test@example.invalid");
+  git(originGit, "config", "user.name", "test");
+  const headCommit = git(
+    originGit,
+    "commit-tree",
+    mainTree,
+    "-p",
+    mainCommit,
+    "-m",
+    "pull request head",
+  ).trim();
+  const mergeCommit = git(
+    originGit,
+    "commit-tree",
+    mainTree,
+    "-p",
+    mainCommit,
+    "-p",
+    headCommit,
+    "-m",
+    "synthetic merge",
+  ).trim();
+  const alternateCommit = git(
+    originGit,
+    "commit-tree",
+    mainTree,
+    "-p",
+    mainCommit,
+    "-m",
+    "alternate identity",
+  ).trim();
+  return {
+    repo,
+    originGit,
+    mainCommit,
+    headCommit,
+    mergeCommit,
+    alternateCommit,
+    mainTree,
+  };
 }
 
 interface FakeBin {
@@ -133,14 +175,14 @@ case "$args" in
     trace "read:review-threads"
     cat "\${FAKE_GH_STATE}/review.json" 2>/dev/null \\
       || printf '[{"data":{"repository":{"pullRequest":{"state":"OPEN","isDraft":false,"reviewDecision":null,"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]\\n' ;;
-  "run list --repo ${REPO_SLUG} --workflow cloud-candidate-bundle.yml --json databaseId,displayTitle,headSha,status,conclusion,event,attempt --limit 30")
+  "api --paginate --slurp --method GET repos/${REPO_SLUG}/actions/workflows/cloud-candidate-bundle.yml/runs -f event=workflow_dispatch -f head_sha="*" -f created=>="*" -F per_page=100")
     trace "run-list"
     n="$(cat "\${FAKE_GH_STATE}/list.count" 2>/dev/null || echo 0)"
     n=$((n + 1))
     printf '%s\\n' "\$n" >"\${FAKE_GH_STATE}/list.count"
     f="\${FAKE_GH_STATE}/runs-\$n.json"
     while [ ! -f "\$f" ] && [ "\$n" -gt 1 ]; do n=$((n - 1)); f="\${FAKE_GH_STATE}/runs-\$n.json"; done
-    cat "\$f" 2>/dev/null || printf '[]\\n' ;;
+    cat "\$f" 2>/dev/null || printf '[{"total_count":0,"workflow_runs":[]}]\\n' ;;
   "workflow run cloud-candidate-bundle.yml --repo ${REPO_SLUG} -f pull_request=7 -f version_tag="*" -f request_id="*)
     trace "dispatch"
     exit 0 ;;
@@ -454,9 +496,9 @@ describe("cloud evidence PR target binding", () => {
       state: "open",
       draft: false,
       mergeable_state: "clean",
-      merge_commit_sha: fixture.mainCommit,
+      merge_commit_sha: fixture.mergeCommit,
       base: { ref: "main", sha: fixture.mainCommit },
-      head: { sha: fixture.mainCommit, repo: { full_name: REPO_SLUG } },
+      head: { sha: fixture.headCommit, repo: { full_name: REPO_SLUG } },
       ...overrides,
     };
   }
@@ -466,7 +508,7 @@ describe("cloud evidence PR target binding", () => {
     const fake = makeFakeBin(prJson(fixture));
     writeFileSync(join(fake.state, "main.sha"), `${fixture.mainCommit}\n`);
     // GitHub's synthetic merge ref, served by the local bare origin.
-    git(fixture.originGit, "update-ref", "refs/pull/7/merge", fixture.mainCommit);
+    git(fixture.originGit, "update-ref", "refs/pull/7/merge", fixture.mergeCommit);
     return { fixture, fake };
   }
 
@@ -485,19 +527,44 @@ describe("cloud evidence PR target binding", () => {
   ) => {
     const pr = identity.pr ?? 7;
     const base = identity.base ?? fixture.mainCommit;
-    const head = identity.head ?? fixture.mainCommit;
-    const merge = identity.merge ?? fixture.mainCommit;
+    const head = identity.head ?? fixture.headCommit;
+    const merge = identity.merge ?? fixture.mergeCommit;
     const requestId = `pr${pr}-${base}-${head}-${merge}`;
     return {
-      databaseId,
-      displayTitle: `Cloud candidate PR #${pr} v0.24.0-rc1 (${requestId})`,
-      headSha: base,
+      id: databaseId,
+      display_title: `Cloud candidate PR #${pr} v0.24.0-rc1 (${requestId})`,
+      head_sha: fixture.mainCommit,
       status,
       conclusion,
       event: "workflow_dispatch",
-      attempt: identity.attempt ?? 1,
+      run_attempt: identity.attempt ?? 1,
     };
   };
+
+  const RUN_PAGES = (...pages: ReturnType<typeof RUN>[][]) =>
+    pages.map((workflow_runs) => ({
+      total_count: pages.reduce((count, page) => count + page.length, 0),
+      workflow_runs,
+    }));
+
+  it("models distinct base, head, merge, and alternate commits with one tree", () => {
+    const { fixture } = prFixture();
+    const commits = [
+      fixture.mainCommit,
+      fixture.headCommit,
+      fixture.mergeCommit,
+      fixture.alternateCommit,
+    ];
+    expect(new Set(commits).size).toBe(4);
+    for (const commit of commits) {
+      expect(git(fixture.originGit, "rev-parse", `${commit}^{tree}`).trim()).toBe(
+        fixture.mainTree,
+      );
+    }
+    expect(
+      git(fixture.originGit, "show", "-s", "--format=%P", fixture.mergeCommit).trim(),
+    ).toBe(`${fixture.mainCommit} ${fixture.headCommit}`);
+  });
 
   it("refuses a PR that does not target main", () => {
     const fixture = initFixture(platforms);
@@ -639,7 +706,7 @@ describe("cloud evidence PR target binding", () => {
 
   it("an unreachable lab host stays fail-closed without the explicit fallback opt-in", () => {
     const { fixture, fake } = prFixture();
-    const envelope = validEnvelope(fixture.mainCommit, fixture.mainTree, platforms);
+    const envelope = validEnvelope(fixture.mergeCommit, fixture.mainTree, platforms);
     const envelopeFile = writeEnvelope(fixture, envelope);
 
     const result = runScript(fixture, fake, ["7", "--set", "--envelope", envelopeFile]);
@@ -653,11 +720,11 @@ describe("cloud evidence PR target binding", () => {
 
   it("--set reuses only an exact request and still requires valid signed evidence", () => {
     const { fixture, fake } = prFixture();
-    const envelope = validEnvelope(fixture.mainCommit, fixture.mainTree, platforms);
+    const envelope = validEnvelope(fixture.mergeCommit, fixture.mainTree, platforms);
     const envelopeFile = writeEnvelope(fixture, envelope);
     writeFileSync(
       join(fake.state, "runs-1.json"),
-      JSON.stringify([RUN(fixture, 42, "completed", "success")]),
+      JSON.stringify(RUN_PAGES([RUN(fixture, 42, "completed", "success")])),
     );
     seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", { tree: fixture.mainTree });
 
@@ -682,12 +749,12 @@ describe("cloud evidence PR target binding", () => {
     const { fixture, fake } = prFixture();
     const foreign = RUN(fixture, 41, "completed", "success", {
       pr: 8,
-      merge: "b".repeat(40),
+      merge: fixture.mainCommit,
     });
-    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([foreign]));
+    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify(RUN_PAGES([foreign])));
     writeFileSync(
       join(fake.state, "runs-2.json"),
-      JSON.stringify([RUN(fixture, 99, "completed", "success"), foreign]),
+      JSON.stringify(RUN_PAGES([RUN(fixture, 99, "completed", "success"), foreign])),
     );
     // The foreign artifact has the exact same tree. Tree-only selection would
     // reuse it even though its PR and merge identity are different.
@@ -703,16 +770,83 @@ describe("cloud evidence PR target binding", () => {
     expect(result.stdout).toContain("every bundle matches tree");
   });
 
+  it.each(["base", "head", "merge"] as const)(
+    "ignores a same-tree run whose %s identity moved",
+    (field) => {
+      const { fixture, fake } = prFixture();
+      const shifted = RUN(fixture, 41, "completed", "success", {
+        [field]: fixture.alternateCommit,
+      });
+      writeFileSync(
+        join(fake.state, "runs-1.json"),
+        JSON.stringify(RUN_PAGES([shifted])),
+      );
+      writeFileSync(
+        join(fake.state, "runs-2.json"),
+        JSON.stringify(
+          RUN_PAGES([RUN(fixture, 99, "completed", "success"), shifted]),
+        ),
+      );
+      seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", {
+        tree: fixture.mainTree,
+      });
+
+      runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
+      const trace = readFileSync(fake.trace, "utf8");
+      expect(trace).toContain("dispatch");
+      expect(trace).toContain("run-download:99");
+      expect(trace).not.toContain("run-download:41");
+    },
+  );
+
+  it("finds an exact reusable run behind more than 30 foreign runs", () => {
+    const { fixture, fake } = prFixture();
+    const foreignRuns = Array.from({ length: 100 }, (_, index) =>
+      RUN(fixture, 200 - index, "completed", "success", {
+        pr: 8,
+        merge: fixture.alternateCommit,
+      }),
+    );
+    writeFileSync(
+      join(fake.state, "runs-1.json"),
+      JSON.stringify(
+        RUN_PAGES(foreignRuns, [RUN(fixture, 42, "completed", "success")]),
+      ),
+    );
+    seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", {
+      tree: fixture.mainTree,
+    });
+
+    const result = runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
+    const trace = readFileSync(fake.trace, "utf8");
+    expect(trace).toContain("run-download:42");
+    expect(trace).not.toContain("dispatch");
+    expect(result.stdout).toContain("reusing run 42");
+  });
+
+  it("fails closed when GitHub reports more runs than its filtered-search cap", () => {
+    const { fixture, fake } = prFixture();
+    writeFileSync(
+      join(fake.state, "runs-1.json"),
+      JSON.stringify([{ total_count: 1001, workflow_runs: [] }]),
+    );
+
+    const result = runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("GitHub caps filtered workflow searches at 1000");
+    expect(readFileSync(fake.trace, "utf8")).not.toContain("dispatch");
+  });
+
   it("does not watch a foreign in-flight run", () => {
     const { fixture, fake } = prFixture();
     const foreign = RUN(fixture, 43, "in_progress", null, {
       pr: 8,
-      merge: "c".repeat(40),
+      merge: fixture.mainCommit,
     });
-    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([foreign]));
+    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify(RUN_PAGES([foreign])));
     writeFileSync(
       join(fake.state, "runs-2.json"),
-      JSON.stringify([RUN(fixture, 99, "completed", "success"), foreign]),
+      JSON.stringify(RUN_PAGES([RUN(fixture, 99, "completed", "success"), foreign])),
     );
     seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", {
       tree: fixture.mainTree,
@@ -730,19 +864,19 @@ describe("cloud evidence PR target binding", () => {
     const rerun = RUN(fixture, 44, "completed", "success", { attempt: 2 });
     const foreignHead = {
       ...RUN(fixture, 45, "completed", "success"),
-      headSha: "d".repeat(40),
+      head_sha: fixture.headCommit,
     };
     writeFileSync(
       join(fake.state, "runs-1.json"),
-      JSON.stringify([foreignHead, rerun]),
+      JSON.stringify(RUN_PAGES([foreignHead, rerun])),
     );
     writeFileSync(
       join(fake.state, "runs-2.json"),
-      JSON.stringify([
+      JSON.stringify(RUN_PAGES([
         RUN(fixture, 99, "completed", "success"),
         foreignHead,
         rerun,
-      ]),
+      ])),
     );
     seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", {
       tree: fixture.mainTree,
@@ -757,8 +891,8 @@ describe("cloud evidence PR target binding", () => {
 
   it("watches an in-flight run first, then reuses it once its artifact proves the target", () => {
     const { fixture, fake } = prFixture();
-    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([RUN(fixture, 42, "in_progress", null)]));
-    writeFileSync(join(fake.state, "runs-2.json"), JSON.stringify([RUN(fixture, 42, "completed", "success")]));
+    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify(RUN_PAGES([RUN(fixture, 42, "in_progress", null)])));
+    writeFileSync(join(fake.state, "runs-2.json"), JSON.stringify(RUN_PAGES([RUN(fixture, 42, "completed", "success")])));
     seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", { tree: fixture.mainTree });
 
     const result = runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
@@ -779,11 +913,11 @@ describe("cloud evidence PR target binding", () => {
 
   it("treats an identity mismatch as 'not ours', dispatches fresh, and hard-stops on a persistent mismatch", () => {
     const { fixture, fake } = prFixture();
-    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([RUN(fixture, 44, "completed", "success")]));
+    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify(RUN_PAGES([RUN(fixture, 44, "completed", "success")])));
     // After the dispatch, a new run appears above the previous max id.
     writeFileSync(
       join(fake.state, "runs-2.json"),
-      JSON.stringify([RUN(fixture, 99, "completed", "success"), RUN(fixture, 44, "completed", "success")]),
+      JSON.stringify(RUN_PAGES([RUN(fixture, 99, "completed", "success"), RUN(fixture, 44, "completed", "success")])),
     );
     // Valid checksums, wrong tree — the fake serves the same wrong artifact
     // for the dispatched run too, so the hard stop must fire before any
@@ -802,10 +936,10 @@ describe("cloud evidence PR target binding", () => {
 
   it("falls back to a fresh dispatch when the reuse artifact is gone, and fails loudly if that one is gone too", () => {
     const { fixture, fake } = prFixture();
-    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([RUN(fixture, 44, "completed", "success")]));
+    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify(RUN_PAGES([RUN(fixture, 44, "completed", "success")])));
     writeFileSync(
       join(fake.state, "runs-2.json"),
-      JSON.stringify([RUN(fixture, 99, "completed", "success"), RUN(fixture, 44, "completed", "success")]),
+      JSON.stringify(RUN_PAGES([RUN(fixture, 99, "completed", "success"), RUN(fixture, 44, "completed", "success")])),
     );
     // No bundles seeded at all: every download fails like an expired artifact.
     const result = runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
@@ -816,7 +950,7 @@ describe("cloud evidence PR target binding", () => {
 
   it("refuses a bundle without its .sha256 instead of running it unverified", () => {
     const { fixture, fake } = prFixture();
-    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([RUN(fixture, 44, "completed", "success")]));
+    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify(RUN_PAGES([RUN(fixture, 44, "completed", "success")])));
     seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", {
       tree: fixture.mainTree,
       checksum: false,

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -152,6 +152,13 @@ bump() {
   printf 'stamp-%s\\n' "\$n" >"\${FAKE_GH_STATE}/\$f.stamp"
 }
 last_arg() { local a v=""; for a in "$@"; do v="$a"; done; printf '%s' "$v"; }
+current_run() {
+  local id="\$1" n f
+  n="$(cat "\${FAKE_GH_STATE}/list.count" 2>/dev/null || echo 1)"
+  f="\${FAKE_GH_STATE}/runs-\$n.json"
+  while [ ! -f "\$f" ] && [ "\$n" -gt 1 ]; do n=$((n - 1)); f="\${FAKE_GH_STATE}/runs-\$n.json"; done
+  jq -c --argjson id "\$id" '[.[] | .workflow_runs[] | select(.id == \$id)] | first // empty' "\$f"
+}
 case "$args" in
   "api user --jq .login")
     printf '%s\\n' "\${FAKE_GH_LOGIN}" ;;
@@ -183,14 +190,34 @@ case "$args" in
     f="\${FAKE_GH_STATE}/runs-\$n.json"
     while [ ! -f "\$f" ] && [ "\$n" -gt 1 ]; do n=$((n - 1)); f="\${FAKE_GH_STATE}/runs-\$n.json"; done
     cat "\$f" 2>/dev/null || printf '[{"total_count":0,"workflow_runs":[]}]\\n' ;;
+  "api repos/${REPO_SLUG}/actions/runs/"*)
+    id="\${args##*/}"
+    trace "run-view:\$id"
+    n="$(cat "\${FAKE_GH_STATE}/run-\$id.count" 2>/dev/null || echo 0)"
+    n=$((n + 1))
+    printf '%s\\n' "\$n" >"\${FAKE_GH_STATE}/run-\$id.count"
+    f="\${FAKE_GH_STATE}/run-\$id-\$n.json"
+    while [ ! -f "\$f" ] && [ "\$n" -gt 1 ]; do n=$((n - 1)); f="\${FAKE_GH_STATE}/run-\$id-\$n.json"; done
+    if [ -f "\$f" ]; then cat "\$f"; else current_run "\$id"; fi ;;
   "workflow run cloud-candidate-bundle.yml --repo ${REPO_SLUG} -f pull_request=7 -f version_tag="*" -f request_id="*)
     trace "dispatch"
     exit 0 ;;
   "run watch "*" --repo ${REPO_SLUG} --exit-status")
-    trace "run-watch:$3"
+    id="$3"
+    trace "run-watch:\$id"
+    if [ -f "\${FAKE_GH_STATE}/watch-\$id.exit" ]; then
+      exit "$(cat "\${FAKE_GH_STATE}/watch-\$id.exit")"
+    fi
+    if current_run "\$id" | jq -e '.status == "completed" and .conclusion != "success"' >/dev/null; then
+      exit 1
+    fi
     exit 0 ;;
   "run download "*" --repo ${REPO_SLUG} --name cloud-candidate-install-bundles --dir "*)
     trace "run-download:$3"
+    if ! compgen -G "\${FAKE_GH_STATE}/bundles/*" >/dev/null; then
+      echo "fake-gh: candidate artifact unavailable" >&2
+      exit 1
+    fi
     dest="$(last_arg "$@")"
     mkdir -p "$dest"
     cp "\${FAKE_GH_STATE}/bundles/"* "$dest"/ ;;
@@ -824,6 +851,124 @@ describe("cloud evidence PR target binding", () => {
     expect(result.stdout).toContain("reusing run 42");
   });
 
+  it("binds a dispatch to the newest exact post-fence run", () => {
+    const { fixture, fake } = prFixture();
+    const older = RUN(fixture, 99, "completed", "cancelled");
+    const newer = RUN(fixture, 100, "queued", null);
+    writeFileSync(
+      join(fake.state, "runs-1.json"),
+      JSON.stringify(RUN_PAGES([])),
+    );
+    writeFileSync(
+      join(fake.state, "runs-2.json"),
+      JSON.stringify(RUN_PAGES([older, newer])),
+    );
+    writeFileSync(join(fake.state, "run-100-1.json"), JSON.stringify(newer));
+    writeFileSync(
+      join(fake.state, "run-100-2.json"),
+      JSON.stringify(RUN(fixture, 100, "completed", "success")),
+    );
+    writeFileSync(
+      join(fake.state, "run-100-3.json"),
+      JSON.stringify(RUN(fixture, 100, "completed", "success")),
+    );
+    seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", {
+      tree: fixture.mainTree,
+    });
+
+    const result = runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
+    const trace = readFileSync(fake.trace, "utf8");
+    expect(trace).toContain("dispatch");
+    expect(trace).toContain("run-watch:100");
+    expect(trace).toContain("run-download:100");
+    expect(trace).not.toContain("run-watch:99");
+    expect(trace).not.toContain("run-download:99");
+    expect(result.stdout).toContain("run 100 — waiting for completion");
+  });
+
+  it("discards a reusable run whose attempt changes before download", () => {
+    const { fixture, fake } = prFixture();
+    writeFileSync(
+      join(fake.state, "runs-1.json"),
+      JSON.stringify(
+        RUN_PAGES([RUN(fixture, 42, "completed", "success")]),
+      ),
+    );
+    writeFileSync(
+      join(fake.state, "run-42-1.json"),
+      JSON.stringify(
+        RUN(fixture, 42, "completed", "success", { attempt: 2 }),
+      ),
+    );
+    writeFileSync(
+      join(fake.state, "runs-2.json"),
+      JSON.stringify(
+        RUN_PAGES([
+          RUN(fixture, 99, "completed", "success"),
+          RUN(fixture, 42, "completed", "success", { attempt: 2 }),
+        ]),
+      ),
+    );
+    seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", {
+      tree: fixture.mainTree,
+    });
+
+    runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
+    const trace = readFileSync(fake.trace, "utf8");
+    expect(trace).toContain("run-view:42");
+    expect(trace).toContain("dispatch");
+    expect(trace).toContain("run-download:99");
+    expect(trace).not.toContain("run-download:42");
+  });
+
+  it("discards an in-flight run whose attempt changes during watch", () => {
+    const { fixture, fake } = prFixture();
+    writeFileSync(
+      join(fake.state, "runs-1.json"),
+      JSON.stringify(RUN_PAGES([RUN(fixture, 42, "in_progress", null)])),
+    );
+    writeFileSync(
+      join(fake.state, "run-42-1.json"),
+      JSON.stringify(RUN(fixture, 42, "in_progress", null)),
+    );
+    writeFileSync(
+      join(fake.state, "run-42-2.json"),
+      JSON.stringify(
+        RUN(fixture, 42, "completed", "success", { attempt: 2 }),
+      ),
+    );
+    writeFileSync(
+      join(fake.state, "runs-2.json"),
+      JSON.stringify(
+        RUN_PAGES([
+          RUN(fixture, 42, "completed", "success", { attempt: 2 }),
+        ]),
+      ),
+    );
+    writeFileSync(
+      join(fake.state, "runs-3.json"),
+      JSON.stringify(
+        RUN_PAGES([
+          RUN(fixture, 99, "completed", "success"),
+          RUN(fixture, 42, "completed", "success", { attempt: 2 }),
+        ]),
+      ),
+    );
+    seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", {
+      tree: fixture.mainTree,
+    });
+
+    runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
+    const trace = readFileSync(fake.trace, "utf8");
+    const views = [...trace.matchAll(/run-view:42/g)];
+    expect(views).toHaveLength(2);
+    const secondList = trace.indexOf("run-list", trace.indexOf("run-list") + 1);
+    expect(views[1]?.index).toBeLessThan(secondList);
+    expect(trace).toContain("dispatch");
+    expect(trace).toContain("run-download:99");
+    expect(trace).not.toContain("run-download:42");
+  });
+
   it("fails closed when GitHub reports more runs than its filtered-search cap", () => {
     const { fixture, fake } = prFixture();
     writeFileSync(
@@ -945,6 +1090,7 @@ describe("cloud evidence PR target binding", () => {
     const result = runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
     expect(result.status, result.stdout).not.toBe(0);
     expect(result.stdout).toContain("dispatching fresh");
+    expect(result.stderr).toContain("fake-gh: candidate artifact unavailable");
     expect(result.stderr).toContain("cannot download the install bundles from run 99");
   });
 

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -133,7 +133,7 @@ case "$args" in
     trace "read:review-threads"
     cat "\${FAKE_GH_STATE}/review.json" 2>/dev/null \\
       || printf '[{"data":{"repository":{"pullRequest":{"state":"OPEN","isDraft":false,"reviewDecision":null,"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]\\n' ;;
-  "run list --repo ${REPO_SLUG} --workflow cloud-candidate-bundle.yml --json databaseId,status,conclusion,event --limit 30")
+  "run list --repo ${REPO_SLUG} --workflow cloud-candidate-bundle.yml --json databaseId,displayTitle,headSha,status,conclusion,event,attempt --limit 30")
     trace "run-list"
     n="$(cat "\${FAKE_GH_STATE}/list.count" 2>/dev/null || echo 0)"
     n=$((n + 1))
@@ -145,10 +145,10 @@ case "$args" in
     trace "dispatch"
     exit 0 ;;
   "run watch "*" --repo ${REPO_SLUG} --exit-status")
-    trace "run-watch"
+    trace "run-watch:$3"
     exit 0 ;;
   "run download "*" --repo ${REPO_SLUG} --name cloud-candidate-install-bundles --dir "*)
-    trace "run-download"
+    trace "run-download:$3"
     dest="$(last_arg "$@")"
     mkdir -p "$dest"
     cp "\${FAKE_GH_STATE}/bundles/"* "$dest"/ ;;
@@ -455,7 +455,7 @@ describe("cloud evidence PR target binding", () => {
       draft: false,
       mergeable_state: "clean",
       merge_commit_sha: fixture.mainCommit,
-      base: { ref: "main" },
+      base: { ref: "main", sha: fixture.mainCommit },
       head: { sha: fixture.mainCommit, repo: { full_name: REPO_SLUG } },
       ...overrides,
     };
@@ -469,6 +469,35 @@ describe("cloud evidence PR target binding", () => {
     git(fixture.originGit, "update-ref", "refs/pull/7/merge", fixture.mainCommit);
     return { fixture, fake };
   }
+
+  const RUN = (
+    fixture: Fixture,
+    databaseId: number,
+    status: string,
+    conclusion: string | null,
+    identity: {
+      pr?: number;
+      base?: string;
+      head?: string;
+      merge?: string;
+      attempt?: number;
+    } = {},
+  ) => {
+    const pr = identity.pr ?? 7;
+    const base = identity.base ?? fixture.mainCommit;
+    const head = identity.head ?? fixture.mainCommit;
+    const merge = identity.merge ?? fixture.mainCommit;
+    const requestId = `pr${pr}-${base}-${head}-${merge}`;
+    return {
+      databaseId,
+      displayTitle: `Cloud candidate PR #${pr} v0.24.0-rc1 (${requestId})`,
+      headSha: base,
+      status,
+      conclusion,
+      event: "workflow_dispatch",
+      attempt: identity.attempt ?? 1,
+    };
+  };
 
   it("refuses a PR that does not target main", () => {
     const fixture = initFixture(platforms);
@@ -622,13 +651,13 @@ describe("cloud evidence PR target binding", () => {
     expect(trace).not.toContain("set:");
   });
 
-  it("the opted-in fallback still refuses a bundle without valid signed evidence (2026-08-28)", () => {
+  it("--set reuses only an exact request and still requires valid signed evidence", () => {
     const { fixture, fake } = prFixture();
     const envelope = validEnvelope(fixture.mainCommit, fixture.mainTree, platforms);
     const envelopeFile = writeEnvelope(fixture, envelope);
     writeFileSync(
       join(fake.state, "runs-1.json"),
-      JSON.stringify([{ databaseId: 42, status: "completed", conclusion: "success", event: "workflow_dispatch" }]),
+      JSON.stringify([RUN(fixture, 42, "completed", "success")]),
     );
     seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", { tree: fixture.mainTree });
 
@@ -644,24 +673,96 @@ describe("cloud evidence PR target binding", () => {
     );
     expect(result.stderr).toContain("static signed-evidence verification failed");
     const trace = readFileSync(fake.trace, "utf8");
+    expect(trace).toContain("run-download:42");
+    expect(trace).not.toContain("dispatch");
     expect(trace).not.toContain("set:");
   });
 
-  const RUN = (databaseId: number, status: string, conclusion: string | null) => ({
-    databaseId,
-    status,
-    conclusion,
-    event: "workflow_dispatch",
+  it("ignores a successful foreign PR with the same tree and dispatches the exact request", () => {
+    const { fixture, fake } = prFixture();
+    const foreign = RUN(fixture, 41, "completed", "success", {
+      pr: 8,
+      merge: "b".repeat(40),
+    });
+    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([foreign]));
+    writeFileSync(
+      join(fake.state, "runs-2.json"),
+      JSON.stringify([RUN(fixture, 99, "completed", "success"), foreign]),
+    );
+    // The foreign artifact has the exact same tree. Tree-only selection would
+    // reuse it even though its PR and merge identity are different.
+    seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", {
+      tree: fixture.mainTree,
+    });
+
+    const result = runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
+    const trace = readFileSync(fake.trace, "utf8");
+    expect(trace).toContain("dispatch");
+    expect(trace).toContain("run-download:99");
+    expect(trace).not.toContain("run-download:41");
+    expect(result.stdout).toContain("every bundle matches tree");
+  });
+
+  it("does not watch a foreign in-flight run", () => {
+    const { fixture, fake } = prFixture();
+    const foreign = RUN(fixture, 43, "in_progress", null, {
+      pr: 8,
+      merge: "c".repeat(40),
+    });
+    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([foreign]));
+    writeFileSync(
+      join(fake.state, "runs-2.json"),
+      JSON.stringify([RUN(fixture, 99, "completed", "success"), foreign]),
+    );
+    seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", {
+      tree: fixture.mainTree,
+    });
+
+    runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
+    const trace = readFileSync(fake.trace, "utf8");
+    expect(trace).toContain("dispatch");
+    expect(trace).not.toContain("run-watch:43");
+    expect(trace).not.toContain("run-download:43");
+  });
+
+  it("does not reuse an exact title from a rerun or foreign workflow head", () => {
+    const { fixture, fake } = prFixture();
+    const rerun = RUN(fixture, 44, "completed", "success", { attempt: 2 });
+    const foreignHead = {
+      ...RUN(fixture, 45, "completed", "success"),
+      headSha: "d".repeat(40),
+    };
+    writeFileSync(
+      join(fake.state, "runs-1.json"),
+      JSON.stringify([foreignHead, rerun]),
+    );
+    writeFileSync(
+      join(fake.state, "runs-2.json"),
+      JSON.stringify([
+        RUN(fixture, 99, "completed", "success"),
+        foreignHead,
+        rerun,
+      ]),
+    );
+    seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", {
+      tree: fixture.mainTree,
+    });
+
+    runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
+    const trace = readFileSync(fake.trace, "utf8");
+    expect(trace).toContain("dispatch");
+    expect(trace).not.toContain("run-download:44");
+    expect(trace).not.toContain("run-download:45");
   });
 
   it("watches an in-flight run first, then reuses it once its artifact proves the target", () => {
     const { fixture, fake } = prFixture();
-    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([RUN(42, "in_progress", null)]));
-    writeFileSync(join(fake.state, "runs-2.json"), JSON.stringify([RUN(42, "completed", "success")]));
+    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([RUN(fixture, 42, "in_progress", null)]));
+    writeFileSync(join(fake.state, "runs-2.json"), JSON.stringify([RUN(fixture, 42, "completed", "success")]));
     seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", { tree: fixture.mainTree });
 
     const result = runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
-    expect(result.stdout).toContain("run 42 is in flight — watching it first");
+    expect(result.stdout).toContain("matching run 42 is in flight — watching it first");
     const trace = readFileSync(fake.trace, "utf8");
     expect(trace).toContain("run-watch");
     expect(trace).toContain("run-download");
@@ -678,11 +779,11 @@ describe("cloud evidence PR target binding", () => {
 
   it("treats an identity mismatch as 'not ours', dispatches fresh, and hard-stops on a persistent mismatch", () => {
     const { fixture, fake } = prFixture();
-    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([RUN(44, "completed", "success")]));
+    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([RUN(fixture, 44, "completed", "success")]));
     // After the dispatch, a new run appears above the previous max id.
     writeFileSync(
       join(fake.state, "runs-2.json"),
-      JSON.stringify([RUN(99, "completed", "success"), RUN(44, "completed", "success")]),
+      JSON.stringify([RUN(fixture, 99, "completed", "success"), RUN(fixture, 44, "completed", "success")]),
     );
     // Valid checksums, wrong tree — the fake serves the same wrong artifact
     // for the dispatched run too, so the hard stop must fire before any
@@ -701,10 +802,10 @@ describe("cloud evidence PR target binding", () => {
 
   it("falls back to a fresh dispatch when the reuse artifact is gone, and fails loudly if that one is gone too", () => {
     const { fixture, fake } = prFixture();
-    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([RUN(44, "completed", "success")]));
+    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([RUN(fixture, 44, "completed", "success")]));
     writeFileSync(
       join(fake.state, "runs-2.json"),
-      JSON.stringify([RUN(99, "completed", "success"), RUN(44, "completed", "success")]),
+      JSON.stringify([RUN(fixture, 99, "completed", "success"), RUN(fixture, 44, "completed", "success")]),
     );
     // No bundles seeded at all: every download fails like an expired artifact.
     const result = runScript(fixture, fake, ["7"], { FAKE_SSH_OK: "1" });
@@ -715,7 +816,7 @@ describe("cloud evidence PR target binding", () => {
 
   it("refuses a bundle without its .sha256 instead of running it unverified", () => {
     const { fixture, fake } = prFixture();
-    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([RUN(44, "completed", "success")]));
+    writeFileSync(join(fake.state, "runs-1.json"), JSON.stringify([RUN(fixture, 44, "completed", "success")]));
     seedBundle(fake, "ha-nova-installer-bundle-linux-amd64.tar.gz", {
       tree: fixture.mainTree,
       checksum: false,


### PR DESCRIPTION
## Summary

- bind Cloud candidate discovery, watch, reuse, download, and bundle provenance to the exact PR/base/head/synthetic-merge request identity
- select only attempt 1 on the trusted main workflow head, including individual metadata revalidation around watch and artifact download
- scope workflow concurrency to PR, version, and full request identity; paginate the artifact-retention window and select the newest exact run
- add raw GitHub run-response regressions for duplicate trees, shifted identities, foreign success/in-flight runs, pagination, competing exact runs, and attempt changes

## Root cause

Candidate reuse was selected workflow-wide and proved primarily by version and Git tree. Different PR and commit identities can share a tree, so a foreign run could supply reviews/checks and artifacts for the wrong request. Run selection also trusted a stale attempt snapshot and could bind the older of competing exact post-dispatch runs.

## Verification

- `npx vitest run tests/onboarding/cloud-evidence-behavior.test.ts` — 42/42
- release/evidence contract aggregate — 353/353
- `npm test` — 173 files, 2057/2057
- `npm run typecheck`
- `bash scripts/check-docs.sh`
- `bash scripts/release/verify-cloud-workflow-gate.sh`
- shell syntax and `git diff --check`
- final local `codex review --uncommitted` — no actionable regressions

## Risk

Release-bound/high-risk change. Existing signature, checksum, tree, version, review, and CI gates remain mandatory. Live Cloud evidence will be minted for this exact PR head before merge.