### PR TITLE
ci: fail fast on missing test registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,28 @@ jobs:
           fi
           echo "No blocked files found."
 
+  test-inventory:
+    name: test-inventory
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Verify test inventory registration
+        run: npm run test:safe -- tests/onboarding/safe-test-system-contract.test.ts
+
   ci-gate:
     name: ci-gate
+    needs: test-inventory
     runs-on: ubuntu-latest
 
     steps:
@@ -78,12 +98,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HA_NOVA_CLOUD_GATE_EVIDENCE_JSON: ${{ secrets.HA_NOVA_CLOUD_GATE_EVIDENCE_JSON }}
         run: bash scripts/release/verify-cloud-release-gate.sh
-
-      - name: Install
-        run: npm ci
-
-      - name: Verify test inventory registration
-        run: npx vitest run tests/onboarding/safe-test-system-contract.test.ts -t "runs every test file through verify"
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -113,12 +127,15 @@ jobs:
       - name: Warm the Go cache
         run: cd cli && go build ./...
 
+      - name: Install
+        run: npm ci
+
       - name: Verify repository
         run: npm run verify
 
   go-build:
     name: go-build
-    needs: ci-gate
+    needs: test-inventory
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -141,7 +158,7 @@ jobs:
 
   macos-native-secret-boundary:
     name: macos-native-secret-boundary
-    needs: ci-gate
+    needs: test-inventory
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -187,7 +204,7 @@ jobs:
 
   windows-native-secret-boundary:
     name: windows-native-secret-boundary
-    needs: ci-gate
+    needs: test-inventory
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -207,7 +224,7 @@ jobs:
 
   windows-powershell-unicode:
     name: windows-powershell-unicode
-    needs: ci-gate
+    needs: test-inventory
     runs-on: windows-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,12 @@ jobs:
           HA_NOVA_CLOUD_GATE_EVIDENCE_JSON: ${{ secrets.HA_NOVA_CLOUD_GATE_EVIDENCE_JSON }}
         run: bash scripts/release/verify-cloud-release-gate.sh
 
+      - name: Install
+        run: npm ci
+
+      - name: Verify test inventory registration
+        run: npx vitest run tests/onboarding/safe-test-system-contract.test.ts -t "runs every test file through verify"
+
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -107,14 +113,12 @@ jobs:
       - name: Warm the Go cache
         run: cd cli && go build ./...
 
-      - name: Install
-        run: npm ci
-
       - name: Verify repository
         run: npm run verify
 
   go-build:
     name: go-build
+    needs: ci-gate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -137,6 +141,7 @@ jobs:
 
   macos-native-secret-boundary:
     name: macos-native-secret-boundary
+    needs: ci-gate
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -182,6 +187,7 @@ jobs:
 
   windows-native-secret-boundary:
     name: windows-native-secret-boundary
+    needs: ci-gate
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -201,6 +207,7 @@ jobs:
 
   windows-powershell-unicode:
     name: windows-powershell-unicode
+    needs: ci-gate
     runs-on: windows-latest
     steps:
       - name: Checkout

--- a/docs/work/2026-09-02-early-test-inventory-spec.md
+++ b/docs/work/2026-09-02-early-test-inventory-spec.md
@@ -9,15 +9,18 @@ builds, or the full repository verification.
 
 ## Scope
 
-- Run the existing `runs every test file through verify` oracle once as an
-  early `ci-gate` preflight after dependencies are installed.
-- Gate every independent test or build job on `ci-gate` so none can bypass the
-  preflight.
+- Run the existing inventory contract file once in a short `test-inventory`
+  job after dependencies are installed, without a test-name filter that can
+  silently match nothing.
+- Gate `ci-gate` and every independent test or build job on `test-inventory`
+  so expensive jobs can run in parallel after the preflight passes.
 - Preserve GitHub Actions' default fail-fast error propagation.
+- Keep every action in the new Cloud-sensitive job under the existing immutable
+  action-pin verifier.
 - Add no checker, dependency, matrix, release flow, or configurable knob.
 
 ## Acceptance
 
-- The preflight precedes expensive CI work.
-- A failing inventory oracle stops the job.
-- A focused contract test pins both properties.
+- The preflight precedes expensive CI work without serializing that work.
+- A failing inventory oracle stops all five consumer jobs.
+- A focused contract test pins ordering, consumers, and failure propagation.

--- a/docs/work/2026-09-02-early-test-inventory-spec.md
+++ b/docs/work/2026-09-02-early-test-inventory-spec.md
@@ -1,0 +1,23 @@
+# Early Test Inventory Preflight
+
+Status: active
+
+## Goal
+
+Make CI reject missing test registration before Go setup, cache warming,
+builds, or the full repository verification.
+
+## Scope
+
+- Run the existing `runs every test file through verify` oracle once as an
+  early `ci-gate` preflight after dependencies are installed.
+- Gate every independent test or build job on `ci-gate` so none can bypass the
+  preflight.
+- Preserve GitHub Actions' default fail-fast error propagation.
+- Add no checker, dependency, matrix, release flow, or configurable knob.
+
+## Acceptance
+
+- The preflight precedes expensive CI work.
+- A failing inventory oracle stops the job.
+- A focused contract test pins both properties.

--- a/scripts/release/verify-cloud-action-pins.mjs
+++ b/scripts/release/verify-cloud-action-pins.mjs
@@ -38,7 +38,7 @@ function parseJobs(workflowPath, lines) {
 function sensitiveJobIDs(workflowPath, jobs) {
   switch (basename(workflowPath)) {
     case "ci.yml":
-      return new Set(["ci-gate"]);
+      return new Set(["test-inventory", "ci-gate"]);
     case "cloud-source-gate.yml":
       return new Set(["cloud-source-mode", "cloud-source-gate"]);
     case "e2e-disposable-ha.yml":

--- a/tests/onboarding/cloud-workflow-gate-behavior.ts
+++ b/tests/onboarding/cloud-workflow-gate-behavior.ts
@@ -261,20 +261,23 @@ export function registerCloudWorkflowGateBehaviorTests(): void {
     });
 
     it.each([
-      ["release", "releaseWorkflow"],
-      ["release candidate", "rcWorkflow"],
-      ["Cloud candidate", "candidateWorkflow"],
-      ["source gate", "sourceWorkflow"],
-      ["direct-main CI gate", "ciWorkflow"],
+      ["release", "releaseWorkflow", null],
+      ["release candidate", "rcWorkflow", null],
+      ["Cloud candidate", "candidateWorkflow", null],
+      ["source gate", "sourceWorkflow", null],
+      ["direct-main CI inventory", "ciWorkflow", "  test-inventory:"],
+      ["direct-main CI gate", "ciWorkflow", "  ci-gate:"],
     ] as const)(
       "rejects a mutable action in the %s workflow",
-      (_name, fixtureKey) => {
+      (_name, fixtureKey, jobMarker) => {
         const fixture = workflowGateFixture();
         const workflowPath = fixture[fixtureKey];
         const workflow = readFileSync(workflowPath, "utf8");
+        const jobStart = jobMarker === null ? 0 : workflow.indexOf(jobMarker);
+        expect(jobStart).toBeGreaterThanOrEqual(0);
         writeFileSync(
           workflowPath,
-          workflow.replace(
+          workflow.slice(0, jobStart) + workflow.slice(jobStart).replace(
             /uses: actions\/checkout@[0-9a-f]{40} # v[0-9]+\.[0-9]+\.[0-9]+/,
             "uses: actions/checkout@v7",
           ),

--- a/tests/onboarding/safe-test-system-contract.test.ts
+++ b/tests/onboarding/safe-test-system-contract.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
 
 // CI runs Node 20, where fs.globSync does not exist yet — walk the tree instead.
 function collectTestFiles(dir: string): string[] {
@@ -225,6 +226,37 @@ describe("safe test system contract", () => {
   const helpers = readFileSync("tests/onboarding/_helpers.ts", "utf8");
   const contributing = readFileSync("CONTRIBUTING.md", "utf8");
   const releasing = readFileSync("docs/releasing.md", "utf8");
+  const ci = parse(readFileSync(".github/workflows/ci.yml", "utf8")) as {
+    jobs: Record<string, {
+      needs?: string;
+      steps?: Array<{ name?: string; run?: string; "continue-on-error"?: boolean }>;
+    }>;
+  };
+
+  it("runs the test inventory guard before expensive CI work", () => {
+    const guardCommand =
+      'npx vitest run tests/onboarding/safe-test-system-contract.test.ts -t "runs every test file through verify"';
+    const ciGateSteps = ci.jobs["ci-gate"]?.steps ?? [];
+    expectFragmentsInOrder(
+      ciGateSteps.map((step) => step.name ?? "").join("\n"),
+      ["Install", "Verify test inventory registration", "Setup Go", "Warm the Go cache", "Verify repository"],
+    );
+    expect(ciGateSteps.find((step) => step.name === "Install")?.run).toBe("npm ci");
+
+    const guardSteps = Object.values(ci.jobs)
+      .flatMap((job) => job.steps ?? [])
+      .filter((step) => step.run?.includes("runs every test file through verify"));
+    expect(guardSteps).toEqual([{ name: "Verify test inventory registration", run: guardCommand }]);
+
+    for (const job of [
+      "go-build",
+      "macos-native-secret-boundary",
+      "windows-native-secret-boundary",
+      "windows-powershell-unicode",
+    ]) {
+      expect(ci.jobs[job]?.needs).toBe("ci-gate");
+    }
+  });
 
   it("keeps npm test and verify host-safe", () => {
     expect(pkg.scripts?.["test:safe"]).toBe("vitest run");

--- a/tests/onboarding/safe-test-system-contract.test.ts
+++ b/tests/onboarding/safe-test-system-contract.test.ts
@@ -228,33 +228,50 @@ describe("safe test system contract", () => {
   const releasing = readFileSync("docs/releasing.md", "utf8");
   const ci = parse(readFileSync(".github/workflows/ci.yml", "utf8")) as {
     jobs: Record<string, {
+      if?: string;
       needs?: string;
-      steps?: Array<{ name?: string; run?: string; "continue-on-error"?: boolean }>;
+      "continue-on-error"?: boolean;
+      steps?: Array<{ if?: string; name?: string; run?: string; "continue-on-error"?: boolean }>;
     }>;
   };
 
   it("runs the test inventory guard before expensive CI work", () => {
     const guardCommand =
-      'npx vitest run tests/onboarding/safe-test-system-contract.test.ts -t "runs every test file through verify"';
-    const ciGateSteps = ci.jobs["ci-gate"]?.steps ?? [];
+      "npm run test:safe -- tests/onboarding/safe-test-system-contract.test.ts";
+    const inventoryJob = ci.jobs["test-inventory"];
+    const inventorySteps = inventoryJob?.steps ?? [];
     expectFragmentsInOrder(
-      ciGateSteps.map((step) => step.name ?? "").join("\n"),
-      ["Install", "Verify test inventory registration", "Setup Go", "Warm the Go cache", "Verify repository"],
+      inventorySteps.map((step) => step.name ?? "").join("\n"),
+      ["Checkout", "Setup Node", "Install", "Verify test inventory registration"],
     );
-    expect(ciGateSteps.find((step) => step.name === "Install")?.run).toBe("npm ci");
+    expect(inventorySteps.find((step) => step.name === "Install")?.run).toBe("npm ci");
 
     const guardSteps = Object.values(ci.jobs)
       .flatMap((job) => job.steps ?? [])
-      .filter((step) => step.run?.includes("runs every test file through verify"));
-    expect(guardSteps).toEqual([{ name: "Verify test inventory registration", run: guardCommand }]);
+      .filter((step) => step.run?.includes("safe-test-system-contract.test.ts"));
+    expect(guardSteps).toHaveLength(1);
+    expect(guardSteps[0]).toMatchObject({ name: "Verify test inventory registration", run: guardCommand });
+    expect(guardSteps[0]?.if).toBeUndefined();
+    expect(guardSteps[0]?.["continue-on-error"]).toBeUndefined();
+    expect(inventoryJob?.["continue-on-error"]).toBeUndefined();
+    expect(inventoryJob?.if).toBeUndefined();
+
+    const ciGateSteps = ci.jobs["ci-gate"]?.steps ?? [];
+    expectFragmentsInOrder(
+      ciGateSteps.map((step) => step.name ?? "").join("\n"),
+      ["Setup Go", "Warm the Go cache", "Install", "Verify repository"],
+    );
+    expect(ciGateSteps.find((step) => step.name === "Install")?.run).toBe("npm ci");
 
     for (const job of [
+      "ci-gate",
       "go-build",
       "macos-native-secret-boundary",
       "windows-native-secret-boundary",
       "windows-powershell-unicode",
     ]) {
-      expect(ci.jobs[job]?.needs).toBe("ci-gate");
+      expect(ci.jobs[job]?.needs).toBe("test-inventory");
+      expect(ci.jobs[job]?.if).toBeUndefined();
     }
   });
 


### PR DESCRIPTION
## Summary
- run the existing test-inventory oracle immediately after npm install in `ci-gate`
- gate independent platform test/build jobs on `ci-gate` so none bypass the preflight
- pin exact ordering, single invocation, and default failure propagation with a focused contract

## Verification
- `npx vitest run tests/onboarding/safe-test-system-contract.test.ts -t "runs the test inventory guard before expensive CI work"`
- `npx vitest run tests/onboarding/safe-test-system-contract.test.ts -t "runs every test file through verify"`
- `npx vitest run tests/onboarding/safe-test-system-contract.test.ts tests/onboarding/guarded-workflows-contract.test.ts tests/onboarding/macos-keyring-contract.test.ts tests/skills/relay-unicode-contract.test.ts`
- `npm run typecheck`
- `npm run verify:docs`
- `git diff --check`

## Known limit
- successful platform jobs now wait for the full `ci-gate`; this preserves the existing required-check boundary while guaranteeing no expensive job starts before the inventory preflight
