### PR TITLE
fix(release): bootstrap sensitive workflow approvals

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -446,12 +446,33 @@ dispatch by the exact maintainer account is the candidate approval when GitHub
 reports `REVIEW_REQUIRED`; requested changes and unresolved threads still
 block the run.
 
+Sensitive workflows remain denied by default. One candidate dispatch may
+approve a content-only change to exactly one existing path listed in
+`cloud_source_gate.sensitive_workflows`; adding, deleting, renaming, changing
+the mode of, or changing a second workflow remains denied. Its canonical
+approval ID is
+`pr<PR>-<BASE_SHA>-<HEAD_SHA>-<MERGE_SHA>-<WORKFLOWS_TREE_SHA>`. The resolver
+reads that authority only from `GITHUB_EVENT_PATH.inputs.request_id`, requires
+the exact maintainer actor and numeric user ID, triggering actor,
+`workflow_dispatch`, `refs/heads/main`, and attempt 1, and rechecks the API and
+refs before completion. The broker accepts this sensitive-workflow exception
+only after the existing evidence names both the exact synthetic merge commit
+and its complete source tree. Stale evidence and an identical tree under a
+different commit do not qualify. Sensitive merge-queue targets remain denied.
+
 Dispatch, capture, and monitor that single run:
 
 ```bash
 PR_NUMBER=469 # replace
 VERSION_TAG=v0.22.0-rc1 # replace
-REQUEST_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+PR_JSON="$(gh api "repos/markusleben/ha-nova/pulls/${PR_NUMBER}")"
+BASE_SHA="$(jq -r .base.sha <<<"${PR_JSON}")"
+HEAD_SHA="$(jq -r .head.sha <<<"${PR_JSON}")"
+git fetch --force origin \
+  "+refs/pull/${PR_NUMBER}/merge:refs/cloud-evidence/${PR_NUMBER}"
+MERGE_SHA="$(git rev-parse "refs/cloud-evidence/${PR_NUMBER}")"
+WORKFLOWS_TREE_SHA="$(git rev-parse "${MERGE_SHA}:.github/workflows")"
+REQUEST_ID="pr${PR_NUMBER}-${BASE_SHA}-${HEAD_SHA}-${MERGE_SHA}-${WORKFLOWS_TREE_SHA}"
 # `gh workflow run` prints no run id, and every run before the #574 fix is
 # titled just "Cloud candidate PR", so recovery by name is unreliable. Fence
 # on the highest run id seen BEFORE the dispatch; the id fence plus the
@@ -728,6 +749,10 @@ only the non-sensitive source delta defined above, may reuse evidence from
 its exact ancestor instead. If a merge queue is used,
 `merge_group` creates another synthetic checkout commit and follows the same
 rule.
+
+The identical-tree bridge does not apply to the one-sensitive-workflow
+bootstrap exception: its broker evidence must name the exact synthetic merge
+commit and the exact complete target tree.
 
 After squash merge, the resulting `main` commit has a different SHA but may
 reuse the reviewed PR evidence only while its complete Git tree is identical

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -459,6 +459,8 @@ refs before completion. The broker accepts this sensitive-workflow exception
 only after the existing evidence names both the exact synthetic merge commit
 and its complete source tree. Stale evidence and an identical tree under a
 different commit do not qualify. Sensitive merge-queue targets remain denied.
+Disabling Cloud does not bypass workflow validation: the target workflow tree
+must remain unchanged or pass the existing non-sensitive `uses:`-only rule.
 
 Dispatch, capture, and monitor that single run:
 
@@ -753,6 +755,11 @@ rule.
 The identical-tree bridge does not apply to the one-sensitive-workflow
 bootstrap exception: its broker evidence must name the exact synthetic merge
 commit and the exact complete target tree.
+
+It also does not apply inside `release.yml` or `release-candidate.yml`. Those
+publication paths require the evidence commit itself to equal the checked-out
+release or RC commit, so a squash-merged tree must be repointed before either
+workflow may proceed.
 
 After squash merge, the resulting `main` commit has a different SHA but may
 reuse the reviewed PR evidence only while its complete Git tree is identical

--- a/docs/work/2026-08-30-sensitive-workflow-bootstrap-spec.md
+++ b/docs/work/2026-08-30-sensitive-workflow-bootstrap-spec.md
@@ -67,3 +67,25 @@ the approval and evidence to the exact pull-request state.
 - **One-way doors:** None in this local change. No remote state is mutated.
 - **Recommended order:** Validate tuple and workflow shape first; validate exact
   evidence second; revalidate API and refs immediately before completion.
+
+## 2026-08-31 P1 remediation checklist
+
+- [x] **KISS — pass:** Move the existing workflow-delta gate before the
+  disabled-Cloud exit and derive publication exactness inside the existing
+  evidence verifier.
+- [x] **YAGNI — pass:** Add no workflow, release, label, secret, service,
+  configuration, or compatibility mechanism.
+- [x] **DRY — pass:** Keep all source shapes in
+  `verify-cloud-workflow-uses-only.mjs` and all evidence identities in
+  `verify-cloud-release-gate.sh`.
+- [x] **Fail-fast — pass:** Disabled targets reject every workflow delta except
+  the existing non-sensitive `uses:`-only escape; release and RC workflows
+  reject evidence from any other commit even when its tree is identical.
+- [x] **Retry-safe — pass:** Exact commit and tree comparisons are pure and
+  deterministic; retrying the same state has the same result.
+
+Root causes: the target gate returned before checking workflow changes when
+Cloud was disabled, and publication exactness depended only on a caller-set
+marker that the release workflows do not set. The remediation changes the
+ordering at the shared target gate and recognizes the two immutable GitHub
+workflow identities inside the shared evidence verifier.

--- a/docs/work/2026-08-30-sensitive-workflow-bootstrap-spec.md
+++ b/docs/work/2026-08-30-sensitive-workflow-bootstrap-spec.md
@@ -1,0 +1,69 @@
+# Sensitive Workflow Bootstrap Spec
+
+Status: active
+
+## Goal
+
+Permit one explicitly approved content-only change to one existing
+Cloud-sensitive workflow while preserving the default deny policy and binding
+the approval and evidence to the exact pull-request state.
+
+## Plan checklist
+
+- [x] **KISS — pass:** Extend the existing resolver, workflow-tree verifier,
+  target gate, and evidence builder; add no workflow, service, secret, label,
+  framework, or release path.
+- [x] **YAGNI — pass:** Permit exactly one existing sensitive workflow content
+  change. Additions, deletions, renames, mode changes, multiple workflow
+  changes, forks, merge-queue targets, reruns, and stale state remain denied.
+- [x] **DRY — pass:** Reuse `resolve-cloud-candidate-source.sh` for pull-request,
+  review, check, pagination, identity, and final-ref validation;
+  `verify-cloud-workflow-uses-only.mjs` for workflow-tree comparison;
+  `verify-cloud-target-source-gate.sh` for candidate and broker routing; and
+  `verify-cloud-release-gate.sh` for evidence validation.
+- [x] **Fail-fast — pass:** Every absent, malformed, stale, or mismatched tuple,
+  API result, ref, workflow delta, or evidence identity exits non-zero.
+- [x] **Retry-safe — pass:** The canonical approval ID is deterministic for one
+  exact state. Repeating that dispatch adopts the same successful candidate;
+  any PR, base, head, merge, or workflow-tree movement creates a different ID.
+
+## Tightened plan
+
+- Keep the current default deny and existing non-sensitive `uses:`-only path.
+- Read candidate authority only from `GITHUB_EVENT_PATH.inputs.request_id`.
+- Bind approval to
+  `pr<PR>-<BASE_SHA>-<HEAD_SHA>-<MERGE_SHA>-<WORKFLOWS_TREE_SHA>`.
+- Allow the candidate resolver to select the one-sensitive-workflow verifier
+  only after the canonical approval matches.
+- Allow the broker/release path only when schema-valid evidence names the exact
+  synthetic merge commit and its complete source tree; identical-tree or stale
+  evidence is insufficient.
+- Keep merge-queue sensitive changes fail-closed.
+
+## Existing code reused
+
+- Candidate identity, maintainer identity, exact checks, Codex verdict,
+  pagination, and final ref revalidation:
+  `scripts/release/resolve-cloud-candidate-source.sh`.
+- Workflow entry, path, mode, and action-pin validation:
+  `scripts/release/verify-cloud-workflow-uses-only.mjs`.
+- Trusted target fetch and candidate/broker split:
+  `scripts/release/verify-cloud-target-source-gate.sh`.
+- Exact evidence schema, commit, tree, and Relay App identity:
+  `scripts/release/verify-cloud-release-gate.sh` and
+  `scripts/release/cloud-evidence-envelope.sh`.
+- Deterministic dispatch and artifact reuse:
+  `scripts/release/build-cloud-evidence.sh`.
+
+## New behavior
+
+1. One strict workflow-diff mode for exactly one existing sensitive workflow
+   content change.
+2. One canonical approval-ID check at candidate resolution.
+3. One exact-commit-and-tree evidence mode for the trusted broker path.
+
+## Risk
+
+- **One-way doors:** None in this local change. No remote state is mutated.
+- **Recommended order:** Validate tuple and workflow shape first; validate exact
+  evidence second; revalidate API and refs immediately before completion.

--- a/scripts/release/build-cloud-evidence.sh
+++ b/scripts/release/build-cloud-evidence.sh
@@ -177,8 +177,12 @@ merge_commit="$(jq -r '.merge_commit_sha // ""' <<<"$pr_json")"
 base_ref="$(jq -r '.base.ref // ""' <<<"$pr_json")"
 [ "$base_ref" = "main" ] \
   || die "PR #$PR targets '${base_ref:-unknown}', not main — the candidate workflow only builds PRs into main"
+base_sha="$(jq -r '.base.sha // ""' <<<"$pr_json")"
+[[ "$base_sha" =~ ^[0-9a-f]{40}$ ]] \
+  || die "PR #$PR has no valid base sha in the API response"
 resolved_head_sha="$(jq -r '.head.sha // ""' <<<"$pr_json")"
-[ -n "$resolved_head_sha" ] || die "PR #$PR has no head sha in the API response"
+[[ "$resolved_head_sha" =~ ^[0-9a-f]{40}$ ]] \
+  || die "PR #$PR has no valid head sha in the API response"
 head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr_json")"
 [ "$head_repo" = "$REPO" ] \
   || die "PR #$PR's head lives in '${head_repo:-unknown}', not $REPO — the candidate workflow only builds same-repo branches"
@@ -318,6 +322,8 @@ git -C "$ROOT_DIR" fetch --quiet --force origin "+refs/pull/$PR/merge:refs/cloud
   || die "cannot fetch the synthetic merge ref for #$PR"
 target_commit="$(git -C "$ROOT_DIR" rev-parse "refs/cloud-evidence/$PR")"
 target_tree="$(git -C "$ROOT_DIR" rev-parse "refs/cloud-evidence/$PR^{tree}")"
+target_workflows_tree="$(git -C "$ROOT_DIR" rev-parse "refs/cloud-evidence/$PR:.github/workflows")" \
+  || die "the target has no workflow tree"
 # Bind the API's merge identity to the fetched ref: two views of the same
 # synthetic merge commit that must agree, or GitHub is mid-recompute.
 [ "$merge_commit" = "$target_commit" ] \
@@ -441,11 +447,9 @@ mkdir "$MINT_LOCK" 2>/dev/null \
   || die "another mint session appears to be running (lock: $MINT_LOCK) — if none is, remove that directory and re-run"
 MINT_LOCK_ACQUIRED=1
 
-# request_id is a REQUIRED dispatch input, derived deterministically for the
-# audit trail — but binding never relies on it: every run before the #574
-# fix is titled just "Cloud candidate PR" (the unquoted `#` in run-name
-# started a YAML comment), and `gh run list` cannot filter by dispatch
-# inputs either way. Binding works with what the API reliably has:
+# request_id is the canonical approval for this exact PR state. The candidate
+# resolver reads it only from GITHUB_EVENT_PATH; run titles never grant
+# authority. Run recovery still uses what the list API reliably exposes:
 #   - an in-flight run is watched to completion FIRST — dispatching would
 #     cancel it via the per-PR concurrency group, and in this
 #     single-maintainer repo it is almost certainly ours;
@@ -456,7 +460,7 @@ MINT_LOCK_ACQUIRED=1
 #     above the highest run id seen before the dispatch".
 # A wrong pick can never attest anything: identity is proven from local bytes
 # before any binary executes, and check_identity guards every provenance run.
-request_id="pr${PR}-${target_commit:0:12}"
+request_id="pr${PR}-${base_sha}-${resolved_head_sha}-${target_commit}-${target_workflows_tree}"
 list_candidate_runs() {
   gh run list --repo "$REPO" --workflow cloud-candidate-bundle.yml \
     --json databaseId,status,conclusion,event --limit 30

--- a/scripts/release/resolve-cloud-candidate-source.sh
+++ b/scripts/release/resolve-cloud-candidate-source.sh
@@ -47,8 +47,13 @@ require_sha "${trusted_head}" "trusted checkout HEAD"
   || fail "pull request number must be a positive integer"
 [[ -f "${POLICY_FILE}" ]] || fail "repository policy is missing"
 [[ -n "${GITHUB_OUTPUT:-}" ]] || fail "GITHUB_OUTPUT is required"
+[[ -f "${GITHUB_EVENT_PATH:-}" ]] || fail "GITHUB_EVENT_PATH is required"
 command -v gh >/dev/null 2>&1 || fail "gh is required"
 command -v jq >/dev/null 2>&1 || fail "jq is required"
+request_id="$(
+  jq -er '.inputs.request_id | select(type == "string" and length > 0)' \
+    "${GITHUB_EVENT_PATH}"
+)" || fail "workflow dispatch request_id is missing or malformed"
 
 pr="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
 jq -e '
@@ -429,6 +434,7 @@ HA_NOVA_CLOUD_GATE_SOURCE_REF="${source_ref}" \
 HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT="${merge_sha}" \
 HA_NOVA_CLOUD_GATE_EXPECTED_HEAD_COMMIT="${head_sha}" \
 HA_NOVA_CLOUD_GATE_EXPECTED_BASE_COMMIT="${base_sha}" \
+HA_NOVA_CLOUD_GATE_APPROVAL_ID="${request_id}" \
   bash scripts/release/verify-cloud-target-source-gate.sh candidate
 
 expected_commit="${HA_NOVA_CLOUD_CANDIDATE_EXPECTED_COMMIT:-}"

--- a/scripts/release/verify-cloud-release-gate.sh
+++ b/scripts/release/verify-cloud-release-gate.sh
@@ -240,6 +240,14 @@ function validateEvidenceIdentity(evidence, target) {
   if (targetCommitTree !== target.tree) {
     fail("Home Assistant Cloud gate target tree must match its target commit");
   }
+  if (
+    process.env.HA_NOVA_CLOUD_GATE_REQUIRE_EXACT_EVIDENCE === "1" &&
+    (evidence.commit_sha !== target.commit || evidence.tree_sha !== target.tree)
+  ) {
+    fail(
+      "approved sensitive workflow changes require evidence for the exact target commit and tree",
+    );
+  }
   if (evidence.tree_sha === target.tree) {
     return;
   }

--- a/scripts/release/verify-cloud-release-gate.sh
+++ b/scripts/release/verify-cloud-release-gate.sh
@@ -116,6 +116,19 @@ function requireSHA(value, label) {
   }
 }
 
+function requiresExactEvidence() {
+  const workflowRef = process.env.GITHUB_WORKFLOW_REF ?? "";
+  return (
+    process.env.HA_NOVA_CLOUD_GATE_REQUIRE_EXACT_EVIDENCE === "1" ||
+    workflowRef.startsWith(
+      "markusleben/ha-nova/.github/workflows/release.yml@",
+    ) ||
+    workflowRef.startsWith(
+      "markusleben/ha-nova/.github/workflows/release-candidate.yml@",
+    )
+  );
+}
+
 function readTargetIdentity() {
   const targetCommit = process.env.HA_NOVA_CLOUD_GATE_TARGET_COMMIT ?? "";
   const targetTree = process.env.HA_NOVA_CLOUD_GATE_TARGET_TREE ?? "";
@@ -241,11 +254,11 @@ function validateEvidenceIdentity(evidence, target) {
     fail("Home Assistant Cloud gate target tree must match its target commit");
   }
   if (
-    process.env.HA_NOVA_CLOUD_GATE_REQUIRE_EXACT_EVIDENCE === "1" &&
+    requiresExactEvidence() &&
     (evidence.commit_sha !== target.commit || evidence.tree_sha !== target.tree)
   ) {
     fail(
-      "approved sensitive workflow changes require evidence for the exact target commit and tree",
+      "publication and approved sensitive workflow paths require evidence for the exact target commit and tree",
     );
   }
   if (evidence.tree_sha === target.tree) {

--- a/scripts/release/verify-cloud-target-source-gate.sh
+++ b/scripts/release/verify-cloud-target-source-gate.sh
@@ -64,9 +64,27 @@ cloud_enabled="$(
     'process.stdout.write(String(JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")).cloud_remote_enabled))' \
     "${target_root}/version.json"
 )"
+trusted_workflows_tree="$(
+  git -C "${ROOT_DIR}" rev-parse --verify "HEAD:.github/workflows"
+)"
+target_workflows_tree="$(
+  git -C "${ROOT_DIR}" rev-parse --verify \
+    "${target_commit}:.github/workflows"
+)" || fail "target commit must retain the trusted workflow tree"
+trusted_commit="$(git -C "${ROOT_DIR}" rev-parse HEAD)"
+workflow_uses_only=0
+if [[ "${target_workflows_tree}" != "${trusted_workflows_tree}" ]] \
+  && node "${ROOT_DIR}/scripts/release/verify-cloud-workflow-uses-only.mjs" \
+    "${ROOT_DIR}" "${trusted_commit}" "${target_commit}" \
+    workflow-tree-only >/dev/null 2>&1; then
+  workflow_uses_only=1
+fi
 if [[ "${cloud_enabled}" == "false" ]]; then
   [[ "${MODE}" == "release" ]] \
     || fail "candidate source must enable Home Assistant Cloud"
+  [[ "${target_workflows_tree}" == "${trusted_workflows_tree}" \
+    || "${workflow_uses_only}" == "1" ]] \
+    || fail "disabled Cloud targets may change workflows only through non-sensitive uses-only maintenance"
   HA_NOVA_CLOUD_GATE_TARGET_COMMIT="${target_commit}" \
   HA_NOVA_CLOUD_GATE_TARGET_TREE="${target_tree}" \
   HA_NOVA_CLOUD_GATE_TRUSTED_PR_MODE=1 \
@@ -116,13 +134,6 @@ if (
 }
 NODE
 
-trusted_workflows_tree="$(
-  git -C "${ROOT_DIR}" rev-parse --verify "HEAD:.github/workflows"
-)"
-target_workflows_tree="$(
-  git -C "${ROOT_DIR}" rev-parse --verify \
-    "${target_commit}:.github/workflows"
-)" || fail "target commit must retain the trusted workflow tree"
 exact_evidence=0
 if [[ "${MODE}" == "candidate" ]]; then
   [[ "${SOURCE_REF}" =~ ^refs/pull/([1-9][0-9]*)/merge$ ]] \
@@ -136,20 +147,14 @@ if [[ "${MODE}" == "candidate" ]]; then
     || fail "candidate request_id does not match the exact pull request approval"
 fi
 
-if [[ "${target_workflows_tree}" != "${trusted_workflows_tree}" ]]; then
-  trusted_commit="$(git -C "${ROOT_DIR}" rev-parse HEAD)"
-  if node "${ROOT_DIR}/scripts/release/verify-cloud-workflow-uses-only.mjs" \
+if [[ "${target_workflows_tree}" != "${trusted_workflows_tree}" \
+  && "${workflow_uses_only}" != "1" ]]; then
+  [[ "${SOURCE_REF}" =~ ^refs/pull/[1-9][0-9]*/merge$ ]] \
+    || fail "merge queue cannot approve sensitive workflow changes"
+  node "${ROOT_DIR}/scripts/release/verify-cloud-workflow-uses-only.mjs" \
     "${ROOT_DIR}" "${trusted_commit}" "${target_commit}" \
-    workflow-tree-only >/dev/null 2>&1; then
-    :
-  else
-    [[ "${SOURCE_REF}" =~ ^refs/pull/[1-9][0-9]*/merge$ ]] \
-      || fail "merge queue cannot approve sensitive workflow changes"
-    node "${ROOT_DIR}/scripts/release/verify-cloud-workflow-uses-only.mjs" \
-      "${ROOT_DIR}" "${trusted_commit}" "${target_commit}" \
-      single-sensitive-workflow
-    [[ "${MODE}" == "candidate" ]] || exact_evidence=1
-  fi
+    single-sensitive-workflow
+  [[ "${MODE}" == "candidate" ]] || exact_evidence=1
 fi
 
 if [[ "${MODE}" == "candidate" ]]; then

--- a/scripts/release/verify-cloud-target-source-gate.sh
+++ b/scripts/release/verify-cloud-target-source-gate.sh
@@ -6,6 +6,7 @@ SOURCE_REF="${HA_NOVA_CLOUD_GATE_SOURCE_REF:-}"
 EXPECTED_TARGET="${HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT:-}"
 EXPECTED_HEAD="${HA_NOVA_CLOUD_GATE_EXPECTED_HEAD_COMMIT:-}"
 EXPECTED_BASE="${HA_NOVA_CLOUD_GATE_EXPECTED_BASE_COMMIT:-}"
+APPROVAL_ID="${HA_NOVA_CLOUD_GATE_APPROVAL_ID:-}"
 MODE="${1:-release}"
 
 fail() {
@@ -122,10 +123,34 @@ target_workflows_tree="$(
   git -C "${ROOT_DIR}" rev-parse --verify \
     "${target_commit}:.github/workflows"
 )" || fail "target commit must retain the trusted workflow tree"
-[[ "${target_workflows_tree}" == "${trusted_workflows_tree}" ]] \
-  || node "${ROOT_DIR}/scripts/release/verify-cloud-workflow-uses-only.mjs" \
-    "${ROOT_DIR}" "$(git -C "${ROOT_DIR}" rev-parse HEAD)" "${target_commit}" \
-    workflow-tree-only
+exact_evidence=0
+if [[ "${MODE}" == "candidate" ]]; then
+  [[ "${SOURCE_REF}" =~ ^refs/pull/([1-9][0-9]*)/merge$ ]] \
+    || fail "candidate approval requires one exact pull request base, head, and merge"
+  approval_pr="${BASH_REMATCH[1]}"
+  [[ -n "${EXPECTED_TARGET}" && -n "${EXPECTED_HEAD}" \
+    && -n "${EXPECTED_BASE}" ]] \
+    || fail "candidate approval requires one exact pull request base, head, and merge"
+  expected_approval="pr${approval_pr}-${EXPECTED_BASE}-${EXPECTED_HEAD}-${EXPECTED_TARGET}-${target_workflows_tree}"
+  [[ "${APPROVAL_ID}" == "${expected_approval}" ]] \
+    || fail "candidate request_id does not match the exact pull request approval"
+fi
+
+if [[ "${target_workflows_tree}" != "${trusted_workflows_tree}" ]]; then
+  trusted_commit="$(git -C "${ROOT_DIR}" rev-parse HEAD)"
+  if node "${ROOT_DIR}/scripts/release/verify-cloud-workflow-uses-only.mjs" \
+    "${ROOT_DIR}" "${trusted_commit}" "${target_commit}" \
+    workflow-tree-only >/dev/null 2>&1; then
+    :
+  else
+    [[ "${SOURCE_REF}" =~ ^refs/pull/[1-9][0-9]*/merge$ ]] \
+      || fail "merge queue cannot approve sensitive workflow changes"
+    node "${ROOT_DIR}/scripts/release/verify-cloud-workflow-uses-only.mjs" \
+      "${ROOT_DIR}" "${trusted_commit}" "${target_commit}" \
+      single-sensitive-workflow
+    [[ "${MODE}" == "candidate" ]] || exact_evidence=1
+  fi
+fi
 
 if [[ "${MODE}" == "candidate" ]]; then
   HA_NOVA_CLOUD_GATE_TARGET_COMMIT="${target_commit}" \
@@ -139,5 +164,6 @@ fi
 HA_NOVA_CLOUD_GATE_TARGET_COMMIT="${target_commit}" \
 HA_NOVA_CLOUD_GATE_TARGET_TREE="${target_tree}" \
 HA_NOVA_CLOUD_GATE_TRUSTED_PR_MODE=1 \
+HA_NOVA_CLOUD_GATE_REQUIRE_EXACT_EVIDENCE="${exact_evidence}" \
   bash "${ROOT_DIR}/scripts/release/verify-cloud-release-gate.sh" \
     "${target_root}"

--- a/scripts/release/verify-cloud-workflow-uses-only.mjs
+++ b/scripts/release/verify-cloud-workflow-uses-only.mjs
@@ -175,8 +175,14 @@ function verifyUsesOnly(path, baseRef, targetRef) {
 
 requireCommit(baseCommit, "base commit");
 requireCommit(targetCommit, "target commit");
-if (mode !== "full-tree" && mode !== "workflow-tree-only") {
-  fail("mode must be full-tree or workflow-tree-only");
+if (
+  mode !== "full-tree" &&
+  mode !== "workflow-tree-only" &&
+  mode !== "single-sensitive-workflow"
+) {
+  fail(
+    "mode must be full-tree, workflow-tree-only, or single-sensitive-workflow",
+  );
 }
 if (
   !Array.isArray(policy.cloud_source_gate?.sensitive_workflows) ||
@@ -232,6 +238,12 @@ for (const [path, baseEntry] of base) {
     continue;
   }
   changed += 1;
+  if (mode === "single-sensitive-workflow") {
+    if (!sensitive.has(path) || changed > 1) {
+      fail("approval may change exactly one existing sensitive workflow");
+    }
+    continue;
+  }
   if (sensitive.has(path)) {
     fail(`${path} is Cloud-release-sensitive`);
   }
@@ -242,5 +254,7 @@ if (changed === 0) {
 }
 
 console.log(
-  `[verify-cloud-workflow-uses-only] OK: ${changed} non-sensitive workflow file(s)`,
+  mode === "single-sensitive-workflow"
+    ? "[verify-cloud-workflow-uses-only] OK: one approved sensitive workflow content change"
+    : `[verify-cloud-workflow-uses-only] OK: ${changed} non-sensitive workflow file(s)`,
 );

--- a/tests/onboarding/cloud-candidate-workflow-behavior.ts
+++ b/tests/onboarding/cloud-candidate-workflow-behavior.ts
@@ -15,9 +15,16 @@ import { parse } from "yaml";
 type FixtureChange =
   | "draft"
   | "wrong-actor"
+  | "wrong-user-id"
   | "wrong-trigger"
+  | "wrong-event"
+  | "wrong-ref"
+  | "missing-event-file"
+  | "malformed-request-id"
   | "rerun"
   | "stale-base"
+  | "remote-main-moved"
+  | "merge-ref-moved"
   | "wrong-head-repo"
   | "wrong-parent"
   | "failed-check"
@@ -89,6 +96,12 @@ function runResolver(
   git(root, ["remote", "add", "origin", remote]);
   git(root, ["push", "-q", "origin", `${base}:refs/heads/main`]);
   git(root, ["push", "-q", "origin", `${merge}:refs/pull/42/merge`]);
+  if (change === "remote-main-moved") {
+    git(root, ["push", "-q", "--force", "origin", `${head}:refs/heads/main`]);
+  }
+  if (change === "merge-ref-moved") {
+    git(root, ["push", "-q", "--force", "origin", `${head}:refs/pull/42/merge`]);
+  }
 
   const policy = {
     main_branch_protection: {
@@ -325,6 +338,7 @@ function runResolver(
   const threadsPath = join(root, "threads.json");
   const prCallsPath = join(root, "pr-calls");
   const checkCallsPath = join(root, "check-calls");
+  const eventPath = join(root, "event.json");
   writeFileSync(prPath, JSON.stringify(pr));
   writeFileSync(commitPath, JSON.stringify(commit));
   writeFileSync(checksPath, JSON.stringify([{ check_runs: checks }]));
@@ -495,6 +509,15 @@ function runResolver(
   );
   writeFileSync(prCallsPath, "0\n");
   writeFileSync(checkCallsPath, "0\n");
+  writeFileSync(
+    eventPath,
+    JSON.stringify({
+      inputs: {
+        request_id:
+          change === "malformed-request-id" ? { value: "invalid" } : "approval-id",
+      },
+    }),
+  );
   writeExecutable(
     join(root, "scripts", "release", "verify-cloud-target-source-gate.sh"),
     `#!/usr/bin/env bash
@@ -504,6 +527,7 @@ set -euo pipefail
 [[ "$HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT" == "$FAKE_MERGE" ]]
 [[ "$HA_NOVA_CLOUD_GATE_EXPECTED_HEAD_COMMIT" == "$FAKE_HEAD" ]]
 [[ "$HA_NOVA_CLOUD_GATE_EXPECTED_BASE_COMMIT" == "$FAKE_BASE" ]]
+[[ "$HA_NOVA_CLOUD_GATE_APPROVAL_ID" == "approval-id" ]]
 [[ "$FAKE_CHANGE" != "source-rejected" ]]
 `,
   );
@@ -575,11 +599,14 @@ esac
         FAKE_BASE: base,
         FAKE_HEAD: head,
         FAKE_MERGE: merge,
-        GITHUB_EVENT_NAME: "workflow_dispatch",
-        GITHUB_REF: "refs/heads/main",
+        GITHUB_EVENT_NAME:
+          change === "wrong-event" ? "pull_request" : "workflow_dispatch",
+        GITHUB_EVENT_PATH:
+          change === "missing-event-file" ? join(root, "missing-event.json") : eventPath,
+        GITHUB_REF: change === "wrong-ref" ? "refs/heads/feature" : "refs/heads/main",
         GITHUB_REPOSITORY: "markusleben/ha-nova",
         GITHUB_ACTOR: change === "wrong-actor" ? "other-user" : "markusleben",
-        GITHUB_ACTOR_ID: change === "wrong-actor" ? "999" : "6522814",
+        GITHUB_ACTOR_ID: change === "wrong-user-id" ? "999" : "6522814",
         GITHUB_TRIGGERING_ACTOR:
           change === "wrong-trigger" ? "other-user" : "markusleben",
         GITHUB_RUN_ATTEMPT: change === "rerun" ? "2" : "1",
@@ -629,9 +656,16 @@ describe("Cloud candidate source resolver", () => {
   it.each([
     ["a draft", "draft"],
     ["a non-maintainer dispatcher", "wrong-actor"],
+    ["a dispatcher with the wrong numeric user ID", "wrong-user-id"],
     ["a non-maintainer rerun trigger", "wrong-trigger"],
+    ["a non-dispatch event", "wrong-event"],
+    ["a dispatch outside main", "wrong-ref"],
+    ["a missing dispatch event payload", "missing-event-file"],
+    ["a malformed request ID", "malformed-request-id"],
     ["a rerun attempt", "rerun"],
     ["a stale base", "stale-base"],
+    ["main moving after the workflow starts", "remote-main-moved"],
+    ["a moved pull-request merge ref", "merge-ref-moved"],
     ["a fork", "wrong-head-repo"],
     ["wrong merge parents", "wrong-parent"],
     ["another failed check", "failed-check"],

--- a/tests/onboarding/cloud-evidence-behavior.test.ts
+++ b/tests/onboarding/cloud-evidence-behavior.test.ts
@@ -44,12 +44,14 @@ function initFixture(platforms: string[]): Fixture {
   const originGit = join(root, "origin.git");
   mkdirSync(join(repo, "scripts", "release"), { recursive: true });
   mkdirSync(join(repo, "nova"), { recursive: true });
+  mkdirSync(join(repo, ".github", "workflows"), { recursive: true });
   copyFileSync(SCRIPT_REL, join(repo, SCRIPT_REL));
   chmodSync(join(repo, SCRIPT_REL), 0o755);
   for (const lib of SOURCED_LIBS_REL) {
     copyFileSync(lib, join(repo, lib));
   }
   writeFileSync(join(repo, "nova", "config.yaml"), 'name: HA NOVA\nversion: "0.9.0"\n');
+  writeFileSync(join(repo, ".github", "workflows", "ci.yml"), "jobs: {}\n");
   // The dispatch preflight reads the same policy file as the server resolver.
   mkdirSync(join(repo, ".github", "policy"), { recursive: true });
   writeFileSync(
@@ -143,6 +145,7 @@ case "$args" in
     cat "\$f" 2>/dev/null || printf '[]\\n' ;;
   "workflow run cloud-candidate-bundle.yml --repo ${REPO_SLUG} -f pull_request=7 -f version_tag="*" -f request_id="*)
     trace "dispatch"
+    printf '%s\n' "$args" >"\${FAKE_GH_STATE}/dispatch.args"
     exit 0 ;;
   "run watch "*" --repo ${REPO_SLUG} --exit-status")
     trace "run-watch"
@@ -455,7 +458,7 @@ describe("cloud evidence PR target binding", () => {
       draft: false,
       mergeable_state: "clean",
       merge_commit_sha: fixture.mainCommit,
-      base: { ref: "main" },
+      base: { ref: "main", sha: fixture.mainCommit },
       head: { sha: fixture.mainCommit, repo: { full_name: REPO_SLUG } },
       ...overrides,
     };
@@ -695,6 +698,14 @@ describe("cloud evidence PR target binding", () => {
     expect(result.stdout).toContain("dispatching fresh");
     const trace = readFileSync(fake.trace, "utf8");
     expect(trace).toContain("dispatch");
+    const workflowsTree = git(
+      fixture.repo,
+      "rev-parse",
+      `${fixture.mainCommit}:.github/workflows`,
+    ).trim();
+    expect(readFileSync(join(fake.state, "dispatch.args"), "utf8")).toContain(
+      `request_id=pr7-${fixture.mainCommit}-${fixture.mainCommit}-${fixture.mainCommit}-${workflowsTree}`,
+    );
     expect(result.stderr).toContain("refusing to execute it");
     expect(result.stderr).not.toContain("cannot copy");
   });

--- a/tests/onboarding/cloud-release-commit-gate-behavior.ts
+++ b/tests/onboarding/cloud-release-commit-gate-behavior.ts
@@ -163,15 +163,40 @@ export function registerCloudReleaseCommitGateBehaviorTests(): void {
     it("permits only trusted candidate metadata to remain evidence-pending", () => {
       const { fixture, targetGate, trustedHead } =
         preparePRGateFixture(true);
+      execFileSync("git", ["checkout", "-qb", "candidate-head"], {
+        cwd: fixture.root,
+      });
+      writeFileSync(join(fixture.root, "candidate.txt"), "candidate\n");
+      const head = commitFixtureChanges(fixture, {});
+      execFileSync("git", ["checkout", "-qb", "candidate-merge", trustedHead], {
+        cwd: fixture.root,
+      });
       execFileSync(
         "git",
-        ["update-ref", "refs/pull/1/merge", trustedHead],
-        { cwd: fixture.root },
+        ["merge", "--no-ff", "-qm", "candidate merge", head],
+        {
+          cwd: fixture.root,
+        },
       );
+      const merge = currentFixtureHead(fixture);
+      const workflowsTree = execFileSync(
+        "git",
+        ["rev-parse", `${merge}:.github/workflows`],
+        { cwd: fixture.root, encoding: "utf8" },
+      ).trim();
+      execFileSync("git", ["checkout", "-q", trustedHead], {
+        cwd: fixture.root,
+      });
+      execFileSync("git", ["update-ref", "refs/pull/1/merge", merge], {
+        cwd: fixture.root,
+      });
       const env = {
         ...process.env,
         HA_NOVA_CLOUD_GATE_SOURCE_REF: "refs/pull/1/merge",
-        HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT: trustedHead,
+        HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT: merge,
+        HA_NOVA_CLOUD_GATE_EXPECTED_BASE_COMMIT: trustedHead,
+        HA_NOVA_CLOUD_GATE_EXPECTED_HEAD_COMMIT: head,
+        HA_NOVA_CLOUD_GATE_APPROVAL_ID: `pr1-${trustedHead}-${head}-${merge}-${workflowsTree}`,
       };
       const candidate = spawnSync("bash", [targetGate, "candidate"], {
         cwd: fixture.root,
@@ -323,7 +348,7 @@ export function registerCloudReleaseCommitGateBehaviorTests(): void {
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     });
 
-    it.each(["add", "delete", "rename", "mode", "sensitive", "run", "identity", "comment"])(
+    it.each(["add", "delete", "rename", "mode", "run", "identity", "comment"])(
       "rejects enabled workflow %s deltas outside existing non-sensitive uses versions",
       (mutation) => {
         const { fixture, prGate, trustedHead, workflowDir } = preparePRGateFixture();
@@ -389,6 +414,275 @@ export function registerCloudReleaseCommitGateBehaviorTests(): void {
         expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
       },
     );
+
+    it(
+      "binds one sensitive workflow approval and broker evidence to the exact PR tuple",
+      { timeout: 120000 },
+      () => {
+        const { fixture, prGate, targetGate, trustedHead, workflowDir, env } =
+          preparePRGateFixture(true);
+        execFileSync("git", ["checkout", "-qb", "sensitive-head"], {
+          cwd: fixture.root,
+        });
+        writeFileSync(
+          join(workflowDir, "cloud-source-gate.yml"),
+          "name: approved sensitive change\njobs: {}\n",
+        );
+        const head = commitFixtureChanges(fixture, {});
+        execFileSync(
+          "git",
+          ["checkout", "-qb", "sensitive-merge", trustedHead],
+          {
+            cwd: fixture.root,
+          },
+        );
+        execFileSync(
+          "git",
+          ["merge", "--no-ff", "-qm", "sensitive merge", head],
+          {
+            cwd: fixture.root,
+          },
+        );
+        const merge = currentFixtureHead(fixture);
+        const tree = execFileSync("git", ["rev-parse", `${merge}^{tree}`], {
+          cwd: fixture.root,
+          encoding: "utf8",
+        }).trim();
+        const workflowsTree = execFileSync(
+          "git",
+          ["rev-parse", `${merge}:.github/workflows`],
+          { cwd: fixture.root, encoding: "utf8" },
+        ).trim();
+        const approval = `pr1-${trustedHead}-${head}-${merge}-${workflowsTree}`;
+        execFileSync("git", ["checkout", "-q", trustedHead], {
+          cwd: fixture.root,
+        });
+        execFileSync("git", ["update-ref", "refs/pull/1/merge", merge], {
+          cwd: fixture.root,
+        });
+        const candidateEnv = {
+          ...env,
+          HA_NOVA_CLOUD_GATE_SOURCE_REF: "refs/pull/1/merge",
+          HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT: merge,
+          HA_NOVA_CLOUD_GATE_EXPECTED_BASE_COMMIT: trustedHead,
+          HA_NOVA_CLOUD_GATE_EXPECTED_HEAD_COMMIT: head,
+          HA_NOVA_CLOUD_GATE_APPROVAL_ID: approval,
+        };
+        const candidate = spawnSync("bash", [targetGate, "candidate"], {
+          cwd: fixture.root,
+          encoding: "utf8",
+          env: { ...process.env, ...candidateEnv },
+        });
+        expect(
+          candidate.status,
+          `${candidate.stdout}\n${candidate.stderr}`,
+        ).toBe(0);
+        const retry = spawnSync("bash", [targetGate, "candidate"], {
+          cwd: fixture.root,
+          encoding: "utf8",
+          env: { ...process.env, ...candidateEnv },
+        });
+        expect(retry.status, `${retry.stdout}\n${retry.stderr}`).toBe(0);
+
+        for (const invalid of [
+          "",
+          approval.replace(/^pr1-/, "pr2-"),
+          approval.replace(/^pr1-/, ""),
+          approval.replace(trustedHead, "0".repeat(40)),
+          approval.replace(head, "1".repeat(40)),
+          approval.replace(merge, "2".repeat(40)),
+          approval.replace(workflowsTree, "3".repeat(40)),
+          approval.replace(trustedHead, ""),
+          approval.replace(head, ""),
+          approval.replace(merge, ""),
+          approval.replace(workflowsTree, ""),
+        ]) {
+          const result = spawnSync("bash", [targetGate, "candidate"], {
+            cwd: fixture.root,
+            encoding: "utf8",
+            env: {
+              ...process.env,
+              ...candidateEnv,
+              HA_NOVA_CLOUD_GATE_APPROVAL_ID: invalid,
+            },
+          });
+          expect(result.status, invalid).not.toBe(0);
+        }
+
+        const sameTreeHead = execFileSync(
+          "git",
+          [
+            "commit-tree",
+            `${head}^{tree}`,
+            "-p",
+            head,
+            "-m",
+            "new head identity",
+          ],
+          { cwd: fixture.root, encoding: "utf8" },
+        ).trim();
+        const sameTreeMerge = execFileSync(
+          "git",
+          [
+            "commit-tree",
+            `${merge}^{tree}`,
+            "-p",
+            trustedHead,
+            "-p",
+            sameTreeHead,
+            "-m",
+            "new merge identity",
+          ],
+          { cwd: fixture.root, encoding: "utf8" },
+        ).trim();
+        execFileSync(
+          "git",
+          ["update-ref", "refs/pull/1/merge", sameTreeMerge],
+          {
+            cwd: fixture.root,
+          },
+        );
+        const changedIdentity = spawnSync("bash", [targetGate, "candidate"], {
+          cwd: fixture.root,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            ...candidateEnv,
+            HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT: sameTreeMerge,
+            HA_NOVA_CLOUD_GATE_EXPECTED_HEAD_COMMIT: sameTreeHead,
+          },
+        });
+        expect(changedIdentity.status).not.toBe(0);
+        execFileSync("git", ["update-ref", "refs/pull/1/merge", merge], {
+          cwd: fixture.root,
+        });
+
+        const exact = runPRGate(
+          fixture.root,
+          prGate,
+          merge,
+          validCloudEvidence({ sha: merge, tree }, ["linux"]),
+          {
+            ...env,
+            HA_NOVA_CLOUD_GATE_EXPECTED_BASE_COMMIT: trustedHead,
+            HA_NOVA_CLOUD_GATE_EXPECTED_HEAD_COMMIT: head,
+          },
+        );
+        expect(exact.status, `${exact.stdout}\n${exact.stderr}`).toBe(0);
+
+        execFileSync(
+          "git",
+          ["update-ref", "refs/heads/gh-readonly-queue/main/test", merge],
+          { cwd: fixture.root },
+        );
+        const queue = spawnSync("bash", [targetGate], {
+          cwd: fixture.root,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            ...env,
+            HA_NOVA_CLOUD_GATE_SOURCE_REF:
+              "refs/heads/gh-readonly-queue/main/test",
+            HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT: merge,
+            HA_NOVA_CLOUD_GATE_EVIDENCE_JSON: JSON.stringify(
+              validCloudEvidence({ sha: merge, tree }, ["linux"]),
+            ),
+          },
+        });
+        expect(queue.status).not.toBe(0);
+        expect(`${queue.stdout}\n${queue.stderr}`).toContain(
+          "merge queue cannot approve sensitive workflow changes",
+        );
+
+        const twin = execFileSync(
+          "git",
+          [
+            "commit-tree",
+            `${merge}^{tree}`,
+            "-p",
+            trustedHead,
+            "-p",
+            head,
+            "-m",
+            "same tree",
+          ],
+          { cwd: fixture.root, encoding: "utf8" },
+        ).trim();
+        const identicalTree = runPRGate(
+          fixture.root,
+          prGate,
+          merge,
+          validCloudEvidence({ sha: twin, tree }, ["linux"]),
+          env,
+        );
+        expect(identicalTree.status).not.toBe(0);
+        expect(`${identicalTree.stdout}\n${identicalTree.stderr}`).toContain(
+          "require evidence for the exact target commit and tree",
+        );
+
+        const stale = runPRGate(
+          fixture.root,
+          prGate,
+          merge,
+          validCloudEvidence(
+            {
+              sha: trustedHead,
+              tree: execFileSync(
+                "git",
+                ["rev-parse", `${trustedHead}^{tree}`],
+                {
+                  cwd: fixture.root,
+                  encoding: "utf8",
+                },
+              ).trim(),
+            },
+            ["linux"],
+          ),
+          env,
+        );
+        expect(stale.status).not.toBe(0);
+        const malformed = runPRGate(
+          fixture.root,
+          prGate,
+          merge,
+          { schema: 2 },
+          env,
+        );
+        expect(malformed.status).not.toBe(0);
+      },
+    );
+
+    it("rejects an approved sensitive workflow combined with a second workflow change", () => {
+      const { fixture, prGate, trustedHead, workflowDir, env } =
+        preparePRGateFixture(true);
+      writeFileSync(
+        join(workflowDir, "cloud-source-gate.yml"),
+        "name: sensitive change\njobs: {}\n",
+      );
+      writeFileSync(
+        join(workflowDir, "maintenance.yml"),
+        `steps:\n  - uses: example/action@${ACTION_SHA_124} # v1.2.4\n`,
+      );
+      const target = commitFixtureChanges(fixture, {});
+      const tree = execFileSync("git", ["rev-parse", "HEAD^{tree}"], {
+        cwd: fixture.root,
+        encoding: "utf8",
+      }).trim();
+      execFileSync("git", ["checkout", "-q", trustedHead], {
+        cwd: fixture.root,
+      });
+      const result = runPRGate(
+        fixture.root,
+        prGate,
+        target,
+        validCloudEvidence({ sha: target, tree }, ["linux"]),
+        env,
+      );
+      expect(result.status).not.toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toContain(
+        "approval may change exactly one existing sensitive workflow",
+      );
+    });
 
     it("accepts an identical tree after a squash-style commit rewrite", () => {
       const enabled = {

--- a/tests/onboarding/cloud-release-commit-gate-behavior.ts
+++ b/tests/onboarding/cloud-release-commit-gate-behavior.ts
@@ -257,12 +257,12 @@ export function registerCloudReleaseCommitGateBehaviorTests(): void {
       expect(clean.status, `${clean.stdout}\n${clean.stderr}`).toBe(0);
 
       writeFileSync(
-        join(workflowDir, "spoof.yml"),
-        "jobs:\n  spoof:\n    name: cloud-source-gate\n",
+        join(workflowDir, "maintenance.yml"),
+        `steps:\n  - uses: example/action@${ACTION_SHA_124} # v1.2.4\n`,
         "utf8",
       );
       execFileSync("git", ["add", "."], { cwd: fixture.root });
-      execFileSync("git", ["commit", "-qm", "duplicate context"], {
+      execFileSync("git", ["commit", "-qm", "disabled uses-only maintenance"], {
         cwd: fixture.root,
       });
       const target = execFileSync("git", ["rev-parse", "HEAD"], {
@@ -272,8 +272,14 @@ export function registerCloudReleaseCommitGateBehaviorTests(): void {
       execFileSync("git", ["checkout", "-q", trustedHead], {
         cwd: fixture.root,
       });
-      const duplicate = runPRGate(fixture.root, prGate, target);
-      expect(duplicate.status, `${duplicate.stdout}\n${duplicate.stderr}`).toBe(0);
+      const usesOnly = runPRGate(
+        fixture.root,
+        prGate,
+        target,
+        undefined,
+        env,
+      );
+      expect(usesOnly.status, `${usesOnly.stdout}\n${usesOnly.stderr}`).toBe(0);
 
       const enabled = {
         min_relay_version: "0.8.0",
@@ -320,6 +326,68 @@ export function registerCloudReleaseCommitGateBehaviorTests(): void {
       expect(enabledChange.status, `${enabledChange.stdout}\n${enabledChange.stderr}`).not.toBe(0);
       expect(`${enabledChange.stdout}\n${enabledChange.stderr}`).toContain(
         "enabled Cloud source requires the provisioned, exact App-bound source reporter check",
+      );
+    });
+
+    it("rejects sensitive workflow changes hidden behind disabled Cloud on PR and queue paths", () => {
+      const { fixture, prGate, targetGate, trustedHead, workflowDir, env } =
+        preparePRGateFixture(true);
+      const disabled = {
+        min_relay_version: "0.8.0",
+        cloud_remote_enabled: false,
+        cloud_remote_platforms: [],
+      };
+      writeFileSync(
+        join(fixture.root, "version.json"),
+        `${JSON.stringify(disabled, null, 2)}\n`,
+        "utf8",
+      );
+      writeFileSync(
+        join(fixture.root, "nova", "version.json"),
+        `${JSON.stringify(disabled, null, 2)}\n`,
+        "utf8",
+      );
+      writeFileSync(
+        join(workflowDir, "cloud-source-gate.yml"),
+        "name: hidden sensitive change\njobs: {}\n",
+        "utf8",
+      );
+      const target = commitFixtureChanges(fixture, {});
+      execFileSync("git", ["checkout", "-q", trustedHead], {
+        cwd: fixture.root,
+      });
+
+      const pullRequest = runPRGate(
+        fixture.root,
+        prGate,
+        target,
+        undefined,
+        env,
+      );
+      expect(pullRequest.status).not.toBe(0);
+      expect(`${pullRequest.stdout}\n${pullRequest.stderr}`).toContain(
+        "disabled Cloud targets may change workflows only through non-sensitive uses-only maintenance",
+      );
+
+      execFileSync(
+        "git",
+        ["update-ref", "refs/heads/gh-readonly-queue/main/disabled", target],
+        { cwd: fixture.root },
+      );
+      const queue = spawnSync("bash", [targetGate], {
+        cwd: fixture.root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ...env,
+          HA_NOVA_CLOUD_GATE_SOURCE_REF:
+            "refs/heads/gh-readonly-queue/main/disabled",
+          HA_NOVA_CLOUD_GATE_EXPECTED_TARGET_COMMIT: target,
+        },
+      });
+      expect(queue.status).not.toBe(0);
+      expect(`${queue.stdout}\n${queue.stderr}`).toContain(
+        "disabled Cloud targets may change workflows only through non-sensitive uses-only maintenance",
       );
     });
 
@@ -702,6 +770,42 @@ export function registerCloudReleaseCommitGateBehaviorTests(): void {
 
       const result = runCloudGate(fixture, validCloudEvidence(fixture, ["linux"]), head);
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    });
+
+    it.each([
+      "markusleben/ha-nova/.github/workflows/release.yml@refs/tags/v0.25.1",
+      "markusleben/ha-nova/.github/workflows/release-candidate.yml@refs/heads/main",
+    ])("requires a repointed evidence commit in publication path %s", (workflowRef) => {
+      const enabled = {
+        min_relay_version: "0.8.0",
+        cloud_remote_enabled: true,
+        cloud_remote_platforms: ["linux"],
+      };
+      const fixture = cloudGateFixture(enabled);
+      execFileSync("git", ["commit", "--amend", "-qm", "publication rewrite"], {
+        cwd: fixture.root,
+      });
+      const head = currentFixtureHead(fixture);
+      expect(head).not.toBe(fixture.sha);
+
+      const exact = runCloudGate(
+        fixture,
+        validCloudEvidence({ sha: head, tree: fixture.tree }, ["linux"]),
+        head,
+        { GITHUB_WORKFLOW_REF: workflowRef },
+      );
+      expect(exact.status, `${exact.stdout}\n${exact.stderr}`).toBe(0);
+
+      const staleCommit = runCloudGate(
+        fixture,
+        validCloudEvidence(fixture, ["linux"]),
+        head,
+        { GITHUB_WORKFLOW_REF: workflowRef },
+      );
+      expect(staleCommit.status).not.toBe(0);
+      expect(`${staleCommit.stdout}\n${staleCommit.stderr}`).toContain(
+        "require evidence for the exact target commit and tree",
+      );
     });
 
     it("rejects disabled-source evidence for a later enabled runtime", () => {

--- a/tests/onboarding/cloud-release-gate-contract.ts
+++ b/tests/onboarding/cloud-release-gate-contract.ts
@@ -108,6 +108,13 @@ export function registerCloudReleaseGateContractTests(): void {
     expect(cloudReleaseGateVerifier).toContain("verify-cloud-workflow-uses-only.mjs");
     expect(cloudReleaseGateVerifier).toContain("verify-cloud-nonsensitive-source.mjs");
     expect(cloudReleaseGateVerifier).toContain("workflowCommit !== commit");
+    expect(cloudReleaseGateVerifier).toContain("GITHUB_WORKFLOW_REF");
+    expect(cloudReleaseGateVerifier).toContain(
+      "markusleben/ha-nova/.github/workflows/release.yml@",
+    );
+    expect(cloudReleaseGateVerifier).toContain(
+      "markusleben/ha-nova/.github/workflows/release-candidate.yml@",
+    );
     for (const check of [
       "parity",
       "stress_10000",
@@ -253,6 +260,12 @@ export function registerCloudReleaseGateContractTests(): void {
     );
     expect(sourceGateScript).toContain("verify-cloud-workflow-uses-only.mjs");
     expect(sourceGateScript).toContain("single-sensitive-workflow");
+    expect(sourceGateScript).toContain(
+      "disabled Cloud targets may change workflows only through non-sensitive uses-only maintenance",
+    );
+    expect(sourceGateScript.indexOf('target_workflows_tree="$(')).toBeLessThan(
+      sourceGateScript.indexOf('if [[ "${cloud_enabled}" == "false" ]]'),
+    );
     expect(sourceGateScript).toContain(
       'HA_NOVA_CLOUD_GATE_REQUIRE_EXACT_EVIDENCE="${exact_evidence}"',
     );

--- a/tests/onboarding/cloud-release-gate-contract.ts
+++ b/tests/onboarding/cloud-release-gate-contract.ts
@@ -249,9 +249,13 @@ export function registerCloudReleaseGateContractTests(): void {
     expect(sourceGateScript).toContain("HEAD:.github/workflows");
     expect(sourceGateScript).toContain("${target_commit}:.github/workflows");
     expect(sourceGateScript).toContain(
-      '[[ "${target_workflows_tree}" == "${trusted_workflows_tree}" ]]',
+      '[[ "${target_workflows_tree}" != "${trusted_workflows_tree}" ]]',
     );
     expect(sourceGateScript).toContain("verify-cloud-workflow-uses-only.mjs");
+    expect(sourceGateScript).toContain("single-sensitive-workflow");
+    expect(sourceGateScript).toContain(
+      'HA_NOVA_CLOUD_GATE_REQUIRE_EXACT_EVIDENCE="${exact_evidence}"',
+    );
     expect(sourceGateScript).toContain(
       "pull request merge commit does not bind the expected base and head",
     );


### PR DESCRIPTION
## Summary

- permit exactly one approved content-only change to one existing Cloud-sensitive workflow
- bind candidate approval and broker evidence to the exact PR tuple, synthetic merge commit, workflow tree, actor, review state, checks, and refs
- close disabled-Cloud and publication identical-tree bypasses at the shared release gates
- keep merge-queue sensitive changes fail-closed and preserve the existing non-sensitive uses-only lane

## Safety boundaries

- no workflow file changes
- no version, manifest, README, tag, release, publish, secret, setting, service, label, or dependency changes
- default deny remains in place
- evidence remains exact-state and retry-safe

## Verification

- targeted P1 regressions: 5 passed
- npm run verify:release-contracts: 551 passed
- npm test: 2054 passed
- npm run typecheck
- bash scripts/check-docs.sh
- bash scripts/release/verify-cloud-workflow-gate.sh
- bash -n and shellcheck -S error on changed shell gates
- git diff --check
- local codex review --uncommitted: no correctness findings

## Review and evidence

Release-bound and high-risk. Require a real Codex verdict on the exact final head, resolved threads, green required checks, fresh Cloud candidate evidence for the exact synthetic merge state, PR CI rerun after evidence, and immediate post-merge evidence repointing.
